### PR TITLE
[Feat/#11] 로비 리스트 및 로비 상태 갱신 WebSocket 핸들러 추가

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
@@ -8,32 +8,31 @@ topic을 통해 메시지를 브로드캐스트하는 역할을 수행한다.
 
 package io.github.ascrew.monomatbe.controller;
 
+import io.github.ascrew.monomatbe.service.LobbyEventService;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 @Controller
+@RequiredArgsConstructor
 public class LobbyEventController {
 
-  private final SimpMessagingTemplate messagingTemplate;
-
-  public LobbyEventController(SimpMessagingTemplate messagingTemplate) {
-    this.messagingTemplate = messagingTemplate;
-  }
+  private final LobbyEventService lobbyEventService;
 
   // 로비가 생성될 때 로비 리스트을 보고있는 모든 클라이언트에게 로비 리스트를 새로고침하라는 메시지를 보냄
   // 차후 유저의 수가 증가할 경우 많은 요청이 발생할 수 있으므로
   // 일정시간(예: 5초) 동안 1건 이상 로비 생성 이벤트가 발생할 경우에만 로비 리스트 새로고침 메시지를 보내도록 개선할 수 있음
   @MessageMapping("/lobby/create")
-  public void notifyLobbyListRefresh() {
-    messagingTemplate.convertAndSend("/topic/lobby/refresh", "REFRESH_LOBBY_LIST");
+  public void notifyLobbyListRefresh(Principal principal) {
+    lobbyEventService.notifyLobbyListRefresh(principal);
   }
 
   // 로비 내부 정보가 변경될 때 해당 로비에 참여한 클라이언트들에게 로비 정보를 새로고침하라는 메시지를 보냄
   // 로비 내부 정보 변경의 기준: 유저 입장, 유저 퇴장, 유저 준비, 유저 준비 해제 등
   @MessageMapping("/lobby/{id}/update")
-  public void notifyLobbyInfoRefresh(@DestinationVariable String id) {
-    messagingTemplate.convertAndSend("/topic/lobby/" + id + "/refresh", "REFRESH_LOBBY_INFO");
+  public void notifyLobbyInfoRefresh(@DestinationVariable String id, Principal principal) {
+    lobbyEventService.notifyLobbyInfoRefresh(id, principal);
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
@@ -31,8 +31,8 @@ public class LobbyEventController {
 
   // 로비 내부 정보가 변경될 때 해당 로비에 참여한 클라이언트들에게 로비 정보를 새로고침하라는 메시지를 보냄
   // 로비 내부 정보 변경의 기준: 유저 입장, 유저 퇴장, 유저 준비, 유저 준비 해제 등
-  @MessageMapping("/lobby/{id}/update")
-  public void notifyLobbyInfoRefresh(@DestinationVariable String id, Principal principal) {
-    lobbyEventService.notifyLobbyInfoRefresh(id, principal);
+  @MessageMapping("/lobby/{code}/update")
+  public void notifyLobbyInfoRefresh(@DestinationVariable String code, Principal principal) {
+    lobbyEventService.notifyLobbyInfoRefresh(code, principal);
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
@@ -1,0 +1,41 @@
+/*
+로비 관련 이벤트를 처리하는 WebSocket(STOMP) 컨트롤러
+
+클라이언트로부터 전달된 로비 이벤트(생성, 입장/퇴장, 준비 상태 변경 등)를 받아
+해당 이벤트를 구독(subscribe) 중인 클라이언트들에게
+topic을 통해 메시지를 브로드캐스트하는 역할을 수행한다.
+*/
+
+package io.github.ascrew.monomatbe.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class LobbyEventController {
+
+  private final SimpMessagingTemplate messagingTemplate;
+
+  public LobbyEventController(SimpMessagingTemplate messagingTemplate) {
+    this.messagingTemplate = messagingTemplate;
+  }
+
+  // 로비가 생성될 때 로비 리스트을 보고있는 모든 클라이언트에게 로비 리스트를 새로고침하라는 메시지를 보냄
+  // 차후 유저의 수가 증가할 경우 많은 요청이 발생할 수 있으므로
+  // 일정시간(예: 5초) 동안 1건 이상 로비 생성 이벤트가 발생할 경우에만 로비 리스트 새로고침 메시지를 보내도록 개선할 수 있음
+  @MessageMapping("/lobby/create")
+  @SendTo("/topic/lobby/refresh")
+  public String notifyLobbyListRefresh() {
+    return "REFRESH_LOBBY_LIST";
+  }
+
+  // 로비 내부 정보가 변경될 때 해당 로비에 참여한 클라이언트들에게 로비 정보를 새로고침하라는 메시지를 보냄
+  // 로비 내부 정보 변경의 기준: 유저 입장, 유저 퇴장, 유저 준비, 유저 준비 해제 등
+  @MessageMapping("/lobby/{id}/update")
+  public void notifyLobbyInfoRefresh(@DestinationVariable String id) {
+    messagingTemplate.convertAndSend("/topic/lobby/" + id + "/refresh", "REFRESH_LOBBY_INFO");
+  }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
@@ -10,7 +10,6 @@ package io.github.ascrew.monomatbe.controller;
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
@@ -27,9 +26,8 @@ public class LobbyEventController {
   // 차후 유저의 수가 증가할 경우 많은 요청이 발생할 수 있으므로
   // 일정시간(예: 5초) 동안 1건 이상 로비 생성 이벤트가 발생할 경우에만 로비 리스트 새로고침 메시지를 보내도록 개선할 수 있음
   @MessageMapping("/lobby/create")
-  @SendTo("/topic/lobby/refresh")
-  public String notifyLobbyListRefresh() {
-    return "REFRESH_LOBBY_LIST";
+  public void notifyLobbyListRefresh() {
+    messagingTemplate.convertAndSend("/topic/lobby/refresh", "REFRESH_LOBBY_LIST");
   }
 
   // 로비 내부 정보가 변경될 때 해당 로비에 참여한 클라이언트들에게 로비 정보를 새로고침하라는 메시지를 보냄

--- a/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepository.java
@@ -1,0 +1,6 @@
+package io.github.ascrew.monomatbe.repository;
+
+public interface LobbyRepository {
+  boolean existsById(String id);
+  boolean isParticipant(String code, String userId);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepository.java
@@ -1,6 +1,6 @@
 package io.github.ascrew.monomatbe.repository;
 
 public interface LobbyRepository {
-  boolean existsById(String id);
+  boolean existsByCode(String code);
   boolean isParticipant(String code, String userId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepositoryImpl.java
@@ -11,10 +11,10 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private final StringRedisTemplate redisTemplate;
 
   @Override
-  public boolean existsById(String id) {
+  public boolean existsByCode(String code) {
     // 구현 예정
-    // Redis key 예시: lobby:{id}
-    // return Boolean.TRUE.equals(redisTemplate.hasKey("lobby:" + id));
+    // Redis key 예시: lobby:{code}
+    // return Boolean.TRUE.equals(redisTemplate.hasKey("lobby:" + code));
 
     return true;
   }
@@ -22,7 +22,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   @Override
   public boolean isParticipant(String code, String userId) {
     // 구현 예정
-    // Redis Set key 예시: lobby:{id}:participants
+    // Redis Set key 예시: lobby:{code}:participants
     /**
     Boolean isMember =
         redisTemplate.opsForSet().isMember("lobby:" + code + ":participants", userId);

--- a/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepositoryImpl.java
@@ -1,0 +1,34 @@
+package io.github.ascrew.monomatbe.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LobbyRepositoryImpl implements LobbyRepository {
+
+  private final StringRedisTemplate redisTemplate;
+
+  @Override
+  public boolean existsById(String id) {
+    // 구현 예정
+    // Redis key 예시: lobby:{id}
+    // return Boolean.TRUE.equals(redisTemplate.hasKey("lobby:" + id));
+
+    return true;
+  }
+
+  @Override
+  public boolean isParticipant(String code, String userId) {
+    // 구현 예정
+    // Redis Set key 예시: lobby:{id}:participants
+    /**
+    Boolean isMember =
+        redisTemplate.opsForSet().isMember("lobby:" + code + ":participants", userId);
+    return Boolean.TRUE.equals(isMember);
+    **/
+
+    return true;
+  }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/LobbyEventService.java
@@ -6,14 +6,13 @@ import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class LobbyEventService {
 
   // 로비 ID 패턴을 임시로 정의하였음. 추후 변경 예정
-  private static final Pattern LOBBY_ID_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
+  private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
 
   private final SimpMessagingTemplate messagingTemplate;
   private final LobbyRepository lobbyRepository;
@@ -24,19 +23,19 @@ public class LobbyEventService {
     messagingTemplate.convertAndSend("/topic/lobby/refresh", "REFRESH_LOBBY_LIST");
   }
 
-  public void notifyLobbyInfoRefresh(String id, Principal principal) {
+  public void notifyLobbyInfoRefresh(String code, Principal principal) {
 
     /**
       !! TODO !!
-      1. 로비 ID(id)가 패턴에 맞는지 검증
-      2. 로비 ID(id)가 Redis에 존재하며 활성화된 로비인지 검증
+      1. 로비 ID(code)가 패턴에 맞는지 검증
+      2. 로비 ID(code)가 Redis에 존재하며 활성화된 로비인지 검증
       3. 요청을 보낸 사용자가 현재 해당 로비에 존재하는지 검증(principal)
     **/
 
     /** 아래는 예시 코드
-    if (!StringUtils.hasText(id) || !LOBBY_ID_PATTERN.matcher(id).matches()) {
+    if (!StringUtils.hasText(code) || !LOBBY_ID_PATTERN.matcher(code).matches()) {
       return;
-    }
+    }턴
 
     if (principal == null || !StringUtils.hasText(principal.getName())) {
       return;
@@ -44,15 +43,15 @@ public class LobbyEventService {
 
     String userId = principal.getName();
 
-    if (!lobbyRepository.existsById(id)) {
+    if (!lobbyRepository.existsByCode(code)) {
       return;
     }
 
-    if (!lobbyRepository.isParticipant(id, userId)) {
+    if (!lobbyRepository.isParticipant(code, userId)) {
       return;
     }
     **/
 
-    messagingTemplate.convertAndSend("/topic/lobby/" + id + "/refresh", "REFRESH_LOBBY_INFO");
+    messagingTemplate.convertAndSend("/topic/lobby/" + code + "/refresh", "REFRESH_LOBBY_INFO");
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/LobbyEventService.java
@@ -1,0 +1,58 @@
+package io.github.ascrew.monomatbe.service;
+
+import io.github.ascrew.monomatbe.repository.LobbyRepository;
+import java.security.Principal;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class LobbyEventService {
+
+  // 로비 ID 패턴을 임시로 정의하였음. 추후 변경 예정
+  private static final Pattern LOBBY_ID_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
+
+  private final SimpMessagingTemplate messagingTemplate;
+  private final LobbyRepository lobbyRepository;
+
+  public void notifyLobbyListRefresh(Principal principal) {
+
+    // 필요하면 여기서 principal 기반 권한 검사 추가
+    messagingTemplate.convertAndSend("/topic/lobby/refresh", "REFRESH_LOBBY_LIST");
+  }
+
+  public void notifyLobbyInfoRefresh(String id, Principal principal) {
+
+    /**
+      !! TODO !!
+      1. 로비 ID(id)가 패턴에 맞는지 검증
+      2. 로비 ID(id)가 Redis에 존재하며 활성화된 로비인지 검증
+      3. 요청을 보낸 사용자가 현재 해당 로비에 존재하는지 검증(principal)
+    **/
+
+    /** 아래는 예시 코드
+    if (!StringUtils.hasText(id) || !LOBBY_ID_PATTERN.matcher(id).matches()) {
+      return;
+    }
+
+    if (principal == null || !StringUtils.hasText(principal.getName())) {
+      return;
+    }
+
+    String userId = principal.getName();
+
+    if (!lobbyRepository.existsById(id)) {
+      return;
+    }
+
+    if (!lobbyRepository.isParticipant(id, userId)) {
+      return;
+    }
+    **/
+
+    messagingTemplate.convertAndSend("/topic/lobby/" + id + "/refresh", "REFRESH_LOBBY_INFO");
+  }
+}


### PR DESCRIPTION
## 📣 Related Issue
- #11

## 📝 Summary
- WebSocket(STOMP) 기반의 로비 이벤트 컨트롤러 구현 (`LobbyEventController`)
- 로비 생성 시 로비 리스트를 구독 중인 **모든 클라이언트**에게 새로고침 메시지 브로드캐스트 (`/topic/lobby/refresh`)
- 로비 내부 정보 변경(입장 / 퇴장 / 준비 / 준비 해제) 시 **해당 로비 구독자**에게만 새로고침 메시지 전송 (`/topic/lobby/{id}/refresh`)

## 🙏 PR point
- 현재 로비 생성 이벤트는 발생할 때마다 전체 브로드캐스트를 수행합니다. 유저 수가 증가할 경우 트래픽 부하가 발생할 수 있어, 추후 **일정 시간(예: 5초) 내 이벤트를 debounce 처리**하는 방향으로 개선이 필요할 것 같습니다. 이 부분에 대한 팀원 의견이 궁금합니다.
- `notifyLobbyListRefresh()`는 `@SendTo`로, `notifyLobbyInfoRefresh()`는 `SimpMessagingTemplate`으로 각각 다르게 구현했습니다. 동적 경로(`{id}`) 여부에 따라 방식을 다르게 선택했는데, 일관성을 맞추는 방향으로 변경이 필요한지 리뷰 부탁드립니다.