### PR TITLE
[Feat/#34] 회원가입 API 및 응답 처리 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,41 @@ POST /api/auth/guest
 - 정식 회원 닉네임과 충돌: `정식 회원이 이미 사용 중인 닉네임입니다.`
 - 기존 사용자 닉네임과 충돌: `이미 사용 중인 닉네임입니다.`
 
+#### 회원가입
+
+```
+POST /api/auth/register
+```
+
+로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.  
+회원가입 API는 계정 생성만 수행하며 토큰 발급은 로그인 API에서 처리됩니다.
+
+**Request**
+
+```json
+{
+  "loginId": "member01",
+  "password": "password123",
+  "nickname": "registered-user"
+}
+```
+
+**Response `201 Created`**
+
+```json
+{
+  "userId": 2,
+  "loginId": "member01",
+  "nickname": "registered-user",
+  "userType": "REGISTERED"
+}
+```
+
+**Error**
+
+- `400 Bad Request`: 필수값 누락/비밀번호 길이 조건 불만족
+- `409 Conflict`: 로그인 ID 또는 닉네임 중복
+
 ### 로비 (Lobby)
 
 #### 공개 로비 목록 조회
@@ -255,7 +290,6 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 
 | 분류 | 설명 |
 |---|---|
-| 회원가입 | `POST /api/auth/register` |
 | 로그인 | `POST /api/auth/login` |
 | 로비 생성 | `POST /api/lobbies` |
 | 로비 초대 코드 입장 | `POST /api/lobbies/join` |

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
@@ -2,9 +2,13 @@ package io.github.ascrew.monomatbe.domain.auth.controller;
 
 import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginResponse;
+import io.github.ascrew.monomatbe.domain.auth.dto.RegisterRequest;
+import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
 import io.github.ascrew.monomatbe.domain.auth.service.GuestAuthService;
+import io.github.ascrew.monomatbe.domain.auth.service.RegisterAuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final GuestAuthService guestAuthService;
+    private final RegisterAuthService registerAuthService;
 
     /**
      * 게스트 로그인 엔드포인트
@@ -25,5 +30,19 @@ public class AuthController {
     @PostMapping("/guest")
     public ResponseEntity<GuestLoginResponse> guestLogin(@Valid @RequestBody GuestLoginRequest request) {
         return ResponseEntity.ok(guestAuthService.loginAsGuest(request.nickname()));
+    }
+
+    /**
+     * 회원가입 엔드포인트.
+     * (#34 범위: 계정 생성만 처리, 토큰 발급은 #35 로그인에서 처리)
+     */
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+        RegisterResponse response = registerAuthService.register(
+                request.loginId(),
+                request.password(),
+                request.nickname()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import io.github.ascrew.monomatbe.domain.auth.dto.RegisterRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
 import io.github.ascrew.monomatbe.domain.auth.service.GuestAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.RegisterAuthService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,7 @@ public class AuthController {
      * 게스트 로그인 엔드포인트
      * 닉네임 기반으로 게스트 계정/세션을 생성하고 토큰 정보를 반환
      */
+    @Operation(summary = "게스트 로그인", description = "닉네임으로 게스트 계정/세션을 생성하고 토큰 정보를 반환합니다.")
     @PostMapping("/guest")
     public ResponseEntity<GuestLoginResponse> guestLogin(@Valid @RequestBody GuestLoginRequest request) {
         return ResponseEntity.ok(guestAuthService.loginAsGuest(request.nickname()));
@@ -36,6 +38,7 @@ public class AuthController {
      * 회원가입 엔드포인트.
      * (#34 범위: 계정 생성만 처리, 토큰 발급은 #35 로그인에서 처리)
      */
+    @Operation(summary = "회원가입", description = "로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.")
     @PostMapping("/register")
     public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
         RegisterResponse response = registerAuthService.register(

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
@@ -1,0 +1,22 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 회원가입 요청 DTO.
+ */
+public record RegisterRequest(
+        @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "로그인 ID는 50자를 초과할 수 없습니다.")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
+        @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
+        String password,
+
+        @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+        String nickname
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterResponse.java
@@ -1,0 +1,17 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import lombok.Builder;
+
+/**
+ * 회원가입 응답 DTO.
+ * (#34 범위에서는 계정 생성 결과만 반환하며 토큰은 발급하지 않습니다.)
+ */
+@Builder
+public record RegisterResponse(
+        Long userId,
+        String loginId,
+        String nickname,
+        UserType userType
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserCredentialRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserCredentialRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
  */
 public interface UserCredentialRepository extends JpaRepository<UserCredential, Long> {
 
+    boolean existsByLoginId(String loginId);
+
     /**
      * 로그인 ID로 인증정보 조회.
      * 회원 로그인 시 패스워드 검증 진입점이 됩니다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -1,0 +1,85 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 회원가입 비즈니스 로직.
+ */
+@Service
+@RequiredArgsConstructor
+public class RegisterAuthService {
+
+    private final UserRepository userRepository;
+    private final UserCredentialRepository userCredentialRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
+        String loginId = normalizeRequired(rawLoginId, "로그인 ID");
+        String password = normalizeRequired(rawPassword, "비밀번호");
+        String nickname = normalizeRequired(rawNickname, "닉네임");
+
+        validateDuplicate(loginId, nickname);
+
+        User savedUser;
+        try {
+            savedUser = userRepository.saveAndFlush(User.builder()
+                    .username(nickname)
+                    .userType(UserType.REGISTERED)
+                    .status(UserStatus.ACTIVE)
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+        }
+
+        try {
+            userCredentialRepository.saveAndFlush(UserCredential.builder()
+                    .user(savedUser)
+                    .loginId(loginId)
+                    .passwordHash(passwordEncoder.encode(password))
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다.");
+        }
+
+        return RegisterResponse.builder()
+                .userId(savedUser.getId())
+                .loginId(loginId)
+                .nickname(savedUser.getUsername())
+                .userType(savedUser.getUserType())
+                .build();
+    }
+
+    private void validateDuplicate(String loginId, String nickname) {
+        if (userCredentialRepository.existsByLoginId(loginId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다.");
+        }
+        if (userRepository.existsByUsername(nickname)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+        }
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        if (value == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+        }
+        String normalized = value.trim();
+        if (normalized.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -22,19 +22,25 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class RegisterAuthService {
 
+    private static final String ERR_DUPLICATE_LOGIN_ID = "이미 사용 중인 로그인 ID입니다.";
+    private static final String ERR_DUPLICATE_NICKNAME = "이미 사용 중인 닉네임입니다.";
+
     private final UserRepository userRepository;
     private final UserCredentialRepository userCredentialRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
-        String loginId = normalizeRequired(rawLoginId, "로그인 ID");
-        String password = normalizeRequired(rawPassword, "비밀번호");
-        String nickname = normalizeRequired(rawNickname, "닉네임");
+        String loginId = normalizeRequiredAtServiceBoundary(rawLoginId, "로그인 ID");
+        String password = normalizeRequiredAtServiceBoundary(rawPassword, "비밀번호");
+        String nickname = normalizeRequiredAtServiceBoundary(rawNickname, "닉네임");
 
         validateDuplicate(loginId, nickname);
 
         User savedUser;
+
+        // user_credentials 저장 실패 시 @Transactional에 의해 users 저장도 함께 롤백됨
+        // ResponseStatusException은 런타임 예외이므로 롤백 대상에 포함됨
         try {
             savedUser = userRepository.saveAndFlush(User.builder()
                     .username(nickname)
@@ -42,7 +48,7 @@ public class RegisterAuthService {
                     .status(UserStatus.ACTIVE)
                     .build());
         } catch (DataIntegrityViolationException e) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_NICKNAME);
         }
 
         try {
@@ -52,7 +58,7 @@ public class RegisterAuthService {
                     .passwordHash(passwordEncoder.encode(password))
                     .build());
         } catch (DataIntegrityViolationException e) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_LOGIN_ID);
         }
 
         return RegisterResponse.builder()
@@ -65,14 +71,17 @@ public class RegisterAuthService {
 
     private void validateDuplicate(String loginId, String nickname) {
         if (userCredentialRepository.existsByLoginId(loginId)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_LOGIN_ID);
         }
         if (userRepository.existsByUsername(nickname)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_NICKNAME);
         }
     }
 
-    private String normalizeRequired(String value, String fieldName) {
+    /**
+     * 서비스 직접 호출 경로를 위한 최소 방어선: trim + null/blank 차단.
+     */
+    private String normalizeRequiredAtServiceBoundary(String value, String fieldName) {
         if (value == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
         }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/PasswordConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/PasswordConfig.java
@@ -1,0 +1,18 @@
+package io.github.ascrew.monomatbe.global.config.SecurityConfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 비밀번호 해시 인코더 설정.
+ */
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -9,6 +9,7 @@ import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -47,13 +48,30 @@ class RegisterAuthServiceTest {
     }
 
     @Test
+    void register_trimsInputValues() {
+        String uniqueLoginId = "member_" + System.nanoTime();
+        String uniqueNickname = "nick_" + System.nanoTime();
+
+        RegisterResponse response = registerAuthService.register(
+                "  " + uniqueLoginId + "  ",
+                "  password123  ",
+                "  " + uniqueNickname + "  "
+        );
+
+        assertEquals(uniqueLoginId, response.loginId());
+        assertEquals(uniqueNickname, response.nickname());
+    }
+
+    @Test
     void register_duplicateLoginId_throwsConflict() {
         String loginId = "dup_login_" + System.nanoTime();
 
         registerAuthService.register(loginId, "password123", "dupNick_" + System.nanoTime());
 
-        assertThrows(ResponseStatusException.class, () ->
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
                 registerAuthService.register(loginId, "password123", "anotherNick_" + System.nanoTime()));
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        assertEquals("이미 사용 중인 로그인 ID입니다.", exception.getReason());
     }
 
     @Test
@@ -65,7 +83,25 @@ class RegisterAuthServiceTest {
                 .status(UserStatus.ACTIVE)
                 .build());
 
-        assertThrows(ResponseStatusException.class, () ->
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
                 registerAuthService.register("anotherLogin_" + System.nanoTime(), "password123", nickname));
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        assertEquals("이미 사용 중인 닉네임입니다.", exception.getReason());
+    }
+
+    @Test
+    void register_nullPassword_throwsBadRequest() {
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register("login_" + System.nanoTime(), null, "nick_" + System.nanoTime()));
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("비밀번호는 비어 있을 수 없습니다.", exception.getReason());
+    }
+
+    @Test
+    void register_blankLoginId_throwsBadRequest() {
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register("   ", "password123", "nick_" + System.nanoTime()));
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("로그인 ID는 비어 있을 수 없습니다.", exception.getReason());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -1,0 +1,71 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RegisterAuthServiceTest {
+
+    @Autowired
+    private RegisterAuthService registerAuthService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserCredentialRepository userCredentialRepository;
+
+    @Test
+    void register_success() {
+        String uniqueLoginId = "member_" + System.nanoTime();
+        String uniqueNickname = "nick_" + System.nanoTime();
+
+        RegisterResponse response = registerAuthService.register(
+                uniqueLoginId,
+                "password123",
+                uniqueNickname
+        );
+
+        assertNotNull(response.userId());
+        assertEquals(uniqueLoginId, response.loginId());
+        assertEquals(uniqueNickname, response.nickname());
+        assertEquals(UserType.REGISTERED, response.userType());
+    }
+
+    @Test
+    void register_duplicateLoginId_throwsConflict() {
+        String loginId = "dup_login_" + System.nanoTime();
+
+        registerAuthService.register(loginId, "password123", "dupNick_" + System.nanoTime());
+
+        assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register(loginId, "password123", "anotherNick_" + System.nanoTime()));
+    }
+
+    @Test
+    void register_duplicateNickname_throwsConflict() {
+        String nickname = "dup_nick_" + System.nanoTime();
+        userRepository.saveAndFlush(User.builder()
+                .username(nickname)
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register("anotherLogin_" + System.nanoTime(), "password123", nickname));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #32 
- #34 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `POST /api/auth/register` 회원가입 API 구현 (`AuthController`)
- 회원가입 요청/응답 DTO 추가 (`RegisterRequest`, `RegisterResponse`)
- 회원가입 비즈니스 로직 추가 (`RegisterAuthService`)
  - `users`에 `REGISTERED` 사용자 생성
  - `user_credentials`에 로그인 정보 저장
  - 비밀번호 BCrypt 해시 처리
- 로그인 ID 중복 확인용 `existsByLoginId` 추가 (`UserCredentialRepository`)
- 비밀번호 인코더 빈 등록 (`PasswordConfig`, `BCryptPasswordEncoder`)
- 중복 닉네임/로그인 ID에 대한 충돌 처리(409) 반영

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 이번 PR은 **회원가입(account 생성)까지만** 포함하며, 토큰 발급/로그인은 이슈 #35 범위로 분리했습니다.
- 회원가입은 사전 중복 체크 + DB Unique 제약 예외 매핑을 함께 사용해 동시성 상황에서도 409 응답을 보장합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- [Spring Security Password Encoding](https://docs.spring.io/spring-security/reference/features/authentication/password-storage.html)