### PR TITLE
[Refactor/#1] groupId 및 package 이름 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'org.example'
+group = 'io.github.ascrew'
 version = '0.0.1-SNAPSHOT'
 description = 'Monomat-BE'
 

--- a/src/main/java/io/github/ascrew/monomatbe/MonomatBeApplication.java
+++ b/src/main/java/io/github/ascrew/monomatbe/MonomatBeApplication.java
@@ -1,4 +1,4 @@
-package org.example.monomatbe;
+package io.github.ascrew.monomatbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/test/java/io/github/ascrew/monomatbe/MonomatBeApplicationTests.java
+++ b/src/test/java/io/github/ascrew/monomatbe/MonomatBeApplicationTests.java
@@ -1,4 +1,4 @@
-package org.example.monomatbe;
+package io.github.ascrew.monomatbe;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #1

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 프로젝트 전반의 패키지 네이밍을 `com.example`에서 `io.github.ascrew`로 리팩터링
- Gradle 그룹 정보(`group`)를 `io.github.ascrew`로 맞춰 패키지 정책과 일치시킴

## 🙏 PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 코드 기준 `com.example` 잔존은 확인되지 않았습니다.
- 다만 IntelliJ 실행 설정(`.idea/workspace.xml`)에 구 메인 클래스(`org.example.monomatbe.MonomatBeApplication`) 참조가 남아있을 수 있어, 로컬 Run Configuration 확인이 필요합니다.
- 기존 빌드 산출물에 구 패키지 경로 클래스가 남아있을 수 있으므로, 필요 시 `clean` 후 재빌드로 검증 부탁드립니다.
- 이번 PR은 패키지/네이밍 리팩터링 중심이며, 비즈니스 로직 변경은 없습니다.
