### PR TITLE
[Feat/#19] Redis 기반 로비 생명주기 관리 및 LobbyEventService 고도화

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/LobbyEventController.java
@@ -25,8 +25,8 @@ public class LobbyEventController {
   // 차후 유저의 수가 증가할 경우 많은 요청이 발생할 수 있으므로
   // 일정시간(예: 5초) 동안 1건 이상 로비 생성 이벤트가 발생할 경우에만 로비 리스트 새로고침 메시지를 보내도록 개선할 수 있음
   @MessageMapping("/lobby/create")
-  public void notifyLobbyListRefresh(Principal principal) {
-    lobbyEventService.notifyLobbyListRefresh(principal);
+  public void notifyLobbyListRefresh() {
+    lobbyEventService.notifyLobbyListRefresh();
   }
 
   // 로비 내부 정보가 변경될 때 해당 로비에 참여한 클라이언트들에게 로비 정보를 새로고침하라는 메시지를 보냄

--- a/src/main/java/io/github/ascrew/monomatbe/dto/LobbyRedisDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/dto/LobbyRedisDto.java
@@ -1,0 +1,22 @@
+package io.github.ascrew.monomatbe.dto;
+
+import lombok.*;
+
+/**
+ * [Lobby Redis DTO] Redis Hash에 저장할 로비 메타 정보 객체.
+ * MySQL의 GAME_LOBBY 테이블 정보와 실시간 상태 정보를 통합 관리함.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LobbyRedisDto {
+    private String code;          // 로비 초대 코드 (6자리 난수/문자)
+    private String hostId;        // 현재 방장의 고유 식별자 (userId)
+    private String title;         // 로비 제목
+    private Long mapId;           // 선택된 맵 세트 ID
+    private Integer maxPlayers;   // 최대 참여 가능 인원
+    private Boolean isPrivate;    // 공개/비공개 여부 (목록 노출 제어용)
+    private String status;        // 로비 상태 (WAITING, PLAYING 등)
+}

--- a/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRedisKeys.java
@@ -1,0 +1,25 @@
+package io.github.ascrew.monomatbe.repository;
+
+public class LobbyRedisKeys {
+    private static final String PREFIX = "lobby:";
+
+    public static String getLobbyMetaKey(String code) {
+        return PREFIX + code; // lobby:ABCDEF (Hash: 방 정보)
+    }
+
+    public static String getParticipantsKey(String code) {
+        return PREFIX + code + ":participants"; // lobby:ABCDEF:participants (Set: 유저 목록)
+    }
+
+    public static String getOrderKey(String code) {
+        return PREFIX + code + ":order"; // lobby:ABCDEF:order (List: 입장 순서)
+    }
+
+    public static String getPublicLobbiesKey() {
+        return "lobby:public"; // lobby:public (Set/ZSet: 공개 방 목록 인덱스)
+    }
+
+    public static String getConnectionKey(String sessionId) {
+        return "ws:connection:" + sessionId; // ws:connection:{sessionId} (Hash: 세션 매핑 정보)
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepository.java
@@ -1,6 +1,32 @@
 package io.github.ascrew.monomatbe.repository;
 
+import io.github.ascrew.monomatbe.dto.LobbyRedisDto;
+
 public interface LobbyRepository {
+  // 1. 존재 및 참여 확인
   boolean existsByCode(String code);
   boolean isParticipant(String code, String userId);
+
+  // 2. 로비 생성 및 정보 저장
+  void saveLobby(LobbyRedisDto lobbyDto); // 로비 메타 정보 저장
+  LobbyRedisDto getLobby(String code); // 로비 메타 정보 조회
+
+  // 3. 참여자 관리
+  void addParticipant(String code, String userId);
+  void removeParticipant(String code, String userId);
+
+  // 4. 방장 및 인원 확인
+  String getHostId(String code);
+  void updateHostId(String code, String nextHostId);
+  Long getParticipantCount(String code);
+
+  // 6. 방장 위임을 위한 대기 순번 조회
+  String getNextHostCandidate(String code);
+
+  // 5. 공개 로비 리스트 관리
+  void addToPublicList(String code);
+  void removeFromPublicList(String code);
+
+  // 7. 로비 완전 삭제
+  void deleteLobby(String code);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/LobbyRepositoryImpl.java
@@ -1,34 +1,153 @@
 package io.github.ascrew.monomatbe.repository;
 
+import io.github.ascrew.monomatbe.dto.LobbyRedisDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
 public class LobbyRepositoryImpl implements LobbyRepository {
 
-  private final StringRedisTemplate redisTemplate;
+    private final StringRedisTemplate redisTemplate;
+    private static final Duration LOBBY_TTL = Duration.ofHours(1);
 
-  @Override
-  public boolean existsByCode(String code) {
-    // 구현 예정
-    // Redis key 예시: lobby:{code}
-    // return Boolean.TRUE.equals(redisTemplate.hasKey("lobby:" + code));
+    // 로비 관련 모든 키의 TTL을 1시간으로 연장. 슬라이딩 윈도우 방식 적용
+    private void refreshLobbyTtl(String code) {
+        redisTemplate.expire(LobbyRedisKeys.getLobbyMetaKey(code), LOBBY_TTL);
+        redisTemplate.expire(LobbyRedisKeys.getParticipantsKey(code), LOBBY_TTL);
+        redisTemplate.expire(LobbyRedisKeys.getOrderKey(code), LOBBY_TTL);
+    }
 
-    return true;
-  }
+    // 로비 존재 확인. 로비 메타 정보(Hash) 키 존재 여부 확인 및 유효성 검증
+    @Override
+    public boolean existsByCode(String code) {
+        String key = LobbyRedisKeys.getLobbyMetaKey(code);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
 
-  @Override
-  public boolean isParticipant(String code, String userId) {
-    // 구현 예정
-    // Redis Set key 예시: lobby:{code}:participants
-    /**
-    Boolean isMember =
-        redisTemplate.opsForSet().isMember("lobby:" + code + ":participants", userId);
-    return Boolean.TRUE.equals(isMember);
-    **/
+    // 유저 참여 여부 확인. Redis Set 자료구조를 이용한 특정 유저의 로비 소속 여부 확인
+    @Override
+    public boolean isParticipant(String code, String userId) {
+        String key = LobbyRedisKeys.getParticipantsKey(code);
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, userId));
+    }
 
-    return true;
-  }
-}
+    // 로비 설정 정보 저장. DTO를 Map으로 변환하여 Hash 저장 및 초기 TTL 설정
+    @Override
+    public void saveLobby(LobbyRedisDto lobbyDto) {
+        String key = LobbyRedisKeys.getLobbyMetaKey(lobbyDto.getCode());
+        Map<String, String> data = new HashMap<>();
+        data.put("code", lobbyDto.getCode());
+        data.put("host_user_id", lobbyDto.getHostId());
+        data.put("title", lobbyDto.getTitle());
+        data.put("map_id", String.valueOf(lobbyDto.getMapId()));
+        data.put("max_players", String.valueOf(lobbyDto.getMaxPlayers()));
+        data.put("is_private", String.valueOf(lobbyDto.getIsPrivate()));
+        data.put("status", lobbyDto.getStatus());
+
+        redisTemplate.opsForHash().putAll(key, data);
+        refreshLobbyTtl(lobbyDto.getCode());
+    }
+
+    // 로비 설정 정보 조회. Redis Hash 데이터를 DTO 객체로 변환하여 반환
+    @Override
+    public LobbyRedisDto getLobby(String code) {
+        String key = LobbyRedisKeys.getLobbyMetaKey(code);
+        Map<Object, Object> data = redisTemplate.opsForHash().entries(key);
+        
+        if (data.isEmpty()) return null;
+
+        return LobbyRedisDto.builder()
+                .code((String) data.get("code"))
+                .hostId((String) data.get("host_user_id"))
+                .title((String) data.get("title"))
+                .mapId(data.get("map_id") != null ? Long.parseLong((String) data.get("map_id")) : null)
+                .maxPlayers(data.get("max_players") != null ? Integer.parseInt((String) data.get("max_players")) : null)
+                .isPrivate(data.get("is_private") != null ? Boolean.parseBoolean((String) data.get("is_private")) : null)
+                .status((String) data.get("status"))
+                .build();
+    }
+
+    // 참여자 입장 처리. Set/List에 유저 추가 및 로비 TTL 연장
+    @Override
+    public void addParticipant(String code, String userId) {
+        String participantsKey = LobbyRedisKeys.getParticipantsKey(code);
+        String orderKey = LobbyRedisKeys.getOrderKey(code);
+
+        redisTemplate.opsForSet().add(participantsKey, userId);
+        redisTemplate.opsForList().rightPush(orderKey, userId);
+        refreshLobbyTtl(code);
+    }
+
+    // 참여자 퇴장 처리. 참여자 명단(Set/List)에서 유저 제거 및 로비 TTL 연장
+    @Override
+    public void removeParticipant(String code, String userId) {
+        String participantsKey = LobbyRedisKeys.getParticipantsKey(code);
+        String orderKey = LobbyRedisKeys.getOrderKey(code);
+
+        redisTemplate.opsForSet().remove(participantsKey, userId);
+        redisTemplate.opsForList().remove(orderKey, 1, userId);
+        
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(participantsKey))) {
+            refreshLobbyTtl(code);
+        }
+    }
+
+    // 현재 방장 ID 조회. 로비 메타 정보(Hash)에서 호스트 ID 추출 및 TTL 연장
+    @Override
+    public String getHostId(String code) {
+        String key = LobbyRedisKeys.getLobbyMetaKey(code);
+        String hostId = (String) redisTemplate.opsForHash().get(key, "host_user_id");
+        if (hostId != null) refreshLobbyTtl(code);
+        return hostId;
+    }
+
+    // 방장 권한 위임. 방장 ID 필드 갱신 및 로비 TTL 연장
+    @Override
+    public void updateHostId(String code, String nextHostId) {
+        String key = LobbyRedisKeys.getLobbyMetaKey(code);
+        redisTemplate.opsForHash().put(key, "host_user_id", nextHostId);
+        refreshLobbyTtl(code);
+    }
+
+    // 현재 참여 인원수 확인. 참여자 명단(Set) 크기 조회
+    @Override
+    public Long getParticipantCount(String code) {
+        String key = LobbyRedisKeys.getParticipantsKey(code);
+        return redisTemplate.opsForSet().size(key);
+    }
+
+    // 방장 위임 후보 조회. 입장 순서(List)의 0번 인덱스 유저 반환
+    @Override
+    public String getNextHostCandidate(String code) {
+        String key = LobbyRedisKeys.getOrderKey(code);
+        return redisTemplate.opsForList().index(key, 0);
+    }
+
+    // 공개 로비 목록 노출. 공개 설정된 로비 코드를 인덱스(Set)에 등록
+    @Override
+    public void addToPublicList(String code) {
+        redisTemplate.opsForSet().add(LobbyRedisKeys.getPublicLobbiesKey(), code);
+    }
+
+    // [Discovery] 공개 로비 목록 제외. 로비 비공개 전환 또는 삭제 시 인덱스에서 삭제.
+    @Override
+    public void removeFromPublicList(String code) {
+        redisTemplate.opsForSet().remove(LobbyRedisKeys.getPublicLobbiesKey(), code);
+    }
+
+    // [Cleanup] 로비 데이터 완전 삭제. 메타 정보, 참여자 명단, 순서 리스트를 Redis에서 즉시 제거.
+    @Override
+    public void deleteLobby(String code) {
+        redisTemplate.delete(java.util.List.of(
+                LobbyRedisKeys.getLobbyMetaKey(code),
+                LobbyRedisKeys.getParticipantsKey(code),
+                LobbyRedisKeys.getOrderKey(code)
+        ));
+    }
+    }

--- a/src/main/java/io/github/ascrew/monomatbe/service/LobbyConnectionListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/LobbyConnectionListener.java
@@ -1,0 +1,62 @@
+package io.github.ascrew.monomatbe.service;
+
+import io.github.ascrew.monomatbe.repository.LobbyRedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LobbyConnectionListener {
+
+    private final StringRedisTemplate redisTemplate;
+    private final LobbyEventService lobbyEventService;
+
+    // 웹소켓 세션과 유저/로비 정보 매핑 저장.
+    // 컨트롤러나 인터셉터에서 유저가 로비에 최종 진입했을 때 호출함
+    public void saveConnectionInfo(String sessionId, String userId, String lobbyCode) {
+        String key = LobbyRedisKeys.getConnectionKey(sessionId);
+        Map<String, String> data = Map.of(
+                "userId", userId,
+                "lobbyCode", lobbyCode
+        );
+        redisTemplate.opsForHash().putAll(key, data);
+        // 세션 매핑 정보는 최대 7일간 보존. 실제 웹소켓 연결이 유지되는 동안은 이 정보가 유효하도록 충분히 긴 TTL 설정
+        redisTemplate.expire(key, Duration.ofDays(7));
+    }
+
+    // 웹소켓 연결 종료 이벤트 처리
+    // 비정상 종료를 포함한 모든 연결 해제 시 Redis 세션 정보를 바탕으로 퇴장 로직 실행
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+        
+        if (sessionId == null) return;
+
+        String key = LobbyRedisKeys.getConnectionKey(sessionId);
+        Map<Object, Object> connectionInfo = redisTemplate.opsForHash().entries(key);
+
+        if (connectionInfo.isEmpty()) return;
+
+        String userId = (String) connectionInfo.get("userId");
+        String lobbyCode = (String) connectionInfo.get("lobbyCode");
+
+        // 필요 시 주석 해제하여 사용
+        // log.info("웹소켓 연결 종료 감지 - 세션: {}, 유저: {}, 로비: {}", sessionId, userId, lobbyCode);
+
+        // 1. 로비 퇴장 비즈니스 로직 실행
+        lobbyEventService.handlePlayerLeave(lobbyCode, userId);
+
+        // 2. 세션 매핑 정보 삭제
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/LobbyEventService.java
@@ -1,57 +1,118 @@
 package io.github.ascrew.monomatbe.service;
 
 import io.github.ascrew.monomatbe.repository.LobbyRepository;
-import java.security.Principal;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
+import java.security.Principal;
+import java.util.regex.Pattern;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LobbyEventService {
 
-  // 로비 ID 패턴을 임시로 정의하였음. 추후 변경 예정
-  private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
+    // 로비 ID 패턴: 영문 대문자 및 숫자 조합 6~12자리
+    private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
 
-  private final SimpMessagingTemplate messagingTemplate;
-  private final LobbyRepository lobbyRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final LobbyRepository lobbyRepository;
 
-  public void notifyLobbyListRefresh(Principal principal) {
-
-    // 필요하면 여기서 principal 기반 권한 검사 추가
-    messagingTemplate.convertAndSend("/topic/lobby/refresh", "REFRESH_LOBBY_LIST");
-  }
-
-  public void notifyLobbyInfoRefresh(String code, Principal principal) {
-
-    /**
-      !! TODO !!
-      1. 로비 ID(code)가 패턴에 맞는지 검증
-      2. 로비 ID(code)가 Redis에 존재하며 활성화된 로비인지 검증
-      3. 요청을 보낸 사용자가 현재 해당 로비에 존재하는지 검증(principal)
-    **/
-
-    /** 아래는 예시 코드
-    if (!StringUtils.hasText(code) || !LOBBY_ID_PATTERN.matcher(code).matches()) {
-      return;
-    }턴
-
-    if (principal == null || !StringUtils.hasText(principal.getName())) {
-      return;
+    // 로비 목록 새로고침 알림 송신
+    public void notifyLobbyListRefresh() {
+        messagingTemplate.convertAndSend("/topic/lobby/refresh", "REFRESH_LOBBY_LIST");
     }
 
-    String userId = principal.getName();
-
-    if (!lobbyRepository.existsByCode(code)) {
-      return;
+    // [내부 전용] 실제 WebSocket 메시지 전송 로직 분리
+    private void sendLobbyRefreshSignal(String code) {
+        messagingTemplate.convertAndSend("/topic/lobby/" + code + "/refresh", "REFRESH_LOBBY_INFO");
     }
 
-    if (!lobbyRepository.isParticipant(code, userId)) {
-      return;
+    // 특정 로비 정보 새로고침 알림 송신. 외부 호출용(검증 포함)
+    public void notifyLobbyInfoRefresh(String code, Principal principal) {
+        if (!validateLobbyAccess(code, principal)) {
+            return;
+        }
+        sendLobbyRefreshSignal(code);
     }
-    **/
 
-    messagingTemplate.convertAndSend("/topic/lobby/" + code + "/refresh", "REFRESH_LOBBY_INFO");
-  }
-}
+    // 유저 퇴장 처리 비즈니스 로직. 방장 위임 및 로비 삭제 관리
+    public void handlePlayerLeave(String code, String userId) {
+        if (!StringUtils.hasText(code) || !StringUtils.hasText(userId)) return;
+
+        // [필요 시 주석 해제하여 사용]
+        // log.info("유저 퇴장 처리 시작 - 로비: {}, 유저: {}", code, userId);
+
+        // 1. 현재 방장 확인
+        String currentHost = lobbyRepository.getHostId(code);
+
+        // 2. Redis에서 참여자 제거
+        lobbyRepository.removeParticipant(code, userId);
+
+        // 3. 남은 인원 확인
+        Long participantCount = lobbyRepository.getParticipantCount(code);
+
+        // 4. 인원이 0명이면 로비 파괴
+        if (participantCount == null || participantCount == 0) {
+            destroyLobby(code);
+            notifyLobbyListRefresh();
+            return;
+        }
+
+        // 5. 나간 사람이 방장이었으면 차순위 유저에게 위임
+        if (userId.equals(currentHost)) {
+            delegateHost(code);
+        }
+
+        // 6. 로비 내 유저들에게 상태 변경 알림 (내부 알림 전송 메서드 재사용)
+        sendLobbyRefreshSignal(code);
+    }
+
+    // 로비 액세스 권한 검증. 패턴, 존재 여부, 참여 여부 확인.
+    private boolean validateLobbyAccess(String code, Principal principal) {
+        if (!StringUtils.hasText(code) || !LOBBY_CODE_PATTERN.matcher(code).matches()) {
+            return false;
+        }
+
+        if (principal == null || !StringUtils.hasText(principal.getName())) {
+            return false;
+        }
+
+        String userId = principal.getName();
+
+        if (!lobbyRepository.existsByCode(code)) {
+            // 필요 시 주석 해제하여 사용
+            // log.warn("존재하지 않는 로비 접근 시도: {}", code);
+            return false;
+        }
+
+        if (!lobbyRepository.isParticipant(code, userId)) {
+            // 필요 시 주석 해제하여 사용
+            // log.warn("권한 없는 유저의 로비 접근 시도: {} (유저: {})", code, userId);
+            return false;
+        }
+
+        return true;
+    }
+
+    // 방장 위임 로직. 입장 순서가 가장 빠른 다음 유저 선출.
+    private void delegateHost(String code) {
+        String nextHostId = lobbyRepository.getNextHostCandidate(code);
+        if (nextHostId != null) {
+            lobbyRepository.updateHostId(code, nextHostId);
+            // 필요 시 주석 해제하여 사용
+            // log.info("방장 위임 완료 - 로비: {}, 새 방장: {}", code, nextHostId);
+        }
+    }
+
+    // 로비 파괴 로직. 공개 목록 제외 및 Redis 데이터 완전 삭제 수행.
+    private void destroyLobby(String code) {
+        lobbyRepository.removeFromPublicList(code);
+        lobbyRepository.deleteLobby(code);
+        // [필요 시 주석 해제하여 사용]
+        // log.info("로비 삭제 처리 완료 (인원 0명) - 로비: {}", code);
+    }
+    }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #19

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
### Redis를 기반으로 실시간 게임 로비의 데이터 모델링과 `LobbyEventService`를 통한 핵심 비즈니스 로직을 구현했습니다.
- Redis 데이터 구조 설계:
  - Hash: 로비 메타 정보(`LobbyRedisDto`) 저장
  - Set: 실시간 참여자 명단 및 공개 로비 인덱스 관리
  - List: 입장 순서 기록 (방장 위임용)
- 로비 생명주기 자동화:
  - Sliding Window TTL: 활동 발생 시 로비 수명 1시간 자동 연장 로직 적용
  - 자동 폭파: 참여 인원 0명 시 관련 모든 Redis 데이터 즉시 삭제 처리
  - 자동 위임: 방장 퇴장 시 입장 순서(List) 기반 차순위 유저에게 방장 권한 자동 이양
- `LobbyEventService` 고도화 및 검증:
  - 3중 보안 검증: 초대 코드 패턴, 로비 존재 유무, 사용자 멤버십 여부를 통합 검증하는 `validateLobbyAccess` 구현
  - 통합 알림 시스템: 로비 상태 변화를 실시간으로 브로드캐스트하는 Signaling 기능 구축
- 연결 상태 감지 및 자동 대응:
  - `LobbyConnectionListener`: `SessionDisconnectEvent` 리스너를 통해 비정상 종료(브라우저 닫기 등) 시에도 Redis 세션 매핑 정보를 추적하여 안전하게 퇴장 및 위임 로직이 실행되도록 구현

### Redis Lobby 데이터 구조 명세
#### 로비 정보
 - Key: `lobby:{code}`
 - Type: `Hash`
 - Description: 로비의 기본 설정 및 실시간 상태 정보를 저장합니다.
 - Fields:
   - `code`: 로비 초대 코드 (예: AB12CD)
   - `host_user_id`: 현재 방장의 ID
   - `title`: 로비 제목
   - `map_id`: 선택된 맵 세트 ID
   - `max_players`: 최대 참여 인원
   - `is_private`: 공개 여부 (true/false)
   - `status`: 로비 상태 (WAITING, PLAYING)
- TTL: 1시간 (활동 발생 시마다 초기화되는 슬라이딩 윈도우 방식)

#### 로비 참여자 관리
- 참여자 명단 (Set)
  - Key: `lobby:{code}:participants`
  - Description: 현재 로비에 접속 중인 유저 ID 목록 (중복 방지 및 빠른 존재 확인)
- 입장 순서 기록 (List)
  - Key: `lobby:{code}:order`
  - Description: 유저가 로비에 입장한 순서를 기록하며, 방장 위임 시 차순위 후보 선출에 사용됨 (0번 인덱스가 최우선 후보)

#### 로비 검색 인덱스
- Key: `lobby:public`
- Type: `Set`
- Description: `is_private=false`인 모든 로비 코드를 저장하여, 로비 목록 조회 시 고속 필터링을 지원합니다.

#### 웹소켓 세션 매핑 (Connection Mapping)
- Key: `ws:connection:{sessionId}`
- Type: `Hash`
- Description: 웹소켓 세션 ID와 유저/로비 정보를 매핑하여 연결 해제 시 자동 퇴장 로직을 지원합니다.
- Fields: `userId`, `lobbyCode`
- TTL: 7일 (유령 유저 방지를 위한 장기 보관용)

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 데이터 정합성: 유저 퇴장 시 Set과 List 양쪽에서 데이터를 제거하고, 인원수를 체크하여 방장 위임과 방 폭파 중 어떤 액션을 취할지 결정하는 비즈니스 로직(`LobbyEventService`)을 중점적으로 봐주세요.
- 성능 최적화: 로비 목록 조회 성능을 위해 공개 방 전용 인덱스(`lobby:public`)를 별도로 운영하도록 설계했습니다.
- 안전장치: 웹소켓 세션과 유저 정보를 매핑하는 Redis 키에 7일의 넉넉한 TTL을 설정하여 '유령 유저' 발생을 원천 차단했습니다.
- 현재는 입장 순서를 기반으로 가장 먼저 들어온 유저에게 방장을 위임하도록 구현했습니다.
  - 향후 이전 게임 세션의 점수를 기반으로 가장 점수가 높은 유저가 방장을 승계하는 방식 중 어떤 것이 좋을지 논의가 필요합니다.
  - '대기 시간'과 '점수' 중 어떤 방식이 이 게임의 사용자 경험에 더 적합할지 검토해 주시면 감사하겠습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
