### PR TITLE
[Feat/#33] 게스트 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     // 1. Web & WebSocket (Spring Boot 4.x 모듈화 기준)
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // 2. Database (JPA, MySQL, Redis 추가)
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -30,6 +31,9 @@ dependencies {
 
     // 3. Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.7'
 
     // 4. Utility (.env & Lombok)
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
@@ -47,6 +51,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 
     // 6. Monitoring (Actuator & Prometheus)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,45 @@
 
 ## REST API
 
+### 인증 (Auth)
+
+#### 게스트 로그인
+
+```
+POST /api/auth/guest
+```
+
+닉네임 입력만으로 게스트 계정을 생성하고 `UUID(userIdentifier)` 기반 세션을 발급합니다.
+응답으로 Access/Refresh 토큰이 함께 반환되며, 게스트 세션 정보는 Redis에 30일 TTL로 저장됩니다.
+
+**Request**
+
+```json
+{
+  "nickname": "게스트닉네임"
+}
+```
+
+**Response `200 OK`**
+
+```json
+{
+  "userId": 1,
+  "nickname": "게스트닉네임",
+  "userType": "GUEST",
+  "userIdentifier": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+  "accessToken": "eyJhbGciOi...",
+  "accessTokenExpiresAt": "2026-05-03T07:45:00Z",
+  "refreshToken": "eyJhbGciOi...",
+  "refreshTokenExpiresAt": "2026-06-02T07:30:00Z"
+}
+```
+
+**Error `409 CONFLICT`**
+
+- 정식 회원 닉네임과 충돌: `정식 회원이 이미 사용 중인 닉네임입니다.`
+- 기존 사용자 닉네임과 충돌: `이미 사용 중인 닉네임입니다.`
+
 ### 로비 (Lobby)
 
 #### 공개 로비 목록 조회
@@ -218,7 +257,6 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 |---|---|
 | 회원가입 | `POST /api/auth/register` |
 | 로그인 | `POST /api/auth/login` |
-| 게스트 로그인 | `POST /api/auth/guest` |
 | 로비 생성 | `POST /api/lobbies` |
 | 로비 초대 코드 입장 | `POST /api/lobbies/join` |
 | 맵 CRUD | `GET/POST/PUT/DELETE /api/maps` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,25 @@ src/main/java/io/github/ascrew/monomatbe/
 ├── MonomatBeApplication.java
 │
 ├── domain/                                         # 비즈니스 도메인 레이어
+│   ├── auth/                                       # 인증 도메인
+│   │   ├── controller/
+│   │   │   └── AuthController.java                 # REST 인증 엔드포인트 (/api/auth/**)
+│   │   ├── dto/
+│   │   │   ├── GuestLoginRequest.java              # 게스트 로그인 요청 DTO
+│   │   │   └── GuestLoginResponse.java             # 게스트 로그인 응답 DTO (JWT 포함)
+│   │   ├── entity/
+│   │   │   ├── User.java                           # 사용자 엔티티 (게스트/회원 통합)
+│   │   │   ├── GuestSession.java                   # 게스트 세션 엔티티
+│   │   │   ├── UserCredential.java                 # 회원 인증정보 엔티티 (후속 이슈 대비)
+│   │   │   └── UserSession.java                    # 회원 세션 엔티티 (후속 이슈 대비)
+│   │   ├── repository/
+│   │   │   ├── UserRepository.java
+│   │   │   ├── GuestSessionRepository.java
+│   │   │   ├── UserCredentialRepository.java
+│   │   │   └── UserSessionRepository.java
+│   │   └── service/
+│   │       └── GuestAuthService.java               # 게스트 로그인/세션 발급 로직
+│   │
 │   ├── chat/                                       # 채팅 도메인
 │   │   ├── controller/
 │   │   │   └── ChatController.java                 # STOMP 채팅 메시지 수신 및 라우팅
@@ -45,7 +64,7 @@ src/main/java/io/github/ascrew/monomatbe/
     │   ├── RedisPublisher.java                     # Redis 채널 메시지 발행
     │   └── RedisSubscriber.java                    # Redis 채널 메시지 수신 → WebSocket 브로드캐스트
     │
-    └── websocket/                                  # WebSocket 인프라
+    ├── websocket/                                  # WebSocket 인프라
         ├── CustomStompErrorHandler.java            # STOMP ERROR 프레임 핸들러
         ├── StompChannelInterceptor.java            # CONNECT/SUBSCRIBE/SEND 인증 검증
         ├── WebSocketEventListener.java             # WebSocket 연결 생명주기 이벤트 처리
@@ -55,6 +74,10 @@ src/main/java/io/github/ascrew/monomatbe/
         │   └── ChatMessageDto.java                 # WebSocket 채팅 메시지 DTO
         └── event/
             └── PlayerLeaveEvent.java               # 플레이어 퇴장 Spring 이벤트 객체
+    └── security/
+        └── jwt/
+            ├── JwtTokenProvider.java               # JWT Access/Refresh 토큰 발급
+            └── TokenWithExpiry.java                # 토큰 + 만료시각 DTO
 ```
 
 ---

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package io.github.ascrew.monomatbe.domain.auth.controller;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginRequest;
+import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginResponse;
+import io.github.ascrew.monomatbe.domain.auth.service.GuestAuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final GuestAuthService guestAuthService;
+
+    /**
+     * 게스트 로그인 엔드포인트
+     * 닉네임 기반으로 게스트 계정/세션을 생성하고 토큰 정보를 반환
+     */
+    @PostMapping("/guest")
+    public ResponseEntity<GuestLoginResponse> guestLogin(@Valid @RequestBody GuestLoginRequest request) {
+        return ResponseEntity.ok(guestAuthService.loginAsGuest(request.nickname()));
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
@@ -1,0 +1,17 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 게스트 로그인 요청 DTO.
+ *
+ * 클라이언트는 닉네임만 전달하고,
+ * 서버가 게스트 계정 생성/세션 발급을 담당합니다.
+ */
+public record GuestLoginRequest(
+        @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+        String nickname
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginResponse.java
@@ -1,0 +1,36 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import lombok.Builder;
+
+import java.time.Instant;
+
+/**
+ * 게스트 로그인 응답 DTO.
+ *
+ * 프론트는 이 응답으로
+ * 1) 사용자 표시 정보
+ * 2) WebSocket 연결 식별자(userIdentifier)
+ * 3) API 인증용 JWT(access/refresh)
+ * 를 한 번에 획득합니다.
+ */
+@Builder
+public record GuestLoginResponse(
+        // users PK
+        Long userId,
+        // 화면 표시용 닉네임
+        String nickname,
+        // 현재는 GUEST, 향후 REGISTERED와 동일 포맷 사용
+        UserType userType,
+        // STOMP CONNECT 헤더에 넣는 UUID 식별자
+        String userIdentifier,
+        // API 인증용 단기 토큰
+        String accessToken,
+        // Access Token 만료 시각
+        Instant accessTokenExpiresAt,
+        // Access Token 재발급용 장기 토큰
+        String refreshToken,
+        // Refresh Token 만료 시각
+        Instant refreshTokenExpiresAt
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/GuestSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/GuestSession.java
@@ -1,0 +1,51 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게스트 세션 엔티티.
+ *
+ * guest_token(UUID)은 브라우저 보관값(localStorage)과 1:1로 매핑되는 식별자입니다.
+ * users(게스트 사용자)와 guest_sessions를 분리해 두면
+ * 토큰 재발급/만료 정책을 사용자 기본정보와 독립적으로 관리할 수 있습니다.
+ */
+@Getter
+@Entity
+@Builder
+@Table(name = "guest_sessions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GuestSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "guest_token", nullable = false, unique = true, length = 255)
+    private String guestToken;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/User.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/User.java
@@ -1,0 +1,86 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 기본 엔티티.
+ *
+ * 게스트/회원을 하나의 users 테이블로 통합 관리합니다.
+ * 인증 방식(게스트/회원)은 userType으로 구분하고,
+ * 공통 프로필 정보(닉네임, 상태, 생성일 등)는 이 엔티티에서 관리합니다.
+ */
+@Getter
+@Entity
+@Builder
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_type", nullable = false, length = 20)
+    private UserType userType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private UserStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        // 서비스 코드에서 누락해도 안전한 기본값을 DB 저장 전에 보정
+        if (this.status == null) {
+            this.status = UserStatus.ACTIVE;
+        }
+        if (this.userType == null) {
+            this.userType = UserType.GUEST;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        // 모든 업데이트 시각을 일관되게 갱신
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 로그인 성공 시 마지막 로그인 시각을 갱신할 때 사용합니다.
+     */
+    public void updateLastLoginAt(LocalDateTime lastLoginAt) {
+        this.lastLoginAt = lastLoginAt;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
@@ -1,0 +1,82 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 회원 인증정보 엔티티.
+ *
+ * users와 분리하여 관리하는 이유:
+ * - 비밀번호 해시/로그인 실패 카운트/잠금 시각은 보안 민감 데이터
+ * - 게스트 사용자에게는 불필요한 컬럼이므로 분리 시 모델이 단순해짐
+ */
+@Getter
+@Entity
+@Builder
+@Table(name = "user_credentials")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserCredential {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "login_id", nullable = false, unique = true, length = 50)
+    private String loginId;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
+
+    @Column(name = "failed_login_count", nullable = false)
+    private Integer failedLoginCount;
+
+    @Column(name = "locked_until")
+    private LocalDateTime lockedUntil;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        // 로그인 실패 카운트 초기값 보정
+        if (this.failedLoginCount == null) {
+            this.failedLoginCount = 0;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        // 인증정보 변경 시각 자동 갱신
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserSession.java
@@ -1,0 +1,57 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 회원 세션 엔티티(확장 대비).
+ *
+ * 현재 게스트 로그인은 guest_sessions + Redis를 사용하지만,
+ * 회원 로그인 이슈(#35)에서 서버 세션 추적이 필요할 수 있어
+ * user_sessions 테이블 매핑을 미리 준비해 둔 상태입니다.
+ */
+@Getter
+@Entity
+@Builder
+@Table(name = "user_sessions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "session_token", nullable = false, unique = true, length = 255)
+    private String sessionToken;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserStatus.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserStatus.java
@@ -1,0 +1,13 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+/**
+ * 계정 상태.
+ * - ACTIVE: 정상 사용 가능
+ * - BANNED: 운영 정책상 차단
+ * - DELETED: 탈퇴/삭제 처리
+ */
+public enum UserStatus {
+    ACTIVE,
+    BANNED,
+    DELETED
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserType.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserType.java
@@ -1,0 +1,11 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+/**
+ * 사용자 유형.
+ * - REGISTERED: 회원가입/로그인 완료 사용자
+ * - GUEST: 닉네임 기반 임시 사용자
+ */
+public enum UserType {
+    REGISTERED,
+    GUEST
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/GuestSessionRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/GuestSessionRepository.java
@@ -1,0 +1,18 @@
+package io.github.ascrew.monomatbe.domain.auth.repository;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.GuestSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * guest_sessions 접근 리포지토리.
+ */
+public interface GuestSessionRepository extends JpaRepository<GuestSession, Long> {
+
+    /**
+     * 게스트 UUID 토큰으로 세션 조회.
+     * 자동 로그인/세션 유효성 확인에 사용됩니다.
+     */
+    Optional<GuestSession> findByGuestToken(String guestToken);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserCredentialRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserCredentialRepository.java
@@ -1,0 +1,18 @@
+package io.github.ascrew.monomatbe.domain.auth.repository;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * user_credentials 접근 리포지토리.
+ */
+public interface UserCredentialRepository extends JpaRepository<UserCredential, Long> {
+
+    /**
+     * 로그인 ID로 인증정보 조회.
+     * 회원 로그인 시 패스워드 검증 진입점이 됩니다.
+     */
+    Optional<UserCredential> findByLoginId(String loginId);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserRepository.java
@@ -1,0 +1,34 @@
+package io.github.ascrew.monomatbe.domain.auth.repository;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * users 테이블 접근 리포지토리.
+ *
+ * 게스트 닉네임 정책에서
+ * - 전체 중복 체크
+ * - REGISTERED 선점 닉네임 체크
+ * 를 빠르게 처리하기 위해 exists 쿼리를 사용합니다.
+ */
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    /**
+     * 게스트/회원 구분 없이 닉네임 존재 여부 확인.
+     */
+    boolean existsByUsername(String username);
+
+    /**
+     * 특정 사용자 유형에서 닉네임 존재 여부 확인.
+     * (예: REGISTERED 닉네임 선점 검사)
+     */
+    boolean existsByUsernameAndUserType(String username, UserType userType);
+
+    /**
+     * 닉네임으로 사용자 단건 조회.
+     */
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserSessionRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserSessionRepository.java
@@ -1,0 +1,20 @@
+package io.github.ascrew.monomatbe.domain.auth.repository;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * user_sessions 접근 리포지토리.
+ *
+ * JWT 단독 전략이더라도,
+ * 강제 로그아웃/세션 추적 요구가 생기면 서버 세션 저장소로 확장할 수 있습니다.
+ */
+public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
+
+    /**
+     * 세션 토큰으로 세션 조회.
+     */
+    Optional<UserSession> findBySessionToken(String sessionToken);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
@@ -11,10 +11,13 @@ import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenWithExpiry;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
@@ -55,44 +58,55 @@ public class GuestAuthService {
         validateNicknameAvailability(nickname);
 
         LocalDateTime now = LocalDateTime.now();
-        // users: 게스트 사용자 기본 정보 저장
-        User savedUser = userRepository.save(User.builder()
-                .username(nickname)
-                .userType(UserType.GUEST)
-                .status(UserStatus.ACTIVE)
-                .lastLoginAt(now)
-                .build());
+        User savedUser;
+        try {
+            // users: 게스트 사용자 기본 정보 저장 (saveAndFlush로 즉시 쿼리 실행하여 중복 예외 캐치)
+            savedUser = userRepository.saveAndFlush(User.builder()
+                    .username(nickname)
+                    .userType(UserType.GUEST)
+                    .status(UserStatus.ACTIVE)
+                    .lastLoginAt(now)
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            // Check-then-Act 구간 사이 다른 요청으로 인해 닉네임 중복이 발생한 경우
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+        }
 
         // 게스트/회원 공통 식별 정책: userIdentifier는 UUID 사용
-        String guestToken = UUID.randomUUID().toString();
+        String userIdentifier = UUID.randomUUID().toString();
 
-        // guest_sessions: UUID와 사용자 매핑 저장 (30일 만료 기준)
+        // guest_sessions: UUID와 사용자 매핑 저장 (TTL 상수로 교체)
         guestSessionRepository.save(GuestSession.builder()
                 .user(savedUser)
-                .guestToken(guestToken)
-                .expiresAt(now.plusDays(30))
+                .guestToken(userIdentifier)
+                .expiresAt(now.plus(GUEST_SESSION_TTL))
                 .createdAt(now)
                 .build());
 
         TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(
                 savedUser.getId(),
                 savedUser.getUserType(),
-                guestToken
+                userIdentifier
         );
         TokenWithExpiry refreshToken = jwtTokenProvider.createRefreshToken(
                 savedUser.getId(),
                 savedUser.getUserType(),
-                guestToken
+                userIdentifier
         );
 
-        // Redis에는 빠른 조회/유효성 확인에 필요한 최소 세션 정보를 저장
-        storeGuestSessionToRedis(savedUser, guestToken, refreshToken.token());
+        // Redis에는 DB 트랜잭션이 성공적으로 커밋된 이후에만 세션 정보를 저장합니다. (고아 데이터 방지)
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                storeGuestSessionToRedis(savedUser, userIdentifier, refreshToken.token());
+            }
+        });
 
         return GuestLoginResponse.builder()
                 .userId(savedUser.getId())
                 .nickname(savedUser.getUsername())
                 .userType(savedUser.getUserType())
-                .userIdentifier(guestToken)
+                .userIdentifier(userIdentifier)
                 .accessToken(accessToken.token())
                 .accessTokenExpiresAt(accessToken.expiresAt())
                 .refreshToken(refreshToken.token())
@@ -101,20 +115,11 @@ public class GuestAuthService {
     }
 
     /**
-     * 입력 닉네임을 trim 후 유효성 검증합니다.
+     * 입력 닉네임을 trim 합니다.
+     * (null 체크나 길이 검증은 Controller의 @Valid에서 수행되므로 중복 검증 제거)
      */
     private String normalizeNickname(String rawNickname) {
-        if (rawNickname == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 비어 있을 수 없습니다.");
-        }
-        String normalized = rawNickname.trim();
-        if (normalized.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 비어 있을 수 없습니다.");
-        }
-        if (normalized.length() > 50) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 50자를 초과할 수 없습니다.");
-        }
-        return normalized;
+        return rawNickname.trim();
     }
 
     /**
@@ -140,8 +145,8 @@ public class GuestAuthService {
      * - Hash: 게스트 식별/조회용 사용자 정보
      * - String: Refresh Token
      */
-    private void storeGuestSessionToRedis(User user, String guestToken, String refreshToken) {
-        String guestSessionKey = RedisKeys.guestSessionKey(guestToken);
+    private void storeGuestSessionToRedis(User user, String userIdentifier, String refreshToken) {
+        String guestSessionKey = RedisKeys.guestSessionKey(userIdentifier);
         redisTemplate.opsForHash().putAll(guestSessionKey, Map.of(
                 "userId", String.valueOf(user.getId()),
                 "username", user.getUsername(),
@@ -149,7 +154,7 @@ public class GuestAuthService {
         ));
         redisTemplate.expire(guestSessionKey, GUEST_SESSION_TTL);
 
-        String refreshTokenKey = RedisKeys.refreshTokenKey(guestToken);
+        String refreshTokenKey = RedisKeys.refreshTokenKey(userIdentifier);
         redisTemplate.opsForValue().set(refreshTokenKey, refreshToken, jwtTokenProvider.refreshTokenTtl());
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
@@ -1,0 +1,155 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginResponse;
+import io.github.ascrew.monomatbe.domain.auth.entity.GuestSession;
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
+import io.github.ascrew.monomatbe.global.security.jwt.TokenWithExpiry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 게스트 인증 서비스.
+ *
+ * 핵심 책임:
+ * - 닉네임 기반 게스트 계정 생성
+ * - UUID(userIdentifier) 발급
+ * - JWT Access/Refresh 발급
+ * - DB + Redis 세션 상태를 함께 저장
+ */
+@Service
+@RequiredArgsConstructor
+public class GuestAuthService {
+
+    private static final Duration GUEST_SESSION_TTL = Duration.ofDays(30);
+
+    private final UserRepository userRepository;
+    private final GuestSessionRepository guestSessionRepository;
+    private final StringRedisTemplate redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 게스트 로그인 메인 플로우
+     * 1) 닉네임 정규화/검증
+     * 2) users + guest_sessions 저장
+     * 3) Access/Refresh 토큰 발급
+     * 4) Redis 세션/리프레시 정보 저장
+     */
+    @Transactional
+    public GuestLoginResponse loginAsGuest(String rawNickname) {
+        String nickname = normalizeNickname(rawNickname);
+        validateNicknameAvailability(nickname);
+
+        LocalDateTime now = LocalDateTime.now();
+        // users: 게스트 사용자 기본 정보 저장
+        User savedUser = userRepository.save(User.builder()
+                .username(nickname)
+                .userType(UserType.GUEST)
+                .status(UserStatus.ACTIVE)
+                .lastLoginAt(now)
+                .build());
+
+        // 게스트/회원 공통 식별 정책: userIdentifier는 UUID 사용
+        String guestToken = UUID.randomUUID().toString();
+
+        // guest_sessions: UUID와 사용자 매핑 저장 (30일 만료 기준)
+        guestSessionRepository.save(GuestSession.builder()
+                .user(savedUser)
+                .guestToken(guestToken)
+                .expiresAt(now.plusDays(30))
+                .createdAt(now)
+                .build());
+
+        TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(
+                savedUser.getId(),
+                savedUser.getUserType(),
+                guestToken
+        );
+        TokenWithExpiry refreshToken = jwtTokenProvider.createRefreshToken(
+                savedUser.getId(),
+                savedUser.getUserType(),
+                guestToken
+        );
+
+        // Redis에는 빠른 조회/유효성 확인에 필요한 최소 세션 정보를 저장
+        storeGuestSessionToRedis(savedUser, guestToken, refreshToken.token());
+
+        return GuestLoginResponse.builder()
+                .userId(savedUser.getId())
+                .nickname(savedUser.getUsername())
+                .userType(savedUser.getUserType())
+                .userIdentifier(guestToken)
+                .accessToken(accessToken.token())
+                .accessTokenExpiresAt(accessToken.expiresAt())
+                .refreshToken(refreshToken.token())
+                .refreshTokenExpiresAt(refreshToken.expiresAt())
+                .build();
+    }
+
+    /**
+     * 입력 닉네임을 trim 후 유효성 검증합니다.
+     */
+    private String normalizeNickname(String rawNickname) {
+        if (rawNickname == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 비어 있을 수 없습니다.");
+        }
+        String normalized = rawNickname.trim();
+        if (normalized.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 비어 있을 수 없습니다.");
+        }
+        if (normalized.length() > 50) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 50자를 초과할 수 없습니다.");
+        }
+        return normalized;
+    }
+
+    /**
+     * 닉네임 중복 정책:
+     * - 등록되어 있는 회원이 선점한 닉네임은 게스트가 사용할 수 없음
+     * - 게스트/회원 포함 전체 중복도 차단
+     */
+    private void validateNicknameAvailability(String nickname) {
+        if (userRepository.existsByUsernameAndUserType(nickname, UserType.REGISTERED)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "다른 회원이 이미 사용 중인 닉네임입니다."
+            );
+        }
+
+        if (userRepository.existsByUsername(nickname)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+        }
+    }
+
+    /**
+     * 게스트 세션을 Redis에 저장합니다.
+     * - Hash: 게스트 식별/조회용 사용자 정보
+     * - String: Refresh Token
+     */
+    private void storeGuestSessionToRedis(User user, String guestToken, String refreshToken) {
+        String guestSessionKey = RedisKeys.guestSessionKey(guestToken);
+        redisTemplate.opsForHash().putAll(guestSessionKey, Map.of(
+                "userId", String.valueOf(user.getId()),
+                "username", user.getUsername(),
+                "userType", user.getUserType().name()
+        ));
+        redisTemplate.expire(guestSessionKey, GUEST_SESSION_TTL);
+
+        String refreshTokenKey = RedisKeys.refreshTokenKey(guestToken);
+        redisTemplate.opsForValue().set(refreshTokenKey, refreshToken, jwtTokenProvider.refreshTokenTtl());
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
@@ -11,6 +11,7 @@ import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenWithExpiry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ import java.util.UUID;
  * - JWT Access/Refresh 발급
  * - DB + Redis 세션 상태를 함께 저장
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GuestAuthService {
@@ -98,7 +100,11 @@ public class GuestAuthService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                storeGuestSessionToRedis(savedUser, userIdentifier, refreshToken.token());
+                try {
+                    storeGuestSessionToRedis(savedUser, userIdentifier, refreshToken.token());
+                } catch (Exception e) {
+                    log.error("Redis 게스트 세션 저장 실패 - userId: {}", savedUser.getId(), e);
+                }
             }
         });
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -21,6 +21,7 @@ import tools.jackson.databind.json.JsonMapper;
 import io.github.ascrew.monomatbe.global.redis.RedisSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -144,6 +145,7 @@ public class RedisConfig {
      * 다수의 동시 메시지 처리 시 플랫폼 스레드 풀 고갈을 방지합니다.
      */
     @Bean
+    @Profile("!test")
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
             RedisSubscriber redisSubscriber

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
@@ -21,6 +21,7 @@ public class SecurityConfigDev {
             .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/ws/**").permitAll()
+                    .requestMatchers("/api/auth/guest", "/api/auth/register", "/api/auth/login").permitAll()
                     .anyRequest()
                     .permitAll()
             ); // 모든 요청 허용 (개발 환경에서는 인증 없이 접근 허용)

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
@@ -21,8 +21,8 @@ public class SecurityConfigProd {
             .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
             .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
             .authorizeHttpRequests(auth -> auth
-                    // 향후 회원가입, 로그인 등 인증없이 들어와야 하는 URL이 생기면 추가
-                    // .requestMatchers("/api/auth/**").permitAll()
+                    .requestMatchers("/ws/**").permitAll()
+                    .requestMatchers("/api/auth/guest", "/api/auth/register", "/api/auth/login").permitAll()
                     .anyRequest().authenticated()
 
             ); // 모든 요청에 대해 인증 필요 (운영 환경에서는 인증된 사용자만 접근 허용)

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -49,6 +49,12 @@ public final class RedisKeys {
     /** WebSocket 세션 매핑 Hash 키 접두사 */
     private static final String WS_CONNECTION_PREFIX = "ws:connection:";
 
+    /** 게스트 세션 저장 키 접두사 */
+    private static final String GUEST_SESSION_PREFIX = "auth:guest:session:";
+
+    /** Refresh Token 저장 키 접두사 */
+    private static final String REFRESH_TOKEN_PREFIX = "auth:refresh:";
+
     // [삭제] USER_ROOM_PREFIX 및 userRoomKey() 제거
     // lobby:{code}:participants가 단일 진실의 원천으로 통일되었으므로
     // user_room:{lobbyCode} 관련 상수는 더 이상 필요하지 않습니다.
@@ -168,5 +174,25 @@ public final class RedisKeys {
      */
     public static String wsConnectionKey(String wsSessionId) {
         return WS_CONNECTION_PREFIX + wsSessionId;
+    }
+
+    /**
+     * 게스트 세션 정보를 저장하는 Redis Hash 키를 반환합니다.
+     *
+     * @param guestToken 게스트 UUID 토큰
+     * @return "auth:guest:session:{guestToken}"
+     */
+    public static String guestSessionKey(String guestToken) {
+        return GUEST_SESSION_PREFIX + guestToken;
+    }
+
+    /**
+     * Refresh Token 저장 키를 반환합니다.
+     *
+     * @param sessionId 세션 식별자(UUID)
+     * @return "auth:refresh:{sessionId}"
+     */
+    public static String refreshTokenKey(String sessionId) {
+        return REFRESH_TOKEN_PREFIX + sessionId;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,91 @@
+package io.github.ascrew.monomatbe.global.security.jwt;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${auth.jwt.secret}")
+    private String secret;
+
+    @Value("${auth.jwt.access-token-validity-seconds:900}")
+    private long accessTokenValiditySeconds;
+
+    @Value("${auth.jwt.refresh-token-validity-seconds:2592000}")
+    private long refreshTokenValiditySeconds;
+
+    private SecretKey secretKey;
+
+    /**
+     * 애플리케이션 시작 시 JWT 서명 키를 초기화합니다.
+     * HMAC-SHA 계열 키 길이 요구사항(최소 32바이트)을 강제합니다.
+     */
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+        if (keyBytes.length < 32) {
+            throw new IllegalStateException("JWT secret은 최소 32바이트 이상이어야 합니다.");
+        }
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * API 인증에 사용하는 단기 Access Token을 발급합니다.
+     * userIdentifier(게스트/회원 공통 UUID)를 claim으로 포함합니다.
+     */
+    public TokenWithExpiry createAccessToken(Long userId, UserType userType, String userIdentifier) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusSeconds(accessTokenValiditySeconds);
+
+        String token = Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claims(Map.of(
+                        "userType", userType.name(),
+                        "userIdentifier", userIdentifier
+                ))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiresAt))
+                .signWith(secretKey)
+                .compact();
+
+        return new TokenWithExpiry(token, expiresAt);
+    }
+
+    /**
+     * 세션 갱신에 사용하는 장기 Refresh Token을 발급합니다.
+     * sessionId는 Redis refresh key와 동일 식별자를 사용합니다.
+     */
+    public TokenWithExpiry createRefreshToken(Long userId, UserType userType, String sessionId) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusSeconds(refreshTokenValiditySeconds);
+
+        String token = Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claims(Map.of(
+                        "userType", userType.name(),
+                        "sessionId", sessionId
+                ))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiresAt))
+                .signWith(secretKey)
+                .compact();
+
+        return new TokenWithExpiry(token, expiresAt);
+    }
+
+    public Duration refreshTokenTtl() {
+        return Duration.ofSeconds(refreshTokenValiditySeconds);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/TokenWithExpiry.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/TokenWithExpiry.java
@@ -1,0 +1,15 @@
+package io.github.ascrew.monomatbe.global.security.jwt;
+
+import java.time.Instant;
+
+/**
+ * JWT 문자열과 만료시각을 함께 전달하기 위한 값 객체.
+ *
+ * 토큰만 반환하면 만료시각 계산을 호출부가 다시 해야 하므로
+ * 발급 시점에서 계산된 expiresAt을 함께 전달해 응답/캐시 처리에 재사용합니다.
+ */
+public record TokenWithExpiry(
+        String token,
+        Instant expiresAt
+) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,7 @@
 spring.application.name=Monomat-BE
 spring.profiles.active=dev
 spring.config.import=optional:file:.env[.properties]
+
+auth.jwt.secret=${JWT_SECRET:MonomatJwtSecretKeyForLocalDevOnly_ChangeMe_AtLeast32Bytes}
+auth.jwt.access-token-validity-seconds=${JWT_ACCESS_TOKEN_VALIDITY_SECONDS:900}
+auth.jwt.refresh-token-validity-seconds=${JWT_REFRESH_TOKEN_VALIDITY_SECONDS:2592000}

--- a/src/test/java/io/github/ascrew/monomatbe/MonomatBeApplicationTests.java
+++ b/src/test/java/io/github/ascrew/monomatbe/MonomatBeApplicationTests.java
@@ -2,8 +2,10 @@ package io.github.ascrew.monomatbe;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MonomatBeApplicationTests {
 
     @Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,11 @@
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:monomat_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #32 
- #33 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `domain/auth` 패키지 생성 (`controller/service/dto/entity/repository`)
- `POST /api/auth/guest` 구현 (`AuthController`, `GuestAuthService`)
- 게스트 닉네임 검증 및 중복 처리 로직 추가 (정식 회원 선점 닉네임 포함)
- 게스트 UUID(`userIdentifier`) 발급 후 `users`, `guest_sessions` 저장
- JWT 발급 기반 추가 (`JwtTokenProvider`, `TokenWithExpiry`) 및 Access/Refresh 응답 구조 적용
- Redis 세션 저장 키 확장 (`RedisKeys.guestSessionKey`, `RedisKeys.refreshTokenKey`) 및 TTL 적용
- `SecurityConfigDev` / `SecurityConfigProd`에 `/api/auth/guest` permitAll 반영
   (후속 `/api/auth/register`, `/api/auth/login` 확장 포인트 포함)
- `docs/API.md`, `docs/ARCHITECTURE.md` 문서 갱신
- 테스트 환경 안정화: `application-test.properties` 추가, 
`@ActiveProfiles("test")` 적용, 테스트에서 Redis Pub/Sub 리스너 비활성화

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 현재 인증 전략은 **JWT Access/Refresh + Redis 세션 상태 저장** 기준입니다.
- WebSocket/STOMP 식별자 정책은 게스트/회원 모두 **UUID 기반 `userIdentifier` 통일**을 전제로 구현했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- JJWT 공식 문서: https://github.com/jwtk/jjwt