### PR TITLE
[Feat/#11] ws end point

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -8,10 +8,17 @@ package io.github.ascrew.monomatbe.controller;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public ChatController(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
 
     // 메시지 타입 정의
     public enum MessageType {
@@ -45,8 +52,8 @@ public class ChatController {
      */
     @MessageMapping("/chat/lobby/{code}")
     @SendTo("/topic/chat/lobby/{code}")
-    public String broadcastLobby(@DestinationVariable("code")String code, String message){
+    public void broadcastLobby(@DestinationVariable("code")String code, String message){
+        messagingTemplate.convertAndSend("/topic/lobby/" + code, message);
 
-        return message;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -39,10 +39,9 @@ public class ChatController {
      * 클라이언트 수신(구독): /topic/global
      */
     @MessageMapping("/chat/global")
-    @SendTo("/topic/chat/global")
-    public String broadcastGlobal(String message){
+    public void broadcastGlobal(ChatMessageDto message){
+        messagingTemplate.convertAndSend("/topic/chat/global", message);
 
-        return message;
     }
 
     /*

--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -5,9 +5,9 @@
  */
 package io.github.ascrew.monomatbe.controller;
 
+import io.github.ascrew.monomatbe.dto.ChatMessageDto;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
@@ -20,18 +20,6 @@ public class ChatController {
         this.messagingTemplate = messagingTemplate;
     }
 
-    // 메시지 타입 정의
-    public enum MessageType {
-        CHAT, ANSWER, ENTER, LEAVE
-    }
-
-    // DTO 레코드 생성
-    public record ChatMessageDto(
-            MessageType type,
-            String sender,
-            String content,
-            String timestamp
-    ) {}
 
     /*
      * 1. 전체 채팅 라우팅

--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -11,7 +11,20 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 
 @Controller
-public class chatController {
+public class ChatController {
+
+    // 메시지 타입 정의
+    public enum MessageType {
+        CHAT, ANSWER, ENTER, LEAVE
+    }
+
+    // DTO 레코드 생성
+    public record ChatMessageDto(
+            MessageType type,
+            String sender,
+            String content,
+            String timestamp
+    ) {}
 
     /*
      * 1. 전체 채팅 라우팅
@@ -19,7 +32,7 @@ public class chatController {
      * 클라이언트 수신(구독): /topic/global
      */
     @MessageMapping("/chat/global")
-    @SendTo("/topic/global")
+    @SendTo("/topic/chat/global")
     public String broadcastGlobal(String message){
 
         return message;
@@ -27,12 +40,12 @@ public class chatController {
 
     /*
      * 2. 로비 전용 채팅 라우팅
-     * 클라이언트 송신: /app/chat/lobby/{id} (ex: /app/chat/lobby/123)
-     * 클라이언트 수신(구독): /topic/lobby/{id}
+     * 클라이언트 송신: /app/chat/lobby/{code} (ex: /app/chat/lobby/난수+문자 6자리)
+     * 클라이언트 수신(구독): /topic/lobby/{code}
      */
-    @MessageMapping("/chat/lobby/{id}")
-    @SendTo("/topic/lobby/{id}")
-    public String broadcastLobby(@DestinationVariable("id")Long id, String message){
+    @MessageMapping("/chat/lobby/{code}")
+    @SendTo("/topic/chat/lobby/{code}")
+    public String broadcastLobby(@DestinationVariable("code")String code, String message){
 
         return message;
     }

--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -51,7 +51,6 @@ public class ChatController {
      * 클라이언트 수신(구독): /topic/lobby/{code}
      */
     @MessageMapping("/chat/lobby/{code}")
-    @SendTo("/topic/chat/lobby/{code}")
     public void broadcastLobby(@DestinationVariable("code")String code, String message){
         messagingTemplate.convertAndSend("/topic/lobby/" + code, message);
 

--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -50,7 +50,7 @@ public class ChatController {
      * 클라이언트 수신(구독): /topic/lobby/{code}
      */
     @MessageMapping("/chat/lobby/{code}")
-    public void broadcastLobby(@DestinationVariable("code")String code, String message){
+    public void broadcastLobby(@DestinationVariable("code")String code, ChatMessageDto message){
         messagingTemplate.convertAndSend("/topic/lobby/" + code, message);
 
     }

--- a/src/main/java/io/github/ascrew/monomatbe/controller/chatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/chatController.java
@@ -1,0 +1,39 @@
+/*
+전체 채팅 라우팅
+로비 채팅 라우팅
+밑에 주석 참조
+ */
+package io.github.ascrew.monomatbe.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class chatController {
+
+    /*
+     * 1. 전체 채팅 라우팅
+     * 클라이언트 송신: /app/chat/global
+     * 클라이언트 수신(구독): /topic/global
+     */
+    @MessageMapping("/chat/global")
+    @SendTo("/topic/global")
+    public String broadcastGlobal(String message){
+
+        return message;
+    }
+
+    /*
+     * 2. 로비 전용 채팅 라우팅
+     * 클라이언트 송신: /app/chat/lobby/{id} (ex: /app/chat/lobby/123)
+     * 클라이언트 수신(구독): /topic/lobby/{id}
+     */
+    @MessageMapping("/chat/lobby/{id}")
+    @SendTo("/topic/lobby/{id}")
+    public String broadcastLobby(@DestinationVariable("id")Long id, String message){
+
+        return message;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/dto/ChatMessageDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/dto/ChatMessageDto.java
@@ -1,0 +1,16 @@
+package io.github.ascrew.monomatbe.dto;
+
+
+
+// DTO 레코드 생성
+public record ChatMessageDto(
+        MessageType type,
+        String sender,
+        String content,
+        String timestamp
+) {
+    // 메시지 타입 정의
+    public enum MessageType {
+        CHAT, ANSWER, ENTER, LEAVE
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -17,12 +17,15 @@ package io.github.ascrew.monomatbe.global.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
-    public void registerStompEndpoints(org.springframework.web.socket.config.annotation.StompEndpointRegistry registry) {
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
                 .addEndpoint("/ws") //최초로 웹소켓 연결을 하기위해 url /ws 지정
                 .setAllowedOriginPatterns("*") //모든 도메인에서 접속을 허용
@@ -30,8 +33,17 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     }
 
     @Override
-    public void configureMessageBroker(org.springframework.messaging.simp.config.MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic"); //수신용
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 하트비트를 담당할 스레드 생성 및 초기화
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);                                           //스레드 1개로 제한
+        taskScheduler.setThreadNamePrefix("wss-heartbeat-thread-");             //스레드 이름 접두사 설정
+        taskScheduler.initialize();
+
+        registry.enableSimpleBroker("/topic")                   //수신용
+                .setTaskScheduler(taskScheduler)
+                .setHeartbeatValue(new long[]{10000,10000}); //클라이언트와 서버가 10000ms(10초)마다 하트비트를 주고받도록 설정
+
         registry.setApplicationDestinationPrefixes("/app");  //송신용(발행)
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -12,13 +12,6 @@
     - SockJS: 웹소켓 연결이 실패할 경우, 폴링 등의 대체 통신 방법을 사용하여 연결을 유지할 수 있도록 지원
  */
 
-
-
-
-
-
-
-
 package io.github.ascrew.monomatbe.global.config;
 
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -1,0 +1,45 @@
+/*
+1.기본 연결 정보
+    엔드포인트(접속 주소): http://{서버_도메인_또는_IP}:8080/ws
+2.통신 경로 규칙
+    STOMP 통신 시 사용하는 경로 규칙
+    - 송신용 경로: /app/** (클라이언트가 메시지를 보낼 때 사용하는 경로)
+    - 수신용 경로: /topic/** (서버가 클라이언트에게 메시지를 보낼 때 사용하는 경로)
+3.메시지 브로커
+    - Simple Broker: /topic/** (서버가 클라이언트에게 메시지를 보낼 때 사용하는 경로)
+    - Application Destination Prefix: /app/** (클라이언트가 메시지를 보낼 때 사용하는 경로)
+4.웹소켓 연결 실패 시 대체 통신 방법
+    - SockJS: 웹소켓 연결이 실패할 경우, 폴링 등의 대체 통신 방법을 사용하여 연결을 유지할 수 있도록 지원
+ */
+
+
+
+
+
+
+
+
+package io.github.ascrew.monomatbe.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(org.springframework.web.socket.config.annotation.StompEndpointRegistry registry) {
+        registry
+                .addEndpoint("/ws") //최초로 웹소켓 연결을 하기위해 url /ws 지정
+                .setAllowedOriginPatterns("*") //모든 도메인에서 접속을 허용
+                .withSockJS(); //웹소켓 연결 실패시 일반 HTTP통신으로 연결
+    }
+
+    @Override
+    public void configureMessageBroker(org.springframework.messaging.simp.config.MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); //수신용
+        registry.setApplicationDestinationPrefixes("/app");  //송신용(발행)
+    }
+
+}


### PR DESCRIPTION
## 📣 Related Issue
- #11

## 📝 Summary
- **웹소켓 및 STOMP 브로커 초기 설정**: `@EnableWebSocketMessageBroker`를 활용하여 클라이언트 연결을 위한 `/ws` 엔드포인트를 개방하고, 연결 실패 시 대체 통신을 위한 SockJS를 적용했습니다.
- **메시지 라우팅 구조 정의 및 채널 분리**: 프론트엔드와 통신할 수 있도록 전체 채팅(`/topic/global`)과 개별 로비 채팅(`/topic/lobby/{id}`) 목적지로 메시지를 브로드캐스팅하는 구조를 구현했습니다.

## 🙏PR point
- 프론트엔드(React)에서 작업하실 때, 메시지 송신(발행) 시에는 `/app/...` 경로를, 수신(구독) 시에는 `/topic/...` 경로를 사용해 주시면 됩니다.
- 특정 로비의 채팅을 구현할 때는 동적 경로인 `/topic/lobby/{id}`를 구독하여 해당 방의 메시지만 독립적으로 받아볼 수 있습니다.


## 📬 Reference
- [Spring Boot WebSockets with STOMP 공식 가이드](https://spring.io/guides/gs/messaging-stomp-websocket/)