### PR TITLE
[Feat/#21]Security Setting

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -7,20 +7,17 @@ package io.github.ascrew.monomatbe.controller;
 
 import io.github.ascrew.monomatbe.dto.ChatMessageDto;
 import io.github.ascrew.monomatbe.service.RedisPublisher;
+import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 @Controller
+@RequiredArgsConstructor
 public class ChatController {
 
     private final RedisPublisher redisPublisher;
-
-    public ChatController(RedisPublisher redisPublisher) {
-        this.redisPublisher = redisPublisher;
-    }
-
 
     /*
      * 1. 전체 채팅 라우팅

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
@@ -1,0 +1,30 @@
+package io.github.ascrew.monomatbe.global.config.SecurityConfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+@Configuration
+@EnableWebSecurity
+@Profile("dev")
+public class SecurityConfigDev {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)      // CSRF 보호 비활성화
+            .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+            .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/ws/**").permitAll()
+                    .anyRequest()
+                    .permitAll()
+            ); // 모든 요청 허용 (개발 환경에서는 인증 없이 접근 허용)
+
+        return http.build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
@@ -1,0 +1,32 @@
+package io.github.ascrew.monomatbe.global.config.SecurityConfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+
+@Configuration
+@EnableWebSecurity
+@Profile("prod")
+public class SecurityConfigProd {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)      // CSRF 보호 비활성화
+            .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+            .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+            .authorizeHttpRequests(auth -> auth
+                    // 향후 회원가입, 로그인 등 인증없이 들어와야 하는 URL이 생기면 추가
+                    // .requestMatchers("/api/auth/**").permitAll()
+                    .anyRequest().authenticated()
+
+            ); // 모든 요청에 대해 인증 필요 (운영 환경에서는 인증된 사용자만 접근 허용)
+
+        return http.build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -1,0 +1,45 @@
+/*
+1.기본 연결 정보
+    엔드포인트(접속 주소): http://{서버_도메인_또는_IP}:8080/ws
+2.통신 경로 규칙
+    STOMP 통신 시 사용하는 경로 규칙
+    - 송신용 경로: /app/** (클라이언트가 메시지를 보낼 때 사용하는 경로)
+    - 수신용 경로: /topic/** (서버가 클라이언트에게 메시지를 보낼 때 사용하는 경로)
+3.메시지 브로커
+    - Simple Broker: /topic/** (서버가 클라이언트에게 메시지를 보낼 때 사용하는 경로)
+    - Application Destination Prefix: /app/** (클라이언트가 메시지를 보낼 때 사용하는 경로)
+4.웹소켓 연결 실패 시 대체 통신 방법
+    - SockJS: 웹소켓 연결이 실패할 경우, 폴링 등의 대체 통신 방법을 사용하여 연결을 유지할 수 있도록 지원
+ */
+
+
+
+
+
+
+
+
+package io.github.ascrew.monomatbe.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(org.springframework.web.socket.config.annotation.StompEndpointRegistry registry) {
+        registry
+                .addEndpoint("/ws") //최초로 웹소켓 연결을 하기위해 url /ws 지정
+                .setAllowedOriginPatterns("*") //모든 도메인에서 접속을 허용
+                .withSockJS(); //웹소켓 연결 실패시 일반 HTTP통신으로 연결
+    }
+
+    @Override
+    public void configureMessageBroker(org.springframework.messaging.simp.config.MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); //수신용
+        registry.setApplicationDestinationPrefixes("/app");  //송신용(발행)
+    }
+
+}

--- a/src/main/java/io/github/ascrew/monomatbe/service/RedisPublisher.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/RedisPublisher.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.service;
 
+import lombok.RequiredArgsConstructor;
 import tools.jackson.databind.json.JsonMapper;
 import io.github.ascrew.monomatbe.dto.ChatMessageDto;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -7,15 +8,11 @@ import org.springframework.stereotype.Service;
 
 
 @Service
+@RequiredArgsConstructor
 public class RedisPublisher {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final JsonMapper jsonMapper;
-
-    public RedisPublisher(RedisTemplate<String , Object> redisTemplate, JsonMapper jsonMapper) {
-        this.jsonMapper = jsonMapper;
-        this.redisTemplate = redisTemplate;
-    }
 
     public void publish(String topic, ChatMessageDto messageDto) {
         try {

--- a/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.service;
 
 import io.github.ascrew.monomatbe.dto.ChatMessageDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -12,17 +13,12 @@ import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class RedisSubscriber implements MessageListener {
 
     private final JsonMapper jsonMapper;                            // JSON 직렬화/역직렬화를 위한 JsonMapper
     private final RedisTemplate<String, Object> redisTemplate;      // RedisTemplate을 사용하여 Redis와 상호작용
     private final SimpMessagingTemplate simpMessagingTemplate;      // WebSocket을 통해 클라이언트에게 메시지를 전송하기 위한 SimpMessagingTemplate
-
-    public RedisSubscriber(JsonMapper jsonMapper, RedisTemplate<String , Object> redisTemplate, SimpMessagingTemplate simpMessagingTemplate) {
-        this.jsonMapper = jsonMapper;
-        this.redisTemplate = redisTemplate;
-        this.simpMessagingTemplate = simpMessagingTemplate;
-    }
 
     @Override
     public void onMessage(Message message, byte[] pattern){

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,5 +1,5 @@
 #==========================================
-#  Develop 환경 설정 파일
+#  Production 환경 설정 파일
 #==========================================
 # 1. Database 설정 (OCI MySQL 8.x DB)
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -13,9 +13,9 @@ spring.datasource.hikari.maximum-pool-size=10
 
 
 # 3. JPA / Hibernate 설정
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 
@@ -25,9 +25,11 @@ spring.data.redis.port=${OCI_REDIS_PORT}
 
 
 # 5. 로깅 설정
-# Spring Boot 4.x: SQL + 바인딩 파라미터 로그
-logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.orm.jdbc.bind=TRACE
+# Spring Boot 4.x: SQL + 바인딩 파라미터 로그 prod에서는 로그 레벨 최소화
+logging.level.root=INFO
+logging.level.org.hibernate.SQL=ERROR
+logging.level.io.github.ascrew.monomatbe=INFO
+logging.level.org.hibernate.orm.jdbc.bind=ERROR
 
 
 # 6. Java Virtual Thread 활성화

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
-#spring.application.name=Monomat-BE
+spring.application.name=Monomat-BE
 spring.profiles.active=dev
 spring.config.import=optional:file:.env[.properties]


### PR DESCRIPTION
## 📣 Related Issue
- #21 

## 📝 Summary
- **운영 환경(Prod) 설정 파일 구축**: `application-prod.properties`를 신규 생성하여 DB 커넥션 풀 최적화, `ddl-auto=validate` 안전 설정 및 시스템 로그 레벨 최소화 적용
- **환경별 Spring Security 정책 분리**: `@Profile`을 활용하여 환경별 보안 세팅 격리
  - `SecurityConfigDev`: 로컬/개발 단계의 원활한 WebSocket 연동(`/ws/**`) 및 API 테스트를 위한 접근 전면 개방
  - `SecurityConfigProd`: 운영 환경 대비 전 구역 인증 필수(`.anyRequest().authenticated()`)로 접근 차단 로직 구현
- **Lombok `@RequiredArgsConstructor` 리팩토링**: `ChatController`, `RedisSubscriber`, `RedisPublisher` 내 길고 반복적인 수동 의존성 주입(DI) 코드를 어노테이션으로 교체하여 가독성 개선
- **`JsonMapper` 빈(Bean) 충돌 해결**: `NoSuchBeanDefinitionException` 방지를 위해 `RedisPublisher` 내부에서 직접 통역사 객체를 생성(`JsonMapper.builder().build()`)하도록 구조 개선

## 🙏PR point
- 운영 서버 배포 시 반드시 환경 변수나 실행 옵션을 통해 `spring.profiles.active=prod`로 설정해야 운영용 방패(`SecurityConfigProd`)가 정상 작동합니다.
- 현재 Prod 시큐리티 설정은 **모든 요청을 막아둔 상태**입니다. 추후 인증 없이 접근해야 하는 퍼블릭 API(로그인, 회원가입 등)가 생기면 `SecurityConfigProd` 내부에 `.requestMatchers("...").permitAll()` 코드를 추가해 주시면 됩니다!
- 웹소켓 STOMP 통신 내부(`/topic`, `/app`)에 대한 유저 권한 검증은 향후 JWT 인증 도입과 함께 `ChannelInterceptor`를 활용하여 추가 작업할 예정입니다.

## 📬 Reference
