### PR TITLE
[Feat/#13] 세션 인가 보안 제어 및 모니터링 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // 6. Monitoring (Actuator & Prometheus)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/ChatController.java
@@ -10,8 +10,10 @@ import io.github.ascrew.monomatbe.service.RedisPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
+
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -25,8 +27,10 @@ public class ChatController {
      * 클라이언트 수신(구독): /topic/global
      */
     @MessageMapping("/chat/global")
-    public void broadcastGlobal(ChatMessageDto message){
-        redisPublisher.publish("/topic/chat/global", message);
+    public void broadcastGlobal(ChatMessageDto message, SimpMessageHeaderAccessor accessor) {
+        String uuid = extractUuid(accessor);
+        ChatMessageDto secureMessage = createSecureMessage(message, "global", uuid);
+        redisPublisher.publish("/topic/chat/global", secureMessage);
 
     }
 
@@ -36,8 +40,26 @@ public class ChatController {
      * 클라이언트 수신(구독): /topic/lobby/{code}
      */
     @MessageMapping("/chat/lobby/{code}")
-    public void broadcastLobby(@DestinationVariable("code")String code, ChatMessageDto message){
-        redisPublisher.publish("/topic/lobby/" + code, message);
+    public void broadcastLobby(@DestinationVariable("code")String code, ChatMessageDto message, SimpMessageHeaderAccessor accessor) {
+        String uuid = extractUuid(accessor);
+        ChatMessageDto secureMessage = createSecureMessage(message, code, uuid);
+        redisPublisher.publish("/topic/lobby/" + code, secureMessage);
 
+    }
+
+    private String extractUuid(SimpMessageHeaderAccessor headerAccessor){
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        return (sessionAttributes != null && sessionAttributes.get("uuid") != null)
+                ? (String) sessionAttributes.get("uuid"): "Unknown";
+    }
+
+    private ChatMessageDto createSecureMessage(ChatMessageDto message, String secureRoomId, String secureSenderUuid){
+        return ChatMessageDto.builder()
+                .type(message.getType())
+                .roomId(secureRoomId)
+                .sender(secureSenderUuid)
+                .content(message.getContent())
+                .timestamp(message.getTimestamp())
+                .build();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/dto/ChatMessageDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/dto/ChatMessageDto.java
@@ -1,15 +1,23 @@
 package io.github.ascrew.monomatbe.dto;
 
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 // DTO 레코드 생성
-public record ChatMessageDto(
-        MessageType type,
-        String sender,
-        String content,
-        String timestamp
-) {
-    // 메시지 타입 정의
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageDto {
+    private MessageType type;
+    private String roomId;      // 방 번호
+    private String sender;      // 메시지 보낸 사람
+    private String content;     // 메시지 내용
+    private String timestamp;   // 메시지 전송 시간
+
     public enum MessageType {
         CHAT, ANSWER, ENTER, LEAVE
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -17,7 +17,10 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import tools.jackson.databind.json.JsonMapper;
+
 import java.util.concurrent.Executors;
 
 @Configuration
@@ -40,7 +43,10 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);           // Redis 연결 팩토리 설정
         template.setKeySerializer(new StringRedisSerializer());     // 키 직렬화 방식 설정
-        template.setValueSerializer(new StringRedisSerializer());   // 값 직렬화 방식 설정
+        GenericJacksonJsonRedisSerializer serializer = GenericJacksonJsonRedisSerializer.builder()
+                .enableUnsafeDefaultTyping()
+                .build();
+        template.setValueSerializer(serializer);   // 값 직렬화 방식 설정
         return template;
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -19,7 +19,7 @@ import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import tools.jackson.databind.json.JsonMapper;
+
 
 import java.util.concurrent.Executors;
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -15,12 +15,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
+import tools.jackson.databind.DefaultTyping;
 import java.util.concurrent.Executors;
 
 @Configuration
@@ -43,9 +46,19 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);           // Redis 연결 팩토리 설정
         template.setKeySerializer(new StringRedisSerializer());     // 키 직렬화 방식 설정
-        GenericJacksonJsonRedisSerializer serializer = GenericJacksonJsonRedisSerializer.builder()
-                .enableUnsafeDefaultTyping()
+
+        // 화이트 리스트 방식의 검증기
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("io.github.ascrew.monomatbe.") //우리 프로젝트의 모든 DTO 허용
+                .allowIfSubType("java.util.")                  //List, Map 등 자바 컬렉션 허용
+                .allowIfSubType("java.lang.")                  //String, Integer 등 자바 기본 타입 허용
                 .build();
+
+        JsonMapper jsonMapper = JsonMapper.builder()
+                .activateDefaultTyping(ptv, DefaultTyping.NON_FINAL) //비 final 클래스에 대한 타입 정보 포함
+                .build();
+
+        GenericJacksonJsonRedisSerializer serializer = new GenericJacksonJsonRedisSerializer(jsonMapper);
         template.setValueSerializer(serializer);   // 값 직렬화 방식 설정
         return template;
     }
@@ -62,7 +75,7 @@ public class RedisConfig {
         // 비동기 처리를 위해 가상 스레드 기반의 TaskExecutor 설정 (Java 19 이상에서 사용 가능)
         container.setTaskExecutor(Executors.newVirtualThreadPerTaskExecutor());
 
-        container.addMessageListener(redisSubscriber, new PatternTopic("/topic/chat/global")); // 전체 채팅 구독
+        container.addMessageListener(redisSubscriber, new ChannelTopic("/topic/chat/global")); // 전체 채팅 구독
         container.addMessageListener(redisSubscriber, new PatternTopic("/topic/lobby/*")); // 로비 채팅 구독
         return container;
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -14,7 +14,6 @@
 
 package io.github.ascrew.monomatbe.global.config;
 
-import io.github.ascrew.monomatbe.global.websocket.GuestHandshakeInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.WebSocketHandler;
@@ -29,14 +28,13 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    private final GuestHandshakeInterceptor guestHandshakeInterceptor;
+
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
                 .addEndpoint("/ws") //최초로 웹소켓 연결을 하기위해 url /ws 지정
                 .setAllowedOriginPatterns("*") //모든 도메인에서 접속을 허용
-                .addInterceptors(guestHandshakeInterceptor) //핸드쉐이크 인터셉터 등록하여 웹소켓 연결 시 UUID 검증
                 .withSockJS(); //웹소켓 연결 실패시 일반 HTTP통신으로 연결
 
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -14,7 +14,10 @@
 
 package io.github.ascrew.monomatbe.global.config;
 
+import io.github.ascrew.monomatbe.global.websocket.GuestHandshakeInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -23,13 +26,19 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final GuestHandshakeInterceptor guestHandshakeInterceptor;
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
                 .addEndpoint("/ws") //최초로 웹소켓 연결을 하기위해 url /ws 지정
                 .setAllowedOriginPatterns("*") //모든 도메인에서 접속을 허용
+                .addInterceptors(guestHandshakeInterceptor) //핸드쉐이크 인터셉터 등록하여 웹소켓 연결 시 UUID 검증
                 .withSockJS(); //웹소켓 연결 실패시 일반 HTTP통신으로 연결
+
     }
 
     @Override

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -14,9 +14,9 @@
 
 package io.github.ascrew.monomatbe.global.config;
 
+import io.github.ascrew.monomatbe.global.websocket.CustomStompErrorHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -28,7 +28,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-
+    private final CustomStompErrorHandler customStompErrorHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -37,7 +37,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOriginPatterns("*") //모든 도메인에서 접속을 허용
                 .withSockJS(); //웹소켓 연결 실패시 일반 HTTP통신으로 연결
 
+        registry.setErrorHandler(customStompErrorHandler);
+
     }
+
+
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -15,6 +15,7 @@
 package io.github.ascrew.monomatbe.global.config;
 
 import io.github.ascrew.monomatbe.global.websocket.CustomStompErrorHandler;
+import io.github.ascrew.monomatbe.global.websocket.StompChannelInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -22,6 +23,8 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -29,6 +32,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final CustomStompErrorHandler customStompErrorHandler;
+    private final StompChannelInterceptor stompChannelInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -56,6 +60,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setHeartbeatValue(new long[]{10000,10000}); //클라이언트와 서버가 10000ms(10초)마다 하트비트를 주고받도록 설정
 
         registry.setApplicationDestinationPrefixes("/app");  //송신용(발행)
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompChannelInterceptor);
     }
 
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandler.java
@@ -1,0 +1,50 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.nio.charset.StandardCharsets;
+
+
+@Component
+public class CustomStompErrorHandler extends StompSubProtocolErrorHandler {
+
+    public CustomStompErrorHandler() {
+        super();
+    }
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+        // 인터셉터에서 발생한 예외는 보통 MessageDeliveryException 등으로 래핑되어 전달됩니다.
+        // ex.getCause()를 통해 우리가 직접 던진 실제 예외(IllegalArgumentException 등)를 추출합니다.
+        Throwable cause = ex.getCause();
+
+        // 의도한 예외 (인증 실패, 권한 부족 등)인 경우
+        if (cause instanceof IllegalArgumentException || cause instanceof IllegalStateException) {
+            return handleCustomException(cause.getMessage());
+        }
+
+        // 그 외의 예상치 못한 서버 에러인 경우 기본 처리
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+
+    private Message<byte[]> handleCustomException(String errorMessage) {
+        // STOMP의 ERROR 프레임 생성
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+
+        // 프론트엔드가 에러 원인을 파악할 수 있도록 메시지(message) 헤더 세팅
+        accessor.setMessage(errorMessage);
+        accessor.setLeaveMutable(true);
+
+        // 에러 상세 내용을 Body에 담아 전송
+        return MessageBuilder.createMessage(
+                errorMessage.getBytes(StandardCharsets.UTF_8),
+                accessor.getMessageHeaders()
+        );
+
+    }
+}
+

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/GuestHandshakeInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/GuestHandshakeInterceptor.java
@@ -1,3 +1,6 @@
+/*
+Query String방식을 예상하고 만들었는데 필요없어짐
+
 package io.github.ascrew.monomatbe.global.websocket;
 
 import lombok.RequiredArgsConstructor;
@@ -46,3 +49,4 @@ public class GuestHandshakeInterceptor  implements HandshakeInterceptor {
         log.info("WebSocket Handshake Completed: {}", request.getURI());
     }
 }
+*/

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/GuestHandshakeInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/GuestHandshakeInterceptor.java
@@ -1,0 +1,35 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketHandler;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class GuestHandshakeInterceptor  implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request,
+                                   ServerHttpResponse response,
+                                   WebSocketHandler wsHandler,
+                                   Map<String, Object> attributes) throws Exception {
+        log.info("WebSocket Handshake Intercepted: {}", request.getURI());
+        // 여기에 인증 로직을 추가할 수 있습니다. 예를 들어, JWT 토큰 검증 등을 수행할 수 있습니다.
+        // 현재는 모든 요청을 허용하도록 설정되어 있습니다.
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request,
+                               ServerHttpResponse response,
+                               WebSocketHandler wsHandler,
+                               Exception exception) {
+        log.info("WebSocket Handshake Completed: {}", request.getURI());
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/GuestHandshakeInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/GuestHandshakeInterceptor.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.global.websocket;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 import org.springframework.http.server.ServerHttpRequest;
@@ -19,10 +20,22 @@ public class GuestHandshakeInterceptor  implements HandshakeInterceptor {
                                    ServerHttpResponse response,
                                    WebSocketHandler wsHandler,
                                    Map<String, Object> attributes) throws Exception {
-        log.info("WebSocket Handshake Intercepted: {}", request.getURI());
-        // 여기에 인증 로직을 추가할 수 있습니다. 예를 들어, JWT 토큰 검증 등을 수행할 수 있습니다.
-        // 현재는 모든 요청을 허용하도록 설정되어 있습니다.
+
+
+        if (request instanceof ServletServerHttpRequest) {
+            log.info("WebSocket Handshake Intercepted: {}", request.getURI()); // 핸드쉐이크 요청이 들어올 때마다 로그에 URI를 기록하여 디버깅에 도움을 줌
+
+            String uuid = ((ServletServerHttpRequest) request).getServletRequest().getParameter("uuid");
+
+            if (uuid == null || uuid.trim().isEmpty()) {
+                return false; // uuid가 없거나 빈 문자열인 경우, 핸드쉐이크를 거부하여 연결을 차단
+            }
+
+            attributes.put("uuid", uuid);   // WebSocket 세션에서 uuid를 사용할 수 있도록 attributes에 저장
+        }
+
         return true;
+
     }
 
     @Override

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -18,39 +18,43 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        log.info("STOMP Message Intercepted: {}", message.getHeaders().get("simpMessageType")); // STOMP 메시지가 전송되기 전에 메시지 유형을 로그에 기록하여 디버깅에 도움을 줌
 
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
         if (accessor != null && accessor.getCommand() != null) {
             Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-            String uuid = (sessionAttributes != null) ? (String) sessionAttributes.get("uuid") : "UNKNOWN";
 
             StompCommand command = accessor.getCommand();
 
             //유저의 행동(Command)에 따라 감시 및 차단 로직
             switch (command) {
                 case CONNECT:
-                    log.info("STOMP CONNECTED: {}", uuid);
-                    break;
-                case SUBSCRIBE:
-                    String subDestination = accessor.getDestination();
-                    log.info("[STOMP SUBSCRIBE] 방 입장(구독) 시도 - UUID: {}, 목적지: {}", uuid, subDestination);
-                    // log.info("STOMP SUBSCRIBE 올바르지 않은 접근 시도: uuid :{}, 목적지: {}", uuid, subDestination);
-                    break;
-                case SEND:
-                    String sendDestination = accessor.getDestination();
-                    log.info("메세지 발송: uuid :{}, 목적지: {}", uuid, sendDestination);
-                    // 욕설 필터링 and 도배하는지 검사 로직 추가 예정
+                    // 최초 연결 시 헤더에서 uuid 추출
+                    String uuid = accessor.getFirstNativeHeader("uuid");
+
+                    // 검증 로직: uuid가 null이거나 빈 문자열인 경우, 연결을 차단
+                    if (uuid == null || uuid.trim().isEmpty()) {
+                        log.warn("STOMP CONNECT 올바르지 않은 접근 시도: uuid :{}, 목적지: {}", uuid, accessor.getDestination());
+                        throw new IllegalArgumentException("STOMP CONNECT: uuid가 없거나 빈 문자열입니다. 연결이 거부되었습니다.");
+                    }
+                    // 검증 이후 sub나 send에 꺼내 쓸 수 있도록 세션에 uuid 저장
+                    if (sessionAttributes != null){
+                        sessionAttributes.put("uuid", uuid); // 세션 속성에 uuid 저장
+                    }
+
+                    log.info("STOMP CONNECT: {} 연결됨", uuid);
 
                     break;
+
+                case SUBSCRIBE:
+                case SEND:
                 case UNSUBSCRIBE:
-                    log.info("STOMP UNSUBSCRIBE: {}", uuid);
-                    // "홍길동님이 퇴장" 로직 구현 예
+                    validateSession(accessor, sessionAttributes); // 세션 검증 메서드 호출
                     break;
                 case DISCONNECT:
-                    log.info("STOMP DISCONNECTED: {}", uuid);
-                    // redis에서 유저 정보 지우는 로직 추가
+                    String disconnectUuid = (sessionAttributes != null) ? (String) sessionAttributes.get("uuid") : "UNKNOWN";
+
+                    log.info("STOMP DISCONNECTED: {}", disconnectUuid);
                     break;
 
                 default:
@@ -59,6 +63,36 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         }
         return message; // 메시지를 그대로 반환하여 STOMP 메시지 처리를 계속 진행
     }
+
+    private void validateSession(StompHeaderAccessor accessor, Map<String, Object> sessionAttributes) {
+        String uuid = (sessionAttributes != null) ? (String) sessionAttributes.get("uuid") : null;
+
+        if (uuid == null) {
+            log.warn("[{} 차단] 인증되지 않은 세션 접근", accessor.getCommand());
+            throw new IllegalStateException("세션 인증 정보가 존재하지 않습니다.");
+        }
+
+        // 정상 로직 수행 (로그 기록 등)
+        if (accessor.getCommand() == StompCommand.SUBSCRIBE) {
+            String destination = accessor.getDestination();
+            if (destination != null && destination.startsWith("/topic/lobby/")) {
+                String roomId = destination.replace("/topic/lobby/", "");
+
+                if (sessionAttributes != null) {
+                    sessionAttributes.put("roomId", roomId); // 세션 속성에 roomId 저장
+                }
+            }
+            log.info("[SUBSCRIBE] 방 입장 - UUID: {}, Destination: {}", uuid, destination);
+            // 특정 방에 대한 인가 검사 로직 추가해야함
+        } else if (accessor.getCommand() == StompCommand.SEND) {
+            log.info("[SEND] 메시지 발송 - UUID: {}, Destination: {}", uuid, accessor.getDestination());
+            // 도배 방지 만들꺼면 로직 추가
+        }else if (accessor.getCommand() == StompCommand.UNSUBSCRIBE) {
+            log.info("[UNSUBSCRIBE] 방 퇴장 - UUID: {}", uuid);
+            // UNSUBSCRIBE는 일반적으로 추가 차단 로직 없이 로그만 남깁니다.
+        }
+    }
+
 }
 
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -1,0 +1,65 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class StompChannelInterceptor implements ChannelInterceptor {
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        log.info("STOMP Message Intercepted: {}", message.getHeaders().get("simpMessageType")); // STOMP 메시지가 전송되기 전에 메시지 유형을 로그에 기록하여 디버깅에 도움을 줌
+
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor != null && accessor.getCommand() != null) {
+            Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+            String uuid = (sessionAttributes != null) ? (String) sessionAttributes.get("uuid") : "UNKNOWN";
+
+            StompCommand command = accessor.getCommand();
+
+            //유저의 행동(Command)에 따라 감시 및 차단 로직
+            switch (command) {
+                case CONNECT:
+                    log.info("STOMP CONNECTED: {}", uuid);
+                    break;
+                case SUBSCRIBE:
+                    String subDestination = accessor.getDestination();
+                    log.info("[STOMP SUBSCRIBE] 방 입장(구독) 시도 - UUID: {}, 목적지: {}", uuid, subDestination);
+                    // log.info("STOMP SUBSCRIBE 올바르지 않은 접근 시도: uuid :{}, 목적지: {}", uuid, subDestination);
+                    break;
+                case SEND:
+                    String sendDestination = accessor.getDestination();
+                    log.info("메세지 발송: uuid :{}, 목적지: {}", uuid, sendDestination);
+                    // 욕설 필터링 and 도배하는지 검사 로직 추가 예정
+
+                    break;
+                case UNSUBSCRIBE:
+                    log.info("STOMP UNSUBSCRIBE: {}", uuid);
+                    // "홍길동님이 퇴장" 로직 구현 예
+                    break;
+                case DISCONNECT:
+                    log.info("STOMP DISCONNECTED: {}", uuid);
+                    // redis에서 유저 정보 지우는 로직 추가
+                    break;
+
+                default:
+                    break;
+            }
+        }
+        return message; // 메시지를 그대로 반환하여 STOMP 메시지 처리를 계속 진행
+    }
+}
+
+
+

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -10,11 +10,14 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class StompChannelInterceptor implements ChannelInterceptor {
+    // 표준 uuid 형식을 검사하는 정규식 (8-4-4-4-12 포멧)
+    private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -37,6 +40,12 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         log.warn("STOMP CONNECT 올바르지 않은 접근 시도: uuid :{}, 목적지: {}", uuid, accessor.getDestination());
                         throw new IllegalArgumentException("STOMP CONNECT: uuid가 없거나 빈 문자열입니다. 연결이 거부되었습니다.");
                     }
+                    // 값이 있긴 한데 이상한 문자열(hacked 등)을 보낸 경우 차단
+                    if (!UUID_PATTERN.matcher(uuid).matches()) {
+                        log.warn("STOMP CONNECT 악의적인 접근 시도 (형식 위반): 전달된 UUID = {}", uuid);
+                        throw new IllegalArgumentException("STOMP CONNECT: 유효하지 않은 UUID 형식입니다. 연결이 거부되었습니다.");
+                    }
+
                     // 검증 이후 sub나 send에 꺼내 쓸 수 있도록 세션에 uuid 저장
                     if (sessionAttributes != null){
                         sessionAttributes.put("uuid", uuid); // 세션 속성에 uuid 저장

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 public class StompChannelInterceptor implements ChannelInterceptor {
     // 표준 uuid 형식을 검사하는 정규식 (8-4-4-4-12 포멧)
     private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+    private static final String LOBBY_DESTINATION_PREFIX = "/topic/lobby/";
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -42,7 +43,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     }
                     // 값이 있긴 한데 이상한 문자열(hacked 등)을 보낸 경우 차단
                     if (!UUID_PATTERN.matcher(uuid).matches()) {
-                        log.warn("STOMP CONNECT 악의적인 접근 시도 (형식 위반): 전달된 UUID = {}", uuid);
+                        log.warn("STOMP CONNECT 악의적인 접근 시도 (형식 위반): 전달된 UUID = {}", sanitizeForLog(uuid));
                         throw new IllegalArgumentException("STOMP CONNECT: 유효하지 않은 UUID 형식입니다. 연결이 거부되었습니다.");
                     }
 
@@ -85,7 +86,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         if (accessor.getCommand() == StompCommand.SUBSCRIBE) {
             String destination = accessor.getDestination();
             if (destination != null && destination.startsWith("/topic/lobby/")) {
-                String roomId = destination.replace("/topic/lobby/", "");
+                String roomId = destination.substring(LOBBY_DESTINATION_PREFIX.length());
 
                 if (sessionAttributes != null) {
                     sessionAttributes.put("roomId", roomId); // 세션 속성에 roomId 저장
@@ -102,6 +103,14 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         }
     }
 
+    private String sanitizeForLog(String uuid) {
+        if (uuid == null) {
+            return "null";
+        }
+        String sanitized = uuid.replaceAll("[\r\n\t]", "");
+
+        return sanitized.length() > 50 ? sanitized.substring(0, 50) + "..." : sanitized; // 로그에 너무 긴 UUID는 일부만 표시
+    }
 }
 
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -1,0 +1,89 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import io.github.ascrew.monomatbe.dto.ChatMessageDto;
+import io.github.ascrew.monomatbe.service.RedisPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventListener {
+
+
+    private final RedisPublisher redisPublisher;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final WebSocketMetric webSocketMetric; // WebSocketMetric을 주입받아 세션 수를 관리
+
+    private final String USER_STATUS_KEY_PREFIX = "user_status:"; // Redis에서 사용자 상태를 저장할 때 사용할 키 접두사
+    private final String USER_ROOM_KEY_PREFIX = "user_room:"; // Redis에서 사용자가 참여한 방 정보를 저장할 때 사용할 키 접두사
+
+    // redis 템플릿 주입해야함
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        String uuid = (sessionAttributes != null) ? (String) sessionAttributes.get("uuid") : "UNKNOWN";
+
+        if (!"UNKNOWN".equals(uuid)) {
+            // Redis에 사용자 상태를 온라인으로 저장
+            String userStatusKey = USER_STATUS_KEY_PREFIX + uuid;
+            redisTemplate.opsForValue().set(userStatusKey, "ONLINE",2, TimeUnit.HOURS); // 2시간 동안 온라인 상태 유지, 필요에 따라 조정 가능
+            log.info("Redis에 사용자 상태 저장: {} = ONLINE", userStatusKey);
+        }
+
+        // WebSocket 연결이 성공적으로 이루어졌을 때 실행되는 이벤트 리스너
+        log.info("WebSocket 연결 성공: {}", uuid);
+        webSocketMetric.increment(); //유저 접속시 증가
+
+        // 필요에 따라 클라이언트에게 알림 전송 가능
+        // messagingTemplate.convertAndSend("/topic/connect", "새로운 WebSocket 연결이 생성되었습니다.");
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        // WebSocket 연결이 끊어졌을 때 실행되는 이벤트 리스너
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+
+        if(sessionAttributes != null){
+            String uuid = (String) sessionAttributes.get("uuid");
+            String roomId = (String) sessionAttributes.get("roomId");
+
+            if(uuid != null){
+                log.info("WebSocket 연결 끊김: uuid={}, roomId={}", uuid, roomId);
+                redisTemplate.delete(USER_STATUS_KEY_PREFIX + uuid); // Redis에서 사용자 상태 제거
+                webSocketMetric.decrement(); //유저 접속 끊김시 감소
+                if(roomId != null){
+                    log.info("퇴장 알림 방송 - 방번호: {}",roomId);
+
+                    String leaveMessage = uuid + "님이 퇴장하셨습니다.";
+                    ChatMessageDto chatMessageDto = ChatMessageDto.builder()
+                            .type(ChatMessageDto.MessageType.LEAVE)
+                            .roomId(roomId)
+                            .sender(uuid)
+                            .content(leaveMessage)
+                            .build();
+                    String topicUrl = "/topic/lobby/"+roomId;
+                    redisPublisher.publish(topicUrl, chatMessageDto);
+                    // redis에서 해당 유저가 참여한 방 정보 제거 로직 추가 필요
+                    redisTemplate.opsForSet().remove(USER_ROOM_KEY_PREFIX + roomId, uuid); // Redis에서 사용자가 참여한 방 정보 제거
+                }
+            }
+        }
+
+
+
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -24,29 +24,26 @@ public class WebSocketEventListener {
     private final RedisTemplate<String, Object> redisTemplate;
     private final WebSocketMetric webSocketMetric; // WebSocketMetric을 주입받아 세션 수를 관리
 
-    private final String USER_STATUS_KEY_PREFIX = "user_status:"; // Redis에서 사용자 상태를 저장할 때 사용할 키 접두사
-    private final String USER_ROOM_KEY_PREFIX = "user_room:"; // Redis에서 사용자가 참여한 방 정보를 저장할 때 사용할 키 접두사
-
-    // redis 템플릿 주입해야함
+    private static final String USER_STATUS_KEY_PREFIX = "user_status:"; // Redis에서 사용자 상태를 저장할 때 사용할 키 접두사
+    private static final String USER_ROOM_KEY_PREFIX = "user_room:"; // Redis에서 사용자가 참여한 방 정보를 저장할 때 사용할 키 접두사
 
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
-
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-        String uuid = (sessionAttributes != null) ? (String) sessionAttributes.get("uuid") : "UNKNOWN";
+
+        String uuid = (sessionAttributes != null && sessionAttributes.get("uuid") != null)
+                ? (String) sessionAttributes.get("uuid") : "UNKNOWN";
 
         if (!"UNKNOWN".equals(uuid)) {
             // Redis에 사용자 상태를 온라인으로 저장
             String userStatusKey = USER_STATUS_KEY_PREFIX + uuid;
             redisTemplate.opsForValue().set(userStatusKey, "ONLINE",2, TimeUnit.HOURS); // 2시간 동안 온라인 상태 유지, 필요에 따라 조정 가능
+            webSocketMetric.increment(); //유저 접속시 증가
             log.info("Redis에 사용자 상태 저장: {} = ONLINE", userStatusKey);
+        } else {
+            log.warn("인증되지 않은 세션 연결 시도");
         }
-
-        // WebSocket 연결이 성공적으로 이루어졌을 때 실행되는 이벤트 리스너
-        log.info("WebSocket 연결 성공: {}", uuid);
-        webSocketMetric.increment(); //유저 접속시 증가
-
         // 필요에 따라 클라이언트에게 알림 전송 가능
         // messagingTemplate.convertAndSend("/topic/connect", "새로운 WebSocket 연결이 생성되었습니다.");
     }
@@ -61,7 +58,7 @@ public class WebSocketEventListener {
             String uuid = (String) sessionAttributes.get("uuid");
             String roomId = (String) sessionAttributes.get("roomId");
 
-            if(uuid != null){
+            if(uuid != null && !"UNKNOWN".equals(uuid)){
                 log.info("WebSocket 연결 끊김: uuid={}, roomId={}", uuid, roomId);
                 redisTemplate.delete(USER_STATUS_KEY_PREFIX + uuid); // Redis에서 사용자 상태 제거
                 webSocketMetric.decrement(); //유저 접속 끊김시 감소
@@ -82,8 +79,28 @@ public class WebSocketEventListener {
                 }
             }
         }
+    }
 
+    // 유저가 채널을 구독 했을 때 redis set에 참여자 정보 추가
+    @EventListener
+    public void handleWebsocketSubscribeListener(SessionConnectedEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
 
+        if(sessionAttributes != null){
+            String uuid = (String) sessionAttributes.get("uuid");
+            String destination = accessor.getDestination();
 
+            // 목적지가 로비 채팅방인 경우에만 동작
+            if(destination != null && destination.startsWith("/topic/lobby")){
+                String roomId = destination.replace("/topic/lobby", "");
+
+                // 정상적으로 인증 된 유저만 redis 참여자 set에 추가
+                if (uuid != null && !"UNKNOWN".equals(uuid)) {
+                    redisTemplate.opsForSet().add(USER_ROOM_KEY_PREFIX + roomId, uuid); // Redis에서 사용자가 참여한 방 정보 추가
+                    log.info("Redis에 참여자 정보 추가: {} -> {}", roomId, uuid);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -10,6 +10,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -84,7 +85,7 @@ public class WebSocketEventListener {
 
     // 유저가 채널을 구독 했을 때 redis set에 참여자 정보 추가
     @EventListener
-    public void handleWebsocketSubscribeListener(SessionConnectedEvent event) {
+    public void handleWebsocketSubscribeListener(SessionSubscribeEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -26,6 +26,7 @@ public class WebSocketEventListener {
 
     private static final String USER_STATUS_KEY_PREFIX = "user_status:"; // Redis에서 사용자 상태를 저장할 때 사용할 키 접두사
     private static final String USER_ROOM_KEY_PREFIX = "user_room:"; // Redis에서 사용자가 참여한 방 정보를 저장할 때 사용할 키 접두사
+    private static final String LOBBY_DESTINATION_PREFIX = "/topic/lobby/"; // 로비 채팅방의 목적지 접두사
 
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
@@ -93,7 +94,7 @@ public class WebSocketEventListener {
 
             // 목적지가 로비 채팅방인 경우에만 동작
             if(destination != null && destination.startsWith("/topic/lobby")){
-                String roomId = destination.replace("/topic/lobby", "");
+                String roomId = destination.substring(LOBBY_DESTINATION_PREFIX.length()); // "/topic/lobby/" 접두사 제거하여 roomId 추출
 
                 // 정상적으로 인증 된 유저만 redis 참여자 set에 추가
                 if (uuid != null && !"UNKNOWN".equals(uuid)) {

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketMetric.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketMetric.java
@@ -1,0 +1,30 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class WebSocketMetric {
+    // 동시성 이슈 때문에 아토믹인티저 사용
+    private final AtomicInteger activeSessions = new AtomicInteger(0);
+
+    public WebSocketMetric(MeterRegistry meterRegistry) {
+        //
+        Gauge.builder("websocketActiveSessions", activeSessions, AtomicInteger::get)
+                .description("웹소켓 현재 활성화된 세션 수")
+                .register(meterRegistry);
+    }
+
+    public void increment() {
+        // 증가
+        activeSessions.incrementAndGet();
+    }
+
+    public void decrement() {
+        // 감소 0과 v-1과 비교해서 더 큰값 반환 0밑으로 떨어지지마라
+        activeSessions.updateAndGet(v->Math.max(0, v-1));
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/service/RedisPublisher.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/RedisPublisher.java
@@ -1,7 +1,6 @@
 package io.github.ascrew.monomatbe.service;
 
 import lombok.RequiredArgsConstructor;
-import tools.jackson.databind.json.JsonMapper;
 import io.github.ascrew.monomatbe.dto.ChatMessageDto;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -12,18 +11,9 @@ import org.springframework.stereotype.Service;
 public class RedisPublisher {
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final JsonMapper jsonMapper;
 
     public void publish(String topic, ChatMessageDto messageDto) {
-        try {
-            String JsonMessage = jsonMapper.writeValueAsString(messageDto);    //ChatMessageDto 객체를 JSON 문자열로 직렬화
-
-            // Redis의 특정 채널(topic)에 메시지를 발행
-            redisTemplate.convertAndSend(topic, JsonMessage);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
+        redisTemplate.convertAndSend(topic, messageDto);
     }
+
 }

--- a/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
@@ -23,13 +23,14 @@ public class RedisSubscriber implements MessageListener {
         try{
             byte[] body =message.getBody();
             ChatMessageDto chatMessageDto = (ChatMessageDto) redisTemplate.getValueSerializer().deserialize(body); //메시지 바디를 역직렬화하여 ChatMessageDto 객체로 변환
+
             if(chatMessageDto != null){
-                String destination = "/topic/lobby/" + chatMessageDto.getRoomId();
+                String destination = new String(message.getChannel());
                 simpMessagingTemplate.convertAndSend(destination, chatMessageDto);
             }
 
         }catch (Exception e){
-            log.error("Redis 메시지 파싱 및 브로드캐스트 실패. 채널: {}",new String(message.getChannel()));                                                          //예외 발생 시 스택 트레이스 출력
+            log.error("Redis 메시지 파싱 및 브로드캐스트 실패. 채널: {}",new String(message.getChannel()));               //예외 발생 시 스택 트레이스 출력
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
-import tools.jackson.databind.json.JsonMapper;
 
 
 @Slf4j
@@ -16,17 +15,18 @@ import tools.jackson.databind.json.JsonMapper;
 @RequiredArgsConstructor
 public class RedisSubscriber implements MessageListener {
 
-    private final JsonMapper jsonMapper;                            // JSON 직렬화/역직렬화를 위한 JsonMapper
     private final RedisTemplate<String, Object> redisTemplate;      // RedisTemplate을 사용하여 Redis와 상호작용
     private final SimpMessagingTemplate simpMessagingTemplate;      // WebSocket을 통해 클라이언트에게 메시지를 전송하기 위한 SimpMessagingTemplate
 
     @Override
     public void onMessage(Message message, byte[] pattern){
         try{
-            String channel = new String(message.getChannel());                                                  //문자열로 채널 이름 추출
-            String messageBody = (String) redisTemplate.getValueSerializer().deserialize(message.getBody());    //메시지 바디를 문자열로 역직렬화
-            ChatMessageDto chatMessageDto = jsonMapper.readValue(messageBody, ChatMessageDto.class);            //문자열로 된 메시지 바디를 ChatMessageDto 객체로 역직렬화
-            simpMessagingTemplate.convertAndSend(channel, chatMessageDto);                                      //WebSocket을 통해 해당 채널을 구독 중인 클라이언트에게 메시지 전송
+            byte[] body =message.getBody();
+            ChatMessageDto chatMessageDto = (ChatMessageDto) redisTemplate.getValueSerializer().deserialize(body); //메시지 바디를 역직렬화하여 ChatMessageDto 객체로 변환
+            if(chatMessageDto != null){
+                String destination = "/topic/lobby/" + chatMessageDto.getRoomId();
+                simpMessagingTemplate.convertAndSend(destination, chatMessageDto);
+            }
 
         }catch (Exception e){
             log.error("Redis 메시지 파싱 및 브로드캐스트 실패. 채널: {}",new String(message.getChannel()));                                                          //예외 발생 시 스택 트레이스 출력

--- a/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/RedisSubscriber.java
@@ -30,7 +30,7 @@ public class RedisSubscriber implements MessageListener {
             }
 
         }catch (Exception e){
-            log.error("Redis 메시지 파싱 및 브로드캐스트 실패. 채널: {}",new String(message.getChannel()));               //예외 발생 시 스택 트레이스 출력
+            log.error("Redis 메시지 파싱 및 브로드캐스트 실패. 채널: {}",new String(message.getChannel()),e);               //예외 발생 시 스택 트레이스 출력
         }
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
- #13 

## 📝 Summary
- **STOMP/WebSocket 통신 인프라 뼈대 구축**
- **문지기(`StompChannelInterceptor`) 구현:** `CONNECT` 프레임에서 UUID를 추출하여 인증하고, 미인증 접근 및 비정상적인 채널 구독/발송을 원천 차단
- **백그라운드 감시자(`WebSocketEventListener`) 구현:** 연결 시 Redis에 유저 상태(`ONLINE`) 저장 및 만료 시간(TTL 2시간) 설정 (고스트 세션 방지)
  - 비정상 종료(브라우저 강제 종료 등) 시에도 TCP 끊김을 감지하여 Redis 상태를 즉시 지우고 퇴장 알림 브로드캐스트
- **Redis Pub/Sub 수정:**
  - `RedisPublisher`와 `RedisSubscriber`를 구현하여 서버 간 글로벌 퇴장 메시지 전파 로직 완성
- **Prometheus 커스텀 모니터링 지표 노출:**`WebSocketMetric`을 생성하여 현재 활성 웹소켓 세션 수(`websocketActiveSessions`)를 안전하게(`AtomicInteger`) 측정 및 노출

## 🙏PR point
- **[아키텍처] 카운팅 위치 최적화:** 유저 접속/퇴장 지표를 측정할 때, `Interceptor`에서 측정하면 비정상 종료(Dirty Disconnect) 시 퇴장 감지가 누락되는 문제가 있어, 가장 밑단에서 소켓 끊김을 보장하는 `EventListener`로 측정 책임을 완전히 이관했습니다. (Double Counting 방지)
- **[보안/버전] Spring Data Redis 4.x 최신 직렬화기 적용:** 기존 `GenericJackson2JsonRedisSerializer`가 지원 중단(Deprecated)됨에 따라, 보안이 강화된 `GenericJacksonJsonRedisSerializer`를 도입했습니다. RCE 보안 취약점을 막기 위해 `PolymorphicTypeValidator`를 사용하여 우리 패키지(`io.github.ascrew...`)의 DTO만 안전하게 JSON 직렬화/역직렬화되도록 화이트리스트 처리를 진행했습니다.
- **[주의] Pub/Sub 무한 루프 방지:** `RedisSubscriber`에서 메시지를 받아 브라우저로 뿌려줄 때 `redisTemplate`을 쓰면 Redis로 다시 메시지가 들어가 무한 루프에 빠집니다. 리뷰하실 때 이 부분은 반드시 `simpMessagingTemplate`을 써야 함을 참고해 주세요!

## 📬 Reference
- Spring Data Redis 4.x 공식 문서 (Jackson Serializer 보안 업데이트 내역)
- STOMP WebSocket Interceptor vs EventListener 라이프사이클 비교