### PR TITLE
[Feat/#20] 로비 채널 연결 및 실시간 입퇴장 브로드캐스트

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -211,9 +211,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   /**
    * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행한다.
    *
-   * [isPrivate 정규화]
-   * Lua 스크립트는 isPrivate 값을 == "false" 문자열 비교로 판단합니다.
-   * normalizeIsPrivate()로 반드시 소문자 "true"/"false"로 정규화하여 전달합니다.
+   * participants, order 관련 키 제거 이유:
+   * 입장 처리는 WebSocketEventListener.processLobbyEnter()에서 담당하므로, 생성 시점에서는 방장을 추가하지 않는다.
    *
    * @return "OK" (성공) | "LOCK_FAILED" (코드 충돌) | null (Redis 오류)
    */
@@ -223,18 +222,12 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           String userIdentifier
   ) {
     List<String> keys = List.of(
-            RedisKeys.lobbyCodeLockKey(inviteCode),     // KEYS[1]
-            RedisKeys.lobbyKey(inviteCode),             // KEYS[2]
-            RedisKeys.lobbyParticipantsKey(inviteCode), // KEYS[3]
-            RedisKeys.lobbyOrderKey(inviteCode),        // KEYS[4]
-            RedisKeys.LOBBY_PUBLIC                      // KEYS[5]
+            RedisKeys.lobbyCodeLockKey(inviteCode), // KEYS[1]
+            RedisKeys.lobbyKey(inviteCode),         // KEYS[2]
+            RedisKeys.LOBBY_PUBLIC                  // KEYS[3]
     );
 
     String lockTtlMs = String.valueOf(LobbyDefaults.INVITE_CODE_LOCK_TTL.toMillis());
-
-    // isPrivate 정규화
-    // Lua 스크립트의 문자열 비교(isPrivate == "false")와 일치하도록
-    // 반드시 소문자 "true"/"false"로 명시적 정규화하여 전달한다.
     String isPrivateValue = normalizeIsPrivate(request.isPrivate());
 
     return redisTemplate.execute(
@@ -245,7 +238,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             inviteCode,                             // ARGV[3]
             request.title(),                        // ARGV[4]
             String.valueOf(request.maxPlayers()),   // ARGV[5]
-            isPrivateValue,                         // ARGV[6] — 정규화된 isPrivate 값
+            isPrivateValue,                         // ARGV[6]
             LobbyStatus.WAITING.name()              // ARGV[7]
     );
   }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
@@ -1,45 +1,25 @@
 /*
  * 로비 이벤트 비즈니스 로직 및 실시간 상태 동기화(STOMP 브로드캐스트)를 담당하는 서비스.
  *
- * [리팩토링 변경 사항 — 의존 방향 역전 해결]
- * 기존: WebSocketEventListener(global)에서 handlePlayerLeave()를 직접 호출
- *       → global이 domain을 직접 참조하는 의존 방향 역전 문제 존재
- *
- * 변경: handlePlayerLeave(PlayerLeaveEvent)에 @EventListener 추가
- *       → WebSocketEventListener가 PlayerLeaveEvent를 발행하면
- *          Spring이 이 메서드로 자동 전달
- *       → global은 domain을 전혀 알 필요 없어짐
- *
- * [리팩토링 변경 사항 — 하드코딩 제거]
- * saveConnectionInfo()에서 Redis Hash 필드 키로 사용하던
- * "userId", "lobbyCode" 문자열 리터럴을
- * WebSocketHeaders.SESSION_USER_ID, SESSION_LOBBY_CODE 상수로 교체
- *
- * [LeaveLobbyResult sealed interface 도입 이유]
- * 기존 String 반환값 방식은 서비스 레이어에서 "DELEGATED:" 같은
- * Redis 내부 포맷 문자열을 직접 파싱해야 했습니다.
- * sealed interface + switch 패턴 매칭으로 변경하여
- * 컴파일러가 모든 케이스 처리를 검증하도록 개선합니다.
+ * saveConnectionInfo() 제거
+ * - WebSocket 세션과 로비 코드를 Redis에 매핑하는 로직은 순수 인프라 책임이므로 domain 서비스에 위치하는 것이 부적절함
+ * - WebSocketEventListener(global)로 이전하여 global -> domain 의존 방향 역전을 방지한다.
+ * - 함께 사용하던 WS_CONNECTION_TTL 상수도 WebSocketEventListener로 이전한다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
-import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.security.Principal;
-import java.time.Duration;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 @Slf4j
@@ -50,12 +30,8 @@ public class LobbyEventService {
   // 로비 코드 검증 패턴: 영문 대문자 및 숫자 조합 6~12자리
   private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
 
-  // [수정] WS 세션 만료 시간 상수 추가
-  private static final Duration WS_CONNECTION_TTL = Duration.ofDays(1);
-
   private final SimpMessagingTemplate messagingTemplate;
   private final LobbyRepository lobbyRepository;
-  private final StringRedisTemplate redisTemplate;
 
   /**
    * 전역 로비 리스트를 보고 있는 클라이언트들에게 새로고침 신호를 전송합니다.
@@ -106,25 +82,11 @@ public class LobbyEventService {
   /**
    * 플레이어 퇴장 이벤트를 수신하여 퇴장 처리를 수행합니다.
    *
-   * [수정 — 의존 방향 역전 해결]
-   * 기존: public void handlePlayerLeave(String code, String userIdentifier)
-   *       → WebSocketEventListener(global)에서 직접 호출
-   *       → global → domain 의존 방향 역전 문제 존재
-   *
-   * 변경: @EventListener public void handlePlayerLeave(PlayerLeaveEvent event)
-   *       → WebSocketEventListener가 PlayerLeaveEvent를 발행하면
-   *          Spring ApplicationEventPublisher가 이 메서드로 자동 전달
-   *       → WebSocketEventListener는 LobbyEventService를 전혀 알 필요 없음
-   *       → 의존 방향: domain → global (PlayerLeaveEvent) 로 정상화
-   *
    * [처리 분기 — sealed interface + switch 패턴 매칭]
    * - Destroyed : 로비 폭파 → 전역 로비 리스트 새로고침
    * - Delegated : 방장 위임 → 해당 로비 내부 새로고침
    * - Left      : 일반 퇴장 → 해당 로비 내부 새로고침
    * - Error     : 처리 실패 → 브로드캐스트 없이 에러 로그만 기록
-   *
-   * 컴파일러가 모든 permits 구현체의 처리 여부를 검증합니다.
-   * 케이스 누락 시 컴파일 오류가 발생합니다.
    *
    * @param event WebSocketEventListener가 발행한 PlayerLeaveEvent
    */
@@ -169,28 +131,5 @@ public class LobbyEventService {
         log.error("[handlePlayerLeave] 퇴장 처리 실패 - 사유: {}", e.reason());
       }
     }
-  }
-
-  /**
-   * WebSocket 세션과 사용자/로비 정보를 Redis에 매핑하여 저장합니다.
-   * 유저가 로비에 입장하여 WebSocket 연결이 성공했을 때 호출합니다.
-   *
-   * [저장 목적]
-   * WebSocketEventListener의 handleDisconnectEvent에서
-   * wsSessionId만으로 lobbyCode와 userIdentifier를 역추적하는 데 사용됩니다.
-   *
-   * @param wsSessionId    WebSocket 고유 세션 ID
-   * @param userIdentifier 사용자 식별자 (게스트 UUID 또는 회원 ID)
-   * @param lobbyCode      입장한 로비의 초대 코드
-   */
-  public void saveConnectionInfo(String wsSessionId, String userIdentifier, String lobbyCode) {
-    Map<String, String> data = Map.of(
-            WebSocketHeaders.SESSION_USER_ID, userIdentifier,
-            WebSocketHeaders.SESSION_LOBBY_CODE, lobbyCode
-    );
-
-    // TTL 설정으로 비정상 종료 시 좀비 세션 데이터 자동 만료 처리
-    redisTemplate.opsForHash().putAll(RedisKeys.wsConnectionKey(wsSessionId), data);
-    redisTemplate.expire(RedisKeys.wsConnectionKey(wsSessionId), WS_CONNECTION_TTL);
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
@@ -10,6 +10,11 @@
  *     → "/topic/lobby/ABC123"
  * StompDestinations.subscribeLobbyRefresh("ABC123")
  *     → "/topic/lobby/ABC123/refresh"
+ *
+ * isLobbyChatSubscription() 추가
+ * - isLobbySubscription()  : /topic/lobby/** 전체 매칭 (리프레시 채널 포함)
+ * - isLobbyChatSubscription(): /topic/lobby/{code} 정확히 매칭 (하위 경로 제외)
+ * - 입장/퇴장 처리 트리거는 채팅 채널 구독 시점에만 발생해야 하므로 분리
  */
 package io.github.ascrew.monomatbe.global.constant;
 
@@ -22,14 +27,14 @@ public final class StompDestinations {
     // Prefix 상수 (WebSocketConfig에서 설정한 값과 일치해야 함)
     // =========================================================
 
-    /** 클라이언트 → 서버 송신 경로 접두사 (WebSocketConfig applicationDestinationPrefix) */
     private static final String PUBLISH_PREFIX = "/app";
-
-    /** 서버 → 클라이언트 수신 경로 접두사 (WebSocketConfig simpleBroker) */
     private static final String SUBSCRIBE_PREFIX = "/topic";
 
+    /** 로비 채널 공통 접두사 — 내부 판별 메서드에서만 사용 */
+    private static final String LOBBY_CHANNEL_PREFIX = SUBSCRIBE_PREFIX + "/lobby/";
+
     // =========================================================
-    // 고정 구독 경로 (단순 상수)
+    // 고정 구독 경로
     // =========================================================
 
     /** 전체 채팅 구독 경로 */
@@ -42,7 +47,7 @@ public final class StompDestinations {
     public static final String SUBSCRIBE_LOBBY_PATTERN = SUBSCRIBE_PREFIX + "/lobby/*";
 
     // =========================================================
-    // 고정 송신 경로 (단순 상수)
+    // 고정 송신 경로
     // =========================================================
 
     /** 전체 채팅 송신 경로 */
@@ -55,84 +60,72 @@ public final class StompDestinations {
     // 브로드캐스트 메시지 상수
     // =========================================================
 
-    /**
-     * 전역 로비 리스트 새로고침 신호 메시지.
-     * LobbyEventService에서 /topic/lobby/refresh 채널로 전송하는 고정 문자열
-     */
     public static final String MSG_REFRESH_LOBBY_LIST = "REFRESH_LOBBY_LIST";
-
-    /**
-     * 로비 내부 정보 새로고침 신호 메시지.
-     * LobbyEventService에서 /topic/lobby/{code}/refresh 채널로 전송하는 고정 문자열
-     */
     public static final String MSG_REFRESH_LOBBY_INFO = "REFRESH_LOBBY_INFO";
 
     // =========================================================
     // 동적 경로 생성 팩토리 메서드
     // =========================================================
 
-    /**
-     * 로비 채팅 구독 경로를 반환합니다.
-     *
-     * @param code 로비 초대 코드
-     * @return "/topic/lobby/{code}"
-     */
+    /** @return "/topic/lobby/{code}" */
     public static String subscribeLobbyChat(String code) {
-        return SUBSCRIBE_PREFIX + "/lobby/" + code;
+        return LOBBY_CHANNEL_PREFIX + code;
     }
 
-    /**
-     * 로비 내부 정보 새로고침 신호 구독 경로를 반환합니다.
-     *
-     * @param code 로비 초대 코드
-     * @return "/topic/lobby/{code}/refresh"
-     */
+    /** @return "/topic/lobby/{code}/refresh" */
     public static String subscribeLobbyRefresh(String code) {
-        return SUBSCRIBE_PREFIX + "/lobby/" + code + "/refresh";
+        return LOBBY_CHANNEL_PREFIX + code + "/refresh";
     }
 
-    /**
-     * 로비 채팅 송신 경로를 반환합니다.
-     *
-     * @param code 로비 초대 코드
-     * @return "/app/chat/lobby/{code}"
-     */
+    /** @return "/app/chat/lobby/{code}" */
     public static String publishLobbyChat(String code) {
         return PUBLISH_PREFIX + "/chat/lobby/" + code;
     }
 
-    /**
-     * 로비 내부 정보 변경 이벤트 송신 경로를 반환합니다.
-     *
-     * @param code 로비 초대 코드
-     * @return "/app/lobby/{code}/update"
-     */
+    /** @return "/app/lobby/{code}/update" */
     public static String publishLobbyUpdate(String code) {
         return PUBLISH_PREFIX + "/lobby/" + code + "/update";
     }
 
+    // =========================================================
+    // 채널 판별 메서드
+    // =========================================================
+
     /**
-     * 주어진 경로가 로비 구독 채널인지 확인합니다.
-     * 외부에서 SUBSCRIBE_PREFIX를 직접 참조하지 않도록 캡슐화합니다.
-     *
-     * @param destination 확인할 STOMP 경로
-     * @return 로비 구독 채널 여부
+     * 로비 관련 채널 전체를 판별합니다 (/topic/lobby/** 포함).
+     * StompChannelInterceptor에서 로비 코드를 세션에 저장할 때 사용합니다.
      */
     public static boolean isLobbySubscription(String destination) {
-        return destination != null
-                && destination.startsWith(SUBSCRIBE_PREFIX + "/lobby/");
+        return destination != null && destination.startsWith(LOBBY_CHANNEL_PREFIX);
+    }
+
+    /**
+     * 로비 채팅 채널만 정확히 판별합니다.
+     *
+     * [판별 기준]
+     * LOBBY_CHANNEL_PREFIX 이후에 슬래시(/)가 없는 경우만 채팅 채널로 판단합니다.
+     * - /topic/lobby/ABC123         → true  (채팅 채널)
+     * - /topic/lobby/ABC123/refresh → false (리프레시 채널)
+     * - /topic/lobby/ABC123/game    → false (향후 추가 채널도 자동 차단)
+     *
+     * [용도]
+     * 입장 처리(참여자 추가, 세션 매핑, ENTER 브로드캐스트) 트리거에만 사용합니다.
+     */
+    public static boolean isLobbyChatSubscription(String destination) {
+        if (destination == null) return false;
+        if (!destination.startsWith(LOBBY_CHANNEL_PREFIX)) return false;
+
+        String afterPrefix = destination.substring(LOBBY_CHANNEL_PREFIX.length());
+        // 코드가 비어있지 않고 슬래시가 없어야 /topic/lobby/{code} 형태
+        return !afterPrefix.isEmpty() && !afterPrefix.contains("/");
     }
 
     /**
      * 로비 구독 경로에서 로비 코드를 추출합니다.
      * "/topic/lobby/{code}" 또는 "/topic/lobby/{code}/..." 형태에서 코드를 파싱합니다.
-     *
-     * @param destination STOMP 구독 경로
-     * @return 로비 코드
      */
     public static String extractLobbyCode(String destination) {
-        // "/topic/lobby/" 이후의 문자열에서 "/" 이전까지가 로비 코드
-        String afterPrefix = destination.substring((SUBSCRIBE_PREFIX + "/lobby/").length());
+        String afterPrefix = destination.substring(LOBBY_CHANNEL_PREFIX.length());
         int slashIndex = afterPrefix.indexOf('/');
         return slashIndex == -1 ? afterPrefix : afterPrefix.substring(0, slashIndex);
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -2,6 +2,19 @@
  * WebSocket 연결 생명주기 이벤트를 처리하는 리스너.
  * (연결 / 구독 / 연결 해제)
  *
+ * [리팩토링 변경 사항 — 의존 방향 역전 해결]
+ * 기존: WebSocketEventListener(global) → LobbyEventService(domain) 직접 참조
+ *       global이 domain을 직접 참조하는 의존 방향 역전 문제 존재
+ *
+ * 변경: WebSocketEventListener(global) → ApplicationEventPublisher로 이벤트 발행
+ *       LobbyEventService(domain)가 @EventListener로 이벤트 수신
+ *       global은 domain을 전혀 알 필요 없어짐
+ *
+ * [리팩토링 변경 사항 — 하드코딩 제거]
+ * handleDisconnectEvent()에서 Redis Hash 조회 시 사용하던
+ * "lobbyCode" 문자열 리터럴을
+ * WebSocketHeaders.SESSION_LOBBY_CODE 상수로 교체
+ *
  * [의존 방향]
  * global/websocket/WebSocketEventListener
  *         ↓ publishEvent(PlayerLeaveEvent)
@@ -21,30 +34,66 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-/**
- * WebSocket 연결 생명주기 이벤트를 처리하는 리스너.
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebSocketEventListener {
 
-    /** 퇴장 메시지 포맷. userIdentifier가 삽입됩니다. */
+    // 사용자 온라인 상태 TTL (단위: 시간)
+    // 연결이 끊기면 handleDisconnectEvent에서 즉시 삭제하므로
+    // TTL은 비정상 종료(서버 다운 등) 시 Redis 좀비 키 방지용
+    private static final long USER_STATUS_TTL_HOURS = 2;
+
+    /** 퇴장 메시지 포맷. {0} 위치에 userIdentifier가 삽입됩니다. */
     private static final String LEAVE_MESSAGE_FORMAT = "%s님이 퇴장하셨습니다.";
 
-    // [수정] RedisTemplate<String, Object>(JSON 직렬화) → StringRedisTemplate(순수 문자열)
-    // Lua 스크립트(SREM, LREM, user_status 조회)와 포맷 일치를 보장합니다.
-    private final StringRedisTemplate stringRedisTemplate;
     private final RedisPublisher redisPublisher;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final WebSocketMetric webSocketMetric;
     private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * WebSocket 연결 성공 이벤트 처리.
+     *
+     * [처리 내용]
+     * 1. 세션에서 사용자 식별자 추출 (WebSocketSessionUtils 위임)
+     * 2. Redis에 온라인 상태 저장 (TTL 2시간)
+     * 3. 활성 세션 카운터 증가 (Prometheus 메트릭)
+     */
+    @EventListener
+    public void handleConnectEvent(SessionConnectedEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+
+        String userIdentifier = WebSocketSessionUtils.extractUserIdentifier(sessionAttributes);
+
+        if (WebSocketHeaders.UNKNOWN_IDENTIFIER.equals(userIdentifier)) {
+            log.warn("인증되지 않은 세션 연결 감지");
+            return;
+        }
+
+        // 온라인 상태를 Redis에 저장
+        // TTL은 비정상 종료 시 자동 만료 보호용 (정상 종료 시 handleDisconnectEvent에서 즉시 삭제)
+        redisTemplate.opsForValue().set(
+                RedisKeys.userStatusKey(userIdentifier),
+                WebSocketHeaders.STATUS_ONLINE,
+                USER_STATUS_TTL_HOURS,
+                TimeUnit.HOURS
+        );
+
+        webSocketMetric.increment();
+        log.info("WebSocket 연결 - 식별자: {}", userIdentifier);
+    }
 
     /**
      * WebSocket 연결 해제 이벤트 처리 (단일 진입점).
@@ -55,9 +104,11 @@ public class WebSocketEventListener {
      * 3. LEAVE 메시지 브로드캐스트
      * 4. Redis 키 정리 (user_status, ws:connection)
      *
-     * [수정 — StringRedisTemplate 사용]
-     * ws:connection Hash는 LobbyEventService.saveConnectionInfo()에서
-     * StringRedisTemplate으로 저장되므로, 조회/삭제도 stringRedisTemplate을 사용합니다.
+     * [수정 — 하드코딩 제거]
+     * Redis Hash 조회 시 사용하던 "lobbyCode" 문자열 리터럴
+     * → WebSocketHeaders.SESSION_LOBBY_CODE 상수로 교체
+     * LobbyEventService.saveConnectionInfo()의 저장 키와 상수로 통일하여
+     * 오타 시 컴파일 타임에 감지되도록 합니다.
      */
     @EventListener
     public void handleDisconnectEvent(SessionDisconnectEvent event) {
@@ -69,16 +120,18 @@ public class WebSocketEventListener {
         String userIdentifier = (String) sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER);
         String wsSessionId = accessor.getSessionId();
 
+        // 인증되지 않은 세션이거나 식별자 없으면 처리 불필요
         if (userIdentifier == null
                 || WebSocketHeaders.UNKNOWN_IDENTIFIER.equals(userIdentifier)) return;
 
         // 1. Redis에서 세션 매핑 정보 역추적 (wsSessionId → lobbyCode)
+        //    LobbyEventService.saveConnectionInfo()에서 연결 시 저장한 데이터
         String lobbyCode = null;
         if (wsSessionId != null) {
-            // [수정] stringRedisTemplate 사용 — saveConnectionInfo()와 동일한 직렬화 포맷
-            Map<Object, Object> connectionInfo = stringRedisTemplate.opsForHash()
+            Map<Object, Object> connectionInfo = redisTemplate.opsForHash()
                     .entries(RedisKeys.wsConnectionKey(wsSessionId));
             if (!connectionInfo.isEmpty()) {
+                // [수정] "lobbyCode" 문자열 리터럴 → WebSocketHeaders.SESSION_LOBBY_CODE 상수로 교체
                 lobbyCode = (String) connectionInfo.get(WebSocketHeaders.SESSION_LOBBY_CODE);
             }
         }
@@ -86,11 +139,14 @@ public class WebSocketEventListener {
         log.info("WebSocket 연결 해제 - 식별자: {}, 로비: {}", userIdentifier, lobbyCode);
 
         // 2. PlayerLeaveEvent 발행
+        //    Spring이 @EventListener를 가진 LobbyEventService.handlePlayerLeave()로 전달
+        //    WebSocketEventListener는 LobbyEventService를 전혀 알 필요 없음
         if (lobbyCode != null) {
             eventPublisher.publishEvent(new PlayerLeaveEvent(lobbyCode, userIdentifier));
         }
 
         // 3. LEAVE 메시지 브로드캐스트
+        //    채팅 알림은 WebSocket 인프라 책임이므로 이 클래스에서 직접 처리
         if (lobbyCode != null) {
             redisPublisher.publish(
                     StompDestinations.subscribeLobbyChat(lobbyCode),
@@ -104,29 +160,25 @@ public class WebSocketEventListener {
         }
 
         // 4. Redis 키 정리
-        // [수정] stringRedisTemplate 사용 — 저장 시와 동일한 클라이언트로 삭제
-        stringRedisTemplate.delete(RedisKeys.userStatusKey(userIdentifier));
+        // 온라인 상태 키 삭제
+        redisTemplate.delete(RedisKeys.userStatusKey(userIdentifier));
+        // WebSocket 세션 매핑 키 삭제
         if (wsSessionId != null) {
-            stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
+            redisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
         }
+
+        webSocketMetric.decrement();
     }
 
     /**
      * WebSocket 채널 구독 이벤트 처리.
      *
-     * [수정 — StringRedisTemplate + order List 추가]
+     * 로비 채널 구독 시 Redis 참여자 Set에 사용자를 추가합니다.
      *
-     * 기존: redisTemplate(JSON 직렬화)으로 participants Set에만 추가
-     *       → Lua 스크립트의 SREM이 JSON 인코딩된 값과 불일치하여 퇴장 실패
-     *
-     * 수정: stringRedisTemplate(순수 문자열)으로 participants Set + order List 모두 추가
-     *       → Lua 스크립트(create_lobby.lua, leave_lobby.lua)와 동일한 포맷 보장
-     *
-     * [participants와 order의 단일 관리 지점]
-     * create_lobby.lua에서 방장을 SADD/RPUSH로 추가한 이후,
-     * 이후 입장하는 참여자들은 이 이벤트 핸들러에서 동일한 키에 추가합니다.
-     * leave_lobby.lua의 SREM/LREM이 양쪽 모두에서 정상 동작하려면
-     * 저장 포맷이 순수 문자열이어야 합니다.
+     * [참여자 키 단일화]
+     * lobby:{code}:participants를 단일 진실의 원천으로 사용합니다.
+     * Lua 스크립트(leave_lobby.lua)가 퇴장 시 이 키에서 SREM으로 제거하므로
+     * 입장 시에도 동일한 키에 추가하여 일관성을 보장합니다.
      */
     @EventListener
     public void handleSubscribeEvent(SessionSubscribeEvent event) {
@@ -144,15 +196,10 @@ public class WebSocketEventListener {
 
             String roomId = StompDestinations.extractLobbyCode(destination);
 
-            // [수정] stringRedisTemplate 사용 — Lua 스크립트와 동일한 순수 문자열 포맷
-            // participants Set: leave_lobby.lua의 SREM과 포맷 일치
-            stringRedisTemplate.opsForSet().add(
+            // lobby:{code}:participants에 추가
+            // Lua 스크립트가 퇴장 시 삭제하는 키와 동일하게 맞춰 일관성 보장
+            redisTemplate.opsForSet().add(
                     RedisKeys.lobbyParticipantsKey(roomId),
-                    userIdentifier
-            );
-            // order List: leave_lobby.lua의 LREM과 포맷 일치
-            stringRedisTemplate.opsForList().rightPush(
-                    RedisKeys.lobbyOrderKey(roomId),
                     userIdentifier
             );
 

--- a/src/main/resources/scripts/create_lobby.lua
+++ b/src/main/resources/scripts/create_lobby.lua
@@ -3,17 +3,19 @@
 -- ============================================================================
 -- 로비 생성 원자적 처리 스크립트
 --
--- SETNX 선점 + Hash/Set/List 저장을 단일 트랜잭션으로 처리하여
+-- SETNX 선점 + Hash 저장을 단일 트랜잭션으로 처리하여
 -- 중간 실패 시 부분 데이터가 남는 문제를 방지한다.
 -- Redis는 Lua 스크립트를 싱글 스레드로 실행하므로
 -- 스크립트 실행 중에는 다른 명령이 끼어들 수 없다.
+--
+-- [책임 분리 원칙]
+-- create_lobby.lua : 로비 메타 정보(Hash) 저장 + 공개 목록 등록만 담당
+-- processLobbyEnter(): 입장 처리(participants, order, 세션 매핑, ENTER 브로드캐스트) 담당
 -- ============================================================================
 
 local lockKey         = KEYS[1]   -- lobby:code:lock:{code}
 local lobbyKey        = KEYS[2]   -- lobby:{code}
-local participantsKey = KEYS[3]   -- lobby:{code}:participants
-local orderKey        = KEYS[4]   -- lobby:{code}:order
-local publicListKey   = KEYS[5]   -- lobby:public
+local publicListKey   = KEYS[3]   -- lobby:public
 
 local userIdentifier  = ARGV[1]   -- 방장 식별자 (SETNX 선점자)
 local lockTtlMs       = ARGV[2]   -- 락 TTL (밀리초)
@@ -41,17 +43,10 @@ redis.call('HSET', lobbyKey,
     'status',       status
 )
 
--- 3. 참여자 Set에 방장 추가 (lobby:{code}:participants)
-redis.call('SADD', participantsKey, userIdentifier)
-
--- 4. 입장 순서 List에 방장 추가 (lobby:{code}:order)
-redis.call('RPUSH', orderKey, userIdentifier)
-
--- 5. 공개 로비인 경우 전역 공개 목록 Set에 코드 추가 (lobby:public)
+-- 3. 공개 로비인 경우 전역 공개 목록 Set에 코드 추가 (lobby:public)
 -- [isPrivate 값 보장]
 -- Java LobbyRepositoryImpl.normalizeIsPrivate()에서 반드시 소문자 "true"/"false"로
 -- 정규화하여 전달하므로, 이 비교는 항상 일관되게 동작한다.
-
 if isPrivate == "false" then
     redis.call('SADD', publicListKey, inviteCode)
 end


### PR DESCRIPTION
## 📣 Related Issue

- #20

## 📝 Summary

- `StompDestinations`에 `isLobbyChatSubscription()` 추가 및 `LOBBY_CHANNEL_PREFIX` 상수화
  - 채팅 채널(`/topic/lobby/{code}`)과 리프레시 채널(`/topic/lobby/{code}/refresh`)을 명확히 구분
  - 기존에 중복되던 `/topic/lobby/` 문자열을 `LOBBY_CHANNEL_PREFIX`로 상수화
- `WebSocketEventListener` 입장/퇴장 처리 구현
  - `isLobbySubscription()` → `isLobbyChatSubscription()` 교체
  - `processLobbyEnter()` 추가: 입장 4단계 처리 (participants 추가, order 추가, 세션 매핑, ENTER 브로드캐스트)
  - `extractLobbyCodeFromSession()` 추가: lobbyCode 역추적 로직 추출
  - `wsSessionId` null 시 입장 처리 전체 중단으로 방어 로직 강화
  - `saveConnectionInfo()` 이전: `LobbyEventService`(domain) → `WebSocketEventListener`(global)
    - WebSocket 세션 매핑은 순수 인프라 책임이므로 domain 위치가 부적절했음
    - `WS_CONNECTION_TTL` 상수도 함께 이전
- `LobbyEventService`에서 `saveConnectionInfo()` 및 관련 의존성 제거
- `create_lobby.lua`에서 participants, order 추가 로직 제거
  - 로비 생성과 입장 처리의 책임을 분리
  - 생성 시점에 방장을 추가하면 구독 시점의 `processLobbyEnter()`와 중복되어
    order List에 방장 식별자가 2개 쌓이는 버그 발생
- `LobbyRepositoryImpl.executeCreateLobbyScript()` KEYS를 5개에서 3개로 축소
  - `create_lobby.lua` 변경에 따라 Java 호출부 KEYS 배열 동기화
- Redis Pub/Sub 직렬화 분리
  - `RedisConfig`에 `pubSubObjectMapper()` Bean 추가
  - `RedisPublisher`: `RedisTemplate` → `StringRedisTemplate` + `pubSubObjectMapper` 직렬화로 변경
  - `RedisSubscriber`: 역직렬화 제거, Redis 수신 JSON 문자열을 그대로 WebSocket으로 전달
  - WebSocket 클라이언트에 `["클래스명", {...}]` 형태의 타입 정보가 노출되던 문제 해결

## 🙏 PR point

- `saveConnectionInfo()`가 기존에 호출되지 않아 `handleDisconnectEvent()`의 lobbyCode 역추적이 항상 null이었던 버그를 함께 수정했습니다.
- Redis Pub/Sub 직렬화 문제는 테스트 중 발견된 이슈입니다. `RedisTemplate`의 `activateDefaultTyping` 설정이 WebSocket 클라이언트까지 노출되는 문제로, `RedisTemplate`은 Hash/Set/List 일반 데이터 저장 전용으로 유지하고 Pub/Sub은 별도 `pubSubObjectMapper`로 분리하여 해결했습니다.
- `create_lobby.lua` KEYS 배열 변경으로 Java 호출부(`executeCreateLobbyScript()`)도 함께 수정했습니다. Lua 스크립트와 Java 호출부의 KEYS 수가 반드시 일치해야 합니다.

## 📬 Reference
