### PR TITLE
[Feat/#18] 로비 생성 및 초대 코드 발급 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ out/
 #Environment
 .env
 
+# macOS metadata
 .DS_Store
+**/.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,16 @@ dependencies {
     // 3. Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    // 4. Utility (.env & Lombok)
+    // 4. Validation (입력값 검증)
+    // @NotBlank, @Min, @Max 등 Bean Validation 어노테이션 사용을 위해 추가
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // 5. Utility (.env & Lombok)
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // 5. Test (Spring Boot 4.x 모듈화된 전용 테스트 스타터)
+    // 6. Test (Spring Boot 4.x 모듈화된 전용 테스트 스타터)
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test' // Redis 테스트 추가
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/src/main/java/io/github/ascrew/monomatbe/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/controller/LobbyController.java
@@ -1,13 +1,16 @@
 package io.github.ascrew.monomatbe.controller;
 
 import io.github.ascrew.monomatbe.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.dto.request.LobbyCreateRequestDto;
+import io.github.ascrew.monomatbe.dto.response.LobbyCreateResponseDto;
 import io.github.ascrew.monomatbe.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.service.LobbyService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,10 +25,11 @@ import java.util.List;
 public class LobbyController {
 
     private final LobbyRepository lobbyRepository;
+    private final LobbyService lobbyService;
 
     /**
      * 고속 로비 리스트 조회 API
-     * 프론트엔드(React)에서 메인 로비 목록 화면에 진입하거나 '새로고침' 버튼을 눌렀을 때 호출된다.
+     * 프론트엔드에서 메인 로비 목록 화면 진입 시 호출
      */
     @GetMapping
     public ResponseEntity<List<LobbyRedisDto>> getPublicLobbies() {
@@ -39,5 +43,34 @@ public class LobbyController {
 
         // HTTP 상태 코드 200(OK)와 함께 데이터를 프론트엔드에 응답
         return ResponseEntity.ok(publicLobbies);
+    }
+
+    // 로비 생성 API
+    // [인가]
+    // 현재 인증 체계가 미완성이므로 hostUserId를 임시 하드코딩 처리
+    // TODO : 인증 구현 후 Security Context에서 hostUserId를 추출하도록 교체 필요
+
+    // [응답 코드]
+    // 리소스 생성 성공은 REST 관례상 200 OK가 아닌 201 Created
+    // @param requestDto 클라이언트가 전달한 로비 생성 요청 데이터
+    // @return 201 Created + 생성된 로비 정보 및 딥링크
+    @PostMapping
+    public ResponseEntity<LobbyCreateResponseDto> createLobby(
+            @Valid @RequestBody LobbyCreateRequestDto requestDto) {
+
+        log.info ("요청 수신 : 로비 생성 [POST /api/lobbies] - title : {}, maxPlayers : {}, isPrivate: {}",
+                requestDto.getTitle(), requestDto.getMaxPlayers(), requestDto.getIsPrivate());
+
+        // TODO : 인증 구현 후 아래 하드코딩을 Security Context 추출로 교체
+        // 게스트/정식 회원 모두 로비 생성 가능
+        // 게스트의 경우 UUID 기반으로 발급된 users.id를 사용
+        Long hostUserId = 1L;
+
+        LobbyCreateResponseDto responseDto = lobbyService.createLobby(requestDto, hostUserId);
+
+        log.info("로비 생성 완료 - lobbyId : {}, inviteCode : {}", responseDto.getLobbyId(), responseDto.getInviteCode());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/GameLobby.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/GameLobby.java
@@ -1,0 +1,110 @@
+package io.github.ascrew.monomatbe.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+// GAME_LOBBY 테이블과 1:1로 매핑되는 JPA 엔티티
+// invite_code :
+// - 유저가 직접 입력하거나 딥링크 (/lobby/{code})로 공유되는 6자리 고유 코드
+// is_private :
+// - 공개/비공개 설정값
+// - Redis의 lobby:public Set 관리 로직과 직접 연동
+
+@Entity
+@Table(
+        name = "GAME_LOBBY",
+        // DB 레벨 UNIQUE 제약: 애플리케이션 레벨 중복 체크
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_game_lobby_invite_code",
+                columnNames = "invite_code"
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 스펙상 기본 생성자 필요, 외부 직접 생성 방지
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // Builder를 통해서만 생성 가능하도록 제한
+public class GameLobby {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // MySQL AUTO_INCREMENT 전략
+    private Long id;
+
+    // 로비를 생성한 방장의 user.id (FK)
+    // nullable = false: 방장 없는 로비는 존재할 수 없다.
+    @Column(name = "host_user_id", nullable = false)
+    private Long hostUserId;
+
+    // 선택된 맵 세트의 map.id (FK)
+    // 로비 생성 시점에는 맵이 선택되지 않을 수 있으므로 nullable = true
+    @Column(name = "map_id")
+    private Long mapId;
+
+    // 서버 내부 식별용 UUID
+    // 유저에게 노출되는 invite_code와 다름
+    @Column(name = "uuid", nullable = false, length = 225)
+    private String uuid;
+
+    // 유저가 직접 입력하거나 딥링크로 공유되는 6자리 초대 코드
+    // - length = 6
+    // - unique = true : @Table의 uniqueConstraints와 이중으로 선언하여 Hibernate의 스키마 생성과 JPA 명세 양쪽에서 모두 UNIQUE를 인지하도록 함
+
+    @Column(name = "invite_code", nullable = false, length = 6, unique = true, updatable = false)
+    private String inviteCode;
+
+    // 로비 제목 (이름)
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    // 최대 참여 가능 인원
+    @Column(name = "max_players", nullable = false)
+    private Integer maxPlayers;
+
+    // 공개 (false) / 비공개 (true) 여부
+    // Redis의 lobby:public Set 추가 여부를 결정하는 기준값
+    @Column(name = "is_private", nullable = false)
+    private Boolean isPrivate;
+
+    // 로비 상태 :
+    // - WAITING : 게임 시작 전 대기 중
+    // - PLAYING : 게임 진행 중
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Builder.Default
+    private LobbyStatus status = LobbyStatus.WAITING; // 생성 시 항상 WAITING으로 초기화
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 로비 상태를 나타내는 열거형
+    // EnumType.STRING으로 저장하여 DB에 "WAITING", "PLAYING" 문자열로 기록
+    // ORDINAL 방식은 Enum 순서를 변경하면 데이터 정합성이 깨질 위험이 있어서 사용 X
+    public enum LobbyStatus {
+        WAITING,
+        PLAYING
+    }
+
+    // 엔티티 최초 저장 직전에 자동으로 createAt를 현재 시각으로 세팅
+    // 애플리케이션 레벨이서 처리하기 때문에 DB의 DEFAULT NOW()와 이중 관리 하지 않아도 됨
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // 방장을 새로운 유저로 교체
+    // Lua 스크립트 (leave_lobby.lua)에서 방장 위임이 처리된 후, DB 동기화가 필요할 때 호출
+    public void delegateHost(Long newHostUserId) {
+        this.hostUserId = newHostUserId;
+    }
+
+    // 게임 시작 시에 로비 상태를 PLAYING으로 전환
+    public void startGame() {
+        this.status = LobbyStatus.PLAYING;
+    }
+
+    // 게임 종료 시에 로비 상태를 WAITING으로 복귀
+    public void endGame() {
+        this.status = LobbyStatus.WAITING;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/dto/request/LobbyCreateRequestDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/dto/request/LobbyCreateRequestDto.java
@@ -1,0 +1,42 @@
+package io.github.ascrew.monomatbe.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 로비 생성 API (POST /api/lobbies)의 요청 바디 DTO
+
+// [필드 설명]
+// - title : 로비 이름 (제목), 로비 목록 화면에 노출되는 이름
+// - maxPlayers : 최대 참여 가능 인원 (방장 포함 인원수)
+// - isPrivate : 공개 (false) / 비공개 (true) 여부
+//               true면 로비 목록에 노출되지 않고 초대 코드로만 입장 가능
+
+@Getter
+@NoArgsConstructor
+public class LobbyCreateRequestDto {
+
+    // 로비 이름 (제목)
+    // @NotBlank : null, 빈 문자열 (""), 공백만 있는 문자열 (" ") 모두 차단
+    // @NotEmpty와 달리 공백 문자열까지 잡아주므로 이름 (제목) 용도에 더 적절
+    @NotBlank(message = "로비 제목은 필수입니다.")
+    private String title;
+
+    // 최대 참여 가능 인원
+    // @NotNull : maxPlayers 자체가 null인 경우 차단
+    // @Min(2) : 방장 혼자만 있는 로비는 게임이 불가능하므로 최소 2명
+    // @MAX(10) : 기능명세서에 명시된 최대 인원 기준, 춯수 조정 가능
+    @NotNull(message = "최대 인원은 필수입니다.")
+    @Min(value = 2, message = "최소 인원은 2명입니다.")
+    @Max(value = 10, message = "최대 인원은 10명입니다.")
+    private Integer maxPlayers;
+
+    // 공개 (false) / 비공개 (true) 여부
+    // @NotNull : true/false 중 하나를 반드시 명시하도록 강제
+    // null 허용 시 서비스 레이어에서 기본값 처리가 필요해져서 로직이 복잡해짐
+    @NotNull(message = "공개 여부는 필수입니다.")
+    private Boolean isPrivate;
+}

--- a/src/main/java/io/github/ascrew/monomatbe/dto/response/LobbyCreateResponseDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/dto/response/LobbyCreateResponseDto.java
@@ -1,0 +1,44 @@
+package io.github.ascrew.monomatbe.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 로비 생성 API (POST /api/lobbies)의 응답 바디 DTO
+
+// [필드 설명]
+// - lobbyId : DB에 저장된 로비의 PK, 이후 로비 관련 API 호출 시 식별자로 활용
+// - inviteCode : 발급된 6자리 초대 코드
+// - title : 생성된 로비 제목
+// - maxPlayers : 최대 참여 가능 인원
+// - isPrivate : 공개/비공개 여부
+// - deepLink : 프론트엔드가 클립보드 복사 기능에 활용할 딥링크 경로
+//              예시 : /lobby/AB3K9Z
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LobbyCreateResponseDto {
+
+    // DB에 저장된 로비의 PK
+    private Long lobbyId;
+
+    // 발급된 6자리 초대 코드
+    // 비공개 로비의 유일한 입장 수단이며, 공개 로비의 빠른 참여 수단으로도 활용
+    private String inviteCode;
+
+    // 생성된 로비 이름 (제목)
+    private String title;
+
+    // 최대 참여 가능 인원
+    private Integer maxPlayers;
+
+    // 공개 (false) / 비공개 (true) 여부
+    private Boolean isPrivate;
+
+    // 프론트엔드가 클립보드 복사 기능에 활용할 딥링크 경로
+    // 서버에서 "/lobby/" + inviteCode 형태로 조립하여 반환
+    private String deepLink;
+}

--- a/src/main/java/io/github/ascrew/monomatbe/repository/GameLobbyJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/repository/GameLobbyJpaRepository.java
@@ -1,0 +1,36 @@
+package io.github.ascrew.monomatbe.repository;
+
+import io.github.ascrew.monomatbe.domain.GameLobby;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+// GAME_LOBBY 테이블에 대한 JPA 데이터 접근 인터페이스
+
+// [역할 구분]
+// - GameLobbyJpaRepository : MySQL (DB) 영속석 담당
+// - LobbyRespository : Redis 인메모리 데이터 담당
+// 두 인터페이스는 역할이 완전히 다르니까 혼용하지 않도록 주의
+
+// 파일명에 Jpa를 붙여 같은 패키지의 LobbyRepository (Redis)와 구분하기
+
+public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
+
+    // invite_code 기준으로 로비 존재 여부 확인
+
+    // [사용 목적]
+    // 로비 생성 서비스에서 6자리 코드 중복 체크 루프에 사용됨
+    // Spring Data JPA가 SELECT COUNT(1) > 0 쿼리를 자동 생성하므로 SELECT *보다 가볍게 동작함
+
+    boolean existsByInviteCode(String inviteCode);
+
+    // invite_code로 로비 조회
+
+    // [사용 목적]
+    // 유저가 초대 코드를 직접 입력하거나 딥링크 (/lobby/{code})로 접근할 때, 해당 로비 정보를 DB에서 가져오기 위해 사용함
+
+    // [Optional 반환 이유]
+    // 존재하지 않는 코드로 조회 시 NullPointerException 대신
+    // Optional.empty()를 반환하여 호출부에서 안전하게 처리하도록 강제함
+    Optional<GameLobby> findByInviteCode(String inviteCode);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/LobbyService.java
@@ -1,0 +1,188 @@
+// 로비 생성 서비스
+// invite_code 생성 및 중복 체크 6자리 코드를 랜덤으로 생성하고, Redis (1차) -> DB (2차) 순서로 중복 체크
+// Redis를 먼저 체크하는 이유는 현재 활성화된 로비는 Redis에 올라와 있으므로 DB까지 가지 않고 빠르게 걸러낼 수 있기 때문
+
+// DB 저장 -> Redis 저장 순서 :
+// DB를 먼저 저장하는 이유는 DB 저장이 실패했을 때 Redis에 좀비 데이터가 남는 상황을 방지하기 위함
+
+// 공개 로비면 lobby:public Set에 추가 :
+// LobbyRepositoryImpl.getPublicLobbies()가 이 Set을 기준으로 목록을 반환하므로, 생성 시점에 추가
+
+// TODO : DB 저장 성공 후 Redis 저장이 실패하는 경우, DB에는 로비가 있지만 실시간 목록에는 안 보이는 불일치가 발생할 수 있음. 현재 단계에서는 로그로 감지하는 수준으로 처리하고, 추후 필요 시 보상 트랜잭션 고려
+
+package io.github.ascrew.monomatbe.service;
+
+import io.github.ascrew.monomatbe.domain.GameLobby;
+import io.github.ascrew.monomatbe.dto.request.LobbyCreateRequestDto;
+import io.github.ascrew.monomatbe.dto.response.LobbyCreateResponseDto;
+import io.github.ascrew.monomatbe.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.repository.LobbyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.core.parameters.P;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LobbyService {
+
+    private final GameLobbyJpaRepository gameLobbyJpaRepository;
+    private final LobbyRepository lobbyRepository;      // Redis 담당
+    private final StringRedisTemplate redisTemplate;
+    private final LobbyEventService lobbyEventService;      // 생성 후 목록 브로드캐스트
+
+    // 초대 코드 생성에 사용할 문자셋
+    // 숫자 (0~9) + 대문자 (A~Z)에서 혼동하기 쉬운 O, I, 0, 1을 제거하여 UX 개선
+    private static final String CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final int CODE_LENGTH = 6;
+
+    // SecureRandom : Random보다 예측 불가능한 난수를 생성 -> 코드 추측 공격 방지
+    // ThreadLocal이 아닌 단일 인스턴스로 사용해도 SecureRandom은 thread-safe
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    // invite_code 생성 재시도 횟수 상한선
+    // 6자리 코드의 경우의 수는 32^6 = 약 10억개이므로 3회 시도
+    // 3회 초과 시 서버 상태 이상으로 판단하고 예외를 던진다.
+    private static final int MAX_RETRY = 3;
+
+    // 로비 생성 메인 로직
+    // [처리 순서]
+    // 1. invite_code 생성 및 중복 체크 (Redis 1차 -> DB 2차)
+    // 2. DB에 로비 저장 (@Transactional 범위)
+    // 3. Redis에 로비 정보 저장
+    // 4. 공개 로비면 lobby:public Set에 추가
+    // 5. 로비 목록 화면 구독자들에게 새로고침 브로드캐스트
+
+    // @param requestDto - 클라이언트가 전달한 로비 생성 요청 데이터
+    // @param hostUserId - 로비를 생성하는 방장의 userId (인증 레이어에서 추출)
+    // @return - 생성된 로비 정보 및 딥링크를 담은 응답 DTO
+
+    @Transactional
+    public LobbyCreateResponseDto createLobby(LobbyCreateRequestDto requestDto, Long hostUserId) {
+
+        // 1. invite_code 생성 및 중복 체크
+        String inviteCode = generateUniqueInviteCode();
+
+        // 2. DB에 로비 저장
+        GameLobby gameLobby = GameLobby.builder()
+                .hostUserId(hostUserId)
+                .uuid(UUID.randomUUID().toString())
+                .inviteCode(inviteCode)
+                .title(requestDto.getTitle())
+                .maxPlayers(requestDto.getMaxPlayers())
+                .isPrivate(requestDto.getIsPrivate())
+                .build();
+
+        GameLobby savedLobby = gameLobbyJpaRepository.save(gameLobby);
+        log.info("[LobbyService] DB 저장 완료 - lobbyId : {}, inviteCode : {}", savedLobby.getId(), inviteCode);
+
+        // 3. Redis에 로비 Hash 저장
+        // getPublicLobbies()가 읽는 키명과 반드시 일치해야 함
+        try {
+            saveToRedis(savedLobby);
+        } catch (Exception e) {
+            // DB 저장은 성공했지만 Redis 저장 실패 시
+            // 실시간 목록에는 안 보이지만 DB에는 존재하는 불일치 상태
+            // 현재는 로그로 감지하고, 추후 보상 트랜잭션 또는 재시도 로직 도입 가능
+            log.error("[LobbyService] Redis 저장 실패 - lobbyId : {}, inviteCode : {}", savedLobby.getId(), inviteCode, e);
+        }
+
+        // 5. 로비 목록 화면을 보고 있는 클라이언트들에게 새로고침 신호 전송
+        lobbyEventService.notifyLobbyInfoRefresh();
+
+        // 6. 응답 DTO 반환 (딥링크 포함)
+        return LobbyCreateResponseDto.builder()
+                .lobbyId(savedLobby.getId())
+                .inviteCode(inviteCode)
+                .title(savedLobby.getTitle())
+                .maxPlayers(savedLobby.getMaxPlayers())
+                .isPrivate(savedLobby.getIsPrivate())
+                .deepLink("/lobby/" + inviteCode)
+                .build();
+    }
+
+    // 중복되지 않는 invite_code 생성
+
+    // [중복 체크 순서]
+    // 1. Redis 1차 체크 : 현재 활성화된 로비는 Redis에 있으므로 DB보다 빠르게 걸러낸다.
+    // 2. DB 2차 체크 : Redis에 없더라도 DB에 존재할 수 있으므로 확인
+
+    // [재시도 상한선]
+    // MAX_RETRY(3회) 초과 시 서버 상태 이상으로 판단하고 예외 던짐
+    // 32^6 ≈ 10억 가지의 경우의 수를 가지므로 실제로 3회를 초과할 가능성은 낮음
+
+    private String generateUniqueInviteCode() {
+        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
+            String code = generateRandomCode();
+
+            // Redis 1차 체크
+            if (lobbyRepository.existsByCode(code)) {
+                log.warn("[LobbyService] invite_code Redis 중복 감지 ({}회차) : {}", attempt, code);
+                continue;
+            }
+
+            // DB 2차 체크
+            if (gameLobbyJpaRepository.existsByInviteCode(code)) {
+                log.warn("[LobbyService] invite_code DB 중복 감지 ({}회차) : {}", attempt, code);
+                continue;
+            }
+
+            return code;
+
+        }
+
+        // MAX_RETRY 초과 시 서버 상태 이상으로 판단
+        throw new IllegalStateException("invite_code 생성 실패 : " + MAX_RETRY + "회 재시도 초과");
+
+    }
+
+    // CODE_CHARS에서 CODE_LENGTH 길이의 랜덤 문자열을 생성
+    // SecureRandom을 사용하여 예측 공격을 방지
+
+    private String generateRandomCode() {
+        StringBuilder sb = new StringBuilder(CODE_LENGTH);
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            sb.append(CODE_CHARS.charAt(SECURE_RANDOM.nextInt(CODE_CHARS.length())));
+        }
+        return sb.toString();
+    }
+
+    // 생성된 로비 정보를 Redis Hash에 저장
+
+    // [키 구조]
+    // - lobby:{inviteCode} : 로비 메타 정보 Hash
+    // - lobby:public : 공개 로비 코드 목록 Set
+
+    // Hash 필드명은 LobbyRepositoryImpl.getPublicLobbies()가 읽는 키명과 반드시 일치해야 함.
+    // 불일치 시 목록 조회에서 null 반환
+
+    private void saveToRedis(GameLobby lobby) {
+        String redisKey = "lobby:" + lobby.getInviteCode();
+
+        // Redis Hash에 로비 메타 정보 저장
+        redisTemplate.opsForHash().putAll(redisKey, Map.of(
+                "code", lobby.getInviteCode(),
+                "host_user_id", String.valueOf(lobby.getHostUserId()),
+                "title", lobby.getTitle(),
+                "status", lobby.getStatus().name(),
+                "max_players", String.valueOf(lobby.getMaxPlayers()),
+                "is_private", String.valueOf(lobby.getIsPrivate())
+        ));
+
+        log.info("[LobbyService] Redis Hash 저장 완료 - key : {}", redisKey);
+
+        // 공개 로비인 경우에만 lobby:public Set에 추가
+        // LobbyRepositoryImpl.getPublicLobbies()가 이 Set을 기준으로 목록 반환
+        if (!lobby.getIsPrivate()) {
+            redisTemplate.opsForSet().add("lobby:public", lobby.getInviteCode());
+            log.info("[LobbyService] 공개 로비 등록 완료 - lobby:public Set에 추가 : {}", lobby.getInviteCode());
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/service/LobbyService.java
@@ -20,7 +20,6 @@ import io.github.ascrew.monomatbe.repository.LobbyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,7 +94,7 @@ public class LobbyService {
         }
 
         // 5. 로비 목록 화면을 보고 있는 클라이언트들에게 새로고침 신호 전송
-        lobbyEventService.notifyLobbyInfoRefresh();
+        lobbyEventService.notifyLobbyListRefresh();
 
         // 6. 응답 DTO 반환 (딥링크 포함)
         return LobbyCreateResponseDto.builder()


### PR DESCRIPTION
## 📣 Related Issue

- #18 

## 📝 Summary

- `GameLobby` 엔티티 추가 (`invite_code`, `is_private` 컬럼 포함)
- `GameLobbyJpaRepository` 추가
- `LobbyService` 추가 (`invite_code` 중복 체크 및 `Redis` 저장 로직)
- `LobbyCreateRequestDto`, `LobbyCreateResponseDto` 추가
- `LobbyController`에 `POST /api/lobbies` 엔드포인트 추가
- `build.gradle`에 `spring-boot-starter-validation` 의존성 추가

## 🙏PR point

- `hostUserId`는 인증 체계 미완성으로 현재 1L 하드코딩 처리, 인증 이슈에서 교체 예정
- DB 저장 성공 후 Redis 저장 실패 시 불일치 상태 발생 가능, 현재는 로그로 감지하며 추후 보상 트랜잭션 도입 고려
- 로비 생성은 게스트/정식 회원 모두 가능하도록 결정 (기능명세서 업데이트 필요)

## 📬 Reference
