### PR TITLE
[Feat/#18] 로비 생성 및 초대 코드 발급 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -52,6 +52,72 @@ POST /api/auth/guest
 
 ### 로비 (Lobby)
 
+### 로비 생성
+
+```
+POST /api/lobbies
+```
+
+로비를 생성하고 6자리 초대 코드를 발급합니다.
+JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 가능합니다.
+
+**Request Header**
+
+| 헤더 | 필수 | 설명 |
+|---|---|---|
+| `Authorization` | ✅ | `Bearer {accessToken}` |
+
+**Request Body**
+
+```json
+{
+  "title": "K-POP 퀴즈방",
+  "maxPlayers": 8,
+  "isPrivate": false,
+  "roundCount": 5,
+  "timeLimitSeconds": 30
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `title` | String | ✅ | 로비 제목 (최대 255자) |
+| `maxPlayers` | Integer | ✅ | 최대 참여 인원 (2~8) |
+| `isPrivate` | Boolean | ✅ | 비공개 여부 |
+| `roundCount` | Integer | ❌ | 라운드 수 (1~20, 기본값 5) |
+| `timeLimitSeconds` | Integer | ❌ | 제한 시간 초 (10~120, 기본값 30) |
+
+**Response `201 Created`**
+
+```json
+{
+  "lobbyId": 1,
+  "inviteCode": "ABC123",
+  "title": "K-POP 퀴즈방",
+  "maxPlayers": 8,
+  "isPrivate": false,
+  "status": "WAITING"
+}
+```
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `lobbyId` | Long | DB GAME_LOBBY.id (신고 참조용) |
+| `inviteCode` | String | 6자리 초대 코드 (딥링크: `/lobby/{inviteCode}`) |
+| `title` | String | 로비 제목 |
+| `maxPlayers` | Integer | 최대 참여 인원 |
+| `isPrivate` | Boolean | 비공개 여부 |
+| `status` | String | 로비 상태 (`WAITING`) |
+
+**Error**
+
+| 상태 코드 | 설명 |
+|---|---|
+| `401 Unauthorized` | JWT 토큰 없음 또는 만료 |
+| `503 Service Unavailable` | 초대 코드 생성 실패 (재시도 초과) |
+
+---
+
 #### 공개 로비 목록 조회
 
 ```
@@ -257,7 +323,6 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 |---|---|
 | 회원가입 | `POST /api/auth/register` |
 | 로그인 | `POST /api/auth/login` |
-| 로비 생성 | `POST /api/lobbies` |
 | 로비 초대 코드 입장 | `POST /api/lobbies/join` |
 | 맵 CRUD | `GET/POST/PUT/DELETE /api/maps` |
 | 맵 아이템(문제) CRUD | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,7 @@
 # Monomat-BE Architecture
 
 ## 📦 패키지 구조
-
-```
+```text
 src/main/java/io/github/ascrew/monomatbe/
 ├── MonomatBeApplication.java
 │
@@ -35,16 +34,23 @@ src/main/java/io/github/ascrew/monomatbe/
 │   └── lobby/                                      # 로비 도메인
 │       ├── LeaveLobbyResult.java                   # 퇴장 처리 결과 (sealed interface)
 │       ├── controller/
-│       │   ├── LobbyController.java                # HTTP REST API (로비 목록 조회)
+│       │   ├── LobbyController.java                # HTTP REST API (로비 생성, 목록 조회)
 │       │   └── LobbyEventController.java           # STOMP 로비 이벤트 수신
 │       ├── dto/
-│       │   └── LobbyRedisDto.java                  # 로비 정보 응답 DTO
+│       │   ├── CreateLobbyRequest.java             # 로비 생성 요청 DTO
+│       │   ├── CreateLobbyResponse.java            # 로비 생성 응답 DTO (inviteCode 포함)
+│       │   └── LobbyRedisDto.java                  # 로비 목록 조회 응답 DTO
+│       ├── entity/
+│       │   ├── GameLobby.java                      # GAME_LOBBY 테이블 엔티티
+│       │   ├── LobbyDefaults.java                  # 로비 생성 기본값 및 상수
+│       │   └── LobbyStatus.java                    # 로비 상태 열거형 (WAITING, PLAYING, FINISHED)
 │       ├── repository/
-│       │   ├── LobbyRepository.java                # 로비 데이터 접근 인터페이스
-│       │   └── LobbyRepositoryImpl.java            # Redis 기반 구현체 (Lua 스크립트 활용)
+│       │   ├── GameLobbyJpaRepository.java         # GAME_LOBBY JPA 리포지토리
+│       │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
+│       │   └── LobbyRepositoryImpl.java            # Redis 기반 구현체 (SETNX, Lua 스크립트 활용)
 │       └── service/
 │           ├── LobbyEventService.java              # 로비 이벤트 처리 및 STOMP 브로드캐스트
-│           └── LobbyService.java                   # 로비 조회 비즈니스 로직
+│           └── LobbyService.java                   # 로비 생성/조회 비즈니스 로직
 │
 └── global/                                         # 전역 인프라 레이어
     ├── config/                                     # 애플리케이션 설정
@@ -65,21 +71,24 @@ src/main/java/io/github/ascrew/monomatbe/
     │   └── RedisSubscriber.java                    # Redis 채널 메시지 수신 → WebSocket 브로드캐스트
     │
     ├── websocket/                                  # WebSocket 인프라
-        ├── CustomStompErrorHandler.java            # STOMP ERROR 프레임 핸들러
-        ├── StompChannelInterceptor.java            # CONNECT/SUBSCRIBE/SEND 인증 검증
-        ├── WebSocketEventListener.java             # WebSocket 연결 생명주기 이벤트 처리
-        ├── WebSocketMetric.java                    # 활성 세션 수 Prometheus 메트릭
-        ├── WebSocketSessionUtils.java              # 세션 식별자 추출 공통 유틸
-        ├── dto/
-        │   └── ChatMessageDto.java                 # WebSocket 채팅 메시지 DTO
-        └── event/
-            └── PlayerLeaveEvent.java               # 플레이어 퇴장 Spring 이벤트 객체
+    │   ├── CustomStompErrorHandler.java            # STOMP ERROR 프레임 핸들러
+    │   ├── StompChannelInterceptor.java            # CONNECT/SUBSCRIBE/SEND 인증 검증
+    │   ├── WebSocketEventListener.java             # WebSocket 연결 생명주기 이벤트 처리
+    │   ├── WebSocketMetric.java                    # 활성 세션 수 Prometheus 메트릭
+    │   ├── WebSocketSessionUtils.java              # 세션 식별자 추출 공통 유틸
+    │   ├── dto/
+    │   │   └── ChatMessageDto.java                 # WebSocket 채팅 메시지 DTO
+    │   └── event/
+    │       └── PlayerLeaveEvent.java               # 플레이어 퇴장 Spring 이벤트 객체
     └── security/
+        ├── SecurityEndpoints.java                  # Security 경로 상수 중앙화
         └── jwt/
+            ├── CustomPrincipal.java                # JWT 인증 주체 (userId + userIdentifier)
+            ├── JwtAuthenticationFilter.java        # Bearer 토큰 검증 및 SecurityContext 저장
+            ├── JwtClaims.java                      # JWT 클레임 키 상수 (발급/검증 공유)
             ├── JwtTokenProvider.java               # JWT Access/Refresh 토큰 발급
             └── TokenWithExpiry.java                # 토큰 + 만료시각 DTO
 ```
-
 ---
 
 ## 🏛️ 아키텍처 원칙
@@ -174,6 +183,8 @@ leave_lobby.lua
 | `lobby:{code}:participants` | Set | 로비 참여자 식별자 목록 |
 | `lobby:{code}:order` | List | 입장 순서 (방장 위임 시 LINDEX 0 사용) |
 | `lobby:public` | Set | 공개 로비 코드 목록 (고속 필터링용) |
+| `auth:guest:session:{token}` | Hash | 게스트 세션 정보 (userId, username, userType, TTL 30일) |
+| `auth:refresh:{sessionId}` | String | Refresh Token (TTL 30일) |
 | `user_status:{userIdentifier}` | String | 사용자 온라인 상태 (`ONLINE`, TTL 2시간) |
 | `ws:connection:{wsSessionId}` | Hash | WebSocket 세션 → userId, lobbyCode 매핑 |
 
@@ -217,6 +228,26 @@ Redis는 싱글 스레드로 Lua 스크립트를 실행하므로 다수의 동�
 `lobby:{code}:participants`를 단일 진실의 원천으로 통일하여
 입장(Java) → 퇴장(Lua) 모두 동일한 키를 사용합니다.
 
+### SETNX 기반 초대 코드 중복 방지
+
+`LobbyRepositoryImpl.acquireInviteCode()`는 6자리 초대 코드를 생성할 때
+`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.
+선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`(5회)까지 재시도합니다.
+락 TTL은 10초로 설정하여 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
+
+### JWT 인증 구조
+
+`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.
+파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.
+컨트롤러에서는 `@AuthenticationPrincipal CustomPrincipal`로 주입받아 사용합니다.
+
+JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
+`JwtTokenProvider`(발급)와 `JwtAuthenticationFilter`(검증) 간 키 불일치를 컴파일 타임에 방지합니다.
+
+[식별자 분리]
+- `userId` (Long) : DB users.id FK 참조용
+- `userIdentifier` (UUID String) : Redis/WebSocket 식별자
+
 ---
 
 ## 🌐 STOMP 채널 구조
@@ -257,4 +288,24 @@ StompChannelInterceptor.handleConnect()
     │ 세션에 userIdentifier 저장
     ▼
 이후 모든 STOMP 명령에서 세션의 userIdentifier 검증
+```
+
+### REST API 인증 흐름
+
+```
+HTTP 요청 (Authorization: Bearer {accessToken})
+    │
+    ▼
+JwtAuthenticationFilter
+    │ 1. Authorization 헤더에서 Bearer 토큰 추출
+    │ 2. JWT 서명 검증 (secretKey)
+    │ 3. userId, userIdentifier, userType 클레임 추출 (JwtClaims 상수)
+    │ 4. CustomPrincipal 생성 → SecurityContext 저장
+    ▼
+Controller
+    │ @AuthenticationPrincipal CustomPrincipal로 주입
+    │ - principal.userId()          → DB Insert FK 용도
+    │ - principal.userIdentifier()  → Redis 저장 식별자 용도
+    ▼
+Service
 ```

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
@@ -153,10 +153,12 @@ public class GuestAuthService {
      */
     private void storeGuestSessionToRedis(User user, String userIdentifier, String refreshToken) {
         String guestSessionKey = RedisKeys.guestSessionKey(userIdentifier);
+
+        // RedisKeys.FIELD_GUEST_* 상수로 Hash 필드 키 참조 (오타 방지)
         redisTemplate.opsForHash().putAll(guestSessionKey, Map.of(
-                "userId", String.valueOf(user.getId()),
-                "username", user.getUsername(),
-                "userType", user.getUserType().name()
+                RedisKeys.FIELD_GUEST_USER_ID, String.valueOf(user.getId()),
+                RedisKeys.FIELD_GUEST_USERNAME, user.getUsername(),
+                RedisKeys.FIELD_GUEST_USER_TYPE, user.getUserType().name()
         ));
         redisTemplate.expire(guestSessionKey, GUEST_SESSION_TTL);
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -7,14 +7,23 @@
  */
 package io.github.ascrew.monomatbe.domain.lobby.controller;
 
+import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
+import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,7 +36,55 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LobbyController {
 
+    // =========================================================
+    // 로그 메시지 상수
+    // =========================================================
+
+    private static final String LOG_CREATE_LOBBY_REQUEST =
+            "요청 수신: 로비 생성 [POST /api/lobbies] - 방장: {}";
+    private static final String LOG_CREATE_LOBBY_RESPONSE =
+            "로비 생성 응답 - 코드: {}";
+    private static final String LOG_GET_PUBLIC_LOBBIES_REQUEST =
+            "요청 수신: 공개 로비 목록 조회 [GET /api/lobbies]";
+    private static final String LOG_GET_PUBLIC_LOBBIES_RESPONSE =
+            "조회 완료: 공개 로비 {}개 반환";
+
     private final LobbyService lobbyService;
+
+    /**
+     * 로비 생성 API
+     *
+     * [인증]
+     * JWT Access Token이 필요합니다.
+     * @AuthenticationPrincipal로 CustomPrincipal을 주입받아
+     * userId(DB용)와 userIdentifier(Redis용)를 서비스로 전달한다.
+     *
+     * [권한]
+     * 게스트(GUEST)와 정식 회원(REGISTERED) 모두 로비를 생성할 수 있다.
+     *
+     * @param request   로비 생성 요청 DTO (@Valid 검증 적용)
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 201 Created + 생성된 로비 정보
+     */
+    @Operation(
+            summary = "로비 생성",
+            description = "로비를 생성하고 6자리 초대 코드를 발급합니다. JWT 인증이 필요합니다."
+    )
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<CreateLobbyResponse> createLobby(
+            @Valid @RequestBody CreateLobbyRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(LOG_CREATE_LOBBY_REQUEST, principal.userIdentifier());
+
+        CreateLobbyResponse response = lobbyService.createLobby(request, principal);
+
+        log.info(LOG_CREATE_LOBBY_RESPONSE, response.inviteCode());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
 
     /**
      * 공개 로비 목록 조회 API.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -95,11 +95,11 @@ public class LobbyController {
     @Operation(summary = "공개 로비 목록 조회", description = "Redis에서 공개 상태인 로비만 필터링하여 반환합니다.")
     @GetMapping
     public ResponseEntity<List<LobbyRedisDto>> getPublicLobbies() {
-        log.info("요청 수신: 공개 로비 목록 조회 [GET /api/lobbies]");
+        log.info(LOG_GET_PUBLIC_LOBBIES_REQUEST);
 
         List<LobbyRedisDto> publicLobbies = lobbyService.getPublicLobbies();
 
-        log.info("조회 완료: 공개 로비 {}개 반환", publicLobbies.size());
+        log.info(LOG_GET_PUBLIC_LOBBIES_RESPONSE, publicLobbies.size());
 
         return ResponseEntity.ok(publicLobbies);
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyRequest.java
@@ -1,0 +1,54 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 로비 생성 요청 DTO.
+ *
+ * [기본값 처리]
+ * roundCount, timeLimitSeconds는 클라이언트가 null로 생략하면 LobbyDefaults 상수값으로 자동 적용된다.
+ *
+ * [검증 규칙 — 기능명세서 기준]
+ * - title      : 필수, 최대 255자
+ * - maxPlayers : 2~8명
+ * - roundCount : 1~20 (생략 시 기본값 5)
+ * - timeLimitSeconds : 10~120초 (생략 시 기본값 30)
+ */
+public record CreateLobbyRequest(
+
+        @NotBlank(message = "로비 제목은 비어 있을 수 없습니다.")
+        @Size(max = 255, message = "로비 제목은 255자를 초과할 수 없습니다.")
+        String title,
+
+        @Min(value = 2, message = "최대 인원은 2명 이상이어야 합니다.")
+        @Max(value = 8, message = "최대 인원은 8명 이하이어야 합니다.")
+        int maxPlayers,
+
+        boolean isPrivate,
+
+        @Min(value = 1, message = "라운드 수는 1 이상이어야 합니다.")
+        @Max(value = 20, message = "라운드 수는 20 이하이어야 합니다.")
+        Integer roundCount,
+
+        @Min(value = 10, message = "제한 시간은 10초 이상이어야 합니다.")
+        @Max(value = 120, message = "제한 시간은 120초 이하이어야 합니다.")
+        Integer timeLimitSeconds
+) {
+    /**
+     * 기본값 적용 compact constructor.
+     * roundCount, timeLimitSeconds가 null이면 LobbyDefaults 상수값으로 대체한다.
+     * Integer(nullable) 선언으로 @Min 검증과 충돌 없이 기본값을 적용한다.
+     */
+    public CreateLobbyRequest {
+        if (roundCount == null) {
+            roundCount = LobbyDefaults.DEFAULT_ROUND_COUNT;
+        }
+        if (timeLimitSeconds == null) {
+            timeLimitSeconds = LobbyDefaults.DEFAULT_TIME_LIMIT_SECONDS;
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyResponse.java
@@ -1,0 +1,27 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import lombok.Builder;
+
+/**
+ * 로비 생성 응답 DTO.
+ *
+ * [딥링크 설계]
+ * 프론트엔드가 /lobby/{inviteCode} 경로로 바로 이동할 수 있도록 inviteCode를 응답에 포함한다.
+ *
+ * [필드 구성]
+ * - lobbyId    : DB GAME_LOBBY.id (신고 등 참조용)
+ * - inviteCode : 6자리 고유 코드 (딥링크 및 초대용)
+ * - title      : 로비 제목
+ * - maxPlayers : 최대 참여 인원
+ * - isPrivate  : 공개/비공개 여부
+ * - status     : 로비 상태 (생성 직후 WAITING)
+ */
+@Builder
+public record CreateLobbyResponse(
+        Long lobbyId,
+        String inviteCode,
+        String title,
+        int maxPlayers,
+        boolean isPrivate,
+        String status
+) {}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
@@ -37,20 +37,25 @@ import java.time.LocalDateTime;
  * [host_user_id]
  * Redis의 host_user_id(UUID String)와 달리 DB에는 users.id(Long)를 FK로 저장한다.
  * 두 식별자의 역할 분리는 ARCHITECTURE.md 인증 구조를 따른다.
+ *
+ * [기본값 정책 — @PrePersist 단일 책임]
+ * status, isDeleted, createdAt의 기본값은 @PrePersist에서만 설정한다.
+ * 서비스 레이어(LobbyService)는 이 필드들을 Builder에서 명시하지 않으며,
+ * @PrePersist가 유일한 기본값 설정 지점이다.
+ * 이를 통해 기본값 로직이 분산되지 않고 엔티티에 캡슐화된다.
  */
 @Getter
 @Entity
-@Builder // 객체 생성 시 가독성과 유연성을 높이기 위해 빌더 패턴을 적용
-@Table(name = "GAME_LOBBY") // 데이터베이스에 생성될 테이블 이름
+@Builder
+@Table(name = "GAME_LOBBY")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GameLobby {
 
-    @Id // 이 필드가 테이블의 기본 키 (Primary Key)
+    @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 방장 (User) 정보와의 다대일 (N:1) 연관관계 매핑
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "host_user_id", nullable = false)
     private User host;
@@ -58,7 +63,15 @@ public class GameLobby {
     @Column(name = "map_id")
     private Long mapId;
 
-    @Column(name = "invite_code", nullable = false, unique = true, length = 12)
+    /**
+     * 로비 초대 코드.
+     *
+     * [length 설정]
+     * 초대 코드는 LobbyDefaults.INVITE_CODE_LENGTH 상수 기준 6자리
+     * @Column의 length는 컴파일 타임 상수만 허용하므로 직접 참조할 수 없다.
+     * LobbyDefaults.INVITE_CODE_LENGTH 값과 반드시 동기화되어야 한다.
+     */
+    @Column(name = "invite_code", nullable = false, unique = true, length = 6)
     private String inviteCode;
 
     @Column(name = "title", nullable = false, length = 255)
@@ -76,26 +89,25 @@ public class GameLobby {
     @Column(name = "is_private", nullable = false)
     private Boolean isPrivate;
 
-    // 로비 현재 상태 (예 : WAITING, PLAYING 등)
-    // EnumType.STRING : Enum의 순서 (숫자)가 아닌 문자열 이름 자체를 DB에 저장하여 데이터 정합성을 보호한다.
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private LobbyStatus status;
 
-    // 로비가 파괴되었는지 여부를 나타내는 논리적 삭제 (Soft Delete) 플래그
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted;
 
-    // 로비 생성 시간
-    // 한 번 생성된 이후에는 수정되지 않도록 막아 데이터 불변성을 보장한다.
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     /**
      * DB 저장 전 기본값을 보정한다.
      *
+     * [단일 책임 원칙 — 기본값 설정의 유일한 지점]
+     * status, isDeleted, createdAt의 기본값은 이 메서드에서만 설정한다.
+     * 서비스 레이어에서 이 필드들을 Builder로 명시하지 않는 것이 의도된 설계이다.
+     *
      * [보정 항목]
-     * - createdAt : 서비스 레이어에서 누락 시 자동 세팅 (User, GuestSession과 동일한 패턴)
+     * - createdAt : Builder에서 누락 시 자동 세팅
      * - status    : 로비 생성 시 항상 WAITING이 초기값
      * - isDeleted : 생성 시 삭제 상태가 아님
      */
@@ -105,10 +117,10 @@ public class GameLobby {
             this.createdAt = LocalDateTime.now();
         }
         if (this.status == null) {
-            this.status = LobbyStatus.WAITING; // 초기 상태는 항상 '대기 중'
+            this.status = LobbyStatus.WAITING;
         }
         if (this.isDeleted == null) {
-            this.isDeleted = false; // 방금 생성했으므로 삭제되지 않은 상태
+            this.isDeleted = false;
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
@@ -1,0 +1,130 @@
+package io.github.ascrew.monomatbe.domain.lobby.entity;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게임 로비 엔티티.
+ *
+ * [설계 의도 — ARCHITECTURE.md 기준]
+ * 실시간 로비 상태는 Redis에서 관리한다.
+ * 이 테이블은 아래 두 가지 목적으로만 사용된다.
+ *   1. 로비 생성 시점의 스냅샷 영속화 (장애 복구 대비)
+ *   2. 신고(report) 기능의 target_id 레퍼런스
+ *
+ * [Soft Delete]
+ * 로비 폭파 시 레코드를 물리 삭제하지 않고 is_deleted = true로 처리한다.
+ * 신고 이력 추적 및 운영 감사 로그 보존을 위해 map, map_item과 동일한 정책을 적용한다.
+ *
+ * [host_user_id]
+ * Redis의 host_user_id(UUID String)와 달리 DB에는 users.id(Long)를 FK로 저장한다.
+ * 두 식별자의 역할 분리는 ARCHITECTURE.md 인증 구조를 따른다.
+ */
+@Getter
+@Entity
+@Builder // 객체 생성 시 가독성과 유연성을 높이기 위해 빌더 패턴을 적용
+@Table(name = "GAME_LOBBY") // 데이터베이스에 생성될 테이블 이름
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GameLobby {
+
+    @Id // 이 필드가 테이블의 기본 키 (Primary Key)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 방장 (User) 정보와의 다대일 (N:1) 연관관계 매핑
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "host_user_id", nullable = false)
+    private User host;
+
+    @Column(name = "map_id")
+    private Long mapId;
+
+    @Column(name = "invite_code", nullable = false, unique = true, length = 12)
+    private String inviteCode;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "max_players", nullable = false)
+    private Integer maxPlayers;
+
+    @Column(name = "round_count", nullable = false)
+    private Integer roundCount;
+
+    @Column(name = "time_limit_seconds", nullable = false)
+    private Integer timeLimitSeconds;
+
+    @Column(name = "is_private", nullable = false)
+    private Boolean isPrivate;
+
+    // 로비 현재 상태 (예 : WAITING, PLAYING 등)
+    // EnumType.STRING : Enum의 순서 (숫자)가 아닌 문자열 이름 자체를 DB에 저장하여 데이터 정합성을 보호한다.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private LobbyStatus status;
+
+    // 로비가 파괴되었는지 여부를 나타내는 논리적 삭제 (Soft Delete) 플래그
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+    // 로비 생성 시간
+    // 한 번 생성된 이후에는 수정되지 않도록 막아 데이터 불변성을 보장한다.
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * DB 저장 전 기본값을 보정한다.
+     *
+     * [보정 항목]
+     * - createdAt : 서비스 레이어에서 누락 시 자동 세팅 (User, GuestSession과 동일한 패턴)
+     * - status    : 로비 생성 시 항상 WAITING이 초기값
+     * - isDeleted : 생성 시 삭제 상태가 아님
+     */
+    @PrePersist
+    public void prePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+        if (this.status == null) {
+            this.status = LobbyStatus.WAITING; // 초기 상태는 항상 '대기 중'
+        }
+        if (this.isDeleted == null) {
+            this.isDeleted = false; // 방금 생성했으므로 삭제되지 않은 상태
+        }
+    }
+
+    /**
+     * 로비 폭파 시 Soft Delete 처리한다.
+     * Redis에서 로비가 제거된 이후 DB 이력 보존을 위해 사용한다.
+     */
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+    /**
+     * 로비 상태를 변경한다.
+     * WAITING → PLAYING 전이 시 사용한다.
+     */
+    public void changeStatus(LobbyStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/LobbyDefaults.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/LobbyDefaults.java
@@ -1,0 +1,39 @@
+package io.github.ascrew.monomatbe.domain.lobby.entity;
+
+import java.time.Duration;
+
+/**
+ * 로비 생성 시 사용하는 기본값 및 상수 클래스
+ *
+ * [기능명세서 기준]
+ * - 라운드 수 기본값: 5
+ * - 제한 시간 기본값: 30초
+ * - 초대 코드 길이: 6자리
+ * - 초대 코드 최대 재시도: 5회
+ * - 초대 코드 락 TTL: 10초 (생성 실패 시 자동 해제)
+ */
+public final class LobbyDefaults {
+
+    private LobbyDefaults() {}
+
+    /** 기본 라운드 수 */
+    public static final int DEFAULT_ROUND_COUNT = 5;
+
+    /** 기본 문제당 제한 시간 (초) */
+    public static final int DEFAULT_TIME_LIMIT_SECONDS = 30;
+
+    /** 초대 코드 길이 */
+    public static final int INVITE_CODE_LENGTH = 6;
+
+    /** 초대 코드 생성 최대 재시도 횟수 */
+    public static final int INVITE_CODE_MAX_RETRY = 5;
+
+    /** 초대 코드 구성 문자 (대문자 + 숫자) */
+    public static final String INVITE_CODE_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    /**
+     * 초대 코드 SETNX 락 TTL.
+     * 로비 생성 실패 시 자동 해제되어 코드 공간을 반환한다.
+     */
+    public static final Duration INVITE_CODE_LOCK_TTL = Duration.ofSeconds(10);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/LobbyStatus.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/LobbyStatus.java
@@ -1,0 +1,13 @@
+package io.github.ascrew.monomatbe.domain.lobby.entity;
+
+/**
+ * 로비 상태 열거형.
+ * - WAITING  : 게임 시작 전 대기 중
+ * - PLAYING  : 게임 진행 중
+ * - FINISHED : 게임 종료
+ */
+public enum LobbyStatus {
+    WAITING,
+    PLAYING,
+    FINISHED
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
@@ -1,0 +1,33 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository;
+
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * GAME_LOBBY 테이블 접근 JPA 리포지토리.
+ *
+ * [LobbyRepository(Redis)와 분리한 이유]
+ * LobbyRepository는 실시간 Redis 데이터를 다루는 인터페이스
+ * DB 영속성은 JPA 리포지토리로 분리하여 각 저장소의 책임을 명확히 한다.
+ *
+ * [네이밍 규칙]
+ * Redis 기반 LobbyRepository와 구분하기 위해 GameLobbyJpaRepository로 명명함
+ */
+// JpaRepository<엔티티 클래스, 엔티티의 PK 타입>을 상속받아 기본적인 CRUD 메서드를 자동으로 제공받는다.
+public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
+
+    /**
+     * 초대 코드로 로비를 조회
+     * 로비 입장, 신고 등 invite_code 기반 조회에 사용된다.
+     */
+    Optional<GameLobby> findByInviteCode(String inviteCode);
+
+    /**
+     * 초대 코드 존재 여부를 확인한다.
+     * 로비 생성 시 invite_code 중복 체크에 사용된다.
+     * Redis SETNX와 이중 방어선으로 동작한다.
+     */
+    boolean existsByInviteCode(String inviteCode);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -20,36 +20,35 @@ public interface LobbyRepository {
 
   /**
    * Redis에 로비 데이터를 저장하고 초대 코드를 반환한다.
-   *
-   * [SETNX 기반 초대 코드 중복 방지]
-   * 코드 생성 → SETNX 선점 → 실패 시 재시도 로직을 포함한다.
-   * 최대 재시도 횟수 초과 시 예외를 던진다.
    */
   String saveToRedis(CreateLobbyRequest request, String userIdentifier);
 
   /**
    * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
-   * [보장 삭제 대상]
+   *
+   * [보상 삭제 대상]
    * - lobby:{code} Hash
    * - lobby:{code}:participants Set
    * - lobby:{code}:order List
    * - lobby:public Set에서 코드 제거
    * - lobby:code:lock:{code} 락 키
+   *
+   * 반환 타입을 void → boolean으로 변경
+   * 보상 삭제 성공 여부를 서비스 레이어에서 확인하여
+   * 실패 시 모니터링 가능한 로그/알림 처리를 가능하게 한다.
+   *
+   * @param inviteCode 삭제할 로비 초대 코드
+   * @return 보상 삭제 성공 여부 (true: 성공, false: 실패)
    */
-  void deleteFromRedis(String inviteCode);
+  boolean deleteFromRedis(String inviteCode);
 
   /**
-   * Lua 스크립트를 실행하여 퇴장 처리를 원자적으로 수행합니다.
-   *
-   * [반환 타입 변경 이유]
-   * 기존 String 반환 방식은 서비스 레이어에서 문자열 파싱을 해야 했습니다.
-   * LeaveLobbyResult sealed interface로 변경하여 파싱 책임을 Repository로 캡슐화하고
-   * 서비스 레이어는 순수한 도메인 결과만 받도록 개선합니다.
+   * Lua 스크립트를 실행하여 퇴장 처리를 원자적으로 수행한다.
    *
    * @return LeaveLobbyResult (Destroyed | Delegated | Left | Error)
    */
   LeaveLobbyResult executeLeaveLobbyProcess(String code, String userId);
 
-  /** Redis에서 공개 로비 목록을 필터링하여 반환합니다. */
+  /** Redis에서 공개 로비 목록을 필터링하여 반환한다. */
   List<LobbyRedisDto> getPublicLobbies();
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -5,6 +5,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 
 import java.util.List;
@@ -16,6 +17,15 @@ public interface LobbyRepository {
 
   /** 해당 유저가 해당 로비의 참여자인지 확인합니다. */
   boolean isParticipant(String code, String userId);
+
+  /**
+   * Redis에 로비 데이터를 저장하고 초대 코드를 반환한다.
+   *
+   * [SETNX 기반 초대 코드 중복 방지]
+   * 코드 생성 → SETNX 선점 → 실패 시 재시도 로직을 포함한다.
+   * 최대 재시도 횟수 초과 시 예외를 던진다.
+   */
+  String saveToRedis(CreateLobbyRequest request, String userIdentifier);
 
   /**
    * Lua 스크립트를 실행하여 퇴장 처리를 원자적으로 수행합니다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -28,6 +28,17 @@ public interface LobbyRepository {
   String saveToRedis(CreateLobbyRequest request, String userIdentifier);
 
   /**
+   * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
+   * [보장 삭제 대상]
+   * - lobby:{code} Hash
+   * - lobby:{code}:participants Set
+   * - lobby:{code}:order List
+   * - lobby:public Set에서 코드 제거
+   * - lobby:code:lock:{code} 락 키
+   */
+  void deleteFromRedis(String inviteCode);
+
+  /**
    * Lua 스크립트를 실행하여 퇴장 처리를 원자적으로 수행합니다.
    *
    * [반환 타입 변경 이유]

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -11,13 +11,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,9 +27,17 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   private final StringRedisTemplate redisTemplate;
   private final RedisScript<String> leaveLobbyScript;
+  private final RedisScript<String> createLobbyScript;
 
   // =========================================================
-  // Lua 스크립트 반환값 상수
+  // create_lobby.lua 반환값 상수
+  // =========================================================
+
+  private static final String RESULT_OK = "OK";
+  private static final String RESULT_LOCK_FAILED = "LOCK_FAILED";
+
+  // =========================================================
+  // leave_lobby.lua 반환값 상수
   // =========================================================
 
   private static final String RESULT_DESTROYED = "DESTROYED";
@@ -66,7 +72,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   /**
-   * Redis에 로비 데이터를 저장하고 초대 코드를 반환한다.
+   * Lua 스크립트로 SETNX 선점과 로비 데이터 저장을 원자적으로 수행하고 초대 코드를 반환한다.
    *
    * [저장 구조]
    * - lobby:{code}              Hash — 로비 메타 정보
@@ -74,26 +80,35 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    * - lobby:{code}:order        List — 입장 순서 (방장 선 추가)
    * - lobby:public              Set  — 공개 로비 목록 (isPrivate=false 시만)
    *
-   * [SETNX 기반 코드 중복 방지]
-   * lobby:code:lock:{code} 키를 SETNX로 원자적 선점한다.
-   * 선점 실패 시 새 코드를 생성하여 재시도
-   * LobbyDefaults.INVITE_CODE_MAX_RETRY 초과 시 503 반환한다.
+   * [재시도 전략]
+   * LOCK_FAILED 반환 시 새 코드를 생성하여 재시도
+   * LobbyDefaults.INVITE_CODE_MAX_RETRY 초과 시 503을 반환한다.
    */
   @Override
   public String saveToRedis(CreateLobbyRequest request, String userIdentifier) {
-    String inviteCode = acquireInviteCode(userIdentifier);
+    for (int attempt = 0; attempt < LobbyDefaults.INVITE_CODE_MAX_RETRY; attempt++) {
+      String candidate = generateInviteCode();
+      String result = executeCreateLobbyScript(candidate, request, userIdentifier);
 
-    storelobbyData(request, inviteCode, userIdentifier);
+      if (RESULT_OK.equals(result)) {
+        log.info("로비 Redis 저장 완료 - 코드: {}, 방장: {}", candidate, userIdentifier);
+        return candidate;
+      }
 
-    log.info("로비 Redis 저장 완료 - 코드: {}, 방장: {}", inviteCode, userIdentifier);
-    return inviteCode;
+      log.warn("초대 코드 충돌 - 재시도 {}/{}: {}",
+              attempt + 1, LobbyDefaults.INVITE_CODE_MAX_RETRY, candidate);
+    }
+
+    throw new ResponseStatusException(
+            HttpStatus.SERVICE_UNAVAILABLE, ERROR_INVITE_CODE_EXHAUSTED);
   }
 
   /**
    * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
    *
    * [보상 삭제 이유]
-   * saveToRedis() 성공 후 DB Insert가 실패하면 Redis에 잔존 데이터가 남아 실제로 입장 불가능한 로비가 공개 목록에 노출되는 데이터 불일치가 발생한다.
+   * saveToRedis() 성공 후 DB Insert가 실패하면 Redis에 잔존 데이터가 남아
+   * 실제로 입장 불가능한 로비가 공개 목록에 노출되는 데이터 불일치가 발생한다.
    * 이를 방지하기 위해 DB 실패 시 Redis 데이터를 보상 삭제한다.
    *
    * [삭제 실패 처리]
@@ -103,22 +118,18 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   @Override
   public void deleteFromRedis(String inviteCode) {
     try {
-      // 로비 관련 키 일괄 삭제
       redisTemplate.delete(List.of(
               RedisKeys.lobbyKey(inviteCode),
               RedisKeys.lobbyParticipantsKey(inviteCode),
               RedisKeys.lobbyOrderKey(inviteCode),
-              RedisKeys.lobbyCodeLockKey(inviteCode) // 락 키도 함께 삭제
+              RedisKeys.lobbyCodeLockKey(inviteCode)
       ));
 
-      // 공개 로비 Set에서 제거
       redisTemplate.opsForSet().remove(RedisKeys.LOBBY_PUBLIC, inviteCode);
 
-      log.info("Redis 보상 삭제 완료 - 코드 : {}", inviteCode);
+      log.info("Redis 보상 삭제 완료 - 코드: {}", inviteCode);
     } catch (Exception e) {
-      // 보상 삭제 실패는 ERROR 레벨로 기록
-      // 수동 정리 또는 향ㅎ cleanup 배치 작업 필요
-      log.error("Redis 보상 삭제 실패 - 코드 : {}, 수동 정리 필요.", inviteCode, e);
+      log.error("Redis 보상 삭제 실패 - 코드: {}. 수동 정리 필요.", inviteCode, e);
     }
   }
 
@@ -135,8 +146,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       String result = redisTemplate.execute(leaveLobbyScript, keys, userId, code);
       return parseLuaResult(result, code, userId);
     } catch (Exception e) {
-      return new LeaveLobbyResult.Error(
-              "Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
+      return new LeaveLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
     }
   }
 
@@ -164,8 +174,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               .status((String) data.get(RedisKeys.FIELD_STATUS))
               .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
               .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
-              .isPrivate(Boolean.parseBoolean(
-                      (String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
+              .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
               .build());
     }
 
@@ -177,78 +186,44 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   // =========================================================
 
   /**
-   * SETNX로 초대 코드를 원자적으로 선점한다.
-   * 최대 재시도 횟수 초과 시 503 예외를 던진다.
+   * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행
+   *
+   * @return "OK" (성공) | "LOCK_FAILED" (코드 충돌)
    */
-  private String acquireInviteCode(String userIdentifier) {
-    for (int attempt = 0; attempt < LobbyDefaults.INVITE_CODE_MAX_RETRY; attempt++) {
-      String candidate = generateInviteCode();
-      String lockKey = RedisKeys.lobbyCodeLockKey(candidate);
-
-      Boolean acquired = redisTemplate.opsForValue()
-              .setIfAbsent(lockKey, userIdentifier, LobbyDefaults.INVITE_CODE_LOCK_TTL);
-
-      if (Boolean.TRUE.equals(acquired)) {
-        return candidate;
-      }
-
-      log.warn("초대 코드 충돌 - 재시도 {}/{}: {}",
-              attempt + 1, LobbyDefaults.INVITE_CODE_MAX_RETRY, candidate);
-    }
-
-    throw new ResponseStatusException(
-            HttpStatus.SERVICE_UNAVAILABLE, ERROR_INVITE_CODE_EXHAUSTED);
-  }
-
-  /**
-   * Redis에 로비 관련 데이터를 저장
-   * Hash, 참여자 Set, 입장 순서 List, 공개 Set에 각각 기록한다.
-   */
-  private void storelobbyData(
-          CreateLobbyRequest request,
+  private String executeCreateLobbyScript(
           String inviteCode,
+          CreateLobbyRequest request,
           String userIdentifier
   ) {
-    redisTemplate.opsForHash().putAll(
-            RedisKeys.lobbyKey(inviteCode),
-            buildLobbyHashData(request, inviteCode, userIdentifier)
+    List<String> keys = List.of(
+            RedisKeys.lobbyCodeLockKey(inviteCode),     // KEYS[1]
+            RedisKeys.lobbyKey(inviteCode),             // KEYS[2]
+            RedisKeys.lobbyParticipantsKey(inviteCode), // KEYS[3]
+            RedisKeys.lobbyOrderKey(inviteCode),        // KEYS[4]
+            RedisKeys.LOBBY_PUBLIC                      // KEYS[5]
     );
 
-    redisTemplate.opsForSet().add(
-            RedisKeys.lobbyParticipantsKey(inviteCode), userIdentifier);
+    String lockTtlMs = String.valueOf(LobbyDefaults.INVITE_CODE_LOCK_TTL.toMillis());
 
-    redisTemplate.opsForList().rightPush(
-            RedisKeys.lobbyOrderKey(inviteCode), userIdentifier);
-
-    if (!request.isPrivate()) {
-      redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, inviteCode);
-    }
+    return redisTemplate.execute(
+            createLobbyScript,
+            keys,
+            userIdentifier,                         // ARGV[1]
+            lockTtlMs,                              // ARGV[2]
+            inviteCode,                             // ARGV[3]
+            request.title(),                        // ARGV[4]
+            String.valueOf(request.maxPlayers()),   // ARGV[5]
+            String.valueOf(request.isPrivate()),    // ARGV[6]
+            LobbyStatus.WAITING.name()              // ARGV[7]
+    );
   }
 
   /**
-   * RedisKeys.FIELD_* 상수 기반으로 Redis Hash에 저장할 로비 데이터를 구성한다.
-   */
-  private Map<String, String> buildLobbyHashData(
-          CreateLobbyRequest request,
-          String inviteCode,
-          String userIdentifier
-  ) {
-    Map<String, String> data = new HashMap<>();
-    data.put(RedisKeys.FIELD_CODE, inviteCode);
-    data.put(RedisKeys.FIELD_HOST_USER_ID, userIdentifier);
-    data.put(RedisKeys.FIELD_TITLE, request.title());
-    data.put(RedisKeys.FIELD_MAX_PLAYERS, String.valueOf(request.maxPlayers()));
-    data.put(RedisKeys.FIELD_IS_PRIVATE, String.valueOf(request.isPrivate()));
-    data.put(RedisKeys.FIELD_STATUS, LobbyStatus.WAITING.name());
-    return data;
-  }
-
-  /**
-   * LobbyDefaults 상수 기반으로 6자리 초대 코드를 생성한다.
+   * LobbyDefaults 상수 기반으로 6자리 초대 코드를 생성
    *
    * [SecureRandom 사용 이유]
    * Random 대신 SecureRandom을 사용하여 코드 예측 가능성을 낮춘다.
-   * 게임 특성상 코드 추측으로 비공개 로비에 무단 입장하는 것을 방지한다..
+   * 게임 특성상 코드 추측으로 비공개 로비에 무단 입장하는 것을 방지한다.
    */
   private String generateInviteCode() {
     StringBuilder sb = new StringBuilder(LobbyDefaults.INVITE_CODE_LENGTH);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -1,41 +1,22 @@
-/*
- * LobbyRepository의 Redis 구현체.
- *
- * [설계 결정]
- * - StringRedisTemplate을 사용하는 이유:
- *   로비 데이터는 Redis Hash로 저장되며 Key/Value 모두 String입니다.
- *   RedisTemplate<String, Object>보다 가볍고 직렬화 오버헤드가 없습니다.
- *
- * - Lua 스크립트를 사용하는 이유:
- *   퇴장 처리 시 여러 Redis 키를 조작해야 하는데,
- *   Java 레벨에서 순차 처리하면 Race Condition이 발생할 수 있습니다.
- *   Lua 스크립트는 Redis 서버에서 원자적으로 실행되므로 이를 방지합니다.
- *
- * - Lua 반환값 파싱을 이 클래스에서 담당하는 이유:
- *   Redis 반환값의 문자열 포맷은 인프라 세부사항입니다.
- *   서비스 레이어가 "DELEGATED:" 같은 문자열 포맷을 알 필요가 없으며,
- *   파싱 책임을 Repository에 캡슐화하여 서비스는 순수한 도메인 결과만 받습니다.
- *
- * [리팩토링 변경 사항]
- * - getPublicLobbies()에서 Redis Hash 필드 키를 문자열 리터럴 대신 RedisKeys.FIELD_* 상수로 교체
- *   → 오타 방지 및 저장/조회 필드명 일관성 보장
- * - 누락된 DTO 필드(mapId, maxPlayers, isPrivate) 매핑 추가
- *   → 클라이언트에 완전한 로비 정보 전달
- * - Redis String → 숫자 타입 파싱 방어 메서드 추가 (parseNullableLong, parseNullableInt)
- *   → ClassCastException 및 NumberFormatException 방지
- */
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,40 +31,32 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   // =========================================================
   // Lua 스크립트 반환값 상수
-  // 서비스 레이어에 노출되지 않고 이 클래스 안에서만 사용됩니다.
   // =========================================================
 
-  /** Lua 스크립트 반환값 — 로비 폭파 (모든 인원 퇴장) */
   private static final String RESULT_DESTROYED = "DESTROYED";
-
-  /** Lua 스크립트 반환값 — 일반 유저 퇴장 */
   private static final String RESULT_LEFT = "LEFT";
-
-  /** Lua 스크립트 반환값 접두사 — 방장 위임 (뒤에 새 방장 ID가 붙음) */
   private static final String RESULT_DELEGATED_PREFIX = "DELEGATED:";
+
+  // =========================================================
+  // 초대 코드 생성 상수
+  // =========================================================
+
+  /** 초대 코드 생성용 보안 난수 생성기 */
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+  /** 초대 코드 생성 실패 시 반환할 에러 메시지 */
+  private static final String ERROR_INVITE_CODE_EXHAUSTED =
+          "초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
 
   // =========================================================
   // 공개 메서드
   // =========================================================
 
-  /**
-   * 해당 코드의 로비가 Redis에 존재하는지 확인합니다.
-   *
-   * @param code 로비 초대 코드
-   * @return 로비 Hash 키 존재 여부
-   */
   @Override
   public boolean existsByCode(String code) {
     return Boolean.TRUE.equals(redisTemplate.hasKey(RedisKeys.lobbyKey(code)));
   }
 
-  /**
-   * 해당 유저가 해당 로비의 참여자 Set에 포함되어 있는지 확인합니다.
-   *
-   * @param code   로비 초대 코드
-   * @param userId 사용자 식별자
-   * @return 참여자 여부
-   */
   @Override
   public boolean isParticipant(String code, String userId) {
     return Boolean.TRUE.equals(
@@ -92,23 +65,29 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   /**
-   * Lua 스크립트를 실행하여 퇴장 처리를 원자적으로 수행하고
-   * 결과를 도메인 객체(LeaveLobbyResult)로 변환하여 반환합니다.
+   * Redis에 로비 데이터를 저장하고 초대 코드를 반환한다.
    *
-   * [KEYS 구성]
-   * KEYS[1] = lobby:{code}              — 로비 메타 정보 Hash
-   * KEYS[2] = lobby:{code}:participants — 참여자 Set
-   * KEYS[3] = lobby:{code}:order        — 입장 순서 List
-   * KEYS[4] = lobby:public              — 전역 공개 로비 Set
+   * [저장 구조]
+   * - lobby:{code}              Hash — 로비 메타 정보
+   * - lobby:{code}:participants Set  — 참여자 목록 (방장 선 추가)
+   * - lobby:{code}:order        List — 입장 순서 (방장 선 추가)
+   * - lobby:public              Set  — 공개 로비 목록 (isPrivate=false 시만)
    *
-   * [ARGV 구성]
-   * ARGV[1] = userId  — 퇴장하는 유저 식별자
-   * ARGV[2] = code    — 로비 코드
-   *
-   * @param code   퇴장 처리 대상 로비 코드
-   * @param userId 퇴장하는 유저 식별자
-   * @return LeaveLobbyResult (Destroyed | Delegated | Left | Error)
+   * [SETNX 기반 코드 중복 방지]
+   * lobby:code:lock:{code} 키를 SETNX로 원자적 선점한다.
+   * 선점 실패 시 새 코드를 생성하여 재시도
+   * LobbyDefaults.INVITE_CODE_MAX_RETRY 초과 시 503 반환한다.
    */
+  @Override
+  public String saveToRedis(CreateLobbyRequest request, String userIdentifier) {
+    String inviteCode = acquireInviteCode(userIdentifier);
+
+    storelobbyData(request, inviteCode, userIdentifier);
+
+    log.info("로비 Redis 저장 완료 - 코드: {}, 방장: {}", inviteCode, userIdentifier);
+    return inviteCode;
+  }
+
   @Override
   public LeaveLobbyResult executeLeaveLobbyProcess(String code, String userId) {
     List<String> keys = List.of(
@@ -127,20 +106,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  /**
-   * Redis에서 공개 로비 목록을 조회하여 반환합니다.
-   *
-   * [동작 순서]
-   * 1. lobby:public Set에서 공개 로비 코드 목록을 가져옵니다.
-   * 2. 각 코드로 lobby:{code} Hash를 조회하여 DTO로 변환합니다.
-   * 3. Hash 데이터가 없는 코드(좀비 항목)는 건너뜁니다.
-   *
-   * [성능 고려사항]
-   * 현재 로비 수만큼 반복하여 Redis를 조회하는 N+1 구조입니다.
-   * TODO: 로비 수가 증가할 경우 Redis Pipeline 또는 MGET으로 최적화 필요
-   *
-   * @return 현재 공개 상태인 로비 DTO 목록
-   */
   @Override
   public List<LobbyRedisDto> getPublicLobbies() {
     Set<String> publicLobbyCodes =
@@ -156,21 +121,15 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       Map<Object, Object> data =
               redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(code));
 
-      // lobby:public에는 있지만 실제 Hash가 삭제된 좀비 항목 방어
       if (data.isEmpty()) continue;
 
       result.add(LobbyRedisDto.builder()
-              // [수정] 문자열 리터럴 → RedisKeys.FIELD_* 상수로 교체 (오타 방지)
               .code((String) data.get(RedisKeys.FIELD_CODE))
               .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
               .title((String) data.get(RedisKeys.FIELD_TITLE))
               .status((String) data.get(RedisKeys.FIELD_STATUS))
-
-              // [수정] 누락된 필드 3개 추가
-              // Redis는 모든 값을 String으로 저장하므로 숫자 타입은 안전하게 파싱
               .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
               .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
-              // "true" / "false" 문자열을 Boolean으로 변환
               .isPrivate(Boolean.parseBoolean(
                       (String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
               .build());
@@ -184,51 +143,106 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   // =========================================================
 
   /**
-   * Lua 스크립트 반환값을 LeaveLobbyResult 도메인 객체로 변환합니다.
-   *
-   * [캡슐화 이유]
-   * "DELEGATED:", "DESTROYED" 같은 Redis 반환 포맷은 인프라 세부사항입니다.
-   * 파싱 책임을 이 Repository 내부에 숨겨 서비스 레이어가
-   * Redis 반환 포맷을 알 필요 없도록 합니다.
-   *
-   * @param result Lua 스크립트 반환값 문자열
-   * @param code   퇴장 처리 대상 로비 코드
-   * @param userId 퇴장하는 유저 식별자
-   * @return 파싱된 LeaveLobbyResult 도메인 객체
+   * SETNX로 초대 코드를 원자적으로 선점한다.
+   * 최대 재시도 횟수 초과 시 503 예외를 던진다.
    */
+  private String acquireInviteCode(String userIdentifier) {
+    for (int attempt = 0; attempt < LobbyDefaults.INVITE_CODE_MAX_RETRY; attempt++) {
+      String candidate = generateInviteCode();
+      String lockKey = RedisKeys.lobbyCodeLockKey(candidate);
+
+      Boolean acquired = redisTemplate.opsForValue()
+              .setIfAbsent(lockKey, userIdentifier, LobbyDefaults.INVITE_CODE_LOCK_TTL);
+
+      if (Boolean.TRUE.equals(acquired)) {
+        return candidate;
+      }
+
+      log.warn("초대 코드 충돌 - 재시도 {}/{}: {}",
+              attempt + 1, LobbyDefaults.INVITE_CODE_MAX_RETRY, candidate);
+    }
+
+    throw new ResponseStatusException(
+            HttpStatus.SERVICE_UNAVAILABLE, ERROR_INVITE_CODE_EXHAUSTED);
+  }
+
+  /**
+   * Redis에 로비 관련 데이터를 저장
+   * Hash, 참여자 Set, 입장 순서 List, 공개 Set에 각각 기록한다.
+   */
+  private void storelobbyData(
+          CreateLobbyRequest request,
+          String inviteCode,
+          String userIdentifier
+  ) {
+    redisTemplate.opsForHash().putAll(
+            RedisKeys.lobbyKey(inviteCode),
+            buildLobbyHashData(request, inviteCode, userIdentifier)
+    );
+
+    redisTemplate.opsForSet().add(
+            RedisKeys.lobbyParticipantsKey(inviteCode), userIdentifier);
+
+    redisTemplate.opsForList().rightPush(
+            RedisKeys.lobbyOrderKey(inviteCode), userIdentifier);
+
+    if (!request.isPrivate()) {
+      redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, inviteCode);
+    }
+  }
+
+  /**
+   * RedisKeys.FIELD_* 상수 기반으로 Redis Hash에 저장할 로비 데이터를 구성한다.
+   */
+  private Map<String, String> buildLobbyHashData(
+          CreateLobbyRequest request,
+          String inviteCode,
+          String userIdentifier
+  ) {
+    Map<String, String> data = new HashMap<>();
+    data.put(RedisKeys.FIELD_CODE, inviteCode);
+    data.put(RedisKeys.FIELD_HOST_USER_ID, userIdentifier);
+    data.put(RedisKeys.FIELD_TITLE, request.title());
+    data.put(RedisKeys.FIELD_MAX_PLAYERS, String.valueOf(request.maxPlayers()));
+    data.put(RedisKeys.FIELD_IS_PRIVATE, String.valueOf(request.isPrivate()));
+    data.put(RedisKeys.FIELD_STATUS, LobbyStatus.WAITING.name());
+    return data;
+  }
+
+  /**
+   * LobbyDefaults 상수 기반으로 6자리 초대 코드를 생성한다.
+   *
+   * [SecureRandom 사용 이유]
+   * Random 대신 SecureRandom을 사용하여 코드 예측 가능성을 낮춘다.
+   * 게임 특성상 코드 추측으로 비공개 로비에 무단 입장하는 것을 방지한다..
+   */
+  private String generateInviteCode() {
+    StringBuilder sb = new StringBuilder(LobbyDefaults.INVITE_CODE_LENGTH);
+    for (int i = 0; i < LobbyDefaults.INVITE_CODE_LENGTH; i++) {
+      sb.append(LobbyDefaults.INVITE_CODE_CHARACTERS.charAt(
+              SECURE_RANDOM.nextInt(LobbyDefaults.INVITE_CODE_CHARACTERS.length())
+      ));
+    }
+    return sb.toString();
+  }
+
   private LeaveLobbyResult parseLuaResult(String result, String code, String userId) {
     if (result == null) {
       return new LeaveLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
     }
-
     if (RESULT_DESTROYED.equals(result)) {
       return new LeaveLobbyResult.Destroyed(code);
     }
-
     if (RESULT_LEFT.equals(result)) {
       return new LeaveLobbyResult.Left(code, userId);
     }
-
     if (result.startsWith(RESULT_DELEGATED_PREFIX)) {
-      // "DELEGATED:{newHostId}" 형태에서 새 방장 ID 추출
       String newHostId = result.substring(RESULT_DELEGATED_PREFIX.length());
       return new LeaveLobbyResult.Delegated(code, newHostId);
     }
-
     return new LeaveLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
   }
 
-  /**
-   * Redis에서 조회한 Object 값을 Long으로 안전하게 변환합니다.
-   *
-   * Redis는 모든 Hash 값을 String으로 저장하므로,
-   * Long 타입 필드는 반드시 String → Long 파싱이 필요합니다.
-   * 값이 null이거나 숫자가 아닌 경우 null을 반환하여
-   * NumberFormatException이 서비스 레이어로 전파되는 것을 방지합니다.
-   *
-   * @param value Redis Hash에서 조회한 원시 값 (null 허용)
-   * @return 변환된 Long, 변환 불가 시 null
-   */
   private Long parseNullableLong(Object value) {
     if (value == null) return null;
     try {
@@ -239,17 +253,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  /**
-   * Redis에서 조회한 Object 값을 Integer로 안전하게 변환합니다.
-   *
-   * Redis는 모든 Hash 값을 String으로 저장하므로,
-   * Integer 타입 필드는 반드시 String → Integer 파싱이 필요합니다.
-   * 값이 null이거나 숫자가 아닌 경우 null을 반환하여
-   * NumberFormatException이 서비스 레이어로 전파되는 것을 방지합니다.
-   *
-   * @param value Redis Hash에서 조회한 원시 값 (null 허용)
-   * @return 변환된 Integer, 변환 불가 시 null
-   */
   private Integer parseNullableInt(Object value) {
     if (value == null) return null;
     try {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -45,6 +45,16 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String RESULT_DELEGATED_PREFIX = "DELEGATED:";
 
   // =========================================================
+  // isPrivate 정규화 상수
+  // =========================================================
+
+  /** Lua 스크립트에 전달할 공개 로비 isPrivate 값 */
+  private static final String IS_PRIVATE_TRUE = "true";
+
+  /** Lua 스크립트에 전달할 비공개 로비 isPrivate 값 */
+  private static final String IS_PRIVATE_FALSE = "false";
+
+  // =========================================================
   // 초대 코드 생성 상수
   // =========================================================
 
@@ -54,6 +64,10 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   /** 초대 코드 생성 실패 시 반환할 에러 메시지 */
   private static final String ERROR_INVITE_CODE_EXHAUSTED =
           "초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
+  /** Lua 스크립트 null 반환 시 에러 메시지 */
+  private static final String ERROR_REDIS_SCRIPT_NULL =
+          "Redis 스크립트 실행 결과가 null입니다. Redis 연결 상태를 확인해주세요.";
 
   // =========================================================
   // 공개 메서드
@@ -81,8 +95,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    * - lobby:public              Set  — 공개 로비 목록 (isPrivate=false 시만)
    *
    * [재시도 전략]
-   * LOCK_FAILED 반환 시 새 코드를 생성하여 재시도
-   * LobbyDefaults.INVITE_CODE_MAX_RETRY 초과 시 503을 반환한다.
+   * - LOCK_FAILED : 코드 충돌 → 새 코드 생성 후 재시도
+   * - null        : Redis 오류 → 재시도하지 않고 즉시 503 반환
+   * - 최대 재시도 횟수 초과 시 503 반환
    */
   @Override
   public String saveToRedis(CreateLobbyRequest request, String userIdentifier) {
@@ -90,11 +105,19 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       String candidate = generateInviteCode();
       String result = executeCreateLobbyScript(candidate, request, userIdentifier);
 
+      // null 반환은 코드 충돌이 아닌 Redis 오류이므로 즉시 503 반환
+      if (result == null) {
+        log.error("Lua 스크립트 null 반환 - Redis 연결 오류 가능성. 코드: {}", candidate);
+        throw new ResponseStatusException(
+                HttpStatus.SERVICE_UNAVAILABLE, ERROR_REDIS_SCRIPT_NULL);
+      }
+
       if (RESULT_OK.equals(result)) {
         log.info("로비 Redis 저장 완료 - 코드: {}, 방장: {}", candidate, userIdentifier);
         return candidate;
       }
 
+      // LOCK_FAILED: 코드 충돌 → 새 코드로 재시도
       log.warn("초대 코드 충돌 - 재시도 {}/{}: {}",
               attempt + 1, LobbyDefaults.INVITE_CODE_MAX_RETRY, candidate);
     }
@@ -106,17 +129,14 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   /**
    * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
    *
-   * [보상 삭제 이유]
-   * saveToRedis() 성공 후 DB Insert가 실패하면 Redis에 잔존 데이터가 남아
-   * 실제로 입장 불가능한 로비가 공개 목록에 노출되는 데이터 불일치가 발생한다.
-   * 이를 방지하기 위해 DB 실패 시 Redis 데이터를 보상 삭제한다.
-   *
    * [삭제 실패 처리]
-   * 보상 삭제 자체가 실패하는 경우 ERROR 로그를 남긴다.
-   * 이 경우 수동 정리가 필요하며, 향후 cleanup 배치 작업으로 보완할 수 있다.
+   * 보상 삭제 실패 시 ERROR 로그를 남기고 false를 반환한다.
+   * 서비스 레이어에서 반환값을 확인하여 추가 알림 처리가 가능하다.
+   *
+   * @return 보상 삭제 성공 여부 (true: 성공, false: 실패)
    */
   @Override
-  public void deleteFromRedis(String inviteCode) {
+  public boolean deleteFromRedis(String inviteCode) {
     try {
       redisTemplate.delete(List.of(
               RedisKeys.lobbyKey(inviteCode),
@@ -128,8 +148,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       redisTemplate.opsForSet().remove(RedisKeys.LOBBY_PUBLIC, inviteCode);
 
       log.info("Redis 보상 삭제 완료 - 코드: {}", inviteCode);
+      return true;
+
     } catch (Exception e) {
       log.error("Redis 보상 삭제 실패 - 코드: {}. 수동 정리 필요.", inviteCode, e);
+      return false;
     }
   }
 
@@ -186,9 +209,13 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   // =========================================================
 
   /**
-   * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행
+   * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행한다.
    *
-   * @return "OK" (성공) | "LOCK_FAILED" (코드 충돌)
+   * [isPrivate 정규화]
+   * Lua 스크립트는 isPrivate 값을 == "false" 문자열 비교로 판단합니다.
+   * normalizeIsPrivate()로 반드시 소문자 "true"/"false"로 정규화하여 전달합니다.
+   *
+   * @return "OK" (성공) | "LOCK_FAILED" (코드 충돌) | null (Redis 오류)
    */
   private String executeCreateLobbyScript(
           String inviteCode,
@@ -205,6 +232,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
     String lockTtlMs = String.valueOf(LobbyDefaults.INVITE_CODE_LOCK_TTL.toMillis());
 
+    // isPrivate 정규화
+    // Lua 스크립트의 문자열 비교(isPrivate == "false")와 일치하도록
+    // 반드시 소문자 "true"/"false"로 명시적 정규화하여 전달한다.
+    String isPrivateValue = normalizeIsPrivate(request.isPrivate());
+
     return redisTemplate.execute(
             createLobbyScript,
             keys,
@@ -213,13 +245,29 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             inviteCode,                             // ARGV[3]
             request.title(),                        // ARGV[4]
             String.valueOf(request.maxPlayers()),   // ARGV[5]
-            String.valueOf(request.isPrivate()),    // ARGV[6]
+            isPrivateValue,                         // ARGV[6] — 정규화된 isPrivate 값
             LobbyStatus.WAITING.name()              // ARGV[7]
     );
   }
 
   /**
-   * LobbyDefaults 상수 기반으로 6자리 초대 코드를 생성
+   * isPrivate 값을 Lua 스크립트와 일치하는 소문자 문자열로 정규화한다.
+   *
+   * [정규화 이유]
+   * Lua 스크립트(create_lobby.lua)에서 isPrivate 값을
+   * if isPrivate == "false" then 으로 비교합니다.
+   * IS_PRIVATE_TRUE / IS_PRIVATE_FALSE 상수를 사용하여
+   * 대소문자 불일치나 예상치 못한 값이 전달되는 것을 방지합니다.
+   *
+   * @param isPrivate 로비 비공개 여부
+   * @return "true" (비공개) 또는 "false" (공개)
+   */
+  private String normalizeIsPrivate(boolean isPrivate) {
+    return isPrivate ? IS_PRIVATE_TRUE : IS_PRIVATE_FALSE;
+  }
+
+  /**
+   * LobbyDefaults 상수 기반으로 6자리 초대 코드를 생성한다.
    *
    * [SecureRandom 사용 이유]
    * Random 대신 SecureRandom을 사용하여 코드 예측 가능성을 낮춘다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -86,6 +87,39 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
     log.info("로비 Redis 저장 완료 - 코드: {}, 방장: {}", inviteCode, userIdentifier);
     return inviteCode;
+  }
+
+  /**
+   * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
+   *
+   * [보상 삭제 이유]
+   * saveToRedis() 성공 후 DB Insert가 실패하면 Redis에 잔존 데이터가 남아 실제로 입장 불가능한 로비가 공개 목록에 노출되는 데이터 불일치가 발생한다.
+   * 이를 방지하기 위해 DB 실패 시 Redis 데이터를 보상 삭제한다.
+   *
+   * [삭제 실패 처리]
+   * 보상 삭제 자체가 실패하는 경우 ERROR 로그를 남긴다.
+   * 이 경우 수동 정리가 필요하며, 향후 cleanup 배치 작업으로 보완할 수 있다.
+   */
+  @Override
+  public void deleteFromRedis(String inviteCode) {
+    try {
+      // 로비 관련 키 일괄 삭제
+      redisTemplate.delete(List.of(
+              RedisKeys.lobbyKey(inviteCode),
+              RedisKeys.lobbyParticipantsKey(inviteCode),
+              RedisKeys.lobbyOrderKey(inviteCode),
+              RedisKeys.lobbyCodeLockKey(inviteCode) // 락 키도 함께 삭제
+      ));
+
+      // 공개 로비 Set에서 제거
+      redisTemplate.opsForSet().remove(RedisKeys.LOBBY_PUBLIC, inviteCode);
+
+      log.info("Redis 보상 삭제 완료 - 코드 : {}", inviteCode);
+    } catch (Exception e) {
+      // 보상 삭제 실패는 ERROR 레벨로 기록
+      // 수동 정리 또는 향ㅎ cleanup 배치 작업 필요
+      log.error("Redis 보상 삭제 실패 - 코드 : {}, 수동 정리 필요.", inviteCode, e);
+    }
   }
 
   @Override

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
@@ -50,6 +50,9 @@ public class LobbyEventService {
   // 로비 코드 검증 패턴: 영문 대문자 및 숫자 조합 6~12자리
   private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
 
+  // [수정] WS 세션 만료 시간 상수 추가
+  private static final Duration WS_CONNECTION_TTL = Duration.ofDays(1);
+
   private final SimpMessagingTemplate messagingTemplate;
   private final LobbyRepository lobbyRepository;
   private final StringRedisTemplate redisTemplate;
@@ -60,7 +63,8 @@ public class LobbyEventService {
    */
   public void notifyLobbyListRefresh() {
     messagingTemplate.convertAndSend(
-            StompDestinations.SUBSCRIBE_LOBBY_LIST_REFRESH, "REFRESH_LOBBY_LIST");
+            StompDestinations.SUBSCRIBE_LOBBY_LIST_REFRESH,
+            StompDestinations.MSG_REFRESH_LOBBY_LIST);
   }
 
   /**
@@ -95,7 +99,8 @@ public class LobbyEventService {
     }
 
     messagingTemplate.convertAndSend(
-            StompDestinations.subscribeLobbyRefresh(code), "REFRESH_LOBBY_INFO");
+            StompDestinations.subscribeLobbyRefresh(code),
+            StompDestinations.MSG_REFRESH_LOBBY_INFO);
   }
 
   /**
@@ -149,7 +154,7 @@ public class LobbyEventService {
         // 방장이 바뀌었으므로 로비 내부 클라이언트에게 새로고침 신호
         messagingTemplate.convertAndSend(
                 StompDestinations.subscribeLobbyRefresh(d.lobbyCode()),
-                "REFRESH_LOBBY_INFO");
+                StompDestinations.MSG_REFRESH_LOBBY_INFO);
       }
       case LeaveLobbyResult.Left l -> {
         log.info("[handlePlayerLeave] 일반 퇴장 - 로비: {}, 식별자: {}",
@@ -157,7 +162,7 @@ public class LobbyEventService {
         // 참여자가 줄었으므로 로비 내부 클라이언트에게 새로고침 신호
         messagingTemplate.convertAndSend(
                 StompDestinations.subscribeLobbyRefresh(l.lobbyCode()),
-                "REFRESH_LOBBY_INFO");
+                StompDestinations.MSG_REFRESH_LOBBY_INFO);
       }
       case LeaveLobbyResult.Error e -> {
         // 정상 흐름이 아니므로 브로드캐스트 없이 에러 로그만 남깁니다.
@@ -174,17 +179,11 @@ public class LobbyEventService {
    * WebSocketEventListener의 handleDisconnectEvent에서
    * wsSessionId만으로 lobbyCode와 userIdentifier를 역추적하는 데 사용됩니다.
    *
-   * [수정 — 하드코딩 제거]
-   * "userId", "lobbyCode" 문자열 리터럴
-   * → WebSocketHeaders.SESSION_USER_ID, SESSION_LOBBY_CODE 상수로 교체
-   * WebSocketEventListener의 조회 키와 반드시 일치해야 하므로 상수로 통일합니다.
-   *
    * @param wsSessionId    WebSocket 고유 세션 ID
    * @param userIdentifier 사용자 식별자 (게스트 UUID 또는 회원 ID)
    * @param lobbyCode      입장한 로비의 초대 코드
    */
   public void saveConnectionInfo(String wsSessionId, String userIdentifier, String lobbyCode) {
-    // [수정] 문자열 리터럴 → WebSocketHeaders 상수로 교체
     Map<String, String> data = Map.of(
             WebSocketHeaders.SESSION_USER_ID, userIdentifier,
             WebSocketHeaders.SESSION_LOBBY_CODE, lobbyCode
@@ -192,6 +191,6 @@ public class LobbyEventService {
 
     // TTL 설정으로 비정상 종료 시 좀비 세션 데이터 자동 만료 처리
     redisTemplate.opsForHash().putAll(RedisKeys.wsConnectionKey(wsSessionId), data);
-    redisTemplate.expire(RedisKeys.wsConnectionKey(wsSessionId), Duration.ofDays(1));
+    redisTemplate.expire(RedisKeys.wsConnectionKey(wsSessionId), WS_CONNECTION_TTL);
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -8,11 +8,21 @@
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
+import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -21,7 +31,59 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LobbyService {
 
+    private static final String ERROR_USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
+
     private final LobbyRepository lobbyRepository;
+    private final GameLobbyJpaRepository gameLobbyJpaRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 로비를 생성한다.
+     *
+     * [처리 순서]
+     * 1. JWT에서 추출한 userId로 User 엔티티 조회
+     * 2. SETNX로 초대 코드 선점 및 Redis에 로비 데이터 저장
+     * 3. DB에 GAME_LOBBY 스냅샷 Insert
+     *
+     * [트랜잭션 설계]
+     * Redis 저장을 DB Insert보다 먼저 수행합니다.
+     * Redis 저장 실패 시 DB Insert가 실행되지 않아 고아 데이터가 발생하지 않습니다.
+     * DB Insert 실패 시 Redis 데이터는 남을 수 있으나,
+     * 로비 폭파(leave_lobby.lua) 시 Redis 키가 정리되므로 허용 가능한 수준입니다.
+     *
+     * @param request   로비 생성 요청 DTO
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 생성된 로비 정보 응답 DTO
+     */
+    @Transactional
+    public CreateLobbyResponse createLobby(CreateLobbyRequest request, CustomPrincipal principal) {
+        User host = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, ERROR_USER_NOT_FOUND));
+
+        String inviteCode = lobbyRepository.saveToRedis(request, principal.userIdentifier());
+
+        GameLobby gameLobby = gameLobbyJpaRepository.save(GameLobby.builder()
+                .host(host)
+                .inviteCode(inviteCode)
+                .title(request.title())
+                .maxPlayers(request.maxPlayers())
+                .roundCount(request.roundCount())
+                .timeLimitSeconds(request.timeLimitSeconds())
+                .isPrivate(request.isPrivate())
+                .build());
+
+        log.info("로비 생성 완료 - 코드: {}, 방장: {}", inviteCode, principal.userIdentifier());
+
+        return CreateLobbyResponse.builder()
+                .lobbyId(gameLobby.getId())
+                .inviteCode(inviteCode)
+                .title(gameLobby.getTitle())
+                .maxPlayers(gameLobby.getMaxPlayers())
+                .isPrivate(gameLobby.getIsPrivate())
+                .status(gameLobby.getStatus().name())
+                .build();
+    }
 
     /**
      * 공개 로비 목록을 조회합니다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -33,6 +33,9 @@ public class LobbyService {
 
     private static final String ERROR_USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
 
+    // DB Insert 실패 시 클라이언트에 반환할 에러 메시지
+    private static final String ERROR_CREATE_LOBBY_FAILED = "로비 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
     private final LobbyRepository lobbyRepository;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final UserRepository userRepository;
@@ -63,26 +66,35 @@ public class LobbyService {
 
         String inviteCode = lobbyRepository.saveToRedis(request, principal.userIdentifier());
 
-        GameLobby gameLobby = gameLobbyJpaRepository.save(GameLobby.builder()
-                .host(host)
-                .inviteCode(inviteCode)
-                .title(request.title())
-                .maxPlayers(request.maxPlayers())
-                .roundCount(request.roundCount())
-                .timeLimitSeconds(request.timeLimitSeconds())
-                .isPrivate(request.isPrivate())
-                .build());
+        try {
+            GameLobby gameLobby = gameLobbyJpaRepository.save(GameLobby.builder()
+                    .host(host)
+                    .inviteCode(inviteCode)
+                    .title(request.title())
+                    .maxPlayers(request.maxPlayers())
+                    .roundCount(request.roundCount())
+                    .timeLimitSeconds(request.timeLimitSeconds())
+                    .isPrivate(request.isPrivate())
+                    .build());
 
-        log.info("로비 생성 완료 - 코드: {}, 방장: {}", inviteCode, principal.userIdentifier());
+            log.info("로비 생성 완료 - 코드: {}, 방장: {}", inviteCode, principal.userIdentifier());
 
-        return CreateLobbyResponse.builder()
-                .lobbyId(gameLobby.getId())
-                .inviteCode(inviteCode)
-                .title(gameLobby.getTitle())
-                .maxPlayers(gameLobby.getMaxPlayers())
-                .isPrivate(gameLobby.getIsPrivate())
-                .status(gameLobby.getStatus().name())
-                .build();
+            return CreateLobbyResponse.builder()
+                    .lobbyId(gameLobby.getId())
+                    .inviteCode(inviteCode)
+                    .title(gameLobby.getTitle())
+                    .maxPlayers(gameLobby.getMaxPlayers())
+                    .isPrivate(gameLobby.getIsPrivate())
+                    .status(gameLobby.getStatus().name())
+                    .build();
+
+        } catch (Exception e) {
+            // DB Insert 실패 시 Redis에 저장된 로비 데이터 보상 삭제
+            log.error("DB 로비 저장 실패 - Redis 보상 삭제 시작. 코드: {}", inviteCode, e);
+            lobbyRepository.deleteFromRedis(inviteCode);
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ERROR_CREATE_LOBBY_FAILED);
+        }
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -1,10 +1,5 @@
 /*
  * 로비 조회 관련 비즈니스 로직을 담당하는 서비스.
- *
- * [LobbyController에서 Repository 직접 참조를 제거한 이유]
- * 컨트롤러가 Repository를 직접 참조하면 레이어 경계가 무너집니다.
- * 서비스 레이어를 경유함으로써 향후 캐싱, 트랜잭션, 추가 비즈니스 로직을
- * 적용할 수 있는 확장 지점을 확보합니다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
@@ -31,10 +26,29 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LobbyService {
 
-    private static final String ERROR_USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
+    // =========================================================
+    // 에러 메시지 상수
+    // =========================================================
 
-    // DB Insert 실패 시 클라이언트에 반환할 에러 메시지
-    private static final String ERROR_CREATE_LOBBY_FAILED = "로비 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    private static final String ERROR_INVALID_PRINCIPAL =
+            "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
+    private static final String ERROR_USER_NOT_FOUND =
+            "사용자를 찾을 수 없습니다.";
+    private static final String ERROR_CREATE_LOBBY_FAILED =
+            "로비 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
+    // =========================================================
+    // 로그 메시지 상수
+    // =========================================================
+
+    private static final String LOG_INVALID_PRINCIPAL =
+            "로비 생성 요청 거부 - principal 또는 userId가 null. userIdentifier: {}";
+    private static final String LOG_DB_SAVE_FAILED =
+            "DB 로비 저장 실패 - Redis 보상 삭제 시작. 코드: {}";
+    private static final String LOG_COMPENSATION_SUCCESS =
+            "Redis 보상 삭제 완료 - 코드: {}";
+    private static final String LOG_COMPENSATION_FAILED =
+            "Redis 보상 삭제 실패 - 코드: {}. 수동 정리 필요. [모니터링 필요]";
 
     private final LobbyRepository lobbyRepository;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
@@ -44,15 +58,11 @@ public class LobbyService {
      * 로비를 생성한다.
      *
      * [처리 순서]
-     * 1. JWT에서 추출한 userId로 User 엔티티 조회
-     * 2. SETNX로 초대 코드 선점 및 Redis에 로비 데이터 저장
-     * 3. DB에 GAME_LOBBY 스냅샷 Insert
-     *
-     * [트랜잭션 설계]
-     * Redis 저장을 DB Insert보다 먼저 수행합니다.
-     * Redis 저장 실패 시 DB Insert가 실행되지 않아 고아 데이터가 발생하지 않습니다.
-     * DB Insert 실패 시 Redis 데이터는 남을 수 있으나,
-     * 로비 폭파(leave_lobby.lua) 시 Redis 키가 정리되므로 허용 가능한 수준입니다.
+     * 1. principal null 및 userId null 검증 → 401 반환
+     * 2. JWT에서 추출한 userId로 User 엔티티 조회
+     * 3. Lua 스크립트로 초대 코드 선점 및 Redis에 로비 데이터 원자적 저장
+     * 4. DB에 GAME_LOBBY 스냅샷 Insert
+     * 5. DB 실패 시 Redis 보상 삭제 및 성공/실패 여부를 구분하여 로그 기록
      *
      * @param request   로비 생성 요청 DTO
      * @param principal JWT에서 추출한 인증 주체
@@ -60,6 +70,16 @@ public class LobbyService {
      */
     @Transactional
     public CreateLobbyResponse createLobby(CreateLobbyRequest request, CustomPrincipal principal) {
+
+        // principal 및 userId null 방어
+        // JwtAuthenticationFilter를 통과했더라도 토큰 파싱 이상으로
+        // userId가 null인 채로 진입할 수 있으므로 서비스 레이어에서 재검증한다.
+        if (principal == null || principal.userId() == null) {
+            log.warn(LOG_INVALID_PRINCIPAL,
+                    principal != null ? principal.userIdentifier() : "null");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+        }
+
         User host = userRepository.findById(principal.userId())
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, ERROR_USER_NOT_FOUND));
@@ -89,17 +109,27 @@ public class LobbyService {
                     .build();
 
         } catch (Exception e) {
-            // DB Insert 실패 시 Redis에 저장된 로비 데이터 보상 삭제
-            log.error("DB 로비 저장 실패 - Redis 보상 삭제 시작. 코드: {}", inviteCode, e);
-            lobbyRepository.deleteFromRedis(inviteCode);
+            // 보상 삭제 성공/실패를 구분하여 모니터링 가능한 로그 기록
+            log.error(LOG_DB_SAVE_FAILED, inviteCode, e);
+
+            boolean compensationSuccess = lobbyRepository.deleteFromRedis(inviteCode);
+
+            if (compensationSuccess) {
+                // 보상 삭제 성공: 데이터 정합성 유지됨
+                log.info(LOG_COMPENSATION_SUCCESS, inviteCode);
+            } else {
+                // 보상 삭제 실패: Redis에 좀비 로비 데이터가 남아있을 수 있음
+                log.error(LOG_COMPENSATION_FAILED, inviteCode);
+            }
+
             throw new ResponseStatusException(
                     HttpStatus.INTERNAL_SERVER_ERROR, ERROR_CREATE_LOBBY_FAILED);
         }
     }
 
     /**
-     * 공개 로비 목록을 조회합니다.
-     * Redis에서 직접 필터링하여 공개(isPrivate=false) 로비만 반환합니다.
+     * 공개 로비 목록을 조회한다.
+     * Redis에서 직접 필터링하여 공개(isPrivate=false) 로비만 반환
      *
      * @return 현재 활성화된 공개 로비 목록
      */

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/OpenApiConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/OpenApiConfig.java
@@ -9,13 +9,20 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
+    // =========================================================
+    // 상수 추가
+    // =========================================================
+    private static final String API_TITLE = "Monomat API";
+    private static final String API_DESCRIPTION = "실시간 YouTube 음악 퀴즈 게임 Monomat 백엔드 API 명세";
+    private static final String API_VERSION = "v0.0.1";
+
     @Bean
     public OpenAPI monomatOpenAPI() {
         return new OpenAPI()
                 .components(new Components())
                 .info(new Info()
-                        .title("Monomat API")
-                        .description("실시간 YouTube 음악 퀴즈 게임 Monomat 백엔드 API 명세")
-                        .version("v0.0.1"));
+                        .title(API_TITLE)
+                        .description(API_DESCRIPTION)
+                        .version(API_VERSION));
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/OpenApiConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/OpenApiConfig.java
@@ -3,23 +3,37 @@ package io.github.ascrew.monomatbe.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
 
-    // =========================================================
-    // 상수 추가
-    // =========================================================
     private static final String API_TITLE = "Monomat API";
     private static final String API_DESCRIPTION = "실시간 YouTube 음악 퀴즈 게임 Monomat 백엔드 API 명세";
     private static final String API_VERSION = "v0.0.1";
 
+    /**
+     * Swagger UI의 Authorize 버튼에 표시될 보안 스킴 이름.
+     * addSecuritySchemes()와 addSecurityItem()에서 동일한 이름을 사용해야 합니다.
+     */
+    private static final String SECURITY_SCHEME_NAME = "BearerAuth";
+
     @Bean
     public OpenAPI monomatOpenAPI() {
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components()
+                        // Bearer 인증 스킴 등록 → Swagger UI 우측 상단에 Authorize 버튼 활성화
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("게스트 로그인 후 발급받은 accessToken을 입력하세요.")))
+                // 전체 API에 Bearer 인증을 기본 적용
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
                 .info(new Info()
                         .title(API_TITLE)
                         .description(API_DESCRIPTION)

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -22,4 +22,12 @@ public class RedisScriptConfig {
         redisScript.setResultType(String.class);
         return redisScript;
     }
+
+    @Bean
+    public RedisScript<String> createLobbyScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/create_lobby.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity // @PreAuthorize 활성화
 @Profile("dev")
 @RequiredArgsConstructor
 public class SecurityConfigDev {

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
@@ -1,37 +1,43 @@
 package io.github.ascrew.monomatbe.global.config.SecurityConfig;
 
+import io.github.ascrew.monomatbe.global.security.SecurityEndpoints;
+import io.github.ascrew.monomatbe.global.security.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @Profile("dev")
+@RequiredArgsConstructor
 public class SecurityConfigDev {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(AbstractHttpConfigurer::disable)      // CSRF 보호 비활성화
-            .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
-            .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
-            .authorizeHttpRequests(auth -> auth
-                    .requestMatchers(
-                            "/ws/**",
-                            "/v3/api-docs",
-                            "/v3/api-docs/**",
-                            "/swagger-ui/**",
-                            "/swagger-ui.html",
-                            "/api/auth/guest", 
-                            "/api/auth/register", 
-                            "/api/auth/login"
-                    ).permitAll()
-                    .anyRequest().permitAll()
-            ); // 모든 요청 허용 (개발 환경에서는 인증 없이 접근 허용)
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // Swagger는 dev 환경에서만 허용
+                        .requestMatchers(SecurityEndpoints.swaggerEndpoints()).permitAll()
+                        // 인증 불필요 공통 경로
+                        .requestMatchers(SecurityEndpoints.publicEndpoints()).permitAll()
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
@@ -1,35 +1,43 @@
 package io.github.ascrew.monomatbe.global.config.SecurityConfig;
 
+import io.github.ascrew.monomatbe.global.security.SecurityEndpoints;
+import io.github.ascrew.monomatbe.global.security.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @Profile("prod")
+@RequiredArgsConstructor
 public class SecurityConfigProd {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(AbstractHttpConfigurer::disable)      // CSRF 보호 비활성화
-            .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
-            .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
-            .authorizeHttpRequests(auth -> auth
-                    // 운영 환경이므로 Swagger 관련 URL은 접근 차단
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").denyAll()
-                    
-                    // 인증 없이 접근해야 하는 웹소켓 및 Auth URL 허용
-                    .requestMatchers("/ws/**").permitAll()
-                    .requestMatchers("/api/auth/guest", "/api/auth/register", "/api/auth/login").permitAll()
-                    
-                    // 그 외 모든 요청에 대해 인증 필요 (운영 환경에서는 인증된 사용자만 접근 허용)
-                    .anyRequest().authenticated()
-            ); 
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // Swagger는 prod 환경에서 전면 차단
+                        .requestMatchers(SecurityEndpoints.swaggerEndpoints()).denyAll()
+                        // 인증 불필요 공통 경로
+                        .requestMatchers(SecurityEndpoints.publicEndpoints()).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity // @PreAuthorize 활성화
 @Profile("prod")
 @RequiredArgsConstructor
 public class SecurityConfigProd {

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -47,19 +47,25 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 
 
+    // =========================================================
+    // 상수 추가
+    // =========================================================
+    private static final int HEARTBEAT_SCHEDULER_POOL_SIZE = 1;
+    private static final String HEARTBEAT_THREAD_NAME_PREFIX = "wss-heartbeat-thread-";
+    private static final long HEARTBEAT_INTERVAL_MS = 10000L;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // 하트비트를 담당할 스레드 생성 및 초기화
         ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-        taskScheduler.setPoolSize(1);                                           //스레드 1개로 제한
-        taskScheduler.setThreadNamePrefix("wss-heartbeat-thread-");             //스레드 이름 접두사 설정
+        taskScheduler.setPoolSize(HEARTBEAT_SCHEDULER_POOL_SIZE);
+        taskScheduler.setThreadNamePrefix(HEARTBEAT_THREAD_NAME_PREFIX);
         taskScheduler.initialize();
 
-        registry.enableSimpleBroker("/topic")                   //수신용
+        registry.enableSimpleBroker("/topic")
                 .setTaskScheduler(taskScheduler)
-                .setHeartbeatValue(new long[]{10000,10000}); //클라이언트와 서버가 10000ms(10초)마다 하트비트를 주고받도록 설정
+                .setHeartbeatValue(new long[]{HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS});
 
-        registry.setApplicationDestinationPrefixes("/app");  //송신용(발행)
+        registry.setApplicationDestinationPrefixes("/app");
     }
 
     @Override

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -55,6 +55,9 @@ public final class RedisKeys {
     /** Refresh Token 저장 키 접두사 */
     private static final String REFRESH_TOKEN_PREFIX = "auth:refresh:";
 
+    // 초대 코드 SETNX 락 키 접두사
+    private static final String LOBBY_CODE_LOCK_PREFIX = "lobby:code:lock:";
+
     // [삭제] USER_ROOM_PREFIX 및 userRoomKey() 제거
     // lobby:{code}:participants가 단일 진실의 원천으로 통일되었으므로
     // user_room:{lobbyCode} 관련 상수는 더 이상 필요하지 않습니다.
@@ -194,5 +197,18 @@ public final class RedisKeys {
      */
     public static String refreshTokenKey(String sessionId) {
         return REFRESH_TOKEN_PREFIX + sessionId;
+    }
+
+    // 초대 코드 SETNX 락 키 팩토리 메서드
+    /**
+     * 초대 코드 중복 방지 SETNX 락 키를 반환한다.
+     *
+     * [SETNX 전략]
+     * Redis SET NX 명령으로 원자적으로 코드를 선점한다.
+     * 선점 성공 시 해당 코드를 사용하고, 실패 시 재생성한다.
+     * TTL은 LobbyDefaults.INVITE_CODE_LOCK_TTL을 따르며 생성 실패 시 자동 해제되어 코드 공간을 반환한다.
+     */
+    public static String lobbyCodeLockKey(String inviteCode) {
+        return LOBBY_CODE_LOCK_PREFIX + inviteCode;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -55,8 +55,21 @@ public final class RedisKeys {
     /** Refresh Token 저장 키 접두사 */
     private static final String REFRESH_TOKEN_PREFIX = "auth:refresh:";
 
-    // 초대 코드 SETNX 락 키 접두사
+    /** 초대 코드 중복 방지 SETNX 락 키 접두사 */
     private static final String LOBBY_CODE_LOCK_PREFIX = "lobby:code:lock:";
+
+    // =========================================================
+    // Redis Hash 필드 키 상수 (auth:guest:session:{token} Hash 내부 필드명)
+    // =========================================================
+
+    /** 게스트 세션 Hash의 사용자 DB PK 필드 */
+    public static final String FIELD_GUEST_USER_ID = "userId";
+
+    /** 게스트 세션 Hash의 닉네임 필드 */
+    public static final String FIELD_GUEST_USERNAME = "username";
+
+    /** 게스트 세션 Hash의 사용자 유형 필드 */
+    public static final String FIELD_GUEST_USER_TYPE = "userType";
 
     // [삭제] USER_ROOM_PREFIX 및 userRoomKey() 제거
     // lobby:{code}:participants가 단일 진실의 원천으로 통일되었으므로

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
@@ -52,6 +52,22 @@ public final class StompDestinations {
     public static final String PUBLISH_LOBBY_CREATE = PUBLISH_PREFIX + "/lobby/create";
 
     // =========================================================
+    // 브로드캐스트 메시지 상수
+    // =========================================================
+
+    /**
+     * 전역 로비 리스트 새로고침 신호 메시지.
+     * LobbyEventService에서 /topic/lobby/refresh 채널로 전송하는 고정 문자열
+     */
+    public static final String MSG_REFRESH_LOBBY_LIST = "REFRESH_LOBBY_LIST";
+
+    /**
+     * 로비 내부 정보 새로고침 신호 메시지.
+     * LobbyEventService에서 /topic/lobby/{code}/refresh 채널로 전송하는 고정 문자열
+     */
+    public static final String MSG_REFRESH_LOBBY_INFO = "REFRESH_LOBBY_INFO";
+
+    // =========================================================
     // 동적 경로 생성 팩토리 메서드
     // =========================================================
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/SecurityEndpoints.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/SecurityEndpoints.java
@@ -1,0 +1,55 @@
+package io.github.ascrew.monomatbe.global.security;
+
+/**
+ * Security 설정에서 사용하는 엔드포인트 경로를 중앙에서 관리하는 상수 클래스
+ */
+
+public final class SecurityEndpoints {
+
+    private SecurityEndpoints() {}
+
+    // 인증 없이 허용하는 경로 (permitAll)
+
+    // WebSocket 엔드포인트
+    public static final String WS = "/ws/**";
+
+    // 게스트 로그인
+    public static final String AUTH_GUEST = "/api/auth/guest";
+
+    // 회원가입
+    public static final String AUTH_REGISTER = "/api/auth/register";
+
+    // 로그인
+    public static final String AUTH_LOGIN = "/api/auth/login";
+
+
+    // Swagger (dev 허용 / prod 차단)
+
+    public static final String SWAGGER_UI = "/swagger-ui/**";
+    public static final String SWAGGER_HTML = "/swagger-ui.html";
+    public static final String API_DOCS = "/v3/api-docs";
+    public static final String API_DOCS_ALL = "/v3/api-docs/**";
+
+
+    // 편의 메서드 - permitAll 경로 배열
+
+    /**
+     * 인증 없이 허용할 공통 경로 배열을 반환한다.
+     * SecurityConfigDev / SecurityConfigProd 양쪽에서 재사용한다.
+     */
+    public static String[] publicEndpoints() {
+        return new String[] {
+                WS, AUTH_GUEST, AUTH_REGISTER, AUTH_LOGIN
+        };
+    }
+
+    /**
+     * Swagger 관련 경로 배열을 반환한다.
+     * dev 환경에서는 permitAll, prod 환경에서는 denyAll에 사용한다..
+     */
+    public static String[] swaggerEndpoints() {
+        return new String[] {
+                SWAGGER_UI, SWAGGER_HTML, API_DOCS, API_DOCS_ALL
+        };
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/CustomPrincipal.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/CustomPrincipal.java
@@ -1,0 +1,17 @@
+package io.github.ascrew.monomatbe.global.security.jwt;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+
+/**
+ * JWT 파싱 후 SecurityContext에 저장되는 인증 주체 객체
+ *
+ * [설계 이유]
+ * 컨트롤러에서 @AuthenticationPrincipal로 주입받아 userId (DB용)와 userIdentifier(Redis/WebSocket용)를 동시에 사용할 수 있도록한다.
+ * 두 식별자를 분리함으로써 DB와 Redis 각각 맞는 식별자를 사용할 수 있다.
+ */
+public record CustomPrincipal(
+        Long userId,              // DB users.id (FK 참조용)
+        String userIdentifier,    // UUID (Redis/WebSocket 식별자)
+        UserType userType         // GUEST | REGISTERED
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,141 @@
+package io.github.ascrew.monomatbe.global.security.jwt;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * JWT Access Token을 검증하고 SecurityContext에 인증 정보를 저장하는 필터.
+ *
+ * [처리 흐름]
+ * 1. Authorization 헤더에서 Bearer 토큰 추출
+ * 2. JWT 파싱 및 서명 검증
+ * 3. userId, userIdentifier, userType 클레임 추출 (JwtClaims 상수 사용)
+ * 4. CustomPrincipal 생성 후 SecurityContext 저장
+ *
+ * [토큰 없는 요청 처리]
+ * permitAll 경로는 토큰 없이 통과시킨다.
+ * 경로별 접근 제어는 SecurityConfig의 authorizeHttpRequests에서 담당한다.
+ */
+@Slf4j
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    // JWT가 포함된 HTTP 헤더의 이름과 토큰의 접두사 상수 정의
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+
+    // JWT 서명 검증을 위한 암호화 키
+    private final SecretKey secretKey;
+
+    /**
+     * 필터 생성자
+     * application.yml 등의 설정 파일에서 JWT 시크릿 키를 주입받아 SecretKey 객체로 초기화한다.
+     *
+     * @param secret 설정 파일에 정의된 auth.jwt.secret 값
+     */
+    public JwtAuthenticationFilter(@Value("${auth.jwt.secret}") String secret) {
+        // 주입받은 문자열 형태의 시크릿 키를 UTF-8 바이트 배열로 반환
+        byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+        // JJWT 라이브러리를 사용하여 HMAC SHA 알고리즘에 적합한 암호화 키 객체 (SecretKey) 생성
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * 실제 필터링 로직이 수행되는 메서드
+     * HTTP 요청이 들어올 때마다 토큰의 유효성을 검사하고, 유효한 경우 인증 정보를 설정한다.
+     */
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 1. 요청 헤더에서 JWT 토큰 문자열만 추출
+        String token = extractToken(request);
+
+        // 토큰이 존재하는 경우에만 검증 로직 수행 (토큰이 없다면 바로 다음 필터로 이동)
+        if (token != null) {
+            try {
+                // 2. 토큰 파싱 및 서명 (Signature) 검증
+                Claims claims = Jwts.parser()
+                        .verifyWith(secretKey) // 서버가 가진 시크릿 키로 서명이 변조되지 않았는지 검증
+                        .build()
+                        .parseSignedClaims(token) // 토큰을 파싱하여 클레임 (데이터) 객체 반환 (만료된 경우 여기서 예외 발생)
+                        .getPayload(); // 검증에 성공하면 토큰의 Payload (클레임 내용)를 가져옴
+
+                // 3. Payload에서 비즈니스 로직에 필요한 사용자 정보 추출
+                // JWT의 Subject에는 주로 사용자의 식별자 (PK)를 저장하므로 Long 타입으로 변환하여 가져옴
+                Long userId = Long.valueOf(claims.getSubject());
+
+                // JwtClaims 상수로 클레임 키 참조 (JwtTokenProvider 발급 시와 동일한 키)
+                // JwtClaims 상수로 정의된 키를 사용하여 커스텀 클레임 추출 (토큰 발급 시 넣었던 데이터)
+                String userIdentifier = claims.get(JwtClaims.USER_IDENTIFIER, String.class);
+                UserType userType = UserType.valueOf(claims.get(JwtClaims.USER_TYPE, String.class));
+
+                // 4. 추출한 정보는 Spring Security 환경에서 사용할 인증 주체 (Principal) 객체 생성
+                CustomPrincipal principal = new CustomPrincipal(userId, userIdentifier, userType);
+
+                // 5. Spring Security의 인증 토큰 객체 생성
+                // Principal : 사용자 정보, Credentials : 비밀번호 (이미 인증되었으므로 null), Authorities : 권한 목록)
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                // Spring Security의 Role 기반 인가를 위해 "ROLE_" 접두사를 붙여 권한 부여
+                                List.of(new SimpleGrantedAuthority(
+                                        JwtClaims.ROLE_PREFIX + userType.name()))
+                        );
+
+                // 6. SecurityContext (보안 컨텍스트)에 생성한 인증 정보 객체 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (JwtException e) {
+                // 토큰 만료, 서명 불일치, 형식 오류 등의 JWT 예외 발생 시 처리
+                log.warn("JWT 검증 실패: {}", e.getMessage());
+                // 잘못된 토큰으로 인한 보안 위협을 막기 위해 Context를 완전히 초기화 (비움)
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        // 7. 현재 필터의 작업이 끝났으므로 다음 필터 (혹은 서블릿)로 요청 전달
+        // 토큰이 없거나, 검증에 실패했더라도 permitAll로 설정된 엔드포인트일 수 있으므로 일단 다음으로 넘김
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * HTTP Request의 Authorization 헤더에서 Bearer 토큰 문자열만 잘라내어 추출하는 헬퍼 메서드
+     * Authorization 헤더에서 Bearer 토큰을 추출한다.
+     * 헤더가 없거나 형식이 맞지 않으면 null을 반환한다.
+     */
+    private String extractToken(HttpServletRequest request) {
+        // "Authorization" 헤더의 값을 가져옴
+        String header = request.getHeader(HEADER_AUTHORIZATION);
+
+        // 헤더 값이 존재하고, "Bearer "로 시작하는지 확인 (대소문자/띄어쓰기 주의)
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            // "Bearer " 이후의 실제 토큰 값만 잘라서 반환
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null; // 조건에 맞지 않으면 토큰이 없는 것으로 간주
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
@@ -29,7 +29,8 @@ import java.util.List;
  * 1. Authorization 헤더에서 Bearer 토큰 추출
  * 2. JWT 파싱 및 서명 검증
  * 3. userId, userIdentifier, userType 클레임 추출 (JwtClaims 상수 사용)
- * 4. CustomPrincipal 생성 후 SecurityContext 저장
+ * 4. 클레임 null 검증 — 하나라도 누락 시 인증 실패 처리
+ * 5. CustomPrincipal 생성 후 SecurityContext 저장
  *
  * [토큰 없는 요청 처리]
  * permitAll 경로는 토큰 없이 통과시킨다.
@@ -39,30 +40,22 @@ import java.util.List;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    // JWT가 포함된 HTTP 헤더의 이름과 토큰의 접두사 상수 정의
+    // Authorization 헤더에 들어가는 토큰의 접두사 (공백 포함)
     private static final String BEARER_PREFIX = "Bearer ";
+    // 헤더 키 값
     private static final String HEADER_AUTHORIZATION = "Authorization";
 
-    // JWT 서명 검증을 위한 암호화 키
+    // JWT 서명 검증에 사용할 암호화 키
     private final SecretKey secretKey;
 
     /**
      * 필터 생성자
-     * application.yml 등의 설정 파일에서 JWT 시크릿 키를 주입받아 SecretKey 객체로 초기화한다.
-     *
-     * @param secret 설정 파일에 정의된 auth.jwt.secret 값
-     */
+     * application.yml (또는 properties) 파일에서 'auth.jwt.secret' 값을 주입받아 SecretKey 객체로 초기화한다.     */
     public JwtAuthenticationFilter(@Value("${auth.jwt.secret}") String secret) {
-        // 주입받은 문자열 형태의 시크릿 키를 UTF-8 바이트 배열로 반환
         byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
-        // JJWT 라이브러리를 사용하여 HMAC SHA 알고리즘에 적합한 암호화 키 객체 (SecretKey) 생성
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    /**
-     * 실제 필터링 로직이 수행되는 메서드
-     * HTTP 요청이 들어올 때마다 토큰의 유효성을 검사하고, 유효한 경우 인증 정보를 설정한다.
-     */
     @Override
     protected void doFilterInternal(
             HttpServletRequest request,
@@ -70,72 +63,103 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        // 1. 요청 헤더에서 JWT 토큰 문자열만 추출
+        // 1. 요청 헤더에서 JWT 토큰 문자열을 추출
         String token = extractToken(request);
 
-        // 토큰이 존재하는 경우에만 검증 로직 수행 (토큰이 없다면 바로 다음 필터로 이동)
+        // 2. 토큰이 존재할 경우에만 검증 로직 수행
+        // 토큰이 없으면 그냥 다음 필터로 넘어감 -> permitAll이면 통과, 아니면 인가 예외 발생
         if (token != null) {
             try {
-                // 2. 토큰 파싱 및 서명 (Signature) 검증
+                // 3. JWT 문자열을 파싱하고 서명을 검증하여 Payload (클레임)를 가져옴
                 Claims claims = Jwts.parser()
-                        .verifyWith(secretKey) // 서버가 가진 시크릿 키로 서명이 변조되지 않았는지 검증
+                        .verifyWith(secretKey) // 서버가 가진 secretKey로 서명 (Signature) 위변조 확인
                         .build()
-                        .parseSignedClaims(token) // 토큰을 파싱하여 클레임 (데이터) 객체 반환 (만료된 경우 여기서 예외 발생)
-                        .getPayload(); // 검증에 성공하면 토큰의 Payload (클레임 내용)를 가져옴
+                        .parseSignedClaims(token) // 토큰 유휴성 (만료 시간 등) 검사 및 파싱
+                        .getPayload(); // 파싱된 데이터 (Claims) 추출
 
-                // 3. Payload에서 비즈니스 로직에 필요한 사용자 정보 추출
-                // JWT의 Subject에는 주로 사용자의 식별자 (PK)를 저장하므로 Long 타입으로 변환하여 가져옴
+                // 4. 클레임 추출 후 필수 데이터 null 검증
+                // subject, userIdentifier, userType 중 하나라도 누락되면
+                // 위변조 또는 잘못된 토큰으로 간주하여 인증 실패 처리
+                if (!isValidClaims(claims)) {
+                    log.warn("JWT 클레임 누락 또는 유효하지 않음 - 인증 거부");
+                    SecurityContextHolder.clearContext(); // 비정상 토큰이므로 현재 스레드의 시큐리티 컨텍스트 초기화
+                    filterChain.doFilter(request, response); // 다음 필터로 넘김 (인증되지 않은 상태로 진행됨)
+                    return;
+                }
+
+                // 5. 토큰 클레임에서 사용자 정보 추출
                 Long userId = Long.valueOf(claims.getSubject());
-
-                // JwtClaims 상수로 클레임 키 참조 (JwtTokenProvider 발급 시와 동일한 키)
-                // JwtClaims 상수로 정의된 키를 사용하여 커스텀 클레임 추출 (토큰 발급 시 넣었던 데이터)
                 String userIdentifier = claims.get(JwtClaims.USER_IDENTIFIER, String.class);
-                UserType userType = UserType.valueOf(claims.get(JwtClaims.USER_TYPE, String.class));
+                UserType userType = UserType.valueOf(
+                        claims.get(JwtClaims.USER_TYPE, String.class));
 
-                // 4. 추출한 정보는 Spring Security 환경에서 사용할 인증 주체 (Principal) 객체 생성
+                // 6. 인증된 사용자를 표현하는 커스텀 Principal 객체 생성
                 CustomPrincipal principal = new CustomPrincipal(userId, userIdentifier, userType);
 
-                // 5. Spring Security의 인증 토큰 객체 생성
-                // Principal : 사용자 정보, Credentials : 비밀번호 (이미 인증되었으므로 null), Authorities : 권한 목록)
+                // 7. 스프링 시큐리티의 Authentication 객체 (UsernamePasswordAuthenticationToken) 생성
+                // 비밀번호 (Credentials)는 이미 JWT로 인증이 끝났으므로 null 처리
+                // 사용자의 권한 (Role) 목록을 SimpleGrantedAuthority로 감싸서 전달
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(
                                 principal,
                                 null,
-                                // Spring Security의 Role 기반 인가를 위해 "ROLE_" 접두사를 붙여 권한 부여
                                 List.of(new SimpleGrantedAuthority(
                                         JwtClaims.ROLE_PREFIX + userType.name()))
                         );
 
-                // 6. SecurityContext (보안 컨텍스트)에 생성한 인증 정보 객체 저장
+                // 8. 최종적으로 SecurityContext에 인증 객체를 저장하여 전역에서 사용 가능하게 함
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
             } catch (JwtException e) {
-                // 토큰 만료, 서명 불일치, 형식 오류 등의 JWT 예외 발생 시 처리
+                // 토큰 만료, 서명 불일치, 형식 오류
                 log.warn("JWT 검증 실패: {}", e.getMessage());
-                // 잘못된 토큰으로 인한 보안 위협을 막기 위해 Context를 완전히 초기화 (비움)
+                SecurityContextHolder.clearContext(); // 안전을 위해 컨텍스트 초기화
+
+                // JwtException 외 예외도 인증 실패로 동일 처리
+                // Long.valueOf(null)   → NumberFormatException (IllegalArgumentException 하위)
+                // UserType.valueOf(null) → IllegalArgumentException
+                // claims.get() null 참조 → NullPointerException
+            } catch (IllegalArgumentException | NullPointerException e) {
+                log.warn("JWT 클레임 파싱 실패 - 인증 거부: {}", e.getMessage());
                 SecurityContextHolder.clearContext();
             }
         }
 
-        // 7. 현재 필터의 작업이 끝났으므로 다음 필터 (혹은 서블릿)로 요청 전달
-        // 토큰이 없거나, 검증에 실패했더라도 permitAll로 설정된 엔드포인트일 수 있으므로 일단 다음으로 넘김
         filterChain.doFilter(request, response);
     }
 
     /**
-     * HTTP Request의 Authorization 헤더에서 Bearer 토큰 문자열만 잘라내어 추출하는 헬퍼 메서드
+     * 인증에 필요한 클레임이 모두 존재하고 유효한지 검증한다.
+     *
+     * [검증 항목]
+     * - subject        : userId (null 또는 빈 문자열이면 유효하지 않음)
+     * - userIdentifier : UUID 식별자 (null이면 유효하지 않음)
+     * - userType       : 사용자 유형 (null이면 유효하지 않음)
+     *
+     * @param claims JWT 파싱 후 추출된 클레임
+     * @return 모든 필수 클레임이 존재하면 true, 하나라도 누락이면 false
+     */
+    private boolean isValidClaims(Claims claims) {
+        String subject = claims.getSubject();
+        String userIdentifier = claims.get(JwtClaims.USER_IDENTIFIER, String.class);
+        String userType = claims.get(JwtClaims.USER_TYPE, String.class);
+
+        return subject != null && !subject.isBlank()
+                && userIdentifier != null
+                && userType != null;
+    }
+
+    /**
      * Authorization 헤더에서 Bearer 토큰을 추출한다.
      * 헤더가 없거나 형식이 맞지 않으면 null을 반환한다.
      */
     private String extractToken(HttpServletRequest request) {
-        // "Authorization" 헤더의 값을 가져옴
         String header = request.getHeader(HEADER_AUTHORIZATION);
-
-        // 헤더 값이 존재하고, "Bearer "로 시작하는지 확인 (대소문자/띄어쓰기 주의)
+        // 헤더에 값이 있고, "Bearer "로 시작하는지 확인
         if (header != null && header.startsWith(BEARER_PREFIX)) {
-            // "Bearer " 이후의 실제 토큰 값만 잘라서 반환
+            // "Bearer " 이후의 문자열 (실제 토큰)만 잘라서 반환
             return header.substring(BEARER_PREFIX.length());
         }
-        return null; // 조건에 맞지 않으면 토큰이 없는 것으로 간주
+        return null;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtClaims.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtClaims.java
@@ -1,0 +1,27 @@
+package io.github.ascrew.monomatbe.global.security.jwt;
+
+/**
+ * JWT 클레임 키를 중앙에서 관리하는 상수 클래스
+ *
+ * [설계 이유]
+ * - JwtTokenProvider (발급)와 JwtAuthenticationFilter (검증)가 동일한 클레임 키를 사용해야 한다.
+ * - 문자열 리터럴이 각자 하드코딩하면 오타 시 런타임에서야 발견되므로 상수로 통일하여 컴파일 타임에 감지되도록 한다.
+ */
+
+public final class JwtClaims {
+
+    private JwtClaims() {}
+
+        // 게스트/회원 공통 UUID 식별자 클레임 키
+        public static final String USER_IDENTIFIER = "userIdentifier";
+
+        // 사용자 유형 클레임 키 (GUEST | REGISTERED)
+        public static final String USER_TYPE = "userType";
+
+        // Refresh Token의 세션 ID 클레임 키
+        public static final String SESSION_ID = "sessionId";
+
+        // Spring Security 권한 접두사
+        public static final String ROLE_PREFIX = "ROLE_";
+
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -15,10 +16,30 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * JWT Access/Refresh 토큰 발급 컴포넌트
+ * JWT Access/Refresh 토큰 발급 컴포넌트.
+ *
+ * [입력값 검증 원칙]
+ * 토큰에 포함되는 모든 클레임은 발급 시점에 검증한다.
+ * null/blank 클레임이 포함된 토큰은 JwtAuthenticationFilter에서
+ * isValidClaims()로 걸러지지만, 발급 자체를 차단하는 것이 더 안전하다.
+ * 문제를 발생 원점에서 즉시 감지할 수 있고,
+ * 잘못된 토큰이 Redis나 클라이언트에 전달되는 것을 원천 차단한다.
  */
 @Component
 public class JwtTokenProvider {
+
+    // =========================================================
+    // 에러 메시지 상수
+    // =========================================================
+
+    private static final String ERROR_USER_ID_NULL =
+            "토큰 발급 실패: userId는 null일 수 없습니다.";
+    private static final String ERROR_USER_TYPE_NULL =
+            "토큰 발급 실패: userType은 null일 수 없습니다.";
+    private static final String ERROR_USER_IDENTIFIER_BLANK =
+            "토큰 발급 실패: userIdentifier는 null이거나 빈 값일 수 없습니다.";
+    private static final String ERROR_SESSION_ID_BLANK =
+            "토큰 발급 실패: sessionId는 null이거나 빈 값일 수 없습니다.";
 
     @Value("${auth.jwt.secret}")
     private String secret;
@@ -32,8 +53,8 @@ public class JwtTokenProvider {
     private SecretKey secretKey;
 
     /**
-     * 애플리케이션 시작 시 JWT 서명 키를 초기화합니다.
-     * HMAC-SHA 계열 키 길이 요구사항(최소 32바이트)을 강제합니다.
+     * 애플리케이션 시작 시 JWT 서명 키를 초기화한다.
+     * HMAC-SHA 계열 키 길이 요구사항(최소 32바이트)을 강제한다.
      */
     @PostConstruct
     public void init() {
@@ -45,20 +66,36 @@ public class JwtTokenProvider {
     }
 
     /**
-     * API 인증에 사용하는 단기 Access Token을 발급합니다.
-     * userIdentifier(게스트/회원 공통 UUID)를 claim으로 포함합니다.
+     * API 인증에 사용하는 단기 Access Token을 발급한다.
+     *
      * [클레임 구성]
      * - subject        : userId (DB PK)
      * - userIdentifier : UUID (Redis/WebSocket 식별자)
      * - userType       : GUEST | REGISTERED
+     *
+     * [입력값 검증]
+     * userIdentifier가 null이거나 빈 문자열이면 IllegalArgumentException을 던진다.
+     * 잘못된 클레임이 포함된 토큰이 발급되어 JwtAuthenticationFilter의
+     * isValidClaims()에서 인증 실패로 처리되는 상황을 발급 시점에 차단한다.
+     *
+     * @param userId         DB users.id (subject 클레임)
+     * @param userType       사용자 유형 (GUEST | REGISTERED)
+     * @param userIdentifier Redis/WebSocket 식별자 (UUID)
+     * @return 발급된 토큰과 만료시각
+     * @throws IllegalArgumentException userIdentifier가 null이거나 빈 값인 경우
      */
     public TokenWithExpiry createAccessToken(Long userId, UserType userType, String userIdentifier) {
+        // 발급 시점 입력값 검증
+        validateCommonClaims(userId, userType);
+        if (!StringUtils.hasText(userIdentifier)) {
+            throw new IllegalArgumentException(ERROR_USER_IDENTIFIER_BLANK);
+        }
+
         Instant now = Instant.now();
         Instant expiresAt = now.plusSeconds(accessTokenValiditySeconds);
 
         String token = Jwts.builder()
                 .subject(String.valueOf(userId))
-                // JwtClaims 상수로 클레임 키 참조 (JwtAuthenticationFilter와 동일한 키)
                 .claims(Map.of(
                         JwtClaims.USER_TYPE, userType.name(),
                         JwtClaims.USER_IDENTIFIER, userIdentifier
@@ -72,21 +109,36 @@ public class JwtTokenProvider {
     }
 
     /**
-     * 세션 갱신에 사용하는 장기 Refresh Token을 발급합니다.
-     * sessionId는 Redis refresh key와 동일 식별자를 사용합니다.
+     * 세션 갱신에 사용하는 장기 Refresh Token을 발급한다.
      *
      * [클레임 구성]
      * - subject   : userId (DB PK)
      * - userType  : GUEST | REGISTERED
      * - sessionId : UUID (Redis refresh key와 동일 식별자)
+     *
+     * [입력값 검증]
+     * sessionId가 null이거나 빈 문자열이면 IllegalArgumentException을 던진다.
+     * 유효하지 않은 sessionId로 Refresh Token이 발급되면
+     * Redis에 저장된 토큰과 불일치가 발생하여 갱신이 불가능해진다.
+     *
+     * @param userId    DB users.id (subject 클레임)
+     * @param userType  사용자 유형 (GUEST | REGISTERED)
+     * @param sessionId Redis refresh key 식별자 (UUID)
+     * @return 발급된 토큰과 만료시각
+     * @throws IllegalArgumentException sessionId가 null이거나 빈 값인 경우
      */
     public TokenWithExpiry createRefreshToken(Long userId, UserType userType, String sessionId) {
+        // 발급 시점 입력값 검증
+        validateCommonClaims(userId, userType);
+        if (!StringUtils.hasText(sessionId)) {
+            throw new IllegalArgumentException(ERROR_SESSION_ID_BLANK);
+        }
+
         Instant now = Instant.now();
         Instant expiresAt = now.plusSeconds(refreshTokenValiditySeconds);
 
         String token = Jwts.builder()
                 .subject(String.valueOf(userId))
-                // JwtClaims 상수로 클레임 키 참조
                 .claims(Map.of(
                         JwtClaims.USER_TYPE, userType.name(),
                         JwtClaims.SESSION_ID, sessionId
@@ -101,5 +153,27 @@ public class JwtTokenProvider {
 
     public Duration refreshTokenTtl() {
         return Duration.ofSeconds(refreshTokenValiditySeconds);
+    }
+
+    // =========================================================
+    // private 메서드
+    // =========================================================
+
+    /**
+     * Access/Refresh 토큰 발급 시 공통으로 검증하는 클레임을 확인한다.
+     *
+     * [검증 항목]
+     * - userId    : null이면 subject 클레임을 구성할 수 없음
+     * - userType  : null이면 권한 클레임을 구성할 수 없음
+     *
+     * @throws IllegalArgumentException userId 또는 userType이 null인 경우
+     */
+    private void validateCommonClaims(Long userId, UserType userType) {
+        if (userId == null) {
+            throw new IllegalArgumentException(ERROR_USER_ID_NULL);
+        }
+        if (userType == null) {
+            throw new IllegalArgumentException(ERROR_USER_TYPE_NULL);
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
@@ -14,6 +14,9 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 
+/**
+ * JWT Access/Refresh 토큰 발급 컴포넌트
+ */
 @Component
 public class JwtTokenProvider {
 
@@ -44,6 +47,10 @@ public class JwtTokenProvider {
     /**
      * API 인증에 사용하는 단기 Access Token을 발급합니다.
      * userIdentifier(게스트/회원 공통 UUID)를 claim으로 포함합니다.
+     * [클레임 구성]
+     * - subject        : userId (DB PK)
+     * - userIdentifier : UUID (Redis/WebSocket 식별자)
+     * - userType       : GUEST | REGISTERED
      */
     public TokenWithExpiry createAccessToken(Long userId, UserType userType, String userIdentifier) {
         Instant now = Instant.now();
@@ -51,9 +58,10 @@ public class JwtTokenProvider {
 
         String token = Jwts.builder()
                 .subject(String.valueOf(userId))
+                // JwtClaims 상수로 클레임 키 참조 (JwtAuthenticationFilter와 동일한 키)
                 .claims(Map.of(
-                        "userType", userType.name(),
-                        "userIdentifier", userIdentifier
+                        JwtClaims.USER_TYPE, userType.name(),
+                        JwtClaims.USER_IDENTIFIER, userIdentifier
                 ))
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(expiresAt))
@@ -66,6 +74,11 @@ public class JwtTokenProvider {
     /**
      * 세션 갱신에 사용하는 장기 Refresh Token을 발급합니다.
      * sessionId는 Redis refresh key와 동일 식별자를 사용합니다.
+     *
+     * [클레임 구성]
+     * - subject   : userId (DB PK)
+     * - userType  : GUEST | REGISTERED
+     * - sessionId : UUID (Redis refresh key와 동일 식별자)
      */
     public TokenWithExpiry createRefreshToken(Long userId, UserType userType, String sessionId) {
         Instant now = Instant.now();
@@ -73,9 +86,10 @@ public class JwtTokenProvider {
 
         String token = Jwts.builder()
                 .subject(String.valueOf(userId))
+                // JwtClaims 상수로 클레임 키 참조
                 .claims(Map.of(
-                        "userType", userType.name(),
-                        "sessionId", sessionId
+                        JwtClaims.USER_TYPE, userType.name(),
+                        JwtClaims.SESSION_ID, sessionId
                 ))
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(expiresAt))

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -54,6 +54,9 @@ public class WebSocketEventListener {
     // TTL은 비정상 종료(서버 다운 등) 시 Redis 좀비 키 방지용
     private static final long USER_STATUS_TTL_HOURS = 2;
 
+    /** 퇴장 메시지 포맷. {0} 위치에 userIdentifier가 삽입됩니다. */
+    private static final String LEAVE_MESSAGE_FORMAT = "%s님이 퇴장하셨습니다.";
+
     private final RedisPublisher redisPublisher;
     private final RedisTemplate<String, Object> redisTemplate;
     private final WebSocketMetric webSocketMetric;
@@ -151,7 +154,7 @@ public class WebSocketEventListener {
                             .type(ChatMessageDto.MessageType.LEAVE)
                             .roomId(lobbyCode)
                             .sender(userIdentifier)
-                            .content(userIdentifier + "님이 퇴장하셨습니다.")
+                            .content(String.format(LEAVE_MESSAGE_FORMAT, userIdentifier))
                             .build()
             );
         }

--- a/src/main/resources/scripts/create_lobby.lua
+++ b/src/main/resources/scripts/create_lobby.lua
@@ -48,6 +48,10 @@ redis.call('SADD', participantsKey, userIdentifier)
 redis.call('RPUSH', orderKey, userIdentifier)
 
 -- 5. 공개 로비인 경우 전역 공개 목록 Set에 코드 추가 (lobby:public)
+-- [isPrivate 값 보장]
+-- Java LobbyRepositoryImpl.normalizeIsPrivate()에서 반드시 소문자 "true"/"false"로
+-- 정규화하여 전달하므로, 이 비교는 항상 일관되게 동작한다.
+
 if isPrivate == "false" then
     redis.call('SADD', publicListKey, inviteCode)
 end

--- a/src/main/resources/scripts/create_lobby.lua
+++ b/src/main/resources/scripts/create_lobby.lua
@@ -1,0 +1,55 @@
+---@diagnostic disable: undefined-global
+
+-- ============================================================================
+-- 로비 생성 원자적 처리 스크립트
+--
+-- SETNX 선점 + Hash/Set/List 저장을 단일 트랜잭션으로 처리하여
+-- 중간 실패 시 부분 데이터가 남는 문제를 방지한다.
+-- Redis는 Lua 스크립트를 싱글 스레드로 실행하므로
+-- 스크립트 실행 중에는 다른 명령이 끼어들 수 없다.
+-- ============================================================================
+
+local lockKey         = KEYS[1]   -- lobby:code:lock:{code}
+local lobbyKey        = KEYS[2]   -- lobby:{code}
+local participantsKey = KEYS[3]   -- lobby:{code}:participants
+local orderKey        = KEYS[4]   -- lobby:{code}:order
+local publicListKey   = KEYS[5]   -- lobby:public
+
+local userIdentifier  = ARGV[1]   -- 방장 식별자 (SETNX 선점자)
+local lockTtlMs       = ARGV[2]   -- 락 TTL (밀리초)
+local inviteCode      = ARGV[3]   -- 초대 코드
+local title           = ARGV[4]   -- 로비 제목
+local maxPlayers      = ARGV[5]   -- 최대 인원
+local isPrivate       = ARGV[6]   -- "true" | "false"
+local status          = ARGV[7]   -- "WAITING"
+
+-- 1. SETNX 선점 시도
+--    이미 동일한 코드가 선점되어 있으면 LOCK_FAILED 반환
+local acquired = redis.call('SET', lockKey, userIdentifier, 'NX', 'PX', lockTtlMs)
+
+if acquired == false then
+    return "LOCK_FAILED"
+end
+
+-- 2. 로비 메타 정보 Hash 저장 (lobby:{code})
+redis.call('HSET', lobbyKey,
+    'code',         inviteCode,
+    'host_user_id', userIdentifier,
+    'title',        title,
+    'max_players',  maxPlayers,
+    'is_private',   isPrivate,
+    'status',       status
+)
+
+-- 3. 참여자 Set에 방장 추가 (lobby:{code}:participants)
+redis.call('SADD', participantsKey, userIdentifier)
+
+-- 4. 입장 순서 List에 방장 추가 (lobby:{code}:order)
+redis.call('RPUSH', orderKey, userIdentifier)
+
+-- 5. 공개 로비인 경우 전역 공개 목록 Set에 코드 추가 (lobby:public)
+if isPrivate == "false" then
+    redis.call('SADD', publicListKey, inviteCode)
+end
+
+return "OK"


### PR DESCRIPTION
## 📣 Related Issue

- #18

## 📝 Summary

### JWT 인증 필터
- `JwtClaims`: 발급/검증 클레임 키 상수 중앙화 (`JwtTokenProvider` ↔ `JwtAuthenticationFilter` 공유)
- `SecurityEndpoints`: Security 경로 상수 중앙화 (Dev/Prod 설정 공유)
- `JwtAuthenticationFilter`: Bearer 토큰 파싱 후 `CustomPrincipal` → `SecurityContext` 저장
- `CustomPrincipal`: `userId`(DB용), `userIdentifier`(Redis용) 동시 보유 record
- `JwtTokenProvider`: 클레임 키 하드코딩 → `JwtClaims` 상수로 교체
- `SecurityConfig(Dev/Prod)`: STATELESS 세션 정책 및 JWT 필터 체인 등록, `@EnableMethodSecurity` 추가

### GameLobby 엔티티 및 JPA 리포지토리
- `LobbyStatus`: 로비 상태 열거형 (`WAITING`, `PLAYING`, `FINISHED`)
- `GameLobby`: `GAME_LOBBY` 테이블 엔티티
  - `host` → `users` FK (DB용 Long), Redis `host_user_id`(UUID)와 식별자 분리
  - `@PrePersist`로 `createdAt`, `status`, `isDeleted` 기본값 자동 보정
  - Soft Delete(`delete`), 상태 전이(`changeStatus`) 메서드 포함
- `GameLobbyJpaRepository`: `invite_code` 기반 조회/중복 체크 메서드

### 로비 생성 핵심 로직
- `LobbyDefaults`: 기본값/상수 중앙화 (라운드 수, 제한 시간, 초대 코드 길이, SETNX 락 TTL 등)
- `CreateLobbyRequest`: 로비 생성 요청 DTO (`roundCount`, `timeLimitSeconds` nullable 처리로 기본값 정상화)
- `CreateLobbyResponse`: 로비 생성 응답 DTO (딥링크용 `inviteCode` 포함)
- `RedisKeys`: `lobbyCodeLockKey()` 팩토리 메서드 추가, 게스트 세션 Hash 필드 상수 추가
- `StompDestinations`: REFRESH 브로드캐스트 메시지 상수 추가
- `LobbyRepository`: `saveToRedis()` 인터페이스 추가
- `LobbyRepositoryImpl`: SETNX 기반 초대 코드 중복 방지 + Redis 저장 구현
- `LobbyService`: DB Insert + Redis 저장 로직, `ERROR_USER_NOT_FOUND` 상수화

### 컨트롤러 및 문서
- `LobbyController`: `POST /api/lobbies` 엔드포인트 추가
  - `@PreAuthorize("isAuthenticated()")` JWT 인증 강제
  - `@AuthenticationPrincipal CustomPrincipal`로 `userId`/`userIdentifier` 주입
  - 201 Created 응답
- `docs/API.md`: `POST /api/lobbies` 명세 추가
- `docs/ARCHITECTURE.md`: 패키지 구조, Redis 데이터 구조, JWT 인증 흐름, SETNX 전략 업데이트

### 리팩토링  - 하드코딩 제거
- `GuestAuthService`: Redis Hash 필드 키 → `RedisKeys.FIELD_GUEST_*` 상수로 교체
- `LobbyEventService`: REFRESH 메시지 → `StompDestinations` 상수로 교체, TTL 상수화
- `WebSocketEventListener`: LEAVE 메시지 포맷 상수화
- `LobbyController`: 선언된 로그 상수 실제 적용
- `WebSocketConfig`: 하트비트/스레드 설정값 상수화
- `OpenApiConfig`: API 메타 정보 상수화

## 🙏 PR point

- **Redis ↔ DB 식별자 분리 구조**
  Redis에는 `userIdentifier`(UUID), DB에는 `users.id`(Long)를 저장합니다.
  `JwtAuthenticationFilter`에서 JWT를 파싱하여 두 값을 동시에 추출하고
  `CustomPrincipal`로 컨트롤러까지 전달하는 흐름을 확인 부탁드립니다.

- **SETNX 기반 초대 코드 중복 방지**
  `acquireInviteCode()`에서 `lobby:code:lock:{code}` 키를 Redis SET NX로 원자적 선점합니다.
  Race Condition 없이 동시 로비 생성 시에도 코드 충돌이 발생하지 않는 구조입니다.

- **트랜잭션 설계 — Redis 선행 저장**
  Redis 저장(`saveToRedis`) → DB Insert(`gameLobbyJpaRepository.save`) 순서로 처리합니다.
  Redis 저장 실패 시 DB Insert가 실행되지 않아 고아 데이터가 발생하지 않습니다.

- **Soft Delete 정책**
  `GameLobby` 엔티티는 로비 폭파 시 물리 삭제하지 않고 `is_deleted = true`로 처리합니다.
  신고 기능의 `target_id` 레퍼런스 보존 및 운영 이력 추적을 위한 설계입니다.

## 📬 Reference
- 기능명세서 — 로비 만들기 P0 항목
- `ARCHITECTURE.md` — Redis 데이터 구조, 의존 방향 규칙