### PR TITLE
[Fix/#51] WebSocket 로비 입장 상태 정합성 수정

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,7 @@
 # Monomat-BE Architecture
 
 ## 📦 패키지 구조
+
 ```text
 src/main/java/io/github/ascrew/monomatbe/
 ├── MonomatBeApplication.java
@@ -55,7 +56,7 @@ src/main/java/io/github/ascrew/monomatbe/
 └── global/                                         # 전역 인프라 레이어
     ├── config/                                     # 애플리케이션 설정
     │   ├── RedisConfig.java                        # Redis 연결, 직렬화, Pub/Sub 설정
-    │   ├── RedisScriptConfig.java                  # Lua 스크립트 Bean 등록
+    │   ├── RedisScriptConfig.java                  # create/enter/leave Lua 스크립트 Bean 등록
     │   ├── WebSocketConfig.java                    # STOMP 엔드포인트 및 브로커 설정
     │   └── SecurityConfig/
     │       ├── SecurityConfigDev.java              # 개발 환경 (인증 없이 전체 허용)
@@ -89,25 +90,26 @@ src/main/java/io/github/ascrew/monomatbe/
             ├── JwtTokenProvider.java               # JWT Access/Refresh 토큰 발급
             └── TokenWithExpiry.java                # 토큰 + 만료시각 DTO
 ```
+
 ---
 
 ## 🏛️ 아키텍처 원칙
 
 ### 의존 방향 규칙
 
-```
+```text
 domain  →  global  (허용 ✅)
 global  →  domain  (금지 ❌)
 ```
 
-`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.
+`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.  
 `global`이 `domain`을 직접 참조하면 의존 방향이 역전되어 순환 의존 및 결합도 증가 문제가 발생합니다.
 
 ### 의존 방향 역전 해결 사례 — Spring ApplicationEventPublisher
 
 `WebSocketEventListener(global)`가 `LobbyEventService(domain)`를 직접 호출하던 문제를 아래와 같이 해결했습니다.
 
-```
+```text
 [기존 — 의존 방향 역전]
 global/WebSocketEventListener → domain/LobbyEventService  ❌
 
@@ -125,7 +127,7 @@ global/WebSocketEventListener → ApplicationEventPublisher.publishEvent(PlayerL
 
 ### 채팅 메시지 흐름
 
-```
+```text
 클라이언트
     │ STOMP /app/chat/global (또는 /app/chat/lobby/{code})
     ▼
@@ -143,7 +145,7 @@ Redis
     │
     ▼
 RedisSubscriber.onMessage()
-    │
+    │ JSON 문자열 그대로 WebSocket 브로드캐스트
     ▼
 SimpMessagingTemplate.convertAndSend()
     │ STOMP /topic/chat/global (또는 /topic/lobby/{code})
@@ -151,9 +153,48 @@ SimpMessagingTemplate.convertAndSend()
 클라이언트 (구독자 전체)
 ```
 
+### WebSocket 로비 입장 흐름
+
+```text
+클라이언트
+    │ STOMP SUBSCRIBE /topic/lobby/{code}
+    ▼
+WebSocketEventListener.handleSubscribeEvent()
+    │ 1. 로비 채팅 채널 구독 여부 확인
+    │    - /topic/lobby/{code}         → 입장 처리 대상
+    │    - /topic/lobby/{code}/refresh → 입장 처리 대상 아님
+    │ 2. 세션에서 userIdentifier 추출
+    │ 3. wsSessionId 추출
+    │
+    ▼
+enter_lobby.lua
+    │ Redis Lua 스크립트로 입장 상태를 원자적으로 저장
+    │
+    ├── lobby:{code}:participants Set에 userIdentifier 저장
+    ├── lobby:{code}:order List에 userIdentifier 저장
+    ├── ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
+    └── 중복 구독 시 order List 중복 저장 방지
+    │
+    ▼
+RedisPublisher.publish()
+    │ ENTER 시스템 메시지 발행
+    ▼
+Redis Pub/Sub
+    │
+    ▼
+RedisSubscriber.onMessage()
+    │ JSON 문자열 그대로 WebSocket 브로드캐스트
+    ▼
+클라이언트
+    │ /topic/lobby/{code} 구독자로 ENTER 메시지 수신
+```
+
+> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.  
+> `/topic/lobby/{code}/refresh` 구독은 로비 정보 갱신 신호 수신용이며, 입장 처리 대상이 아닙니다.
+
 ### WebSocket 연결 해제 흐름
 
-```
+```text
 클라이언트 연결 해제
     │
     ▼
@@ -192,8 +233,43 @@ leave_lobby.lua
 
 ### Redis Hash 필드 상수 (`RedisKeys.FIELD_*`)
 
-로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.
+로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.  
 문자열 리터럴 직접 사용 시 오타가 런타임에서야 발견되는 문제를 컴파일 타임에 방지합니다.
+
+### WebSocket 로비 입장 저장 구조
+
+로비 입장 상태는 `enter_lobby.lua`에서 원자적으로 저장합니다.
+
+| 키 패턴 | 타입 | 저장 시점 | 설명 |
+|---|---|---|---|
+| `lobby:{code}:participants` | Set | `/topic/lobby/{code}` 구독 시 | 현재 로비에 참여 중인 userIdentifier 목록 |
+| `lobby:{code}:order` | List | `/topic/lobby/{code}` 구독 시 | 입장 순서. 방장 퇴장 시 다음 방장 위임 기준 |
+| `ws:connection:{wsSessionId}` | Hash | `/topic/lobby/{code}` 구독 시 | WebSocket 세션 ID로 userIdentifier와 lobbyCode를 역추적하기 위한 매핑 |
+
+`ws:connection:{wsSessionId}` Hash 필드:
+
+| 필드 | 값 | 설명 |
+|---|---|---|
+| `userId` | `userIdentifier` | Redis/WebSocket에서 사용하는 사용자 식별자 |
+| `lobbyCode` | `{code}` | 현재 WebSocket 세션이 참여 중인 로비 코드 |
+
+정상 저장 예시:
+
+```redis
+SMEMBERS lobby:R2VJW5:participants
+1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
+
+LRANGE lobby:R2VJW5:order 0 -1
+1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
+
+HGETALL ws:connection:mhrg4it0
+1) "userId"
+2) "9746cc76-f8f2-4859-b602-df6e1032fea4"
+3) "lobbyCode"
+4) "R2VJW5"
+```
+
+중복 구독 시 `participants`는 Set 구조로 중복 저장되지 않으며, `order` List도 `enter_lobby.lua`에서 신규 입장자일 때만 `RPUSH`하여 중복 저장을 방지합니다.
 
 ---
 
@@ -201,50 +277,132 @@ leave_lobby.lua
 
 ### Java 21 Virtual Thread + Lettuce
 
-가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 **Lettuce**를 사용합니다.
-Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,
+가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 **Lettuce**를 사용합니다.  
+Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,  
 Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
+
+### Lua 스크립트 기반 원자적 입장 처리
+
+`enter_lobby.lua`는 WebSocket 로비 입장 시 필요한 Redis 상태 변경을 단일 원자 연산으로 처리합니다.
+
+처리 대상:
+
+```text
+lobby:{code}:participants
+lobby:{code}:order
+ws:connection:{wsSessionId}
+```
+
+Java 코드에서 위 Redis 명령을 개별적으로 실행하면 중간 실패 시 다음과 같은 상태 불일치가 발생할 수 있습니다.
+
+```text
+participants에는 추가됐지만 order에는 없음
+order에는 추가됐지만 ws:connection 매핑이 없음
+ws:connection은 있지만 participants에는 없음
+```
+
+이를 방지하기 위해 `enter_lobby.lua`에서 아래 작업을 한 번에 수행합니다.
+
+```text
+1. lobby:{code} 존재 여부 확인
+2. participants Set에 userIdentifier 추가
+3. 신규 입장자인 경우에만 order List에 userIdentifier 추가
+4. ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
+5. ws:connection:{wsSessionId} TTL 설정
+```
+
+반환값은 다음과 같습니다.
+
+| 반환값 | 의미 |
+|---|---|
+| `ENTERED` | 신규 입장 처리 완료 |
+| `ALREADY_JOINED` | 이미 참여 중인 유저의 중복 구독. order 중복 저장 없음 |
+| `LOBBY_NOT_FOUND` | 존재하지 않는 로비 코드로 구독 요청 |
+
+입장 처리는 반드시 `/topic/lobby/{code}` 구독 시점에만 수행합니다.  
+`/topic/lobby/{code}/refresh`는 입장 처리를 트리거하지 않습니다.
 
 ### Lua 스크립트 기반 원자적 퇴장 처리
 
-`leave_lobby.lua`는 참여자 제거 → 방장 위임 → 로비 폭파를 단일 트랜잭션으로 처리합니다.
+`leave_lobby.lua`는 참여자 제거 → 방장 위임 → 로비 폭파를 단일 트랜잭션으로 처리합니다.  
 Redis는 싱글 스레드로 Lua 스크립트를 실행하므로 다수의 동시 퇴장 시에도 Race Condition이 발생하지 않습니다.
 
-반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,
-`LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여
+반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,  
+`LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여  
 서비스 레이어가 Redis 반환 포맷을 알 필요 없도록 캡슐화합니다.
 
 ### ChatMessageDto 위치
 
-`ChatMessageDto`는 채팅 도메인 전용 객체가 아닌 WebSocket 통신 전반에서 사용되는 메시지 포맷입니다.
-`domain/chat/dto`가 아닌 `global/websocket/dto`에 위치하여
-`global` 레이어의 `RedisPublisher`, `RedisSubscriber`, `WebSocketEventListener`가
+`ChatMessageDto`는 채팅 도메인 전용 객체가 아닌 WebSocket 통신 전반에서 사용되는 메시지 포맷입니다.  
+`domain/chat/dto`가 아닌 `global/websocket/dto`에 위치하여  
+`global` 레이어의 `RedisPublisher`, `RedisSubscriber`, `WebSocketEventListener`가  
 `domain`을 역참조하는 의존 방향 역전을 방지합니다.
+
+### Redis Pub/Sub 직렬화 분리
+
+Redis Pub/Sub 메시지는 WebSocket 클라이언트에게 그대로 전달될 수 있으므로, 일반 Redis 객체 저장용 `RedisTemplate<String, Object>`와 분리하여 처리합니다.
+
+#### 일반 Redis 데이터 저장
+
+`RedisTemplate<String, Object>`는 Redis Hash/Value에 객체 타입 정보를 보존하기 위해 `GenericJacksonJsonRedisSerializer`와 `activateDefaultTyping`을 사용합니다.
+
+사용 예:
+
+```text
+lobby:{code}
+auth:guest:session:{token}
+```
+
+#### Pub/Sub 메시지 발행
+
+Pub/Sub 메시지는 `StringRedisTemplate`과 Pub/Sub 전용 `JsonMapper`를 사용합니다.
+
+이유:
+
+```text
+RedisTemplate<String, Object>로 ChatMessageDto를 발행하면
+WebSocket 클라이언트가 ["클래스명", {...}] 형태의 메시지를 받게 됨
+```
+
+기존 문제 형태:
+
+```json
+["io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto",{"type":"ENTER","roomId":"R2VJW5"}]
+```
+
+수정 후 형태:
+
+```json
+{"type":"ENTER","roomId":"R2VJW5","sender":"...","content":"...","timestamp":"..."}
+```
+
+`RedisSubscriber`는 Pub/Sub 메시지를 DTO로 역직렬화하지 않고, JSON 문자열 그대로 `SimpMessagingTemplate.convertAndSend()`로 WebSocket 클라이언트에게 전달합니다.
 
 ### 참여자 키 단일 진실의 원천
 
-기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로
-동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.
-`lobby:{code}:participants`를 단일 진실의 원천으로 통일하여
-입장(Java) → 퇴장(Lua) 모두 동일한 키를 사용합니다.
+기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로  
+동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.  
+`lobby:{code}:participants`를 단일 진실의 원천으로 통일하여  
+입장(Lua) → 퇴장(Lua) 모두 동일한 키를 사용합니다.
 
 ### SETNX 기반 초대 코드 중복 방지
 
-`LobbyRepositoryImpl.acquireInviteCode()`는 6자리 초대 코드를 생성할 때
-`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.
-선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`(5회)까지 재시도합니다.
+`LobbyRepositoryImpl.acquireInviteCode()`는 6자리 초대 코드를 생성할 때  
+`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.  
+선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`(5회)까지 재시도합니다.  
 락 TTL은 10초로 설정하여 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
 
 ### JWT 인증 구조
 
-`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.
-파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.
+`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.  
+파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.  
 컨트롤러에서는 `@AuthenticationPrincipal CustomPrincipal`로 주입받아 사용합니다.
 
-JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
+JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여  
 `JwtTokenProvider`(발급)와 `JwtAuthenticationFilter`(검증) 간 키 불일치를 컴파일 타임에 방지합니다.
 
 [식별자 분리]
+
 - `userId` (Long) : DB users.id FK 참조용
 - `userIdentifier` (UUID String) : Redis/WebSocket 식별자
 
@@ -259,9 +417,12 @@ JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
 | 클라이언트 → 서버 | `/app/lobby/create` | 로비 생성 이벤트 송신 |
 | 클라이언트 → 서버 | `/app/lobby/{code}/update` | 로비 정보 변경 이벤트 송신 |
 | 서버 → 클라이언트 | `/topic/chat/global` | 전체 채팅 메시지 수신 |
-| 서버 → 클라이언트 | `/topic/lobby/{code}` | 로비 채팅 메시지 수신 |
+| 서버 → 클라이언트 | `/topic/lobby/{code}` | 로비 채팅 메시지 수신 및 로비 입장 처리 트리거 |
 | 서버 → 클라이언트 | `/topic/lobby/{code}/refresh` | 로비 내부 정보 새로고침 신호 |
 | 서버 → 클라이언트 | `/topic/lobby/refresh` | 전역 로비 리스트 새로고침 신호 |
+
+> `/topic/lobby/{code}`는 로비 채팅 메시지 수신 채널이면서 WebSocket 입장 처리 트리거입니다.  
+> `/topic/lobby/{code}/refresh`는 로비 정보 새로고침 신호 수신 전용이며, 입장 처리 트리거가 아닙니다.
 
 ---
 
@@ -269,17 +430,17 @@ JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
 
 ### 정식 회원 (Member)
 
-로그인 성공 시 JWT 또는 Redis 세션을 발급받아 인증합니다.
+로그인 성공 시 JWT 또는 Redis 세션을 발급받아 인증합니다.  
 맵 생성, 로비 호스팅 등 전체 기능에 접근할 수 있습니다.
 
 ### 게스트 (Guest)
 
-닉네임 입력만으로 진입하며, 백엔드에서 UUID를 발급하여 `localStorage`에 저장합니다.
+닉네임 입력만으로 진입하며, 백엔드에서 UUID를 발급하여 `localStorage`에 저장합니다.  
 재방문 시 UUID로 자동 복원됩니다. 퀴즈 플레이 참여만 가능합니다.
 
 ### WebSocket 인증 흐름
 
-```
+```text
 STOMP CONNECT 헤더: { userIdentifier: "UUID 또는 회원 ID" }
     │
     ▼
@@ -292,7 +453,7 @@ StompChannelInterceptor.handleConnect()
 
 ### REST API 인증 흐름
 
-```
+```text
 HTTP 요청 (Authorization: Bearer {accessToken})
     │
     ▼

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -14,17 +14,22 @@
  *   기존에 @Bean jsonMapper()를 등록해 두고도 redisTemplate()에서 주입받지 않아
  *   Dead Code 상태였던 문제를 수정합니다.
  *   파라미터로 주입받도록 변경하여 화이트리스트 보안 정책이 실제로 적용되도록 합니다.
+ *
+ * - Pub/Sub 전용 JsonMapper 추가
+ *   일반 RedisTemplate은 타입 정보를 포함하는 JsonMapper를 사용하고,
+ *   Pub/Sub 메시지는 프론트 계약을 위해 타입 정보 없는 순수 JSON JsonMapper를 사용합니다.
  */
 package io.github.ascrew.monomatbe.global.config;
 
-import org.springframework.data.redis.connection.RedisPassword;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import tools.jackson.databind.json.JsonMapper;
+import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import io.github.ascrew.monomatbe.global.redis.RedisSubscriber;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -33,10 +38,10 @@ import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import tools.jackson.databind.DefaultTyping;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
-import tools.jackson.databind.DefaultTyping;
-import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 
 import java.util.concurrent.Executors;
 
@@ -62,17 +67,12 @@ public class RedisConfig {
      */
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        // 1. 단일 Redis 서버 설정을 위한 객체 생성
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
 
-        // 2. IP 및 포트 설정
         redisConfig.setHostName(redisHost);
         redisConfig.setPort(redisPort);
-
-        // 3. 우분투 서버에서 설정한 비밀번호를 주입
         redisConfig.setPassword(RedisPassword.of(redisPassword));
 
-        // 4. 완성된 설정을 넣어 Factory 반환
         return new LettuceConnectionFactory(redisConfig);
     }
 
@@ -92,21 +92,28 @@ public class RedisConfig {
      */
     @Bean
     public JsonMapper jsonMapper() {
-        // 역직렬화를 허용할 타입을 화이트리스트 방식으로 명시적 제한
         PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-                .allowIfSubType("io.github.ascrew.monomatbe.") // 프로젝트 내 DTO 허용
-                .allowIfSubType("java.util.")                  // List, Map 등 컬렉션 허용
-                .allowIfSubType("java.lang.")                  // String, Integer 등 기본 타입 허용
+                .allowIfSubType("io.github.ascrew.monomatbe.")
+                .allowIfSubType("java.util.")
+                .allowIfSubType("java.lang.")
                 .build();
 
         return JsonMapper.builder()
-                // NON_FINAL 클래스에 한해 @class 타입 정보를 JSON에 포함
                 .activateDefaultTyping(typeValidator, DefaultTyping.NON_FINAL)
                 .build();
     }
 
     /**
-     * Redis Pub/Sub 전용 JsonMapper
+     * Redis Pub/Sub 전용 JsonMapper.
+     *
+     * RedisTemplate<String, Object>에서 사용하는 jsonMapper()는
+     * activateDefaultTyping 설정으로 타입 정보를 JSON에 포함합니다.
+     *
+     * 이 설정은 Redis Hash/Value에 객체 타입을 보존해야 할 때는 유용하지만,
+     * WebSocket 클라이언트로 전달되는 Pub/Sub 메시지에는 부적합합니다.
+     *
+     * 따라서 Pub/Sub 메시지는 클래스 타입 정보 없이 순수 JSON 형태로 직렬화하기 위해
+     * 별도의 JsonMapper를 사용합니다.
      */
     @Bean
     public JsonMapper pubSubJsonMapper() {
@@ -117,40 +124,37 @@ public class RedisConfig {
      * RedisTemplate Bean.
      *
      * [직렬화 전략]
-     * - Key   : StringRedisSerializer              → 사람이 읽을 수 있는 문자열 (디버깅 용이)
-     * - Value : GenericJacksonJsonRedisSerializer  → JSON 직렬화, 타입 정보(@class) 포함
+     * - Key      : StringRedisSerializer             → 사람이 읽을 수 있는 문자열
+     * - Hash Key : StringRedisSerializer             → Hash 필드명도 문자열 유지
+     * - Value    : GenericJacksonJsonRedisSerializer → JSON 직렬화, 타입 정보 포함
+     * - Hash Val : GenericJacksonJsonRedisSerializer → Hash 값 직렬화, 타입 정보 포함
      *
-     * [리팩토링 수정 — JsonMapper 파라미터 주입]
-     * 기존 코드는 @Bean jsonMapper()를 등록해 두고도 이 메서드에서 주입받지 않아
-     * Dead Code 상태였습니다.
+     * [중요]
+     * RedisConfig에는 JsonMapper 타입 Bean이 2개 있습니다.
+     * - jsonMapper       : 일반 RedisTemplate용, 타입 정보 포함
+     * - pubSubJsonMapper : Pub/Sub용, 타입 정보 미포함
      *
-     * 기존: redisTemplate(RedisConnectionFactory connectionFactory)
-     *       → 메서드 내부에서 JsonMapper를 직접 새로 생성 (화이트리스트 정책 미적용 위험)
+     * 따라서 redisTemplate()에는 @Qualifier("jsonMapper")를 명시하여
+     * 일반 RedisTemplate용 Mapper가 주입되도록 고정합니다.
      *
-     * 수정: redisTemplate(RedisConnectionFactory connectionFactory, JsonMapper jsonMapper)
-     *       → Spring이 위에서 등록한 @Bean jsonMapper()를 주입
-     *       → 화이트리스트 보안 정책이 실제 직렬화/역직렬화에 확실히 적용됨
-     *
-     * @param connectionFactory Redis 연결 팩토리 (redisConnectionFactory Bean 주입)
-     * @param jsonMapper        Jackson 3.x 매퍼 (jsonMapper Bean 주입) — Dead Code 수정
+     * @param connectionFactory Redis 연결 팩토리
+     * @param jsonMapper 일반 RedisTemplate 직렬화용 JsonMapper
+     * @return RedisTemplate<String, Object>
      */
     @Bean
     public RedisTemplate<String, Object> redisTemplate(
             RedisConnectionFactory connectionFactory,
-            JsonMapper jsonMapper // [수정] 파라미터 추가 → @Bean jsonMapper() 실제 주입
+            @Qualifier("jsonMapper") JsonMapper jsonMapper
     ) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        // Key: 문자열 그대로 저장 (예: "lobby:ABC123", "user_status:uuid-xxxx")
         template.setKeySerializer(new StringRedisSerializer());
         template.setHashKeySerializer(new StringRedisSerializer());
 
-        // Value: JSON 직렬화
-        // [수정] 메서드 내부에서 JsonMapper를 새로 생성하지 않고
-        //        파라미터로 주입받은 @Bean을 재사용하여 정책 일관성 보장
         GenericJacksonJsonRedisSerializer valueSerializer =
                 new GenericJacksonJsonRedisSerializer(jsonMapper);
+
         template.setValueSerializer(valueSerializer);
         template.setHashValueSerializer(valueSerializer);
 
@@ -161,8 +165,8 @@ public class RedisConfig {
      * Redis Pub/Sub 메시지 리스너 컨테이너 Bean.
      *
      * [구독 채널 목록]
-     * - ChannelTopic("/topic/chat/global") : 전체 채팅 채널 (정확한 채널명 일치)
-     * - PatternTopic("/topic/lobby/*")     : 로비별 채팅 채널 (와일드카드 패턴 매칭)
+     * - ChannelTopic("/topic/chat/global") : 전체 채팅 채널
+     * - PatternTopic("/topic/lobby/*")     : 로비별 채팅 채널
      *
      * [Virtual Thread Executor]
      * 메시지 처리 스레드를 Virtual Thread로 설정하여
@@ -177,16 +181,13 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
 
-        // Java 21 Virtual Thread 기반 Executor로 메시지 처리 (플랫폼 스레드 풀 고갈 방지)
         container.setTaskExecutor(Executors.newVirtualThreadPerTaskExecutor());
 
-        // 전체 채팅 채널 구독 (정확한 채널명 매칭)
         container.addMessageListener(
                 redisSubscriber,
                 new ChannelTopic(StompDestinations.SUBSCRIBE_GLOBAL_CHAT)
         );
 
-        // 로비 채팅 채널 구독 (패턴 매칭으로 모든 로비 채널을 단일 리스너로 처리)
         container.addMessageListener(
                 redisSubscriber,
                 new PatternTopic(StompDestinations.SUBSCRIBE_LOBBY_PATTERN)

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -106,6 +106,14 @@ public class RedisConfig {
     }
 
     /**
+     * Redis Pub/Sub 전용 JsonMapper
+     */
+    @Bean
+    public JsonMapper pubSubJsonMapper() {
+        return JsonMapper.builder().build();
+    }
+
+    /**
      * RedisTemplate Bean.
      *
      * [직렬화 전략]

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -8,8 +8,14 @@ import org.springframework.data.redis.core.script.RedisScript;
 
 /**
  * Redis Lua 스크립트를 관리하는 설정 클래스
- * 매번 스크립트 파일을 읽지 않고, Spring Boot 기동 시 Bean으로 등록하여 캐싱
- * 네트워크 비용 절감 및 스크립트 파싱 오버헤드를 없애기 위한 조치임
+ *
+ * [설계 의도]
+ * Lua 스크립트를 매 요청마다 파일에서 읽지 않고, Spring Boot 가동 시 Bean으로 등록하여 재사용한다.
+ *
+ * [관리 대상]
+ * - create_lobby.lua : 로비 생성 원자 처리
+ * - leave_lobby.lua : 로비 퇴장/방장 위임/폭파 원자 처리
+ * - enter_lobby.lua : 로비 입장 상태 저장 원자 처리
  */
 
 @Configuration
@@ -27,6 +33,24 @@ public class RedisScriptConfig {
     public RedisScript<String> createLobbyScript() {
         DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
         redisScript.setLocation(new ClassPathResource("scripts/create_lobby.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
+
+    /**
+     * 로비 입장 처리 Lua 스크립트
+     *
+     * [처리 내용]
+     * - 로비 존재 여부 확인
+     * - participants Set 저장
+     * - order List 저장
+     * - weSessionId -> lobbyCode/userIdentifier 매핑 저장
+     * - 중복 구독 시 participants/order 중복 저장 방지
+     */
+    @Bean
+    public RedisScript<String> enterLobbyScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/enter_lobby.lua"));
         redisScript.setResultType(String.class);
         return redisScript;
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -44,7 +44,7 @@ public class RedisScriptConfig {
      * - 로비 존재 여부 확인
      * - participants Set 저장
      * - order List 저장
-     * - weSessionId -> lobbyCode/userIdentifier 매핑 저장
+     * - wsSessionId -> lobbyCode/userIdentifier 매핑 저장
      * - 중복 구독 시 participants/order 중복 저장 방지
      */
     @Bean

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -185,7 +185,7 @@ public final class RedisKeys {
 
     /**
      * WebSocket 세션 매핑 Hash 키를 반환합니다.
-     * 저장 구조: Hash { userId, lobbyCode }
+     * 저장 구조: Hash { userIdentifier, lobbyCode }
      * DISCONNECT 이벤트에서 userIdentifier와 lobbyCode를 역추적하는 데 사용됩니다.
      *
      * @param wsSessionId WebSocket 세션 ID

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -6,18 +6,6 @@
  * - FIELD_* : Redis Hash 내부 필드명 상수 (public)
  * - 정적 메서드 : 동적 파라미터가 필요한 키를 생성하는 팩토리 메서드
  *
- * [리팩토링 변경 사항]
- * 1. FIELD_* 상수 추가
- *    LobbyRepositoryImpl에서 Redis Hash 필드 키를 문자열 리터럴로 직접 사용하여
- *    오타 위험과 저장/조회 불일치 문제가 있었습니다.
- *    FIELD_* 상수로 통일하여 컴파일 타임에 오타를 방지합니다.
- *
- * 2. USER_ROOM_PREFIX 및 userRoomKey() 제거
- *    user_room:{lobbyCode} Set과 lobby:{code}:participants Set이 동일한 데이터를
- *    이중으로 관리하는 문제가 있었습니다.
- *    lobby:{code}:participants를 단일 진실의 원천(Source of Truth)으로 통일하고
- *    user_room 관련 상수와 메서드를 제거합니다.
- *
  * [사용 예시]
  * RedisKeys.lobbyKey("ABC123")             → "lobby:ABC123"
  * RedisKeys.lobbyParticipantsKey("ABC123") → "lobby:ABC123:participants"
@@ -31,7 +19,7 @@ public final class RedisKeys {
     private RedisKeys() {}
 
     // =========================================================
-    // Key Prefix 상수 (private — 팩토리 메서드를 통해서만 사용)
+    // Key Prefix 상수
     // =========================================================
 
     /** 로비 메타 정보 Hash 키 접두사 */
@@ -39,12 +27,6 @@ public final class RedisKeys {
 
     /** 사용자 온라인 상태 키 접두사 */
     private static final String USER_STATUS_PREFIX = "user_status:";
-
-    /** 로비별 참여자 Set 키 접미사 */
-    private static final String PARTICIPANTS_SUFFIX = ":participants";
-
-    /** 로비별 입장 순서 List 키 접미사 */
-    private static final String ORDER_SUFFIX = ":order";
 
     /** WebSocket 세션 매핑 Hash 키 접두사 */
     private static final String WS_CONNECTION_PREFIX = "ws:connection:";
@@ -58,11 +40,40 @@ public final class RedisKeys {
     /** 초대 코드 중복 방지 SETNX 락 키 접두사 */
     private static final String LOBBY_CODE_LOCK_PREFIX = "lobby:code:lock:";
 
+    // =========================================================
+    // Key Suffix 상수
+    // =========================================================
+
+    /** 로비별 참여자 Set 키 접미사 */
+    private static final String PARTICIPANTS_SUFFIX = ":participants";
+
+    /** 로비별 입장 순서 List 키 접미사 */
+    private static final String ORDER_SUFFIX = ":order";
+
     /** 로비 내 사용자별 현재 유효 WebSocket 세션 키 접미사 */
     private static final String USER_SESSION_SUFFIX = ":user_session:";
 
+    /** 로비 내 사용자별 현재 유효 WebSocket 세션 sequence 키 접미사 */
+    private static final String USER_SESSION_SEQUENCE_SUFFIX = ":user_session_seq:";
+
     // =========================================================
-    // Redis Hash 필드 키 상수 (auth:guest:session:{token} Hash 내부 필드명)
+    // 전역 단일 키 상수
+    // =========================================================
+
+    /** 공개 로비 코드 목록을 담는 전역 Set 키 */
+    public static final String LOBBY_PUBLIC = "lobby:public";
+
+    /**
+     * WebSocket 세션 sequence 발급용 전역 키.
+     *
+     * 동일 userIdentifier의 재접속이 거의 동시에 발생할 때,
+     * 오래된 세션의 늦은 SUBSCRIBE가 최신 세션을 덮어쓰지 않도록
+     * Redis INCR 기반 단조 증가 sequence를 발급하는 데 사용한다.
+     */
+    public static final String WS_SESSION_SEQUENCE = "ws:session:sequence";
+
+    // =========================================================
+    // Redis Hash 필드 키 상수 (auth:guest:session:{token})
     // =========================================================
 
     /** 게스트 세션 Hash의 사용자 DB PK 필드 */
@@ -74,24 +85,8 @@ public final class RedisKeys {
     /** 게스트 세션 Hash의 사용자 유형 필드 */
     public static final String FIELD_GUEST_USER_TYPE = "userType";
 
-    // [삭제] USER_ROOM_PREFIX 및 userRoomKey() 제거
-    // lobby:{code}:participants가 단일 진실의 원천으로 통일되었으므로
-    // user_room:{lobbyCode} 관련 상수는 더 이상 필요하지 않습니다.
-
     // =========================================================
-    // 전역 단일 키 상수
-    // =========================================================
-
-    /** 공개 로비 코드 목록을 담는 전역 Set 키 */
-    public static final String LOBBY_PUBLIC = "lobby:public";
-
-    // =========================================================
-    // Redis Hash 필드 키 상수 (lobby:{code} Hash 내부 필드명)
-    //
-    // [추가 이유]
-    // LobbyRepositoryImpl에서 "host_user_id", "title" 등의 문자열 리터럴을
-    // 직접 사용하면 오타 발생 시 런타임에서야 발견됩니다.
-    // 상수로 통일하여 컴파일 타임 오타 검출 및 저장/조회 필드명 일관성을 보장합니다.
+    // Redis Hash 필드 키 상수 (lobby:{code})
     // =========================================================
 
     /** 로비 Hash의 초대 코드 필드 */
@@ -102,29 +97,23 @@ public final class RedisKeys {
      *
      * [Lua 스크립트 동기화 필요]
      * leave_lobby.lua에서 이 필드명을 문자열 리터럴로 직접 사용합니다.
-     * Lua 스크립트는 Java 상수를 참조할 수 없는 구조이므로,
      * 이 값을 변경할 경우 leave_lobby.lua의 'host_user_id'도 반드시 함께 수정해야 합니다.
-     *   - HGET lobbyKey, 'host_user_id'
-     *   - HSET lobbyKey, 'host_user_id', nextHost
      */
     public static final String FIELD_HOST_USER_ID = "host_user_id";
 
     /** 로비 Hash의 로비 제목 필드 */
     public static final String FIELD_TITLE = "title";
 
-    /** 로비 Hash의 선택된 맵 ID 필드 (null 가능 — 맵 미선택 상태) */
+    /** 로비 Hash의 선택된 맵 ID 필드 */
     public static final String FIELD_MAP_ID = "map_id";
 
     /** 로비 Hash의 최대 참여 인원 필드 */
     public static final String FIELD_MAX_PLAYERS = "max_players";
 
-    /**
-     * 로비 Hash의 공개/비공개 여부 필드.
-     * 저장 값: "true" (비공개) / "false" (공개)
-     */
+    /** 로비 Hash의 공개/비공개 여부 필드 */
     public static final String FIELD_IS_PRIVATE = "is_private";
 
-    /** 로비 Hash의 상태 필드. 저장 값: "WAITING" / "PLAYING" */
+    /** 로비 Hash의 상태 필드 */
     public static final String FIELD_STATUS = "status";
 
     // =========================================================
@@ -132,8 +121,10 @@ public final class RedisKeys {
     // =========================================================
 
     /**
-     * 로비 메타 정보 Hash 키를 반환합니다.
-     * 저장 구조: Hash { code, host_user_id, title, map_id, max_players, is_private, status }
+     * 로비 메타 정보 Hash 키를 반환한다.
+     *
+     * 저장 구조:
+     * Hash { code, host_user_id, title, map_id, max_players, is_private, status }
      *
      * @param code 로비 초대 코드
      * @return "lobby:{code}"
@@ -143,14 +134,10 @@ public final class RedisKeys {
     }
 
     /**
-     * 로비 참여자 Set 키를 반환합니다.
-     * 저장 구조: Set { userId1, userId2, ... }
+     * 로비 참여자 Set 키를 반환한다.
      *
-     * [단일 진실의 원천]
-     * 기존에 user_room:{lobbyCode}와 이중 관리되던 문제를 해결하고
-     * 이 키를 참여자 관리의 단일 진실의 원천으로 사용합니다.
-     * Lua 스크립트(leave_lobby.lua)의 퇴장 처리와 Java 레벨의 입장 처리 모두
-     * 이 키를 일관되게 사용합니다.
+     * 저장 구조:
+     * Set { userIdentifier1, userIdentifier2, ... }
      *
      * @param code 로비 초대 코드
      * @return "lobby:{code}:participants"
@@ -160,9 +147,10 @@ public final class RedisKeys {
     }
 
     /**
-     * 로비 입장 순서 List 키를 반환합니다.
-     * 저장 구조: List [ 첫 번째 입장 userId, 두 번째 입장 userId, ... ]
-     * 방장 위임 시 LINDEX 0으로 다음 방장을 선정하는 데 사용됩니다.
+     * 로비 입장 순서 List 키를 반환한다.
+     *
+     * 저장 구조:
+     * List [ 첫 번째 입장 userIdentifier, 두 번째 입장 userIdentifier, ... ]
      *
      * @param code 로비 초대 코드
      * @return "lobby:{code}:order"
@@ -172,11 +160,12 @@ public final class RedisKeys {
     }
 
     /**
-     * 사용자 온라인 상태 키를 반환합니다.
-     * 저장 구조: String "ONLINE"
-     * TTL: WebSocketEventListener에서 2시간으로 설정
+     * 사용자 온라인 상태 키를 반환한다.
      *
-     * @param userIdentifier 사용자 식별자 (게스트 UUID 또는 회원 ID)
+     * 저장 구조:
+     * String "ONLINE"
+     *
+     * @param userIdentifier 사용자 식별자
      * @return "user_status:{userIdentifier}"
      */
     public static String userStatusKey(String userIdentifier) {
@@ -184,9 +173,12 @@ public final class RedisKeys {
     }
 
     /**
-     * WebSocket 세션 매핑 Hash 키를 반환합니다.
-     * 저장 구조: Hash { userIdentifier, lobbyCode }
-     * DISCONNECT 이벤트에서 userIdentifier와 lobbyCode를 역추적하는 데 사용됩니다.
+     * WebSocket 세션 매핑 Hash 키를 반환한다.
+     *
+     * 저장 구조:
+     * Hash { userId: userIdentifier, lobbyCode }
+     *
+     * DISCONNECT 이벤트에서 wsSessionId 기준으로 userIdentifier와 lobbyCode를 역추적하는 데 사용한다.
      *
      * @param wsSessionId WebSocket 세션 ID
      * @return "ws:connection:{wsSessionId}"
@@ -196,7 +188,7 @@ public final class RedisKeys {
     }
 
     /**
-     * 게스트 세션 정보를 저장하는 Redis Hash 키를 반환합니다.
+     * 게스트 세션 정보를 저장하는 Redis Hash 키를 반환한다.
      *
      * @param guestToken 게스트 UUID 토큰
      * @return "auth:guest:session:{guestToken}"
@@ -206,7 +198,7 @@ public final class RedisKeys {
     }
 
     /**
-     * Refresh Token 저장 키를 반환합니다.
+     * Refresh Token 저장 키를 반환한다.
      *
      * @param sessionId 세션 식별자(UUID)
      * @return "auth:refresh:{sessionId}"
@@ -215,14 +207,11 @@ public final class RedisKeys {
         return REFRESH_TOKEN_PREFIX + sessionId;
     }
 
-    // 초대 코드 SETNX 락 키 팩토리 메서드
     /**
      * 초대 코드 중복 방지 SETNX 락 키를 반환한다.
      *
-     * [SETNX 전략]
-     * Redis SET NX 명령으로 원자적으로 코드를 선점한다.
-     * 선점 성공 시 해당 코드를 사용하고, 실패 시 재생성한다.
-     * TTL은 LobbyDefaults.INVITE_CODE_LOCK_TTL을 따르며 생성 실패 시 자동 해제되어 코드 공간을 반환한다.
+     * @param inviteCode 로비 초대 코드
+     * @return "lobby:code:lock:{inviteCode}"
      */
     public static String lobbyCodeLockKey(String inviteCode) {
         return LOBBY_CODE_LOCK_PREFIX + inviteCode;
@@ -235,8 +224,8 @@ public final class RedisKeys {
      * 동일 userIdentifier가 같은 로비에 여러 번 연결될 수 있는 상황에서
      * 어떤 wsSessionId가 현재 유효한 세션인지 판별하기 위해 사용한다.
      *
-     * 저장 구조 :
-     * - Key : lobby:{code}:user_session:{userIdentifier}
+     * 저장 구조:
+     * - Key   : lobby:{code}:user_session:{userIdentifier}
      * - Value : wsSessionId
      *
      * @param code 로비 초대 코드
@@ -245,5 +234,24 @@ public final class RedisKeys {
      */
     public static String lobbyUserSessionKey(String code, String userIdentifier) {
         return LOBBY_PREFIX + code + USER_SESSION_SUFFIX + userIdentifier;
+    }
+
+    /**
+     * 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence를 저장하는 키를 반환한다.
+     *
+     * [사용 목적]
+     * 동일 userIdentifier가 같은 로비에 거의 동시에 재접속하는 경우,
+     * 오래된 세션의 늦은 SUBSCRIBE가 최신 세션을 덮어쓰지 않도록 sequence 비교에 사용한다.
+     *
+     * 저장 구조:
+     * - Key   : lobby:{code}:user_session_seq:{userIdentifier}
+     * - Value : sessionSequence
+     *
+     * @param code 로비 초대 코드
+     * @param userIdentifier 사용자 식별자
+     * @return "lobby:{code}:user_session_seq:{userIdentifier}"
+     */
+    public static String lobbyUserSessionSequenceKey(String code, String userIdentifier) {
+        return LOBBY_PREFIX + code + USER_SESSION_SEQUENCE_SUFFIX + userIdentifier;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -58,6 +58,9 @@ public final class RedisKeys {
     /** 초대 코드 중복 방지 SETNX 락 키 접두사 */
     private static final String LOBBY_CODE_LOCK_PREFIX = "lobby:code:lock:";
 
+    /** 로비 내 사용자별 현재 유효 WebSocket 세션 키 접미사 */
+    private static final String USER_SESSION_SUFFIX = ":user_session:";
+
     // =========================================================
     // Redis Hash 필드 키 상수 (auth:guest:session:{token} Hash 내부 필드명)
     // =========================================================
@@ -223,5 +226,24 @@ public final class RedisKeys {
      */
     public static String lobbyCodeLockKey(String inviteCode) {
         return LOBBY_CODE_LOCK_PREFIX + inviteCode;
+    }
+
+    /**
+     * 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID를 저장하는 키를 반환한다.
+     *
+     * [사용 목적]
+     * 동일 userIdentifier가 같은 로비에 여러 번 연결될 수 있는 상황에서
+     * 어떤 wsSessionId가 현재 유효한 세션인지 판별하기 위해 사용한다.
+     *
+     * 저장 구조 :
+     * - Key : lobby:{code}:user_session:{userIdentifier}
+     * - Value : wsSessionId
+     *
+     * @param code 로비 초대 코드
+     * @param userIdentifier 사용자 식별자
+     * @return "lobby:{code}:user_session:{userIdentifier}"
+     */
+    public static String lobbyUserSessionKey(String code, String userIdentifier) {
+        return LOBBY_PREFIX + code + USER_SESSION_SUFFIX + userIdentifier;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -19,7 +19,7 @@ public final class RedisKeys {
     private RedisKeys() {}
 
     // =========================================================
-    // Key Prefix 상수
+    // Key Prefix 상수 (private — 팩토리 메서드를 통해서만 사용)
     // =========================================================
 
     /** 로비 메타 정보 Hash 키 접두사 */
@@ -27,6 +27,18 @@ public final class RedisKeys {
 
     /** 사용자 온라인 상태 키 접두사 */
     private static final String USER_STATUS_PREFIX = "user_status:";
+
+    /** 로비별 참여자 Set 키 접미사 */
+    private static final String PARTICIPANTS_SUFFIX = ":participants";
+
+    /** 로비별 입장 순서 List 키 접미사 */
+    private static final String ORDER_SUFFIX = ":order";
+
+    /** 로비 내 사용자별 현재 유효 WebSocket 세션 키 접미사 */
+    private static final String USER_SESSION_SUFFIX = ":user_session:";
+
+    /** 로비 내 사용자별 현재 유효 WebSocket 세션 sequence 키 접미사 */
+    private static final String USER_SESSION_SEQUENCE_SUFFIX = ":user_session_seq:";
 
     /** WebSocket 세션 매핑 Hash 키 접두사 */
     private static final String WS_CONNECTION_PREFIX = "ws:connection:";
@@ -50,20 +62,21 @@ public final class RedisKeys {
     private static final String MAP_PUBLIC_DETAIL_PREFIX = "map:public:";
 
     // =========================================================
-    // Key Suffix 상수
+    // Redis Hash 필드 키 상수 (auth:guest:session:{token} Hash 내부 필드명)
     // =========================================================
 
-    /** 로비별 참여자 Set 키 접미사 */
-    private static final String PARTICIPANTS_SUFFIX = ":participants";
+    /** 게스트 세션 Hash의 사용자 DB PK 필드 */
+    public static final String FIELD_GUEST_USER_ID = "userId";
 
-    /** 로비별 입장 순서 List 키 접미사 */
-    private static final String ORDER_SUFFIX = ":order";
+    /** 게스트 세션 Hash의 닉네임 필드 */
+    public static final String FIELD_GUEST_USERNAME = "username";
 
-    /** 로비 내 사용자별 현재 유효 WebSocket 세션 키 접미사 */
-    private static final String USER_SESSION_SUFFIX = ":user_session:";
+    /** 게스트 세션 Hash의 사용자 유형 필드 */
+    public static final String FIELD_GUEST_USER_TYPE = "userType";
 
-    /** 로비 내 사용자별 현재 유효 WebSocket 세션 sequence 키 접미사 */
-    private static final String USER_SESSION_SEQUENCE_SUFFIX = ":user_session_seq:";
+    // [삭제] USER_ROOM_PREFIX 및 userRoomKey() 제거
+    // lobby:{code}:participants가 단일 진실의 원천으로 통일되었으므로
+    // user_room:{lobbyCode} 관련 상수는 더 이상 필요하지 않습니다.
 
     // =========================================================
     // 전역 단일 키 상수
@@ -77,25 +90,17 @@ public final class RedisKeys {
      *
      * 동일 userIdentifier의 재접속이 거의 동시에 발생할 때,
      * 오래된 세션의 늦은 SUBSCRIBE가 최신 세션을 덮어쓰지 않도록
-     * Redis INCR 기반 단조 증가 sequence를 발급하는 데 사용한다.
+     * Redis INCR 기반 단조 증가 sequence를 발급하는 데 사용합니다.
      */
     public static final String WS_SESSION_SEQUENCE = "ws:session:sequence";
 
     // =========================================================
-    // Redis Hash 필드 키 상수 (auth:guest:session:{token})
-    // =========================================================
-
-    /** 게스트 세션 Hash의 사용자 DB PK 필드 */
-    public static final String FIELD_GUEST_USER_ID = "userId";
-
-    /** 게스트 세션 Hash의 닉네임 필드 */
-    public static final String FIELD_GUEST_USERNAME = "username";
-
-    /** 게스트 세션 Hash의 사용자 유형 필드 */
-    public static final String FIELD_GUEST_USER_TYPE = "userType";
-
-    // =========================================================
-    // Redis Hash 필드 키 상수 (lobby:{code})
+    // Redis Hash 필드 키 상수 (lobby:{code} Hash 내부 필드명)
+    //
+    // [추가 이유]
+    // LobbyRepositoryImpl에서 "host_user_id", "title" 등의 문자열 리터럴을
+    // 직접 사용하면 오타 발생 시 런타임에서야 발견됩니다.
+    // 상수로 통일하여 컴파일 타임 오타 검출 및 저장/조회 필드명 일관성을 보장합니다.
     // =========================================================
 
     /** 로비 Hash의 초대 코드 필드 */
@@ -106,23 +111,29 @@ public final class RedisKeys {
      *
      * [Lua 스크립트 동기화 필요]
      * leave_lobby.lua에서 이 필드명을 문자열 리터럴로 직접 사용합니다.
+     * Lua 스크립트는 Java 상수를 참조할 수 없는 구조이므로,
      * 이 값을 변경할 경우 leave_lobby.lua의 'host_user_id'도 반드시 함께 수정해야 합니다.
+     *   - HGET lobbyKey, 'host_user_id'
+     *   - HSET lobbyKey, 'host_user_id', nextHost
      */
     public static final String FIELD_HOST_USER_ID = "host_user_id";
 
     /** 로비 Hash의 로비 제목 필드 */
     public static final String FIELD_TITLE = "title";
 
-    /** 로비 Hash의 선택된 맵 ID 필드 */
+    /** 로비 Hash의 선택된 맵 ID 필드 (null 가능 — 맵 미선택 상태) */
     public static final String FIELD_MAP_ID = "map_id";
 
     /** 로비 Hash의 최대 참여 인원 필드 */
     public static final String FIELD_MAX_PLAYERS = "max_players";
 
-    /** 로비 Hash의 공개/비공개 여부 필드 */
+    /**
+     * 로비 Hash의 공개/비공개 여부 필드.
+     * 저장 값: "true" (비공개) / "false" (공개)
+     */
     public static final String FIELD_IS_PRIVATE = "is_private";
 
-    /** 로비 Hash의 상태 필드 */
+    /** 로비 Hash의 상태 필드. 저장 값: "WAITING" / "PLAYING" */
     public static final String FIELD_STATUS = "status";
 
     // =========================================================
@@ -130,10 +141,8 @@ public final class RedisKeys {
     // =========================================================
 
     /**
-     * 로비 메타 정보 Hash 키를 반환한다.
-     *
-     * 저장 구조:
-     * Hash { code, host_user_id, title, map_id, max_players, is_private, status }
+     * 로비 메타 정보 Hash 키를 반환합니다.
+     * 저장 구조: Hash { code, host_user_id, title, map_id, max_players, is_private, status }
      *
      * @param code 로비 초대 코드
      * @return "lobby:{code}"
@@ -143,10 +152,14 @@ public final class RedisKeys {
     }
 
     /**
-     * 로비 참여자 Set 키를 반환한다.
+     * 로비 참여자 Set 키를 반환합니다.
+     * 저장 구조: Set { userId1, userId2, ... }
      *
-     * 저장 구조:
-     * Set { userIdentifier1, userIdentifier2, ... }
+     * [단일 진실의 원천]
+     * 기존에 user_room:{lobbyCode}와 이중 관리되던 문제를 해결하고
+     * 이 키를 참여자 관리의 단일 진실의 원천으로 사용합니다.
+     * Lua 스크립트(leave_lobby.lua)의 퇴장 처리와 Java 레벨의 입장 처리 모두
+     * 이 키를 일관되게 사용합니다.
      *
      * @param code 로비 초대 코드
      * @return "lobby:{code}:participants"
@@ -156,10 +169,9 @@ public final class RedisKeys {
     }
 
     /**
-     * 로비 입장 순서 List 키를 반환한다.
-     *
-     * 저장 구조:
-     * List [ 첫 번째 입장 userIdentifier, 두 번째 입장 userIdentifier, ... ]
+     * 로비 입장 순서 List 키를 반환합니다.
+     * 저장 구조: List [ 첫 번째 입장 userId, 두 번째 입장 userId, ... ]
+     * 방장 위임 시 LINDEX 0으로 다음 방장을 선정하는 데 사용됩니다.
      *
      * @param code 로비 초대 코드
      * @return "lobby:{code}:order"
@@ -169,12 +181,11 @@ public final class RedisKeys {
     }
 
     /**
-     * 사용자 온라인 상태 키를 반환한다.
+     * 사용자 온라인 상태 키를 반환합니다.
+     * 저장 구조: String "ONLINE"
+     * TTL: WebSocketEventListener에서 2시간으로 설정
      *
-     * 저장 구조:
-     * String "ONLINE"
-     *
-     * @param userIdentifier 사용자 식별자
+     * @param userIdentifier 사용자 식별자 (게스트 UUID 또는 회원 ID)
      * @return "user_status:{userIdentifier}"
      */
     public static String userStatusKey(String userIdentifier) {
@@ -182,12 +193,9 @@ public final class RedisKeys {
     }
 
     /**
-     * WebSocket 세션 매핑 Hash 키를 반환한다.
-     *
-     * 저장 구조:
-     * Hash { userId: userIdentifier, lobbyCode }
-     *
-     * DISCONNECT 이벤트에서 wsSessionId 기준으로 userIdentifier와 lobbyCode를 역추적하는 데 사용한다.
+     * WebSocket 세션 매핑 Hash 키를 반환합니다.
+     * 저장 구조: Hash { userId, lobbyCode }
+     * DISCONNECT 이벤트에서 userIdentifier와 lobbyCode를 역추적하는 데 사용됩니다.
      *
      * @param wsSessionId WebSocket 세션 ID
      * @return "ws:connection:{wsSessionId}"
@@ -197,7 +205,7 @@ public final class RedisKeys {
     }
 
     /**
-     * 게스트 세션 정보를 저장하는 Redis Hash 키를 반환한다.
+     * 게스트 세션 정보를 저장하는 Redis Hash 키를 반환합니다.
      *
      * @param guestToken 게스트 UUID 토큰
      * @return "auth:guest:session:{guestToken}"
@@ -207,7 +215,7 @@ public final class RedisKeys {
     }
 
     /**
-     * Refresh Token 저장 키를 반환한다.
+     * Refresh Token 저장 키를 반환합니다.
      *
      * @param sessionId 세션 식별자(UUID)
      * @return "auth:refresh:{sessionId}"
@@ -219,6 +227,11 @@ public final class RedisKeys {
     /**
      * 초대 코드 중복 방지 SETNX 락 키를 반환한다.
      *
+     * [SETNX 전략]
+     * Redis SET NX 명령으로 원자적으로 코드를 선점한다.
+     * 선점 성공 시 해당 코드를 사용하고, 실패 시 재생성한다.
+     * TTL은 LobbyDefaults.INVITE_CODE_LOCK_TTL을 따르며 생성 실패 시 자동 해제되어 코드 공간을 반환한다.
+     *
      * @param inviteCode 로비 초대 코드
      * @return "lobby:code:lock:{inviteCode}"
      */
@@ -227,11 +240,11 @@ public final class RedisKeys {
     }
 
     /**
-     * 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID를 저장하는 키를 반환한다.
+     * 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID를 저장하는 키를 반환합니다.
      *
      * [사용 목적]
      * 동일 userIdentifier가 같은 로비에 여러 번 연결될 수 있는 상황에서
-     * 어떤 wsSessionId가 현재 유효한 세션인지 판별하기 위해 사용한다.
+     * 어떤 wsSessionId가 현재 유효한 세션인지 판별하기 위해 사용합니다.
      *
      * 저장 구조:
      * - Key   : lobby:{code}:user_session:{userIdentifier}
@@ -246,11 +259,11 @@ public final class RedisKeys {
     }
 
     /**
-     * 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence를 저장하는 키를 반환한다.
+     * 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence를 저장하는 키를 반환합니다.
      *
      * [사용 목적]
      * 동일 userIdentifier가 같은 로비에 거의 동시에 재접속하는 경우,
-     * 오래된 세션의 늦은 SUBSCRIBE가 최신 세션을 덮어쓰지 않도록 sequence 비교에 사용한다.
+     * 오래된 세션의 늦은 SUBSCRIBE가 최신 세션을 덮어쓰지 않도록 sequence 비교에 사용합니다.
      *
      * 저장 구조:
      * - Key   : lobby:{code}:user_session_seq:{userIdentifier}
@@ -263,15 +276,34 @@ public final class RedisKeys {
     public static String lobbyUserSessionSequenceKey(String code, String userIdentifier) {
         return LOBBY_PREFIX + code + USER_SESSION_SEQUENCE_SUFFIX + userIdentifier;
     }
-}
+
+    /**
+     * 공개 맵 목록 캐시 버전 키를 반환합니다.
+     *
+     * @return "map:public:list:version"
+     */
     public static String mapPublicListVersionKey() {
         return MAP_PUBLIC_LIST_VERSION;
     }
 
+    /**
+     * 공개 맵 목록 페이지 캐시 키를 반환합니다.
+     *
+     * @param version 캐시 버전
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @return "map:public:list:v:{version}:p:{page}:s:{size}"
+     */
     public static String mapPublicListKey(String version, int page, int size) {
         return MAP_PUBLIC_LIST_PREFIX + ":v:" + version + ":p:" + page + ":s:" + size;
     }
 
+    /**
+     * 공개 맵 단건 캐시 키를 반환합니다.
+     *
+     * @param mapId 맵 ID
+     * @return "map:public:{mapId}"
+     */
     public static String mapPublicDetailKey(Long mapId) {
         return MAP_PUBLIC_DETAIL_PREFIX + mapId;
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/WebSocketHeaders.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/WebSocketHeaders.java
@@ -1,13 +1,6 @@
 /*
  * WebSocket / STOMP 통신에서 사용하는 헤더 키 및 세션 속성 키를
  * 중앙에서 관리하는 상수 클래스.
- *
- * [수정]
- * SESSION_USER_ID, SESSION_LOBBY_CODE 상수 추가
- * LobbyEventService.saveConnectionInfo()에서 저장할 때와
- * WebSocketEventListener.handleDisconnectEvent()에서 조회할 때
- * 동일한 문자열 리터럴("userId", "lobbyCode")을 각자 하드코딩하고 있었습니다.
- * 상수로 통일하여 오타 시 컴파일 타임에 감지되도록 합니다.
  */
 package io.github.ascrew.monomatbe.global.constant;
 
@@ -18,7 +11,9 @@ public final class WebSocketHeaders {
 
     /**
      * STOMP CONNECT 헤더 및 세션 속성에서 사용자 식별자를 저장/조회할 때 사용하는 키.
-     * 게스트: UUID / 정식 회원: userId
+     *
+     * 게스트: UUID
+     * 회원: userId
      *
      * 사용 위치:
      * - StompChannelInterceptor : CONNECT 시 헤더에서 추출하여 세션에 저장
@@ -37,16 +32,32 @@ public final class WebSocketHeaders {
     public static final String ROOM_ID = "roomId";
 
     /**
+     * 로비 입장 Lua 처리 결과를 STOMP 세션 속성에 임시 저장할 때 사용하는 키.
+     *
+     * 사용 위치:
+     * - StompChannelInterceptor : SUBSCRIBE preSend 단계에서 enter_lobby.lua 실행 후 저장
+     * - WebSocketEventListener  : SessionSubscribeEvent에서 후처리 시 조회
+     */
+    public static final String LOBBY_ENTER_RESULT = "lobbyEnterResult";
+
+    /**
+     * WebSocket 세션 생성 순서값을 STOMP 세션 속성에 저장할 때 사용하는 키.
+     *
+     * 동일 userIdentifier의 재접속이 겹칠 때,
+     * 오래된 세션이 최신 세션을 덮어쓰지 않도록 Lua에서 비교하는 데 사용한다.
+     */
+    public static final String SESSION_SEQUENCE = "sessionSequence";
+
+    /**
      * 사용자 온라인 상태를 Redis에 저장할 때 사용하는 값 상수.
      *
      * 사용 위치:
-     * - WebSocketEventListener : CONNECT 이벤트에서 Redis에 상태 저장
+     * - StompChannelInterceptor : CONNECT 시 Redis에 상태 저장
      */
     public static final String STATUS_ONLINE = "ONLINE";
 
     /**
      * 세션에서 사용자 식별자를 찾지 못했을 때 사용하는 폴백 값.
-     * 로그 추적 및 방어 코드에 활용됩니다.
      *
      * 사용 위치:
      * - WebSocketEventListener : 식별자 조회 실패 시
@@ -56,20 +67,17 @@ public final class WebSocketHeaders {
 
     // =========================================================
     // Redis ws:connection Hash 필드 키 상수
-    //
-    // [추가 이유]
-    // LobbyEventService.saveConnectionInfo()에서 저장 시 사용하는 "userId", "lobbyCode"와
-    // WebSocketEventListener.handleDisconnectEvent()에서 조회 시 사용하는 "userId", "lobbyCode"가
-    // 각자 문자열 리터럴로 하드코딩되어 있었습니다.
-    // 오타 발생 시 런타임에서야 발견되는 문제를 상수 통일로 컴파일 타임 감지로 전환합니다.
     // =========================================================
 
     /**
-     * Redis ws:connection:{wsSessionId} Hash의 사용자 ID 필드 키.
+     * Redis ws:connection:{wsSessionId} Hash의 사용자 식별자 필드 키.
+     *
+     * 필드명은 "userId"이지만 저장 값은 DB PK가 아니라 userIdentifier입니다.
      *
      * 사용 위치:
-     * - LobbyEventService.saveConnectionInfo()     : 저장 시
-     * - WebSocketEventListener.handleDisconnectEvent() : 조회 시
+     * - enter_lobby.lua             : 저장 시
+     * - WebSocketEventListener      : DISCONNECT 조회 시
+     * - StompChannelInterceptor     : enter_lobby.lua ARGV 전달 시
      */
     public static final String SESSION_USER_ID = "userId";
 
@@ -77,8 +85,9 @@ public final class WebSocketHeaders {
      * Redis ws:connection:{wsSessionId} Hash의 로비 코드 필드 키.
      *
      * 사용 위치:
-     * - LobbyEventService.saveConnectionInfo()         : 저장 시
-     * - WebSocketEventListener.handleDisconnectEvent() : 조회 시
+     * - enter_lobby.lua             : 저장 시
+     * - WebSocketEventListener      : DISCONNECT 조회 시
+     * - StompChannelInterceptor     : enter_lobby.lua ARGV 전달 시
      */
     public static final String SESSION_LOBBY_CODE = "lobbyCode";
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisPublisher.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisPublisher.java
@@ -1,57 +1,247 @@
 /*
  * Redis Pub/Sub 채널에 메시지를 발행하는 인프라 컴포넌트.
  *
- * [역할]
- * 서버 내부에서 발생한 채팅/입장/퇴장 메시지를 Redis Pub/Sub 채널로 발행한다.
+ * [global/redis로 분류한 이유]
+ * RedisPublisher는 특정 도메인(chat, lobby 등)에 종속되지 않고
+ * 어느 도메인에서든 Redis 채널에 메시지를 발행할 때 재사용되므로,
+ * domain이 아닌 global/redis 패키지에 위치한다.
  *
- * [중요]
+ * [직렬화 정책]
  * Pub/Sub 메시지는 WebSocket 클라이언트에게 그대로 전달될 수 있으므로,
  * RedisTemplate<String, Object>의 타입 정보 포함 직렬화를 사용하지 않는다.
  *
  * 대신 StringRedisTemplate과 Pub/Sub 전용 JsonMapper를 사용하여
  * 프론트엔드가 바로 JSON.parse() 가능한 순수 JSON 문자열을 발행한다.
+ *
+ * [장애 처리 정책]
+ * Redis Pub/Sub 발행 실패는 ENTER/LEAVE 같은 시스템 메시지 유실로 이어질 수 있다.
+ * 따라서 예외를 단순히 로그로만 삼키지 않고 다음 처리를 수행한다.
+ *
+ * 1. 발행 실패 시 제한된 횟수만큼 재시도
+ * 2. 최종 실패 시 false 반환
+ * 3. 성공/실패 메트릭 기록
+ * 4. 호출부가 반환값을 기반으로 추가 fallback 처리를 할 수 있게 함
  */
 package io.github.ascrew.monomatbe.global.redis;
 
 import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.time.Duration;
+
 @Slf4j
 @Service
 public class RedisPublisher {
 
+    // =========================================================
+    // 재시도 정책 상수
+    // =========================================================
+
+    /**
+     * Redis Pub/Sub 발행 최대 시도 횟수.
+     *
+     * 최초 1회 + 재시도 1회입니다.
+     * WebSocket 이벤트 처리 흐름을 과도하게 지연시키지 않기 위해 무제한 재시도는 하지 않는다.
+     */
+    private static final int MAX_PUBLISH_ATTEMPTS = 2;
+
+    /**
+     * Redis Pub/Sub 발행 재시도 전 대기 시간.
+     *
+     * 아주 짧은 네트워크 흔들림이나 Redis 커넥션 순간 오류를 흡수하기 위한 값
+     */
+    private static final Duration RETRY_BACKOFF = Duration.ofMillis(50);
+
+    /**
+     * 로그에 남길 payload 최대 길이.
+     *
+     * 메시지가 과도하게 길어질 경우 로그가 오염될 수 있으므로 제한한다.
+     */
+    private static final int MAX_PAYLOAD_LOG_LENGTH = 500;
+
+    // =========================================================
+    // 메트릭 이름 상수
+    // =========================================================
+
+    private static final String METRIC_PUBLISH_SUCCESS = "redis.pubsub.publish.success";
+    private static final String METRIC_PUBLISH_FAILURE = "redis.pubsub.publish.failure";
+
+    // =========================================================
+    // 의존성
+    // =========================================================
+
+    /**
+     * Redis Pub/Sub 발행 전용 Template.
+     *
+     * 순수 JSON 문자열을 발행해야 하므로 StringRedisTemplate을 사용한다.
+     */
     private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * Pub/Sub 전용 JsonMapper.
+     *
+     * Redis 데이터 저장용 JsonMapper는 activateDefaultTyping을 사용할 수 있으므로,
+     * Pub/Sub 메시지 직렬화에는 별도 Mapper를 사용한다.
+     */
     private final JsonMapper pubSubJsonMapper;
+
+    /**
+     * Pub/Sub 발행 성공 메트릭.
+     */
+    private final Counter publishSuccessCounter;
+
+    /**
+     * Pub/Sub 발행 실패 메트릭.
+     */
+    private final Counter publishFailureCounter;
 
     public RedisPublisher(
             StringRedisTemplate stringRedisTemplate,
-            @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper
+            @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper,
+            MeterRegistry meterRegistry
     ) {
         this.stringRedisTemplate = stringRedisTemplate;
         this.pubSubJsonMapper = pubSubJsonMapper;
+        this.publishSuccessCounter = Counter.builder(METRIC_PUBLISH_SUCCESS)
+                .description("Redis Pub/Sub publish success count")
+                .register(meterRegistry);
+        this.publishFailureCounter = Counter.builder(METRIC_PUBLISH_FAILURE)
+                .description("Redis Pub/Sub publish failure count")
+                .register(meterRegistry);
     }
 
     /**
      * 지정한 Redis Pub/Sub 채널로 메시지를 발행한다.
      *
-     * [직렬화 정책]
-     * - ChatMessageDto를 순수 JSON 문자열로 변환한다.
-     * - 클래스 타입 정보는 포함하지 않는다.
-     * - Redis 채널에는 문자열 그대로 저장/전송한다.
+     * [반환값]
+     * - true  : 발행 성공
+     * - false : 직렬화 실패 또는 모든 재시도 실패
+     *
+     * [주의]
+     * false가 반환되면 시스템 메시지가 실제 클라이언트에게 전달되지 않았을 수 있다.
+     * 호출부는 필요하면 fallback 로그, 직접 WebSocket 전송, 사용자 재시도 안내 등을 수행해야 한다.
+     *
+     * @param topic      Redis Pub/Sub 채널명. WebSocket destination과 동일하게 사용.
+     * @param messageDto 발행할 메시지 DTO
+     * @return 발행 성공 여부
      */
-    public void publish(String topic, ChatMessageDto messageDto) {
+    public boolean publish(String topic, ChatMessageDto messageDto) {
+        if (topic == null || topic.isBlank()) {
+            log.error("Redis Pub/Sub 발행 실패 - topic이 비어 있습니다. messageType: {}",
+                    messageDto != null ? messageDto.getType() : null);
+            publishFailureCounter.increment();
+            return false;
+        }
+
+        if (messageDto == null) {
+            log.error("Redis Pub/Sub 발행 실패 - messageDto가 null입니다. topic: {}", topic);
+            publishFailureCounter.increment();
+            return false;
+        }
+
+        String payload;
         try {
-            String payload = pubSubJsonMapper.writeValueAsString(messageDto);
-            stringRedisTemplate.convertAndSend(topic, payload);
+            payload = pubSubJsonMapper.writeValueAsString(messageDto);
         } catch (Exception e) {
             log.error("Redis Pub/Sub 메시지 직렬화 실패 - topic: {}, messageType: {}",
                     topic,
-                    messageDto != null ? messageDto.getType() : null,
+                    messageDto.getType(),
                     e);
+            publishFailureCounter.increment();
+            return false;
         }
+
+        return publishWithRetry(topic, messageDto, payload);
+    }
+
+    /**
+     * Redis Pub/Sub 발행을 제한된 횟수만큼 재시도합니다.
+     *
+     * 직렬화는 재시도해도 결과가 달라질 가능성이 낮으므로 publish()에서 한 번만 수행합니다.
+     * 이 메서드는 Redis convertAndSend 실패에 대해서만 재시도합니다.
+     */
+    private boolean publishWithRetry(
+            String topic,
+            ChatMessageDto messageDto,
+            String payload
+    ) {
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= MAX_PUBLISH_ATTEMPTS; attempt++) {
+            try {
+                stringRedisTemplate.convertAndSend(topic, payload);
+
+                publishSuccessCounter.increment();
+
+                if (attempt > 1) {
+                    log.info("Redis Pub/Sub 발행 재시도 성공 - topic: {}, messageType: {}, attempt: {}/{}",
+                            topic, messageDto.getType(), attempt, MAX_PUBLISH_ATTEMPTS);
+                }
+
+                return true;
+
+            } catch (Exception e) {
+                lastException = e;
+
+                log.warn("Redis Pub/Sub 발행 실패 - 재시도 여부 확인. topic: {}, messageType: {}, attempt: {}/{}, message: {}",
+                        topic,
+                        messageDto.getType(),
+                        attempt,
+                        MAX_PUBLISH_ATTEMPTS,
+                        e.getMessage());
+
+                waitBeforeRetry(attempt);
+            }
+        }
+
+        publishFailureCounter.increment();
+
+        log.error("Redis Pub/Sub 발행 최종 실패 - topic: {}, messageType: {}, payload: {}",
+                topic,
+                messageDto.getType(),
+                abbreviatePayload(payload),
+                lastException);
+
+        return false;
+    }
+
+    /**
+     * 다음 재시도 전에 짧게 대기
+     *
+     * 마지막 시도 이후에는 대기하지 않는다.
+     * interrupt 발생 시 인터럽트 상태를 복원하고 즉시 반환한다.
+     */
+    private void waitBeforeRetry(int attempt) {
+        if (attempt >= MAX_PUBLISH_ATTEMPTS) {
+            return;
+        }
+
+        try {
+            Thread.sleep(RETRY_BACKOFF.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Redis Pub/Sub 재시도 대기 중 인터럽트 발생");
+        }
+    }
+
+    /**
+     * payload 로그 길이를 제한한다.
+     */
+    private String abbreviatePayload(String payload) {
+        if (payload == null) {
+            return "null";
+        }
+
+        if (payload.length() <= MAX_PAYLOAD_LOG_LENGTH) {
+            return payload;
+        }
+
+        return payload.substring(0, MAX_PAYLOAD_LOG_LENGTH) + "...";
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisPublisher.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisPublisher.java
@@ -1,30 +1,57 @@
 /*
  * Redis Pub/Sub 채널에 메시지를 발행하는 인프라 컴포넌트.
  *
- * [global/redis로 분류한 이유]
- * RedisPublisher는 특정 도메인(chat, lobby 등)에 종속되지 않고 어느 도메인에서든 Redis 채널에 메시지를 발행할 때 재사용되므로,
- * domain이 아닌 global/redis 패키지에 위치한다.
+ * [역할]
+ * 서버 내부에서 발생한 채팅/입장/퇴장 메시지를 Redis Pub/Sub 채널로 발행한다.
+ *
+ * [중요]
+ * Pub/Sub 메시지는 WebSocket 클라이언트에게 그대로 전달될 수 있으므로,
+ * RedisTemplate<String, Object>의 타입 정보 포함 직렬화를 사용하지 않는다.
+ *
+ * 대신 StringRedisTemplate과 Pub/Sub 전용 JsonMapper를 사용하여
+ * 프론트엔드가 바로 JSON.parse() 가능한 순수 JSON 문자열을 발행한다.
  */
 package io.github.ascrew.monomatbe.global.redis;
 
 import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.json.JsonMapper;
 
+@Slf4j
 @Service
-@RequiredArgsConstructor
 public class RedisPublisher {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final JsonMapper pubSubJsonMapper;
+
+    public RedisPublisher(
+            StringRedisTemplate stringRedisTemplate,
+            @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper
+    ) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.pubSubJsonMapper = pubSubJsonMapper;
+    }
 
     /**
-     * 지정한 Redis 채널 토픽으로 메시지를 발행합니다.
+     * 지정한 Redis Pub/Sub 채널로 메시지를 발행한다.
      *
-     * @param topic      발행할 Redis 채널 경로
-     * @param messageDto 발행할 채팅 메시지 객체
+     * [직렬화 정책]
+     * - ChatMessageDto를 순수 JSON 문자열로 변환한다.
+     * - 클래스 타입 정보는 포함하지 않는다.
+     * - Redis 채널에는 문자열 그대로 저장/전송한다.
      */
     public void publish(String topic, ChatMessageDto messageDto) {
-        redisTemplate.convertAndSend(topic, messageDto);
+        try {
+            String payload = pubSubJsonMapper.writeValueAsString(messageDto);
+            stringRedisTemplate.convertAndSend(topic, payload);
+        } catch (Exception e) {
+            log.error("Redis Pub/Sub 메시지 직렬화 실패 - topic: {}, messageType: {}",
+                    topic,
+                    messageDto != null ? messageDto.getType() : null,
+                    e);
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisSubscriber.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisSubscriber.java
@@ -3,45 +3,88 @@
  *
  * [동작 흐름]
  * Redis 채널 메시지 수신
- * → JSON 문자열로 디코딩
- * → 동일한 destination을 구독 중인 WebSocket 클라이언트에게 그대로 전달
+ * → raw JSON 문자열 디코딩
+ * → ChatMessageDto로 역직렬화하여 메시지 계약 검증
+ * → 검증 성공 시 원본 JSON 문자열을 WebSocket으로 브로드캐스트
  *
  * [중요]
- * 여기서는 ChatMessageDto로 역직렬화하지 않습니다.
- * Pub/Sub 메시지는 이미 RedisPublisher에서 프론트엔드 친화적인 순수 JSON 문자열로 직렬화되었습니다.
+ * WebSocket 클라이언트가 수신하는 STOMP message.body는 문자열입니다.
+ * 따라서 프론트엔드 계약은 다음과 같이 고정합니다.
  *
- * 역직렬화를 생략하면 다음 장점이 있습니다.
- * - 클래스 타입 정보가 클라이언트로 노출되지 않음
- * - RedisTemplate<String, Object> 직렬화 정책과 분리됨
- * - 메시지 릴레이 책임만 수행하므로 구조가 단순해짐
+ * - message.body는 ChatMessageDto 형태의 JSON 문자열이다.
+ * - 클라이언트는 JSON.parse(message.body)로 객체화하여 사용한다.
+ *
+ * RedisSubscriber에서 ChatMessageDto 객체를 그대로 convertAndSend()하면
+ * Spring WebSocket 메시지 변환 과정에서 타입 정보가 포함될 수 있습니다.
+ *
+ * 문제 예:
+ * [
+ *   "io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto",
+ *   { ... }
+ * ]
+ *
+ * 따라서 WebSocket으로는 DTO 객체가 아니라 검증된 원본 JSON 문자열을 그대로 전달합니다.
  */
 package io.github.ascrew.monomatbe.global.redis;
 
-import lombok.RequiredArgsConstructor;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class RedisSubscriber implements MessageListener {
 
+    /**
+     * 로그에 남길 payload 최대 길이.
+     * 잘못된 메시지가 길게 들어왔을 때 로그 오염을 방지한다.
+     */
+    private static final int MAX_PAYLOAD_LOG_LENGTH = 500;
+
+    /**
+     * Redis Pub/Sub 메시지를 WebSocket 구독자에게 전달하는 Spring STOMP 템플릿
+     */
     private final SimpMessagingTemplate simpMessagingTemplate;
 
     /**
-     * Redis 채널에서 메시지를 수신하면 호출된다.
+     * Pub/Sub 전용 JsonMapper입니다.
+     *
+     * Redis 데이터 저장용 JsonMapper는 타입 정보를 포함할 수 있으므로,
+     * Pub/Sub 메시지 파싱에는 클래스 타입 정보를 요구하지 않는 별도 Mapper를 사용합니다.
+     */
+    private final JsonMapper pubSubJsonMapper;
+
+    public RedisSubscriber(
+            SimpMessagingTemplate simpMessagingTemplate,
+            @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper
+    ) {
+        this.simpMessagingTemplate = simpMessagingTemplate;
+        this.pubSubJsonMapper = pubSubJsonMapper;
+    }
+
+    /**
+     * Redis 채널에서 메시지를 수신하면 호출
      *
      * [처리 방식]
-     * - message.channel: WebSocket destination으로 사용한다.
-     * - message.body   : JSON 문자열로 디코딩한 뒤 그대로 전달한다.
+     * 1. Redis message.channel을 WebSocket destination으로 사용합니다.
+     * 2. Redis message.body를 UTF-8 JSON 문자열로 디코딩합니다.
+     * 3. ChatMessageDto로 역직렬화하여 메시지 계약을 검증합니다.
+     * 4. 검증 성공 시 원본 JSON 문자열을 그대로 WebSocket으로 전달합니다.
      *
-     * @param message Redis 메시지. 채널명과 본문을 포함한다.
-     * @param pattern 패턴 구독 시 매칭된 패턴. 현재 로직에서는 사용하지 않는다.
+     * [왜 DTO 객체로 보내지 않는가]
+     * SimpMessagingTemplate에 DTO 객체를 넘기면 현재 Jackson 설정에 따라
+     * WebSocket 응답 body에 클래스 타입 정보가 포함될 수 있습니다.
+     * 따라서 프론트 계약을 "JSON 문자열"로 고정하고, 서버는 JSON.parse 가능한 문자열을 전달합니다.
+     *
+     * @param message Redis 메시지. 채널명과 본문을 포함합니다.
+     * @param pattern 패턴 구독 시 매칭된 패턴. 현재 로직에서는 사용하지 않습니다.
      */
     @Override
     public void onMessage(Message message, byte[] pattern) {
@@ -49,12 +92,91 @@ public class RedisSubscriber implements MessageListener {
         String payload = new String(message.getBody(), StandardCharsets.UTF_8);
 
         try {
+            ChatMessageDto chatMessageDto = parseAndValidatePayload(destination, payload);
+
+            if (chatMessageDto == null) {
+                return;
+            }
+
+            /*
+             * WebSocket 클라이언트로는 DTO 객체가 아니라 JSON 문자열을 그대로 전달
+             *
+             * 프론트 계약:
+             * - message.body는 ChatMessageDto JSON 문자열
+             * - 클라이언트는 JSON.parse(message.body)로 사용
+             *
+             * 이 방식은 ["클래스명", {...}] 형태의 타입 정보 노출을 방지한다.
+             */
             simpMessagingTemplate.convertAndSend(destination, payload);
+
         } catch (Exception e) {
-            log.error("Redis Pub/Sub 메시지 WebSocket 브로드캐스트 실패 - destination: {}, payload: {}",
+            log.error(
+                    "Redis Pub/Sub 메시지 WebSocket 브로드캐스트 실패 - destination: {}, payload: {}",
                     destination,
-                    payload,
-                    e);
+                    abbreviatePayload(payload),
+                    e
+            );
         }
+    }
+
+    /**
+     * Redis Pub/Sub payload를 ChatMessageDto로 역직렬화하고 최소 계약을 검증한다.
+     *
+     * 검증에 성공하면 ChatMessageDto를 반환하고,
+     * 실패하면 null을 반환하여 메시지를 폐기한다.
+     */
+    private ChatMessageDto parseAndValidatePayload(String destination, String payload) {
+        ChatMessageDto chatMessageDto;
+
+        try {
+            chatMessageDto = pubSubJsonMapper.readValue(payload, ChatMessageDto.class);
+        } catch (Exception e) {
+            log.error(
+                    "Redis Pub/Sub 메시지 역직렬화 실패 - destination: {}, payload: {}",
+                    destination,
+                    abbreviatePayload(payload),
+                    e
+            );
+            return null;
+        }
+
+        if (!isValidMessage(chatMessageDto)) {
+            log.warn(
+                    "Redis Pub/Sub 메시지 계약 위반 - destination: {}, payload: {}",
+                    destination,
+                    abbreviatePayload(payload)
+            );
+            return null;
+        }
+
+        return chatMessageDto;
+    }
+
+    /**
+     * WebSocket으로 전달 가능한 최소 메시지 계약을 검증
+     *
+     * type과 roomId는 클라이언트 라우팅 및 UI 분기에 필요한 핵심 필드이므로 필수로 본다.
+     * sender/content/timestamp는 메시지 유형에 따라 비어 있을 수 있으므로 여기서는 강제하지 않는다.
+     */
+    private boolean isValidMessage(ChatMessageDto message) {
+        return message != null
+                && message.getType() != null
+                && message.getRoomId() != null
+                && !message.getRoomId().isBlank();
+    }
+
+    /**
+     * payload 로그 길이를 제한
+     */
+    private String abbreviatePayload(String payload) {
+        if (payload == null) {
+            return "null";
+        }
+
+        if (payload.length() <= MAX_PAYLOAD_LOG_LENGTH) {
+            return payload;
+        }
+
+        return payload.substring(0, MAX_PAYLOAD_LOG_LENGTH) + "...";
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisSubscriber.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/redis/RedisSubscriber.java
@@ -2,54 +2,59 @@
  * Redis Pub/Sub 채널을 구독하고 수신된 메시지를 WebSocket으로 브로드캐스트하는 컴포넌트.
  *
  * [동작 흐름]
- * Redis 채널 메시지 수신 → JSON 역직렬화 → SimpMessagingTemplate으로 WebSocket 브로드캐스트
+ * Redis 채널 메시지 수신
+ * → JSON 문자열로 디코딩
+ * → 동일한 destination을 구독 중인 WebSocket 클라이언트에게 그대로 전달
  *
- * [global/redis로 분류한 이유]
- * RedisPublisher와 마찬가지로 도메인에 종속되지 않는 인프라 컴포넌트
+ * [중요]
+ * 여기서는 ChatMessageDto로 역직렬화하지 않습니다.
+ * Pub/Sub 메시지는 이미 RedisPublisher에서 프론트엔드 친화적인 순수 JSON 문자열로 직렬화되었습니다.
+ *
+ * 역직렬화를 생략하면 다음 장점이 있습니다.
+ * - 클래스 타입 정보가 클라이언트로 노출되지 않음
+ * - RedisTemplate<String, Object> 직렬화 정책과 분리됨
+ * - 메시지 릴레이 책임만 수행하므로 구조가 단순해짐
  */
 package io.github.ascrew.monomatbe.global.redis;
 
-import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisSubscriber implements MessageListener {
 
-    private final RedisTemplate<String, Object> redisTemplate;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
     /**
-     * Redis 채널에서 메시지를 수신하면 호출됩니다.
-     * 수신된 바이트 배열을 ChatMessageDto로 역직렬화한 뒤
-     * 해당 채널을 구독 중인 WebSocket 클라이언트들에게 전달합니다.
+     * Redis 채널에서 메시지를 수신하면 호출된다.
      *
-     * @param message Redis 메시지 (채널명 + 본문 포함)
-     * @param pattern 패턴 구독 시 매칭된 패턴 (ChannelTopic 구독 시 null)
+     * [처리 방식]
+     * - message.channel: WebSocket destination으로 사용한다.
+     * - message.body   : JSON 문자열로 디코딩한 뒤 그대로 전달한다.
+     *
+     * @param message Redis 메시지. 채널명과 본문을 포함한다.
+     * @param pattern 패턴 구독 시 매칭된 패턴. 현재 로직에서는 사용하지 않는다.
      */
     @Override
     public void onMessage(Message message, byte[] pattern) {
+        String destination = new String(message.getChannel(), StandardCharsets.UTF_8);
+        String payload = new String(message.getBody(), StandardCharsets.UTF_8);
+
         try {
-            // Redis 메시지 본문을 ChatMessageDto로 역직렬화
-            ChatMessageDto chatMessageDto =
-                    (ChatMessageDto) redisTemplate.getValueSerializer().deserialize(message.getBody());
-
-            if (chatMessageDto != null) {
-                // 수신된 채널 경로 그대로 WebSocket 구독자에게 브로드캐스트
-                String destination = new String(message.getChannel());
-                simpMessagingTemplate.convertAndSend(destination, chatMessageDto);
-            }
-
+            simpMessagingTemplate.convertAndSend(destination, payload);
         } catch (Exception e) {
-            log.error("Redis 메시지 역직렬화 또는 브로드캐스트 실패 - 채널: {}",
-                    new String(message.getChannel()), e);
+            log.error("Redis Pub/Sub 메시지 WebSocket 브로드캐스트 실패 - destination: {}, payload: {}",
+                    destination,
+                    payload,
+                    e);
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -3,9 +3,11 @@ package io.github.ascrew.monomatbe.global.websocket;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -14,30 +16,110 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
  * STOMP 채널 인터셉터.
+ *
+ * [책임]
+ * - CONNECT 시 userIdentifier 검증 및 세션 저장
+ * - CONNECT 시 Redis INCR 기반 sessionSequence 발급
+ * - CONNECT 시 사용자 온라인 상태 저장
+ * - SUBSCRIBE/SEND/UNSUBSCRIBE 시 인증 세션 검증
+ * - 로비 채팅 채널 SUBSCRIBE 시 enter_lobby.lua를 먼저 실행하여 입장 상태를 확정
+ *
+ * [중요]
+ * SessionSubscribeEvent는 구독 요청이 처리된 이후 발생한다.
+ * 따라서 해당 이벤트에서 Redis 입장 처리를 수행하면 Lua 실패 시에도 클라이언트는 이미 구독된 상태가 될 수 있다.
+ *
+ * 이를 방지하기 위해 /topic/lobby/{code} 구독은 preSend 단계에서
+ * enter_lobby.lua를 먼저 실행하고, Redis 입장 상태가 확정된 경우에만
+ * SUBSCRIBE를 통과시킨다.
  */
 @Slf4j
-@RequiredArgsConstructor
 @Component
 public class StompChannelInterceptor implements ChannelInterceptor {
 
     private static final Pattern UUID_PATTERN =
             Pattern.compile(
-                    "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+                    "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            );
 
-    // 사용자 온라인 상태 TTL (단위: 시간)
-    // 비정상 종료 시 Redis 좀비 키 방지용 — 정상 종료 시 handleDisconnectEvent에서 즉시 삭제
+    // =========================================================
+    // Redis Lua 반환값 상수
+    // =========================================================
+
+    private static final String ENTER_RESULT_ENTERED = "ENTERED";
+    private static final String ENTER_RESULT_ALREADY_JOINED = "ALREADY_JOINED";
+    private static final String ENTER_RESULT_SESSION_REPLACED_PREFIX = "SESSION_REPLACED:";
+    private static final String ENTER_RESULT_STALE_SESSION_PREFIX = "STALE_SESSION:";
+    private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
+    private static final String ENTER_RESULT_INVALID_SEQUENCE = "INVALID_SEQUENCE";
+
+    // =========================================================
+    // 실패 사유 상수
+    // =========================================================
+
+    private static final String ENTER_FAILURE_NULL_RESULT = "Lua result is null";
+    private static final String ENTER_FAILURE_EXCEPTION = "Lua execution exception";
+
+    // =========================================================
+    // TTL 상수
+    // =========================================================
+
+    /**
+     * 사용자 온라인 상태 TTL.
+     *
+     * 비정상 종료 시 Redis 좀비 키 방지용입니다.
+     * 정상 종료 시 WebSocketEventListener에서 즉시 삭제한다.
+     *
+     * user_status 다중 세션 정합성은 후속 이슈 #55에서 개선합니다.
+     */
     private static final long USER_STATUS_TTL_HOURS = 2;
 
-    // [추가] user_status 저장 및 메트릭 처리를 위한 의존성
-    // StringRedisTemplate: 순수 문자열("ONLINE") 저장 — JSON 직렬화 방지
+    /**
+     * ws:connection:{wsSessionId} 및 lobby:{code}:user_session:{userIdentifier} 매핑 TTL.
+     *
+     * 정상 종료 시 DISCONNECT 이벤트에서 즉시 삭제하고,
+     * 비정상 종료 시 TTL로 자동 만료됩니다.
+     */
+    private static final Duration WS_CONNECTION_TTL = Duration.ofHours(2);
+
+    // =========================================================
+    // 의존성
+    // =========================================================
+
     private final StringRedisTemplate stringRedisTemplate;
     private final WebSocketMetric webSocketMetric;
+    private final RedisScript<String> enterLobbyScript;
+
+    /**
+     * 로비 입장 Lua 재시도 횟수.
+     *
+     * 기본값은 2입니다.
+     * 즉, 최초 실행 1회 + 재시도 1회를 의미
+     *
+     * 설정 파일에 값을 추가하지 않아도 기본값 2로 동작합니다.
+     * 운영 환경에서 조정이 필요하면 아래 키를 사용할 수 있습니다.
+     *
+     * monomat.websocket.lobby-enter.retry-attempts=3
+     */
+    @Value("${monomat.websocket.lobby-enter.retry-attempts:2}")
+    private int lobbyEnterRetryAttempts;
+
+    public StompChannelInterceptor(
+            StringRedisTemplate stringRedisTemplate,
+            WebSocketMetric webSocketMetric,
+            @Qualifier("enterLobbyScript") RedisScript<String> enterLobbyScript
+    ) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.webSocketMetric = webSocketMetric;
+        this.enterLobbyScript = enterLobbyScript;
+    }
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -73,24 +155,30 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         if (userIdentifier == null || userIdentifier.isBlank()) {
             log.warn("STOMP CONNECT 거부: 사용자 식별자 없음");
             throw new IllegalArgumentException(
-                    "STOMP CONNECT: 사용자 식별자가 없습니다. 연결이 거부되었습니다.");
+                    "STOMP CONNECT: 사용자 식별자가 없습니다. 연결이 거부되었습니다."
+            );
         }
 
         if (!UUID_PATTERN.matcher(userIdentifier).matches()) {
             log.warn("STOMP CONNECT 거부: 유효하지 않은 식별자 형식 = {}",
                     sanitizeForLog(userIdentifier));
             throw new IllegalArgumentException(
-                    "STOMP CONNECT: 유효하지 않은 식별자 형식입니다. 연결이 거부되었습니다.");
+                    "STOMP CONNECT: 유효하지 않은 식별자 형식입니다. 연결이 거부되었습니다."
+            );
         }
 
-        // 1. 검증 완료 후 세션에 userIdentifier 저장 (이후 SEND/SUBSCRIBE에서 참조)
+        Long sessionSequence = stringRedisTemplate.opsForValue()
+                .increment(RedisKeys.WS_SESSION_SEQUENCE);
+
+        if (sessionSequence == null) {
+            throw new IllegalStateException("STOMP CONNECT: WebSocket 세션 sequence 발급에 실패했습니다.");
+        }
+
         if (sessionAttributes != null) {
             sessionAttributes.put(WebSocketHeaders.USER_IDENTIFIER, userIdentifier);
+            sessionAttributes.put(WebSocketHeaders.SESSION_SEQUENCE, sessionSequence);
         }
 
-        // 2. Redis user_status 저장
-        // [수정] SessionConnectedEvent에서 이전 — Map 인스턴스 불일치 문제 근본 해결
-        // [수정] stringRedisTemplate 사용 — "ONLINE" 순수 문자열로 저장 (JSON 직렬화 방지)
         stringRedisTemplate.opsForValue().set(
                 RedisKeys.userStatusKey(userIdentifier),
                 WebSocketHeaders.STATUS_ONLINE,
@@ -98,13 +186,14 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                 TimeUnit.HOURS
         );
 
-        // 3. 활성 세션 카운터 증가 (Prometheus 메트릭)
-        // [수정] SessionConnectedEvent에서 이전
         webSocketMetric.increment();
 
-        log.info("STOMP CONNECT 성공: {}", userIdentifier);
+        log.info("STOMP CONNECT 성공: {}, sessionSequence: {}", userIdentifier, sessionSequence);
     }
 
+    /**
+     * CONNECT 이후 명령에 대해 인증 세션 존재 여부를 검증한다.
+     */
     private void validateSession(
             StompHeaderAccessor accessor,
             Map<String, Object> sessionAttributes
@@ -127,12 +216,39 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         }
     }
 
+    /**
+     * SUBSCRIBE 명령 처리.
+     */
     private void handleSubscribe(
             StompHeaderAccessor accessor,
             Map<String, Object> sessionAttributes,
             String userIdentifier
     ) {
         String destination = accessor.getDestination();
+        String wsSessionId = accessor.getSessionId();
+
+        if (StompDestinations.isLobbyChatSubscription(destination)) {
+            String lobbyCode = StompDestinations.extractLobbyCode(destination);
+
+            if (sessionAttributes != null) {
+                sessionAttributes.put(WebSocketHeaders.ROOM_ID, lobbyCode);
+            }
+
+            String enterResult = executeEnterLobbyBeforeSubscribe(
+                    lobbyCode,
+                    userIdentifier,
+                    wsSessionId,
+                    sessionAttributes
+            );
+
+            if (sessionAttributes != null) {
+                sessionAttributes.put(WebSocketHeaders.LOBBY_ENTER_RESULT, enterResult);
+            }
+
+            log.info("[SUBSCRIBE] 로비 입장 확정 후 구독 허용 - 식별자: {}, 로비: {}, wsSessionId: {}, result: {}",
+                    userIdentifier, lobbyCode, wsSessionId, enterResult);
+            return;
+        }
 
         if (StompDestinations.isLobbySubscription(destination)) {
             String roomId = StompDestinations.extractLobbyCode(destination);
@@ -144,6 +260,188 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         log.info("[SUBSCRIBE] 구독 - 식별자: {}, 경로: {}", userIdentifier, destination);
     }
 
+    /**
+     * enter_lobby.lua를 SUBSCRIBE 통과 전에 실행한다.
+     */
+    private String executeEnterLobbyBeforeSubscribe(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId,
+            Map<String, Object> sessionAttributes
+    ) {
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            throw new IllegalStateException("로비 입장 실패: WebSocket 세션 ID가 없습니다.");
+        }
+
+        long sessionSequence = extractSessionSequence(sessionAttributes);
+
+        RuntimeException lastException = null;
+        int maxAttempts = Math.max(1, lobbyEnterRetryAttempts);
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                String result = executeEnterLobbyScript(
+                        lobbyCode,
+                        userIdentifier,
+                        wsSessionId,
+                        sessionSequence
+                );
+
+                LobbyEnterResultType resultType = parseLobbyEnterResultType(result);
+
+                switch (resultType) {
+                    case ENTERED, ALREADY_JOINED, SESSION_REPLACED -> {
+                        return result;
+                    }
+
+                    case STALE_SESSION -> {
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalStateException("로비 입장 실패: 더 최신 WebSocket 세션이 이미 존재합니다.");
+                    }
+
+                    case LOBBY_NOT_FOUND -> {
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalArgumentException("로비 입장 실패: 존재하지 않는 로비입니다.");
+                    }
+
+                    case INVALID_SEQUENCE -> {
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalStateException("로비 입장 실패: 세션 순서값이 유효하지 않습니다.");
+                    }
+
+                    case UNKNOWN -> {
+                        if (result == null) {
+                            log.warn("로비 입장 Lua 결과 null - 재시도 여부 확인. attempt: {}/{}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                                    attempt, maxAttempts, lobbyCode, userIdentifier, wsSessionId);
+                            continue;
+                        }
+
+                        log.error("로비 입장 Lua 알 수 없는 반환값 - result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                                result, lobbyCode, userIdentifier, wsSessionId);
+
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalStateException("로비 입장 실패: 알 수 없는 서버 응답입니다.");
+                    }
+                }
+
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                lastException = e;
+                log.warn("로비 입장 Lua 실행 예외 - 재시도 여부 확인. attempt: {}/{}, 로비: {}, 식별자: {}, wsSessionId: {}, message: {}",
+                        attempt, maxAttempts, lobbyCode, userIdentifier, wsSessionId, e.getMessage());
+            }
+        }
+
+        if (lastException != null) {
+            log.error("로비 입장 Lua 최종 실패 - reason: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                    ENTER_FAILURE_EXCEPTION, lobbyCode, userIdentifier, wsSessionId, lastException);
+        } else {
+            log.error("로비 입장 Lua 최종 실패 - reason: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                    ENTER_FAILURE_NULL_RESULT, lobbyCode, userIdentifier, wsSessionId);
+        }
+
+        cleanupWsConnection(wsSessionId);
+        throw new IllegalStateException("로비 입장 처리에 실패했습니다. 새로고침 후 다시 시도해주세요.");
+    }
+
+    /**
+     * STOMP 세션 속성에서 sessionSequence를 추출한다.
+     */
+    private long extractSessionSequence(Map<String, Object> sessionAttributes) {
+        if (sessionAttributes == null) {
+            throw new IllegalStateException("로비 입장 실패: STOMP 세션 속성이 없습니다.");
+        }
+
+        Object value = sessionAttributes.get(WebSocketHeaders.SESSION_SEQUENCE);
+
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+
+        throw new IllegalStateException("로비 입장 실패: WebSocket 세션 sequence가 없습니다.");
+    }
+
+    /**
+     * enter_lobby.lua를 1회 실행
+     */
+    private String executeEnterLobbyScript(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId,
+            long sessionSequence
+    ) {
+        List<String> keys = List.of(
+                RedisKeys.lobbyKey(lobbyCode),
+                RedisKeys.lobbyParticipantsKey(lobbyCode),
+                RedisKeys.lobbyOrderKey(lobbyCode),
+                RedisKeys.wsConnectionKey(wsSessionId),
+                RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier),
+                RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, userIdentifier)
+        );
+
+        return stringRedisTemplate.execute(
+                enterLobbyScript,
+                keys,
+                userIdentifier,
+                lobbyCode,
+                String.valueOf(WS_CONNECTION_TTL.toMillis()),
+                WebSocketHeaders.SESSION_USER_ID,
+                WebSocketHeaders.SESSION_LOBBY_CODE,
+                wsSessionId,
+                String.valueOf(sessionSequence)
+        );
+    }
+
+    /**
+     * Lua 반환값을 enum으로 파싱한다.
+     *
+     * 반환 문자열 분기 처리를 이 메서드로 중앙화하여,
+     * Lua 반환값이 추가될 때 Java 수정 위치를 명확하게 한다.
+     */
+    private LobbyEnterResultType parseLobbyEnterResultType(String result) {
+        if (ENTER_RESULT_ENTERED.equals(result)) {
+            return LobbyEnterResultType.ENTERED;
+        }
+
+        if (ENTER_RESULT_ALREADY_JOINED.equals(result)) {
+            return LobbyEnterResultType.ALREADY_JOINED;
+        }
+
+        if (result != null && result.startsWith(ENTER_RESULT_SESSION_REPLACED_PREFIX)) {
+            return LobbyEnterResultType.SESSION_REPLACED;
+        }
+
+        if (result != null && result.startsWith(ENTER_RESULT_STALE_SESSION_PREFIX)) {
+            return LobbyEnterResultType.STALE_SESSION;
+        }
+
+        if (ENTER_RESULT_LOBBY_NOT_FOUND.equals(result)) {
+            return LobbyEnterResultType.LOBBY_NOT_FOUND;
+        }
+
+        if (ENTER_RESULT_INVALID_SEQUENCE.equals(result)) {
+            return LobbyEnterResultType.INVALID_SEQUENCE;
+        }
+
+        return LobbyEnterResultType.UNKNOWN;
+    }
+
+    /**
+     * Lua 실패 시 현재 ws:connection 키를 보상 삭제한다.
+     */
+    private void cleanupWsConnection(String wsSessionId) {
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            return;
+        }
+
+        try {
+            stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
+        } catch (Exception e) {
+            log.error("로비 입장 실패 후 ws:connection 보상 삭제 실패 - wsSessionId: {}", wsSessionId, e);
+        }
+    }
+
     private void handleDisconnect(Map<String, Object> sessionAttributes) {
         String userIdentifier = sessionAttributes != null
                 ? (String) sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER)
@@ -153,8 +451,21 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     }
 
     private String sanitizeForLog(String value) {
-        if (value == null) return "null";
-        String sanitized = value.replaceAll("[\r\n\t]", "");
+        if (value == null) {
+            return "null";
+        }
+
+        String sanitized = value.replaceAll("[\\r\\n\\t]", "");
         return sanitized.length() > 50 ? sanitized.substring(0, 50) + "..." : sanitized;
+    }
+
+    private enum LobbyEnterResultType {
+        ENTERED,
+        ALREADY_JOINED,
+        SESSION_REPLACED,
+        STALE_SESSION,
+        LOBBY_NOT_FOUND,
+        INVALID_SEQUENCE,
+        UNKNOWN
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -82,12 +82,18 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private static final long USER_STATUS_TTL_HOURS = 2;
 
     /**
-     * ws:connection:{wsSessionId} 및 lobby:{code}:user_session:{userIdentifier} 매핑 TTL.
+     * ws:connection:{wsSessionId}, lobby:{code}:user_session:{userIdentifier},
+     * lobby:{code}:user_session_seq:{userIdentifier} 매핑 TTL.
      *
-     * 정상 종료 시 DISCONNECT 이벤트에서 즉시 삭제하고,
-     * 비정상 종료 시 TTL로 자동 만료됩니다.
+     * WebSocket DISCONNECT 이벤트 누락, 서버 비정상 종료에 대비한 안전장치다.
+     *
+     * 기존 2시간은 장시간 로비 대기 또는 게임 진행 중 TTL 만료 타이밍 이슈가 생길 수 있어
+     * 6시간으로 늘린다.
+     *
+     * 추후 #55에서 사용자 온라인 상태 다중 세션 관리와 함께
+     * WebSocket heartbeat 기반 TTL 연장 구조를 검토한다.
      */
-    private static final Duration WS_CONNECTION_TTL = Duration.ofHours(2);
+    private static final Duration WS_CONNECTION_TTL = Duration.ofHours(6);
 
     // =========================================================
     // 의존성
@@ -305,8 +311,23 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     }
 
                     case INVALID_SEQUENCE -> {
+                        /*
+                         * INVALID_SEQUENCE는 재시도 대상이 아니다.
+                         *
+                         * sessionSequence는 CONNECT 단계에서 Redis INCR로 발급되고,
+                         * SUBSCRIBE 처리 전에 Java의 extractSessionSequence()에서 검증된 뒤 Lua에 전달된다.
+                         *
+                         * 따라서 Lua에서 INVALID_SEQUENCE가 반환된다는 것은 일시적인 Redis 장애라기보다
+                         * Java-Lua 인자 계약이 깨졌거나 세션 속성 저장 흐름이 깨진 서버 내부 오류에 가깝다.
+                         *
+                         * fallback 값(예: 0)을 사용하면 sequence가 없는 세션이 정상 입장될 수 있어
+                         * stale 세션 방지 정책이 약해진다.
+                         *
+                         * 또한 같은 잘못된 ARGV로 재시도해도 결과가 반복될 가능성이 높으므로
+                         * 즉시 STOMP ERROR로 실패시키고 클라이언트가 새 연결을 생성하도록 유도한다.
+                         */
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패: 세션 순서값이 유효하지 않습니다.");
+                        throw new IllegalStateException("로비 입장 실패: 세션 상태가 유효하지 않습니다. 새로고침 후 다시 시도해주세요.");
                     }
 
                     case UNKNOWN -> {
@@ -342,8 +363,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         }
 
         cleanupWsConnection(wsSessionId);
-        throw new IllegalStateException("로비 입장 처리에 실패했습니다. 새로고침 후 다시 시도해주세요.");
-    }
+        throw new IllegalStateException("일시적으로 로비 입장 상태를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.");    }
 
     /**
      * STOMP 세션 속성에서 sessionSequence를 추출한다.

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -477,9 +477,12 @@ public class WebSocketEventListener {
 
     /**
      * 로비 채팅 채널에 ENTER 시스템 메시지를 발행한다.
+     *
+     * Redis Pub/Sub 발행 실패 시 시스템 메시지가 유실될 수 있으므로,
+     * RedisPublisher.publish()의 반환값을 확인하여 실패 로그를 남긴다.
      */
     private void publishEnterMessage(String lobbyCode, String userIdentifier) {
-        redisPublisher.publish(
+        boolean published = redisPublisher.publish(
                 StompDestinations.subscribeLobbyChat(lobbyCode),
                 ChatMessageDto.builder()
                         .type(ChatMessageDto.MessageType.ENTER)
@@ -489,13 +492,20 @@ public class WebSocketEventListener {
                         .timestamp(LocalDateTime.now().toString())
                         .build()
         );
+
+        if (!published) {
+            log.error("ENTER 메시지 발행 실패 - 로비: {}, 식별자: {}", lobbyCode, userIdentifier);
+        }
     }
 
     /**
      * 로비 채팅 채널에 LEAVE 시스템 메시지를 발행한다.
+     *
+     * Redis Pub/Sub 발행 실패 시 퇴장 시스템 메시지가 유실될 수 있으므로,
+     * RedisPublisher.publish()의 반환값을 확인하여 실패 로그를 남긴다.
      */
     private void publishLeaveMessage(String lobbyCode, String userIdentifier) {
-        redisPublisher.publish(
+        boolean published = redisPublisher.publish(
                 StompDestinations.subscribeLobbyChat(lobbyCode),
                 ChatMessageDto.builder()
                         .type(ChatMessageDto.MessageType.LEAVE)
@@ -505,6 +515,10 @@ public class WebSocketEventListener {
                         .timestamp(LocalDateTime.now().toString())
                         .build()
         );
+
+        if (!published) {
+            log.error("LEAVE 메시지 발행 실패 - 로비: {}, 식별자: {}", lobbyCode, userIdentifier);
+        }
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -2,26 +2,17 @@
  * WebSocket 연결 생명주기 이벤트를 처리하는 리스너.
  *
  * [책임]
- * - SUBSCRIBE 이벤트 중 로비 채팅 채널 구독을 감지하여 로비 입장 상태를 Redis에 저장
+ * - SUBSCRIBE 성공 이후 로비 입장 후처리 수행
  * - DISCONNECT 이벤트 발생 시 wsSessionId로 lobbyCode를 역추적하여 자동 퇴장 처리
- * - ENTER / LEAVE / ENTER_FAILED 시스템 메시지 브로드캐스트
+ * - ENTER / LEAVE 시스템 메시지 브로드캐스트
  *
  * [중요 설계]
- * 실제 입장 상태 저장은 enter_lobby.lua에서 원자적으로 처리한다.
- * Java 코드에서 participants Set, order List, ws:connection Hash를 각각 따로 저장하면
- * 중간 실패 시 Redis 상태가 불일치할 수 있기 때문이다.
+ * 실제 입장 상태 저장은 StompChannelInterceptor의 SUBSCRIBE preSend 단계에서
+ * enter_lobby.lua로 먼저 확정한다.
  *
- * [동일 userIdentifier 다중 세션 정책]
- * 같은 userIdentifier가 같은 로비에 다시 입장하면 최신 wsSessionId를 현재 유효 세션으로 본다.
- * 이전 wsSessionId는 stale 세션으로 간주하며, stale 세션의 DISCONNECT는 실제 퇴장으로 처리하지 않는다.
- *
- * [실패 처리 정책]
- * STOMP SUBSCRIBE 프레임은 이미 처리되어 클라이언트가 구독 상태가 될 수 있다.
- * 따라서 Redis Lua 입장 처리가 실패하면 클라이언트는 구독되어 있지만
- * 서버 입장 상태가 누락되는 불일치가 발생할 수 있다.
- *
- * 이를 방지하기 위해 Lua 실행 실패 또는 null 반환 시 재시도하고,
- * 최종 실패 시 ENTER_FAILED 메시지를 클라이언트에게 직접 전송한다.
+ * SessionSubscribeEvent는 구독 요청이 처리된 이후 발생하므로,
+ * 이 리스너에서는 Redis 입장 상태를 직접 만들지 않고,
+ * 인터셉터가 세션에 저장한 입장 결과를 기반으로 ENTER 메시지와 refresh 신호만 처리한다.
  */
 package io.github.ascrew.monomatbe.global.websocket;
 
@@ -36,7 +27,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
@@ -44,9 +34,7 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import tools.jackson.databind.json.JsonMapper;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -57,82 +45,34 @@ public class WebSocketEventListener {
     // Redis Lua 반환값 상수
     // =========================================================
 
-    /**
-     * 신규 입장자가 정상적으로 추가된 경우.
-     * participants Set에 새로 들어갔고, order List에도 추가된 상태.
-     */
+    /** 신규 입장 처리 완료 */
     private static final String ENTER_RESULT_ENTERED = "ENTERED";
 
-    /**
-     * 이미 로비 participants Set에 존재하던 사용자가 다시 구독한 경우.
-     * order List에는 중복 저장하지 않고, ws:connection 매핑만 갱신한다.
-     */
+    /** 이미 참여 중인 사용자의 중복 구독 */
     private static final String ENTER_RESULT_ALREADY_JOINED = "ALREADY_JOINED";
 
-    /**
-     * 동일 userIdentifier의 기존 WebSocket 세션이 새 세션으로 교체된 경우.
-     * 이전 wsSessionId는 stale 세션으로 간주한다.
-     */
+    /** 동일 userIdentifier의 기존 WebSocket 세션이 새 세션으로 교체된 경우 */
     private static final String ENTER_RESULT_SESSION_REPLACED_PREFIX = "SESSION_REPLACED:";
 
-    /**
-     * SESSION_REPLACED 반환값에서 이전 wsSessionId를 추출하기 위한 prefix 길이.
-     */
+    /** 오래된 세션의 늦은 SUBSCRIBE 요청 */
+    private static final String ENTER_RESULT_STALE_SESSION_PREFIX = "STALE_SESSION:";
+
+    /** 유효하지 않은 sessionSequence */
+    private static final String ENTER_RESULT_INVALID_SEQUENCE = "INVALID_SEQUENCE";
+
+    /** SESSION_REPLACED 반환값에서 이전 wsSessionId를 추출하기 위한 prefix 길이 */
     private static final int ENTER_RESULT_SESSION_REPLACED_PREFIX_LENGTH =
             ENTER_RESULT_SESSION_REPLACED_PREFIX.length();
 
-    /**
-     * Redis에 해당 lobby:{code} Hash가 존재하지 않는 경우.
-     * 존재하지 않는 로비에 고스트 participants/order를 만들지 않기 위해 입장을 거부한다.
-     */
-    private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
-
     // =========================================================
-    // 실패 처리 상수
+    // 메시지 상수
     // =========================================================
 
-    /**
-     * Lua 실행 최대 시도 횟수.
-     *
-     * 최초 실행 1회 + 재시도 1회다.
-     * SUBSCRIBE 이벤트 처리를 과도하게 지연시키지 않기 위해 재시도는 1회로 제한한다.
-     */
-    private static final int ENTER_SCRIPT_MAX_ATTEMPTS = 2;
-
-    /** Lua 결과가 null인 경우의 실패 사유. */
-    private static final String ENTER_FAILURE_NULL_RESULT = "Lua result is null";
-
-    /** Redis 또는 Lua 실행 중 예외가 발생한 경우의 실패 사유. */
-    private static final String ENTER_FAILURE_EXCEPTION = "Lua execution exception";
-
-    /** 예상하지 못한 Lua 반환값을 받은 경우의 실패 사유. */
-    private static final String ENTER_FAILURE_UNKNOWN_RESULT = "Unknown Lua result";
-
-    /** 존재하지 않는 로비 코드로 구독한 경우의 실패 메시지. */
-    private static final String ENTER_FAILED_LOBBY_NOT_FOUND_MESSAGE =
-            "존재하지 않는 로비입니다. 로비 목록을 새로고침해주세요.";
-
-    /** 시스템 오류로 입장 처리가 실패한 경우의 실패 메시지. */
-    private static final String ENTER_FAILED_SYSTEM_MESSAGE =
-            "로비 입장 처리에 실패했습니다. 새로고침 후 다시 시도해주세요.";
-
-    // =========================================================
-    // 메시지/TTL 상수
-    // =========================================================
-
-    /** 입장 시스템 메시지 포맷. */
+    /** 입장 시스템 메시지 포맷 */
     private static final String ENTER_MESSAGE_FORMAT = "%s님이 입장하셨습니다.";
 
-    /** 퇴장 시스템 메시지 포맷. */
+    /** 퇴장 시스템 메시지 포맷 */
     private static final String LEAVE_MESSAGE_FORMAT = "%s님이 퇴장하셨습니다.";
-
-    /**
-     * ws:connection:{wsSessionId} 및 lobby:{code}:user_session:{userIdentifier} 매핑 TTL.
-     *
-     * 정상 종료 시 DISCONNECT 이벤트에서 즉시 삭제한다.
-     * TTL은 서버 장애, 이벤트 누락, 비정상 종료에 대비한 안전장치다.
-     */
-    private static final Duration WS_CONNECTION_TTL = Duration.ofHours(2);
 
     // =========================================================
     // 의존성
@@ -140,52 +80,35 @@ public class WebSocketEventListener {
 
     /**
      * 순수 문자열 Redis 작업 전용 Template.
-     *
-     * participants/order/ws:connection에는 문자열만 저장해야 한다.
-     * RedisTemplate<String, Object>를 사용하면 JSON 직렬화로 따옴표가 포함될 수 있고,
-     * leave_lobby.lua의 SREM/LREM 비교가 실패할 수 있다.
      */
     private final StringRedisTemplate stringRedisTemplate;
 
     /**
      * Redis Pub/Sub 기반 시스템 메시지 발행자.
-     * ENTER/LEAVE 메시지를 로비 채팅 채널로 브로드캐스트할 때 사용한다.
      */
     private final RedisPublisher redisPublisher;
 
     /**
      * 현재 서버에 연결된 WebSocket 클라이언트에게 직접 메시지를 전송한다.
      *
-     * ENTER_FAILED 메시지 또는 Pub/Sub 발행 실패 fallback 메시지는 Redis를 거치지 않고
-     * 현재 서버의 Simple Broker로 직접 전송한다.
+     * Redis Pub/Sub 발행 실패 fallback에 사용한다.
      */
     private final SimpMessagingTemplate messagingTemplate;
 
     /**
      * DISCONNECT 시 domain/lobby 쪽 퇴장 처리를 실행하기 위한 이벤트 발행자.
-     * global -> domain 직접 의존을 피하기 위해 Spring ApplicationEvent를 사용한다.
      */
     private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 활성 WebSocket 세션 수 Prometheus 메트릭.
-     *
-     * CONNECT 시 증가는 StompChannelInterceptor에서 처리하고,
-     * DISCONNECT 시 감소는 실제 소켓 종료 이벤트를 받는 이 클래스에서 처리한다.
      */
     private final WebSocketMetric webSocketMetric;
 
     /**
-     * 로비 입장 원자 처리 Lua 스크립트.
-     */
-    private final RedisScript<String> enterLobbyScript;
-
-    /**
      * WebSocket 직접 전송 메시지 직렬화용 JsonMapper.
      *
-     * ENTER_FAILED 또는 Pub/Sub fallback 메시지는 RedisSubscriber를 거치지 않고
-     * 직접 SimpMessagingTemplate으로 전송되므로, DTO 객체를 그대로 보내지 않고
-     * JSON 문자열로 변환하여 프론트 메시지 계약을 통일한다.
+     * Pub/Sub fallback 메시지를 DTO 객체가 아니라 JSON 문자열로 전송하기 위해 사용한다.
      */
     private final JsonMapper pubSubJsonMapper;
 
@@ -195,7 +118,6 @@ public class WebSocketEventListener {
             SimpMessagingTemplate messagingTemplate,
             ApplicationEventPublisher eventPublisher,
             WebSocketMetric webSocketMetric,
-            @Qualifier("enterLobbyScript") RedisScript<String> enterLobbyScript,
             @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper
     ) {
         this.stringRedisTemplate = stringRedisTemplate;
@@ -203,20 +125,17 @@ public class WebSocketEventListener {
         this.messagingTemplate = messagingTemplate;
         this.eventPublisher = eventPublisher;
         this.webSocketMetric = webSocketMetric;
-        this.enterLobbyScript = enterLobbyScript;
         this.pubSubJsonMapper = pubSubJsonMapper;
     }
 
     /**
-     * WebSocket 채널 구독 이벤트 처리.
+     * WebSocket 채널 구독 성공 이벤트 처리.
      *
      * [중요]
-     * 로비 관련 채널은 다음처럼 나뉜다.
-     * - /topic/lobby/{code}         : 로비 채팅 채널
-     * - /topic/lobby/{code}/refresh : 로비 정보 새로고침 채널
+     * enter_lobby.lua 실행은 이미 StompChannelInterceptor의 SUBSCRIBE preSend 단계에서 끝난 상태다.
      *
-     * 입장 처리는 반드시 채팅 채널 구독 시점에만 실행한다.
-     * refresh 채널까지 입장 처리 대상으로 보면 같은 사용자가 participants/order에 중복 저장될 수 있다.
+     * 이 메서드는 Redis 입장 상태를 만들지 않고,
+     * 세션 속성에 저장된 입장 결과를 기반으로 ENTER 메시지와 refresh 신호만 발행한다.
      */
     @EventListener
     public void handleSubscribeEvent(SessionSubscribeEvent event) {
@@ -227,7 +146,7 @@ public class WebSocketEventListener {
         String wsSessionId = accessor.getSessionId();
 
         if (sessionAttributes == null) {
-            log.warn("로비 입장 처리 중단 - STOMP 세션 속성이 없습니다. destination: {}", destination);
+            log.warn("로비 입장 후처리 중단 - STOMP 세션 속성이 없습니다. destination: {}", destination);
             return;
         }
 
@@ -238,12 +157,15 @@ public class WebSocketEventListener {
         }
 
         String lobbyCode = StompDestinations.extractLobbyCode(destination);
+        Object resultValue = sessionAttributes.remove(WebSocketHeaders.LOBBY_ENTER_RESULT);
 
-        // 세션 속성에도 현재 로비 코드를 저장한다.
-        // 동일 연결 내 후속 메시지 처리에서 roomId를 빠르게 참조할 수 있다.
-        sessionAttributes.put(WebSocketHeaders.ROOM_ID, lobbyCode);
+        if (!(resultValue instanceof String result)) {
+            log.warn("로비 입장 후처리 중단 - 인터셉터 입장 결과가 없습니다. 로비: {}, 식별자: {}, wsSessionId: {}",
+                    lobbyCode, userIdentifier, wsSessionId);
+            return;
+        }
 
-        processLobbyEnter(lobbyCode, userIdentifier, wsSessionId);
+        processLobbyEnterResult(lobbyCode, userIdentifier, wsSessionId, result);
     }
 
     /**
@@ -290,10 +212,7 @@ public class WebSocketEventListener {
         log.info("WebSocket 연결 해제 - 식별자: {}, 로비: {}", userIdentifier, lobbyCode);
 
         if (lobbyCode != null) {
-            // domain/lobby 서비스가 퇴장 Lua 스크립트를 실행하도록 이벤트 발행
             eventPublisher.publishEvent(new PlayerLeaveEvent(lobbyCode, userIdentifier));
-
-            // 로비 채팅 채널에 퇴장 시스템 메시지 발행
             publishLeaveMessage(lobbyCode, userIdentifier);
         }
 
@@ -315,12 +234,12 @@ public class WebSocketEventListener {
         }
 
         if (!hasValidUserIdentifier(userIdentifier)) {
-            log.warn("로비 입장 처리 중단 - 사용자 식별자가 없습니다. destination: {}", destination);
+            log.warn("로비 입장 후처리 중단 - 사용자 식별자가 없습니다. destination: {}", destination);
             return false;
         }
 
         if (wsSessionId == null || wsSessionId.isBlank()) {
-            log.warn("로비 입장 처리 중단 - wsSessionId가 없습니다. userIdentifier: {}", userIdentifier);
+            log.warn("로비 입장 후처리 중단 - wsSessionId가 없습니다. userIdentifier: {}", userIdentifier);
             return false;
         }
 
@@ -337,31 +256,16 @@ public class WebSocketEventListener {
     }
 
     /**
-     * 로비 입장 상태를 Redis에 원자적으로 저장한다.
-     *
-     * [Redis 변경 대상]
-     * - lobby:{code}:participants
-     * - lobby:{code}:order
-     * - ws:connection:{wsSessionId}
-     * - lobby:{code}:user_session:{userIdentifier}
-     *
-     * [실패 처리]
-     * SUBSCRIBE 프레임은 이미 처리되어 클라이언트가 구독 상태가 될 수 있다.
-     * 따라서 Lua 실행 실패, null 반환, 알 수 없는 반환값이 발생하면
-     * ENTER_FAILED 메시지를 전송하여 클라이언트가 재시도 또는 로비 이탈을 수행할 수 있게 한다.
+     * 인터셉터에서 확정한 로비 입장 결과를 후처리한다.
      */
-    private void processLobbyEnter(
+    private void processLobbyEnterResult(
             String lobbyCode,
             String userIdentifier,
-            String wsSessionId
+            String wsSessionId,
+            String result
     ) {
-        EnterLobbyExecutionResult executionResult =
-                executeEnterLobbyScriptWithRetry(lobbyCode, userIdentifier, wsSessionId);
-
-        String result = executionResult.result();
-
         if (ENTER_RESULT_ENTERED.equals(result)) {
-            log.info("로비 입장 처리 완료 - 로비: {}, 식별자: {}, wsSessionId: {}",
+            log.info("로비 입장 후처리 완료 - 로비: {}, 식별자: {}, wsSessionId: {}",
                     lobbyCode, userIdentifier, wsSessionId);
 
             publishEnterMessage(lobbyCode, userIdentifier);
@@ -370,148 +274,33 @@ public class WebSocketEventListener {
         }
 
         if (ENTER_RESULT_ALREADY_JOINED.equals(result)) {
-            log.info("로비 중복 구독 처리 - order 중복 저장 방지. 로비: {}, 식별자: {}, wsSessionId: {}",
+            log.info("로비 중복 구독 후처리 - ENTER 메시지 생략. 로비: {}, 식별자: {}, wsSessionId: {}",
                     lobbyCode, userIdentifier, wsSessionId);
             return;
         }
 
-        if (result != null && result.startsWith(ENTER_RESULT_SESSION_REPLACED_PREFIX)) {
+        if (result.startsWith(ENTER_RESULT_SESSION_REPLACED_PREFIX)) {
             String previousWsSessionId = result.substring(ENTER_RESULT_SESSION_REPLACED_PREFIX_LENGTH);
 
-            log.info("로비 세션 교체 처리 - 로비: {}, 식별자: {}, previousWsSessionId: {}, currentWsSessionId: {}",
+            log.info("로비 세션 교체 후처리 - 로비: {}, 식별자: {}, previousWsSessionId: {}, currentWsSessionId: {}",
                     lobbyCode, userIdentifier, previousWsSessionId, wsSessionId);
-
             return;
         }
 
-        if (ENTER_RESULT_LOBBY_NOT_FOUND.equals(result)) {
-            log.warn("로비 입장 거부 - 존재하지 않는 로비입니다. 로비: {}, 식별자: {}, wsSessionId: {}",
+        if (result.startsWith(ENTER_RESULT_STALE_SESSION_PREFIX)) {
+            log.warn("stale 로비 세션 후처리 요청 수신 - 후처리 생략. 로비: {}, 식별자: {}, wsSessionId: {}, result: {}",
+                    lobbyCode, userIdentifier, wsSessionId, result);
+            return;
+        }
+
+        if (ENTER_RESULT_INVALID_SEQUENCE.equals(result)) {
+            log.warn("유효하지 않은 sequence 결과 후처리 요청 수신 - 후처리 생략. 로비: {}, 식별자: {}, wsSessionId: {}",
                     lobbyCode, userIdentifier, wsSessionId);
-
-            publishEnterFailedMessage(lobbyCode, userIdentifier, ENTER_FAILED_LOBBY_NOT_FOUND_MESSAGE);
-            cleanupWsConnection(wsSessionId);
             return;
         }
 
-        handleLobbyEnterFailure(
-                lobbyCode,
-                userIdentifier,
-                wsSessionId,
-                executionResult.failureReason() != null
-                        ? executionResult.failureReason()
-                        : ENTER_FAILURE_UNKNOWN_RESULT,
-                result,
-                executionResult.exception()
-        );
-    }
-
-    /**
-     * enter_lobby.lua를 최대 ENTER_SCRIPT_MAX_ATTEMPTS만큼 실행한다.
-     *
-     * [재시도 대상]
-     * - Redis 예외 발생
-     * - Lua 결과가 null
-     *
-     * [재시도하지 않는 대상]
-     * - ENTERED
-     * - ALREADY_JOINED
-     * - SESSION_REPLACED:{previousWsSessionId}
-     * - LOBBY_NOT_FOUND
-     *
-     * LOBBY_NOT_FOUND는 일시 장애라기보다 잘못된 로비 코드 또는 이미 삭제된 로비 상태이므로
-     * 재시도하지 않고 즉시 반환한다.
-     */
-    private EnterLobbyExecutionResult executeEnterLobbyScriptWithRetry(
-            String lobbyCode,
-            String userIdentifier,
-            String wsSessionId
-    ) {
-        RuntimeException lastException = null;
-
-        for (int attempt = 1; attempt <= ENTER_SCRIPT_MAX_ATTEMPTS; attempt++) {
-            try {
-                String result = executeEnterLobbyScript(lobbyCode, userIdentifier, wsSessionId);
-
-                if (result != null) {
-                    return EnterLobbyExecutionResult.success(result);
-                }
-
-                log.warn("로비 입장 Lua 결과 null - 재시도 여부 확인. attempt: {}/{}, 로비: {}, 식별자: {}, wsSessionId: {}",
-                        attempt, ENTER_SCRIPT_MAX_ATTEMPTS, lobbyCode, userIdentifier, wsSessionId);
-
-            } catch (RuntimeException e) {
-                lastException = e;
-                log.warn("로비 입장 Lua 실행 예외 - 재시도 여부 확인. attempt: {}/{}, 로비: {}, 식별자: {}, wsSessionId: {}, message: {}",
-                        attempt, ENTER_SCRIPT_MAX_ATTEMPTS, lobbyCode, userIdentifier, wsSessionId, e.getMessage());
-            }
-        }
-
-        if (lastException != null) {
-            return EnterLobbyExecutionResult.failure(ENTER_FAILURE_EXCEPTION, lastException);
-        }
-
-        return EnterLobbyExecutionResult.failure(ENTER_FAILURE_NULL_RESULT, null);
-    }
-
-    /**
-     * enter_lobby.lua를 1회 실행한다.
-     *
-     * 재시도 정책은 executeEnterLobbyScriptWithRetry()에서만 관리한다.
-     */
-    private String executeEnterLobbyScript(
-            String lobbyCode,
-            String userIdentifier,
-            String wsSessionId
-    ) {
-        List<String> keys = List.of(
-                RedisKeys.lobbyKey(lobbyCode),
-                RedisKeys.lobbyParticipantsKey(lobbyCode),
-                RedisKeys.lobbyOrderKey(lobbyCode),
-                RedisKeys.wsConnectionKey(wsSessionId),
-                RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier)
-        );
-
-        return stringRedisTemplate.execute(
-                enterLobbyScript,
-                keys,
-                userIdentifier,
-                lobbyCode,
-                String.valueOf(WS_CONNECTION_TTL.toMillis()),
-                WebSocketHeaders.SESSION_USER_ID,
-                WebSocketHeaders.SESSION_LOBBY_CODE,
-                wsSessionId
-        );
-    }
-
-    /**
-     * 로비 입장 처리 최종 실패를 처리한다.
-     *
-     * [처리 내용]
-     * - ERROR 로그 기록
-     * - ENTER_FAILED 메시지 전송
-     * - ws:connection 보상 삭제
-     *
-     * SUBSCRIBE 자체는 이미 완료되었을 수 있으므로,
-     * 클라이언트는 ENTER_FAILED 메시지를 수신하면 로비 화면에서 이탈하거나 재시도해야 한다.
-     */
-    private void handleLobbyEnterFailure(
-            String lobbyCode,
-            String userIdentifier,
-            String wsSessionId,
-            String reason,
-            String result,
-            Exception exception
-    ) {
-        if (exception == null) {
-            log.error("로비 입장 처리 최종 실패 - reason: {}, result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
-                    reason, result, lobbyCode, userIdentifier, wsSessionId);
-        } else {
-            log.error("로비 입장 처리 최종 실패 - reason: {}, result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
-                    reason, result, lobbyCode, userIdentifier, wsSessionId, exception);
-        }
-
-        publishEnterFailedMessage(lobbyCode, userIdentifier, ENTER_FAILED_SYSTEM_MESSAGE);
-        cleanupWsConnection(wsSessionId);
+        log.warn("로비 입장 후처리 중 알 수 없는 결과 수신 - result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                result, lobbyCode, userIdentifier, wsSessionId);
     }
 
     /**
@@ -538,10 +327,6 @@ public class WebSocketEventListener {
 
     /**
      * 현재 DISCONNECT 된 wsSessionId가 로비 내 최신 유효 세션인지 확인한다.
-     *
-     * 동일 userIdentifier가 같은 로비에 재연결된 경우,
-     * 이전 wsSessionId는 stale 세션으로 간주한다.
-     * stale 세션의 DISCONNECT는 participants/order를 제거하면 안 된다.
      */
     private boolean isStaleLobbySession(
             String lobbyCode,
@@ -621,37 +406,9 @@ public class WebSocketEventListener {
     }
 
     /**
-     * 로비 입장 실패 메시지를 해당 로비 채널로 전송한다.
-     *
-     * Redis 장애 때문에 enter_lobby.lua가 실패했을 수 있으므로
-     * 실패 알림은 Redis Pub/Sub을 거치지 않고 현재 서버의 WebSocket Broker로 직접 전송한다.
-     *
-     * 단, 프론트 메시지 계약을 유지하기 위해 DTO 객체가 아니라 JSON 문자열로 전송한다.
-     */
-    private void publishEnterFailedMessage(
-            String lobbyCode,
-            String userIdentifier,
-            String content
-    ) {
-        ChatMessageDto message = ChatMessageDto.builder()
-                .type(ChatMessageDto.MessageType.ENTER_FAILED)
-                .roomId(lobbyCode)
-                .sender(userIdentifier)
-                .content(content)
-                .timestamp(LocalDateTime.now().toString())
-                .build();
-
-        sendDirectJsonMessage(
-                StompDestinations.subscribeLobbyChat(lobbyCode),
-                message,
-                "ENTER_FAILED"
-        );
-    }
-
-    /**
      * 현재 서버의 WebSocket Broker로 JSON 문자열 메시지를 직접 전송한다.
      *
-     * Redis Pub/Sub 장애 또는 ENTER_FAILED처럼 Redis를 거치면 안 되는 상황에서 사용한다.
+     * Redis Pub/Sub 장애 상황의 fallback에 사용한다.
      * DTO 객체를 그대로 보내면 타입 정보가 포함될 수 있으므로 반드시 JSON 문자열로 변환한다.
      */
     private void sendDirectJsonMessage(
@@ -673,30 +430,12 @@ public class WebSocketEventListener {
 
     /**
      * 로비 내부 정보 새로고침 신호를 브로드캐스트한다.
-     *
-     * participants/order가 변경되었으므로,
-     * 로비 화면을 보고 있는 클라이언트가 최신 참여자 목록을 다시 조회하도록 유도한다.
      */
     private void notifyLobbyInfoRefresh(String lobbyCode) {
         messagingTemplate.convertAndSend(
                 StompDestinations.subscribeLobbyRefresh(lobbyCode),
                 StompDestinations.MSG_REFRESH_LOBBY_INFO
         );
-    }
-
-    /**
-     * 입장 처리 실패 또는 세션 교체 시 ws:connection 키를 보상 삭제한다.
-     */
-    private void cleanupWsConnection(String wsSessionId) {
-        if (wsSessionId == null || wsSessionId.isBlank()) {
-            return;
-        }
-
-        try {
-            stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
-        } catch (Exception e) {
-            log.error("로비 입장 실패 후 ws:connection 보상 삭제 실패 - wsSessionId: {}", wsSessionId, e);
-        }
     }
 
     /**
@@ -715,7 +454,9 @@ public class WebSocketEventListener {
     /**
      * DISCONNECT 이후 불필요한 Redis 키를 정리한다.
      *
-     * 현재 유효 세션의 DISCONNECT에서만 user_status와 lobbyUserSessionKey를 삭제한다.
+     * 현재 유효 세션의 DISCONNECT에서만 user_status, lobbyUserSessionKey,
+     * lobbyUserSessionSequenceKey를 삭제한다.
+     *
      * stale 세션은 deleteStaleConnectionKey()에서 ws:connection만 삭제한다.
      */
     private void deleteDisconnectKeys(
@@ -731,26 +472,7 @@ public class WebSocketEventListener {
 
         if (lobbyCode != null && !lobbyCode.isBlank()) {
             stringRedisTemplate.delete(RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier));
-        }
-    }
-
-    /**
-     * enter_lobby.lua 실행 결과를 담는 내부 전용 record.
-     *
-     * result가 null이면 실패로 간주한다.
-     * 실패 시 failureReason과 exception을 함께 보관하여 최종 로그에 남긴다.
-     */
-    private record EnterLobbyExecutionResult(
-            String result,
-            String failureReason,
-            Exception exception
-    ) {
-        private static EnterLobbyExecutionResult success(String result) {
-            return new EnterLobbyExecutionResult(result, null, null);
-        }
-
-        private static EnterLobbyExecutionResult failure(String failureReason, Exception exception) {
-            return new EnterLobbyExecutionResult(null, failureReason, exception);
+            stringRedisTemplate.delete(RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, userIdentifier));
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -11,6 +11,10 @@
  * Java 코드에서 participants Set, order List, ws:connection Hash를 각각 따로 저장하면
  * 중간 실패 시 Redis 상태가 불일치할 수 있기 때문이다.
  *
+ * [동일 userIdentifier 다중 세션 정책]
+ * 같은 userIdentifier가 같은 로비에 다시 입장하면 최신 wsSessionId를 현재 유효 세션으로 본다.
+ * 이전 wsSessionId는 stale 세션으로 간주하며, stale 세션의 DISCONNECT는 실제 퇴장으로 처리하지 않는다.
+ *
  * [실패 처리 정책]
  * STOMP SUBSCRIBE 프레임은 이미 처리되어 클라이언트가 구독 상태가 될 수 있다.
  * 따라서 Redis Lua 입장 처리가 실패하면 클라이언트는 구독되어 있지만
@@ -27,7 +31,6 @@ import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
 import io.github.ascrew.monomatbe.global.redis.RedisPublisher;
 import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
@@ -39,6 +42,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -47,7 +51,6 @@ import java.util.Map;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class WebSocketEventListener {
 
     // =========================================================
@@ -67,6 +70,18 @@ public class WebSocketEventListener {
     private static final String ENTER_RESULT_ALREADY_JOINED = "ALREADY_JOINED";
 
     /**
+     * 동일 userIdentifier의 기존 WebSocket 세션이 새 세션으로 교체된 경우.
+     * 이전 wsSessionId는 stale 세션으로 간주한다.
+     */
+    private static final String ENTER_RESULT_SESSION_REPLACED_PREFIX = "SESSION_REPLACED:";
+
+    /**
+     * SESSION_REPLACED 반환값에서 이전 wsSessionId를 추출하기 위한 prefix 길이.
+     */
+    private static final int ENTER_RESULT_SESSION_REPLACED_PREFIX_LENGTH =
+            ENTER_RESULT_SESSION_REPLACED_PREFIX.length();
+
+    /**
      * Redis에 해당 lobby:{code} Hash가 존재하지 않는 경우.
      * 존재하지 않는 로비에 고스트 participants/order를 만들지 않기 위해 입장을 거부한다.
      */
@@ -79,8 +94,8 @@ public class WebSocketEventListener {
     /**
      * Lua 실행 최대 시도 횟수.
      *
-     * 최초 실행 1회 + 재시도 1회입니다.
-     * SUBSCRIBE 이벤트 처리를 과도하게 지연시키지 않기 위해 재시도는 1회로 제한합니다.
+     * 최초 실행 1회 + 재시도 1회다.
+     * SUBSCRIBE 이벤트 처리를 과도하게 지연시키지 않기 위해 재시도는 1회로 제한한다.
      */
     private static final int ENTER_SCRIPT_MAX_ATTEMPTS = 2;
 
@@ -112,7 +127,7 @@ public class WebSocketEventListener {
     private static final String LEAVE_MESSAGE_FORMAT = "%s님이 퇴장하셨습니다.";
 
     /**
-     * ws:connection:{wsSessionId} 매핑 TTL.
+     * ws:connection:{wsSessionId} 및 lobby:{code}:user_session:{userIdentifier} 매핑 TTL.
      *
      * 정상 종료 시 DISCONNECT 이벤트에서 즉시 삭제한다.
      * TTL은 서버 장애, 이벤트 누락, 비정상 종료에 대비한 안전장치다.
@@ -139,9 +154,9 @@ public class WebSocketEventListener {
     private final RedisPublisher redisPublisher;
 
     /**
-     * 로비 refresh 신호와 입장 실패 메시지를 현재 서버에 연결된 WebSocket 클라이언트에게 전송한다.
+     * 현재 서버에 연결된 WebSocket 클라이언트에게 직접 메시지를 전송한다.
      *
-     * ENTER_FAILED 메시지는 Redis 장애 가능성을 고려하여 Redis Pub/Sub을 거치지 않고
+     * ENTER_FAILED 메시지 또는 Pub/Sub 발행 실패 fallback 메시지는 Redis를 거치지 않고
      * 현재 서버의 Simple Broker로 직접 전송한다.
      */
     private final SimpMessagingTemplate messagingTemplate;
@@ -162,22 +177,45 @@ public class WebSocketEventListener {
 
     /**
      * 로비 입장 원자 처리 Lua 스크립트.
-     *
-     * RedisScript<String> Bean이 여러 개(create/leave/enter) 존재하므로
-     * @Qualifier로 명확하게 주입한다.
      */
-    @Qualifier("enterLobbyScript")
     private final RedisScript<String> enterLobbyScript;
+
+    /**
+     * WebSocket 직접 전송 메시지 직렬화용 JsonMapper.
+     *
+     * ENTER_FAILED 또는 Pub/Sub fallback 메시지는 RedisSubscriber를 거치지 않고
+     * 직접 SimpMessagingTemplate으로 전송되므로, DTO 객체를 그대로 보내지 않고
+     * JSON 문자열로 변환하여 프론트 메시지 계약을 통일한다.
+     */
+    private final JsonMapper pubSubJsonMapper;
+
+    public WebSocketEventListener(
+            StringRedisTemplate stringRedisTemplate,
+            RedisPublisher redisPublisher,
+            SimpMessagingTemplate messagingTemplate,
+            ApplicationEventPublisher eventPublisher,
+            WebSocketMetric webSocketMetric,
+            @Qualifier("enterLobbyScript") RedisScript<String> enterLobbyScript,
+            @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper
+    ) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.redisPublisher = redisPublisher;
+        this.messagingTemplate = messagingTemplate;
+        this.eventPublisher = eventPublisher;
+        this.webSocketMetric = webSocketMetric;
+        this.enterLobbyScript = enterLobbyScript;
+        this.pubSubJsonMapper = pubSubJsonMapper;
+    }
 
     /**
      * WebSocket 채널 구독 이벤트 처리.
      *
      * [중요]
-     * 로비 관련 채널은 다음처럼 나뉩니다.
+     * 로비 관련 채널은 다음처럼 나뉜다.
      * - /topic/lobby/{code}         : 로비 채팅 채널
      * - /topic/lobby/{code}/refresh : 로비 정보 새로고침 채널
      *
-     * 입장 처리는 반드시 채팅 채널 구독 시점에만 실행합니다.
+     * 입장 처리는 반드시 채팅 채널 구독 시점에만 실행한다.
      * refresh 채널까지 입장 처리 대상으로 보면 같은 사용자가 participants/order에 중복 저장될 수 있다.
      */
     @EventListener
@@ -214,10 +252,11 @@ public class WebSocketEventListener {
      * [처리 순서]
      * 1. 세션에서 userIdentifier 조회
      * 2. wsSessionId로 Redis ws:connection:{wsSessionId} 조회
-     * 3. lobbyCode가 있으면 PlayerLeaveEvent 발행
-     * 4. LEAVE 시스템 메시지 브로드캐스트
-     * 5. user_status / ws:connection 키 정리
-     * 6. WebSocket 활성 세션 메트릭 감소
+     * 3. stale 세션 여부 확인
+     * 4. 현재 유효 세션이면 PlayerLeaveEvent 발행
+     * 5. LEAVE 시스템 메시지 브로드캐스트
+     * 6. Redis 키 정리
+     * 7. WebSocket 활성 세션 메트릭 감소
      */
     @EventListener
     public void handleDisconnectEvent(SessionDisconnectEvent event) {
@@ -239,6 +278,15 @@ public class WebSocketEventListener {
 
         String lobbyCode = findLobbyCodeByWsSessionId(wsSessionId);
 
+        if (lobbyCode != null && isStaleLobbySession(lobbyCode, userIdentifier, wsSessionId)) {
+            log.info("stale WebSocket 세션 연결 해제 감지 - 실제 퇴장 처리 생략. 로비: {}, 식별자: {}, wsSessionId: {}",
+                    lobbyCode, userIdentifier, wsSessionId);
+
+            deleteStaleConnectionKey(wsSessionId);
+            webSocketMetric.decrement();
+            return;
+        }
+
         log.info("WebSocket 연결 해제 - 식별자: {}, 로비: {}", userIdentifier, lobbyCode);
 
         if (lobbyCode != null) {
@@ -249,7 +297,7 @@ public class WebSocketEventListener {
             publishLeaveMessage(lobbyCode, userIdentifier);
         }
 
-        deleteDisconnectKeys(userIdentifier, wsSessionId);
+        deleteDisconnectKeys(userIdentifier, wsSessionId, lobbyCode);
 
         webSocketMetric.decrement();
     }
@@ -295,6 +343,7 @@ public class WebSocketEventListener {
      * - lobby:{code}:participants
      * - lobby:{code}:order
      * - ws:connection:{wsSessionId}
+     * - lobby:{code}:user_session:{userIdentifier}
      *
      * [실패 처리]
      * SUBSCRIBE 프레임은 이미 처리되어 클라이언트가 구독 상태가 될 수 있다.
@@ -323,6 +372,16 @@ public class WebSocketEventListener {
         if (ENTER_RESULT_ALREADY_JOINED.equals(result)) {
             log.info("로비 중복 구독 처리 - order 중복 저장 방지. 로비: {}, 식별자: {}, wsSessionId: {}",
                     lobbyCode, userIdentifier, wsSessionId);
+            return;
+        }
+
+        if (result != null && result.startsWith(ENTER_RESULT_SESSION_REPLACED_PREFIX)) {
+            String previousWsSessionId = result.substring(ENTER_RESULT_SESSION_REPLACED_PREFIX_LENGTH);
+
+            log.info("로비 세션 교체 처리 - 로비: {}, 식별자: {}, previousWsSessionId: {}, currentWsSessionId: {}",
+                    lobbyCode, userIdentifier, previousWsSessionId, wsSessionId);
+
+            cleanupWsConnection(previousWsSessionId);
             return;
         }
 
@@ -357,6 +416,7 @@ public class WebSocketEventListener {
      * [재시도하지 않는 대상]
      * - ENTERED
      * - ALREADY_JOINED
+     * - SESSION_REPLACED:{previousWsSessionId}
      * - LOBBY_NOT_FOUND
      *
      * LOBBY_NOT_FOUND는 일시 장애라기보다 잘못된 로비 코드 또는 이미 삭제된 로비 상태이므로
@@ -408,7 +468,8 @@ public class WebSocketEventListener {
                 RedisKeys.lobbyKey(lobbyCode),
                 RedisKeys.lobbyParticipantsKey(lobbyCode),
                 RedisKeys.lobbyOrderKey(lobbyCode),
-                RedisKeys.wsConnectionKey(wsSessionId)
+                RedisKeys.wsConnectionKey(wsSessionId),
+                RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier)
         );
 
         return stringRedisTemplate.execute(
@@ -418,7 +479,8 @@ public class WebSocketEventListener {
                 lobbyCode,
                 String.valueOf(WS_CONNECTION_TTL.toMillis()),
                 WebSocketHeaders.SESSION_USER_ID,
-                WebSocketHeaders.SESSION_LOBBY_CODE
+                WebSocketHeaders.SESSION_LOBBY_CODE,
+                wsSessionId
         );
     }
 
@@ -476,48 +538,86 @@ public class WebSocketEventListener {
     }
 
     /**
+     * 현재 DISCONNECT 된 wsSessionId가 로비 내 최신 유효 세션인지 확인한다.
+     *
+     * 동일 userIdentifier가 같은 로비에 재연결된 경우,
+     * 이전 wsSessionId는 stale 세션으로 간주한다.
+     * stale 세션의 DISCONNECT는 participants/order를 제거하면 안 된다.
+     */
+    private boolean isStaleLobbySession(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId
+    ) {
+        if (lobbyCode == null || userIdentifier == null || wsSessionId == null) {
+            return false;
+        }
+
+        String currentWsSessionId = stringRedisTemplate.opsForValue()
+                .get(RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier));
+
+        return currentWsSessionId != null && !currentWsSessionId.equals(wsSessionId);
+    }
+
+    /**
      * 로비 채팅 채널에 ENTER 시스템 메시지를 발행한다.
      *
-     * Redis Pub/Sub 발행 실패 시 시스템 메시지가 유실될 수 있으므로,
-     * RedisPublisher.publish()의 반환값을 확인하여 실패 로그를 남긴다.
+     * Redis Pub/Sub 발행 실패 시 현재 서버의 WebSocket Broker로 fallback 전송한다.
      */
     private void publishEnterMessage(String lobbyCode, String userIdentifier) {
+        ChatMessageDto message = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.ENTER)
+                .roomId(lobbyCode)
+                .sender(userIdentifier)
+                .content(String.format(ENTER_MESSAGE_FORMAT, userIdentifier))
+                .timestamp(LocalDateTime.now().toString())
+                .build();
+
         boolean published = redisPublisher.publish(
                 StompDestinations.subscribeLobbyChat(lobbyCode),
-                ChatMessageDto.builder()
-                        .type(ChatMessageDto.MessageType.ENTER)
-                        .roomId(lobbyCode)
-                        .sender(userIdentifier)
-                        .content(String.format(ENTER_MESSAGE_FORMAT, userIdentifier))
-                        .timestamp(LocalDateTime.now().toString())
-                        .build()
+                message
         );
 
         if (!published) {
-            log.error("ENTER 메시지 발행 실패 - 로비: {}, 식별자: {}", lobbyCode, userIdentifier);
+            log.error("ENTER 메시지 Pub/Sub 발행 실패 - 로컬 WebSocket fallback 전송. 로비: {}, 식별자: {}",
+                    lobbyCode, userIdentifier);
+
+            sendDirectJsonMessage(
+                    StompDestinations.subscribeLobbyChat(lobbyCode),
+                    message,
+                    "ENTER_FALLBACK"
+            );
         }
     }
 
     /**
      * 로비 채팅 채널에 LEAVE 시스템 메시지를 발행한다.
      *
-     * Redis Pub/Sub 발행 실패 시 퇴장 시스템 메시지가 유실될 수 있으므로,
-     * RedisPublisher.publish()의 반환값을 확인하여 실패 로그를 남긴다.
+     * Redis Pub/Sub 발행 실패 시 현재 서버의 WebSocket Broker로 fallback 전송한다.
      */
     private void publishLeaveMessage(String lobbyCode, String userIdentifier) {
+        ChatMessageDto message = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.LEAVE)
+                .roomId(lobbyCode)
+                .sender(userIdentifier)
+                .content(String.format(LEAVE_MESSAGE_FORMAT, userIdentifier))
+                .timestamp(LocalDateTime.now().toString())
+                .build();
+
         boolean published = redisPublisher.publish(
                 StompDestinations.subscribeLobbyChat(lobbyCode),
-                ChatMessageDto.builder()
-                        .type(ChatMessageDto.MessageType.LEAVE)
-                        .roomId(lobbyCode)
-                        .sender(userIdentifier)
-                        .content(String.format(LEAVE_MESSAGE_FORMAT, userIdentifier))
-                        .timestamp(LocalDateTime.now().toString())
-                        .build()
+                message
         );
 
         if (!published) {
-            log.error("LEAVE 메시지 발행 실패 - 로비: {}, 식별자: {}", lobbyCode, userIdentifier);
+            log.error("LEAVE 메시지 Pub/Sub 발행 실패 - 로컬 WebSocket fallback 전송. 로비: {}, 식별자: {}",
+                    lobbyCode, userIdentifier);
+
+            sendDirectJsonMessage(
+                    StompDestinations.subscribeLobbyChat(lobbyCode),
+                    message,
+                    "LEAVE_FALLBACK"
+            );
         }
     }
 
@@ -526,22 +626,50 @@ public class WebSocketEventListener {
      *
      * Redis 장애 때문에 enter_lobby.lua가 실패했을 수 있으므로
      * 실패 알림은 Redis Pub/Sub을 거치지 않고 현재 서버의 WebSocket Broker로 직접 전송한다.
+     *
+     * 단, 프론트 메시지 계약을 유지하기 위해 DTO 객체가 아니라 JSON 문자열로 전송한다.
      */
     private void publishEnterFailedMessage(
             String lobbyCode,
             String userIdentifier,
             String content
     ) {
-        messagingTemplate.convertAndSend(
+        ChatMessageDto message = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.ENTER_FAILED)
+                .roomId(lobbyCode)
+                .sender(userIdentifier)
+                .content(content)
+                .timestamp(LocalDateTime.now().toString())
+                .build();
+
+        sendDirectJsonMessage(
                 StompDestinations.subscribeLobbyChat(lobbyCode),
-                ChatMessageDto.builder()
-                        .type(ChatMessageDto.MessageType.ENTER_FAILED)
-                        .roomId(lobbyCode)
-                        .sender(userIdentifier)
-                        .content(content)
-                        .timestamp(LocalDateTime.now().toString())
-                        .build()
+                message,
+                "ENTER_FAILED"
         );
+    }
+
+    /**
+     * 현재 서버의 WebSocket Broker로 JSON 문자열 메시지를 직접 전송한다.
+     *
+     * Redis Pub/Sub 장애 또는 ENTER_FAILED처럼 Redis를 거치면 안 되는 상황에서 사용한다.
+     * DTO 객체를 그대로 보내면 타입 정보가 포함될 수 있으므로 반드시 JSON 문자열로 변환한다.
+     */
+    private void sendDirectJsonMessage(
+            String destination,
+            ChatMessageDto message,
+            String context
+    ) {
+        try {
+            String payload = pubSubJsonMapper.writeValueAsString(message);
+            messagingTemplate.convertAndSend(destination, payload);
+        } catch (Exception e) {
+            log.error("WebSocket 직접 메시지 전송 실패 - context: {}, destination: {}, messageType: {}",
+                    context,
+                    destination,
+                    message != null ? message.getType() : null,
+                    e);
+        }
     }
 
     /**
@@ -558,10 +686,7 @@ public class WebSocketEventListener {
     }
 
     /**
-     * 입장 처리 실패 시 ws:connection 키를 보상 삭제한다.
-     *
-     * Redis Lua 스크립트는 원자적으로 실행되므로 일반적으로 부분 성공은 발생하지 않는다.
-     * 다만 재시도 과정 또는 이전 시도에서 남은 ws:connection 키가 있을 수 있으므로 안전하게 정리한다.
+     * 입장 처리 실패 또는 세션 교체 시 ws:connection 키를 보상 삭제한다.
      */
     private void cleanupWsConnection(String wsSessionId) {
         if (wsSessionId == null || wsSessionId.isBlank()) {
@@ -576,13 +701,37 @@ public class WebSocketEventListener {
     }
 
     /**
-     * DISCONNECT 이후 불필요한 Redis 키를 정리한다.
+     * stale 세션의 ws:connection 키만 삭제한다.
+     *
+     * stale 세션은 최신 유효 세션이 아니므로 user_status나 lobbyUserSessionKey를 삭제하면 안 된다.
      */
-    private void deleteDisconnectKeys(String userIdentifier, String wsSessionId) {
+    private void deleteStaleConnectionKey(String wsSessionId) {
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            return;
+        }
+
+        stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
+    }
+
+    /**
+     * DISCONNECT 이후 불필요한 Redis 키를 정리한다.
+     *
+     * 현재 유효 세션의 DISCONNECT에서만 user_status와 lobbyUserSessionKey를 삭제한다.
+     * stale 세션은 deleteStaleConnectionKey()에서 ws:connection만 삭제한다.
+     */
+    private void deleteDisconnectKeys(
+            String userIdentifier,
+            String wsSessionId,
+            String lobbyCode
+    ) {
         stringRedisTemplate.delete(RedisKeys.userStatusKey(userIdentifier));
 
         if (wsSessionId != null && !wsSessionId.isBlank()) {
             stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
+        }
+
+        if (lobbyCode != null && !lobbyCode.isBlank()) {
+            stringRedisTemplate.delete(RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier));
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -160,8 +160,7 @@ public class WebSocketEventListener {
         Object resultValue = sessionAttributes.remove(WebSocketHeaders.LOBBY_ENTER_RESULT);
 
         if (!(resultValue instanceof String result)) {
-            log.warn("로비 입장 후처리 중단 - 인터셉터 입장 결과가 없습니다. 로비: {}, 식별자: {}, wsSessionId: {}",
-                    lobbyCode, userIdentifier, wsSessionId);
+            handleMissingLobbyEnterResult(lobbyCode, userIdentifier, wsSessionId);
             return;
         }
 
@@ -299,8 +298,50 @@ public class WebSocketEventListener {
             return;
         }
 
-        log.warn("로비 입장 후처리 중 알 수 없는 결과 수신 - result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
+        handleUnknownLobbyEnterResult(lobbyCode, userIdentifier, wsSessionId, result);
+    }
+
+    /**
+     * 로비 입장 후처리 결과가 세션 속성에 없는 경우의 fallback 처리.
+     *
+     * 정상 흐름에서는 StompChannelInterceptor가 SUBSCRIBE preSend 단계에서
+     * enter_lobby.lua를 성공시킨 뒤 LOBBY_ENTER_RESULT를 세션 속성에 저장한다.
+     *
+     * 따라서 이 값이 없다는 것은 입장 실패라기보다 후처리 메타데이터 누락에 가깝다.
+     * 이 상황에서 ENTER_FAILED를 보내면 이미 Redis에 입장 처리된 사용자를 실패로 오인시킬 수 있다.
+     *
+     * 안전한 fallback으로 로비 정보 refresh만 전송하여 클라이언트가 서버 상태를 다시 조회하게 한다.
+     */
+    private void handleMissingLobbyEnterResult(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId
+    ) {
+        log.error("로비 입장 후처리 fallback 실행 - 인터셉터 입장 결과가 없습니다. 로비: {}, 식별자: {}, wsSessionId: {}",
+                lobbyCode, userIdentifier, wsSessionId);
+
+        notifyLobbyInfoRefresh(lobbyCode);
+    }
+
+    /**
+     * 알 수 없는 Lua 입장 결과가 후처리 단계까지 전달된 경우의 fallback 처리.
+     *
+     * StompChannelInterceptor에서 Lua 반환값을 enum parser로 검증하므로,
+     * 정상적으로는 알 수 없는 결과가 여기까지 오면 안 된다.
+     *
+     * 다만 반환값 계약 변경 또는 예외적 상황에 대비해 ENTER_FAILED 대신 refresh를 전송한다.
+     * ENTER 메시지는 중복 발행 위험이 있고, ENTER_FAILED는 실제 입장 완료 상태와 충돌할 수 있기 때문이다.
+     */
+    private void handleUnknownLobbyEnterResult(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId,
+            String result
+    ) {
+        log.error("로비 입장 후처리 fallback 실행 - 알 수 없는 결과 수신. result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
                 result, lobbyCode, userIdentifier, wsSessionId);
+
+        notifyLobbyInfoRefresh(lobbyCode);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -381,7 +381,6 @@ public class WebSocketEventListener {
             log.info("로비 세션 교체 처리 - 로비: {}, 식별자: {}, previousWsSessionId: {}, currentWsSessionId: {}",
                     lobbyCode, userIdentifier, previousWsSessionId, wsSessionId);
 
-            cleanupWsConnection(previousWsSessionId);
             return;
         }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -1,26 +1,15 @@
 /*
  * WebSocket 연결 생명주기 이벤트를 처리하는 리스너.
- * (연결 / 구독 / 연결 해제)
  *
- * [리팩토링 변경 사항 — 의존 방향 역전 해결]
- * 기존: WebSocketEventListener(global) → LobbyEventService(domain) 직접 참조
- *       global이 domain을 직접 참조하는 의존 방향 역전 문제 존재
+ * [책임]
+ * - SUBSCRIBE 이벤트 중 로비 채팅 채널 구독을 감지하여 로비 입장 상태를 Redis에 저장
+ * - DISCONNECT 이벤트 발생 시 wsSessionId로 lobbyCode를 역추적하여 자동 퇴장 처리
+ * - ENTER / LEAVE 시스템 메시지 브로드캐스트
  *
- * 변경: WebSocketEventListener(global) → ApplicationEventPublisher로 이벤트 발행
- *       LobbyEventService(domain)가 @EventListener로 이벤트 수신
- *       global은 domain을 전혀 알 필요 없어짐
- *
- * [리팩토링 변경 사항 — 하드코딩 제거]
- * handleDisconnectEvent()에서 Redis Hash 조회 시 사용하던
- * "lobbyCode" 문자열 리터럴을
- * WebSocketHeaders.SESSION_LOBBY_CODE 상수로 교체
- *
- * [의존 방향]
- * global/websocket/WebSocketEventListener
- *         ↓ publishEvent(PlayerLeaveEvent)
- * Spring ApplicationEventPublisher
- *         ↓ 이벤트 전달
- * domain/lobby/service/LobbyEventService (@EventListener)
+ * [중요 설계]
+ * 실제 입장 상태 저장은 enter_lobby.lua에서 원자적으로 처리한다.
+ * Java 코드에서 participants Set, order List, ws:connection Hash를 각각 따로 저장하면
+ * 중간 실패 시 Redis 상태가 불일치할 수 있기 때문이다.
  */
 package io.github.ascrew.monomatbe.global.websocket;
 
@@ -32,178 +21,370 @@ import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebSocketEventListener {
 
-    // 사용자 온라인 상태 TTL (단위: 시간)
-    // 연결이 끊기면 handleDisconnectEvent에서 즉시 삭제하므로
-    // TTL은 비정상 종료(서버 다운 등) 시 Redis 좀비 키 방지용
-    private static final long USER_STATUS_TTL_HOURS = 2;
+    // =========================================================
+    // Redis Lua 반환값 상수
+    // =========================================================
 
-    /** 퇴장 메시지 포맷. {0} 위치에 userIdentifier가 삽입됩니다. */
+    /**
+     * 신규 입장자가 정상적으로 추가된 경우.
+     * participants Set에 새로 들어갔고, order List에도 추가된 상태
+     */
+    private static final String ENTER_RESULT_ENTERED = "ENTERED";
+
+    /**
+     * 이미 로비 participants Set에 존재하던 사용자가 다시 구독한 경우.
+     * order List에는 중복 저장하지 않고, ws:connection 매핑만 갱신
+     */
+    private static final String ENTER_RESULT_ALREADY_JOINED = "ALREADY_JOINED";
+
+    /**
+     * Redis에 해당 lobby:{code} Hash가 존재하지 않는 경우.
+     * 존재하지 않는 로비에 고스트 participants/order를 만들지 않기 위해 입장을 거부한다.
+     */
+    private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
+
+    // =========================================================
+    // 메시지/TTL 상수
+    // =========================================================
+
+    /** 입장 시스템 메시지 포맷. */
+    private static final String ENTER_MESSAGE_FORMAT = "%s님이 입장하셨습니다.";
+
+    /** 퇴장 시스템 메시지 포맷. */
     private static final String LEAVE_MESSAGE_FORMAT = "%s님이 퇴장하셨습니다.";
 
+    /**
+     * ws:connection:{wsSessionId} 매핑 TTL.
+     *
+     * 정상 종료 시 DISCONNECT 이벤트에서 즉시 삭제한다.
+     * TTL은 서버 장애, 이벤트 누락, 비정상 종료에 대비한 안전장치
+     */
+    private static final Duration WS_CONNECTION_TTL = Duration.ofHours(2);
+
+    // =========================================================
+    // 의존성
+    // =========================================================
+
+    /**
+     * 순수 문자열 Redis 작업 전용 Template.
+     *
+     * participants/order/ws:connection에는 문자열만 저장해야 한다.
+     * RedisTemplate<String, Object>를 사용하면 JSON 직렬화로 따옴표가 포함될 수 있고,
+     * leave_lobby.lua의 SREM/LREM 비교가 실패할 수 있다.
+     */
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * Redis Pub/Sub 기반 시스템 메시지 발행자.
+     * ENTER/LEAVE 메시지를 로비 채팅 채널로 브로드캐스트할 때 사용
+     */
     private final RedisPublisher redisPublisher;
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final WebSocketMetric webSocketMetric;
+
+    /**
+     * 로비 refresh 신호를 현재 서버에 연결된 WebSocket 클라이언트에게 전송한다.
+     *
+     * 기존 LobbyEventService도 SimpMessagingTemplate으로 refresh 신호를 보내고 있으므로,
+     * 동일한 방식으로 로비 내부 갱신 신호를 전송한다.
+     */
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * DISCONNECT 시 domain/lobby 쪽 퇴장 처리를 실행하기 위한 이벤트 발행자.
+     * global -> domain 직접 의존을 피하기 위해 Spring ApplicationEvent를 사용한다.
+     */
     private final ApplicationEventPublisher eventPublisher;
 
     /**
-     * WebSocket 연결 성공 이벤트 처리.
+     * 활성 WebSocket 세션 수 Prometheus 메트릭.
      *
-     * [처리 내용]
-     * 1. 세션에서 사용자 식별자 추출 (WebSocketSessionUtils 위임)
-     * 2. Redis에 온라인 상태 저장 (TTL 2시간)
-     * 3. 활성 세션 카운터 증가 (Prometheus 메트릭)
+     * CONNECT 시 증가는 StompChannelInterceptor에서 처리하고,
+     * DISCONNECT 시 감소는 실제 소켓 종료 이벤트를 받는 이 클래스에서 처리한다.
+     */
+    private final WebSocketMetric webSocketMetric;
+
+    /**
+     * 로비 입장 원자 처리 Lua 스크립트.
+     *
+     * RedisScript<String> Bean이 여러 개(create/leave/enter) 존재하므로
+     * @Qualifier로 명확하게 주입
+     */
+    @Qualifier("enterLobbyScript")
+    private final RedisScript<String> enterLobbyScript;
+
+    /**
+     * WebSocket 채널 구독 이벤트 처리.
+     *
+     * [중요]
+     * 로비 관련 채널은 다음처럼 나뉩니다.
+     * - /topic/lobby/{code}         : 로비 채팅 채널
+     * - /topic/lobby/{code}/refresh : 로비 정보 새로고침 채널
+     *
+     * 입장 처리는 반드시 채팅 채널 구독 시점에만 실행합니다.
+     * refresh 채널까지 입장 처리 대상으로 보면 같은 사용자가 participants/order에 중복 저장될 수 있다.
      */
     @EventListener
-    public void handleConnectEvent(SessionConnectedEvent event) {
+    public void handleSubscribeEvent(SessionSubscribeEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        String destination = accessor.getDestination();
+        String wsSessionId = accessor.getSessionId();
 
-        String userIdentifier = WebSocketSessionUtils.extractUserIdentifier(sessionAttributes);
-
-        if (WebSocketHeaders.UNKNOWN_IDENTIFIER.equals(userIdentifier)) {
-            log.warn("인증되지 않은 세션 연결 감지");
+        if (sessionAttributes == null) {
+            log.warn("로비 입장 처리 중단 - STOMP 세션 속성이 없습니다. destination: {}", destination);
             return;
         }
 
-        // 온라인 상태를 Redis에 저장
-        // TTL은 비정상 종료 시 자동 만료 보호용 (정상 종료 시 handleDisconnectEvent에서 즉시 삭제)
-        redisTemplate.opsForValue().set(
-                RedisKeys.userStatusKey(userIdentifier),
-                WebSocketHeaders.STATUS_ONLINE,
-                USER_STATUS_TTL_HOURS,
-                TimeUnit.HOURS
-        );
+        String userIdentifier = (String) sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER);
 
-        webSocketMetric.increment();
-        log.info("WebSocket 연결 - 식별자: {}", userIdentifier);
+        if (!isValidLobbyEnterRequest(destination, userIdentifier, wsSessionId)) {
+            return;
+        }
+
+        String lobbyCode = StompDestinations.extractLobbyCode(destination);
+
+        // 세션 속성에도 현재 로비 코드를 저장
+        // 동일 연결 내 후속 메시지 처리에서 roomId를 빠르게 참조할 수 있다.
+        sessionAttributes.put(WebSocketHeaders.ROOM_ID, lobbyCode);
+
+        processLobbyEnter(lobbyCode, userIdentifier, wsSessionId);
     }
 
     /**
-     * WebSocket 연결 해제 이벤트 처리 (단일 진입점).
+     * WebSocket 연결 해제 이벤트 처리.
      *
      * [처리 순서]
-     * 1. wsSessionId로 Redis에서 lobbyCode 역추적
-     * 2. PlayerLeaveEvent 발행 → LobbyEventService가 @EventListener로 수신하여 퇴장 처리
-     * 3. LEAVE 메시지 브로드캐스트
-     * 4. Redis 키 정리 (user_status, ws:connection)
-     *
-     * [수정 — 하드코딩 제거]
-     * Redis Hash 조회 시 사용하던 "lobbyCode" 문자열 리터럴
-     * → WebSocketHeaders.SESSION_LOBBY_CODE 상수로 교체
-     * LobbyEventService.saveConnectionInfo()의 저장 키와 상수로 통일하여
-     * 오타 시 컴파일 타임에 감지되도록 합니다.
+     * 1. 세션에서 userIdentifier 조회
+     * 2. wsSessionId로 Redis ws:connection:{wsSessionId} 조회
+     * 3. lobbyCode가 있으면 PlayerLeaveEvent 발행
+     * 4. LEAVE 시스템 메시지 브로드캐스트
+     * 5. user_status / ws:connection 키 정리
+     * 6. WebSocket 활성 세션 메트릭 감소
      */
     @EventListener
     public void handleDisconnectEvent(SessionDisconnectEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-
-        if (sessionAttributes == null) return;
-
-        String userIdentifier = (String) sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER);
         String wsSessionId = accessor.getSessionId();
 
-        // 인증되지 않은 세션이거나 식별자 없으면 처리 불필요
-        if (userIdentifier == null
-                || WebSocketHeaders.UNKNOWN_IDENTIFIER.equals(userIdentifier)) return;
-
-        // 1. Redis에서 세션 매핑 정보 역추적 (wsSessionId → lobbyCode)
-        //    LobbyEventService.saveConnectionInfo()에서 연결 시 저장한 데이터
-        String lobbyCode = null;
-        if (wsSessionId != null) {
-            Map<Object, Object> connectionInfo = redisTemplate.opsForHash()
-                    .entries(RedisKeys.wsConnectionKey(wsSessionId));
-            if (!connectionInfo.isEmpty()) {
-                // [수정] "lobbyCode" 문자열 리터럴 → WebSocketHeaders.SESSION_LOBBY_CODE 상수로 교체
-                lobbyCode = (String) connectionInfo.get(WebSocketHeaders.SESSION_LOBBY_CODE);
-            }
+        if (sessionAttributes == null) {
+            log.warn("WebSocket 연결 해제 처리 중단 - 세션 속성이 없습니다. wsSessionId: {}", wsSessionId);
+            return;
         }
+
+        String userIdentifier = (String) sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER);
+
+        if (!hasValidUserIdentifier(userIdentifier)) {
+            return;
+        }
+
+        String lobbyCode = findLobbyCodeByWsSessionId(wsSessionId);
 
         log.info("WebSocket 연결 해제 - 식별자: {}, 로비: {}", userIdentifier, lobbyCode);
 
-        // 2. PlayerLeaveEvent 발행
-        //    Spring이 @EventListener를 가진 LobbyEventService.handlePlayerLeave()로 전달
-        //    WebSocketEventListener는 LobbyEventService를 전혀 알 필요 없음
         if (lobbyCode != null) {
+            // domain/lobby 서비스가 퇴장 Lua 스크립트를 실행하도록 이벤트 발행
             eventPublisher.publishEvent(new PlayerLeaveEvent(lobbyCode, userIdentifier));
+
+            // 로비 채팅 채널에 퇴장 시스템 메시지 발행
+            publishLeaveMessage(lobbyCode, userIdentifier);
         }
 
-        // 3. LEAVE 메시지 브로드캐스트
-        //    채팅 알림은 WebSocket 인프라 책임이므로 이 클래스에서 직접 처리
-        if (lobbyCode != null) {
-            redisPublisher.publish(
-                    StompDestinations.subscribeLobbyChat(lobbyCode),
-                    ChatMessageDto.builder()
-                            .type(ChatMessageDto.MessageType.LEAVE)
-                            .roomId(lobbyCode)
-                            .sender(userIdentifier)
-                            .content(String.format(LEAVE_MESSAGE_FORMAT, userIdentifier))
-                            .build()
-            );
-        }
-
-        // 4. Redis 키 정리
-        // 온라인 상태 키 삭제
-        redisTemplate.delete(RedisKeys.userStatusKey(userIdentifier));
-        // WebSocket 세션 매핑 키 삭제
-        if (wsSessionId != null) {
-            redisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
-        }
+        deleteDisconnectKeys(userIdentifier, wsSessionId);
 
         webSocketMetric.decrement();
     }
 
     /**
-     * WebSocket 채널 구독 이벤트 처리.
-     *
-     * 로비 채널 구독 시 Redis 참여자 Set에 사용자를 추가합니다.
-     *
-     * [참여자 키 단일화]
-     * lobby:{code}:participants를 단일 진실의 원천으로 사용합니다.
-     * Lua 스크립트(leave_lobby.lua)가 퇴장 시 이 키에서 SREM으로 제거하므로
-     * 입장 시에도 동일한 키에 추가하여 일관성을 보장합니다.
+     * 로비 입장 요청으로 처리해도 되는 SUBSCRIBE 이벤트인지 검증한다.
      */
-    @EventListener
-    public void handleSubscribeEvent(SessionSubscribeEvent event) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
-        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+    private boolean isValidLobbyEnterRequest(
+            String destination,
+            String userIdentifier,
+            String wsSessionId
+    ) {
+        if (!StompDestinations.isLobbyChatSubscription(destination)) {
+            return false;
+        }
 
-        if (sessionAttributes == null) return;
+        if (!hasValidUserIdentifier(userIdentifier)) {
+            log.warn("로비 입장 처리 중단 - 사용자 식별자가 없습니다. destination: {}", destination);
+            return false;
+        }
 
-        String userIdentifier = (String) sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER);
-        String destination = accessor.getDestination();
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            log.warn("로비 입장 처리 중단 - wsSessionId가 없습니다. userIdentifier: {}", userIdentifier);
+            return false;
+        }
 
-        if (StompDestinations.isLobbySubscription(destination)
-                && userIdentifier != null
-                && !WebSocketHeaders.UNKNOWN_IDENTIFIER.equals(userIdentifier)) {
+        return true;
+    }
 
-            String roomId = StompDestinations.extractLobbyCode(destination);
+    /**
+     * userIdentifier가 실제 인증된 사용자 식별자인지 확인한다.
+     */
+    private boolean hasValidUserIdentifier(String userIdentifier) {
+        return userIdentifier != null
+                && !userIdentifier.isBlank()
+                && !WebSocketHeaders.UNKNOWN_IDENTIFIER.equals(userIdentifier);
+    }
 
-            // lobby:{code}:participants에 추가
-            // Lua 스크립트가 퇴장 시 삭제하는 키와 동일하게 맞춰 일관성 보장
-            redisTemplate.opsForSet().add(
-                    RedisKeys.lobbyParticipantsKey(roomId),
-                    userIdentifier
-            );
+    /**
+     * 로비 입장 상태를 Redis에 원자적으로 저장한다.
+     *
+     * [Redis 변경 대상]
+     * - lobby:{code}:participants
+     * - lobby:{code}:order
+     * - ws:connection:{wsSessionId}
+     *
+     * [브로드캐스트]
+     * 신규 입장인 경우에만 ENTER 메시지와 refresh 신호를 보낸다.
+     * 이미 입장한 사용자의 중복 구독에는 불필요한 시스템 메시지를 보내지 않는다.
+     */
+    private void processLobbyEnter(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId
+    ) {
+        List<String> keys = List.of(
+                RedisKeys.lobbyKey(lobbyCode),
+                RedisKeys.lobbyParticipantsKey(lobbyCode),
+                RedisKeys.lobbyOrderKey(lobbyCode),
+                RedisKeys.wsConnectionKey(wsSessionId)
+        );
 
-            log.info("로비 참여자 추가 - 로비: {}, 식별자: {}", roomId, userIdentifier);
+        String result = stringRedisTemplate.execute(
+                enterLobbyScript,
+                keys,
+                userIdentifier,
+                lobbyCode,
+                String.valueOf(WS_CONNECTION_TTL.toMillis()),
+                WebSocketHeaders.SESSION_USER_ID,
+                WebSocketHeaders.SESSION_LOBBY_CODE
+        );
+
+        if (ENTER_RESULT_ENTERED.equals(result)) {
+            log.info("로비 입장 처리 완료 - 로비: {}, 식별자: {}, wsSessionId: {}",
+                    lobbyCode, userIdentifier, wsSessionId);
+
+            publishEnterMessage(lobbyCode, userIdentifier);
+            notifyLobbyInfoRefresh(lobbyCode);
+            return;
+        }
+
+        if (ENTER_RESULT_ALREADY_JOINED.equals(result)) {
+            log.info("로비 중복 구독 처리 - order 중복 저장 방지. 로비: {}, 식별자: {}, wsSessionId: {}",
+                    lobbyCode, userIdentifier, wsSessionId);
+            return;
+        }
+
+        if (ENTER_RESULT_LOBBY_NOT_FOUND.equals(result)) {
+            log.warn("로비 입장 거부 - 존재하지 않는 로비입니다. 로비: {}, 식별자: {}",
+                    lobbyCode, userIdentifier);
+            return;
+        }
+
+        log.error("로비 입장 처리 실패 - 알 수 없는 Lua 반환값. 로비: {}, 식별자: {}, 반환값: {}",
+                lobbyCode, userIdentifier, result);
+    }
+
+    /**
+     * wsSessionId 기준으로 Redis에 저장된 lobbyCode를 역추적합니다.
+     */
+    private String findLobbyCodeByWsSessionId(String wsSessionId) {
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            return null;
+        }
+
+        Map<Object, Object> connectionInfo = stringRedisTemplate.opsForHash()
+                .entries(RedisKeys.wsConnectionKey(wsSessionId));
+
+        if (connectionInfo.isEmpty()) {
+            return null;
+        }
+
+        Object lobbyCode = connectionInfo.get(WebSocketHeaders.SESSION_LOBBY_CODE);
+
+        return lobbyCode instanceof String value && !value.isBlank()
+                ? value
+                : null;
+    }
+
+    /**
+     * 로비 채팅 채널에 ENTER 시스템 메시지를 발행합니다.
+     */
+    private void publishEnterMessage(String lobbyCode, String userIdentifier) {
+        redisPublisher.publish(
+                StompDestinations.subscribeLobbyChat(lobbyCode),
+                ChatMessageDto.builder()
+                        .type(ChatMessageDto.MessageType.ENTER)
+                        .roomId(lobbyCode)
+                        .sender(userIdentifier)
+                        .content(String.format(ENTER_MESSAGE_FORMAT, userIdentifier))
+                        .timestamp(LocalDateTime.now().toString())
+                        .build()
+        );
+    }
+
+    /**
+     * 로비 채팅 채널에 LEAVE 시스템 메시지를 발행합니다.
+     */
+    private void publishLeaveMessage(String lobbyCode, String userIdentifier) {
+        redisPublisher.publish(
+                StompDestinations.subscribeLobbyChat(lobbyCode),
+                ChatMessageDto.builder()
+                        .type(ChatMessageDto.MessageType.LEAVE)
+                        .roomId(lobbyCode)
+                        .sender(userIdentifier)
+                        .content(String.format(LEAVE_MESSAGE_FORMAT, userIdentifier))
+                        .timestamp(LocalDateTime.now().toString())
+                        .build()
+        );
+    }
+
+    /**
+     * 로비 내부 정보 새로고침 신호를 브로드캐스트합니다.
+     *
+     * participants/order가 변경되었으므로,
+     * 로비 화면을 보고 있는 클라이언트가 최신 참여자 목록을 다시 조회하도록 유도합니다.
+     */
+    private void notifyLobbyInfoRefresh(String lobbyCode) {
+        messagingTemplate.convertAndSend(
+                StompDestinations.subscribeLobbyRefresh(lobbyCode),
+                StompDestinations.MSG_REFRESH_LOBBY_INFO
+        );
+    }
+
+    /**
+     * DISCONNECT 이후 불필요한 Redis 키를 정리합니다.
+     */
+    private void deleteDisconnectKeys(String userIdentifier, String wsSessionId) {
+        stringRedisTemplate.delete(RedisKeys.userStatusKey(userIdentifier));
+
+        if (wsSessionId != null && !wsSessionId.isBlank()) {
+            stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -4,12 +4,20 @@
  * [책임]
  * - SUBSCRIBE 이벤트 중 로비 채팅 채널 구독을 감지하여 로비 입장 상태를 Redis에 저장
  * - DISCONNECT 이벤트 발생 시 wsSessionId로 lobbyCode를 역추적하여 자동 퇴장 처리
- * - ENTER / LEAVE 시스템 메시지 브로드캐스트
+ * - ENTER / LEAVE / ENTER_FAILED 시스템 메시지 브로드캐스트
  *
  * [중요 설계]
  * 실제 입장 상태 저장은 enter_lobby.lua에서 원자적으로 처리한다.
  * Java 코드에서 participants Set, order List, ws:connection Hash를 각각 따로 저장하면
  * 중간 실패 시 Redis 상태가 불일치할 수 있기 때문이다.
+ *
+ * [실패 처리 정책]
+ * STOMP SUBSCRIBE 프레임은 이미 처리되어 클라이언트가 구독 상태가 될 수 있다.
+ * 따라서 Redis Lua 입장 처리가 실패하면 클라이언트는 구독되어 있지만
+ * 서버 입장 상태가 누락되는 불일치가 발생할 수 있다.
+ *
+ * 이를 방지하기 위해 Lua 실행 실패 또는 null 반환 시 재시도하고,
+ * 최종 실패 시 ENTER_FAILED 메시지를 클라이언트에게 직접 전송한다.
  */
 package io.github.ascrew.monomatbe.global.websocket;
 
@@ -48,13 +56,13 @@ public class WebSocketEventListener {
 
     /**
      * 신규 입장자가 정상적으로 추가된 경우.
-     * participants Set에 새로 들어갔고, order List에도 추가된 상태
+     * participants Set에 새로 들어갔고, order List에도 추가된 상태.
      */
     private static final String ENTER_RESULT_ENTERED = "ENTERED";
 
     /**
      * 이미 로비 participants Set에 존재하던 사용자가 다시 구독한 경우.
-     * order List에는 중복 저장하지 않고, ws:connection 매핑만 갱신
+     * order List에는 중복 저장하지 않고, ws:connection 매핑만 갱신한다.
      */
     private static final String ENTER_RESULT_ALREADY_JOINED = "ALREADY_JOINED";
 
@@ -63,6 +71,35 @@ public class WebSocketEventListener {
      * 존재하지 않는 로비에 고스트 participants/order를 만들지 않기 위해 입장을 거부한다.
      */
     private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
+
+    // =========================================================
+    // 실패 처리 상수
+    // =========================================================
+
+    /**
+     * Lua 실행 최대 시도 횟수.
+     *
+     * 최초 실행 1회 + 재시도 1회입니다.
+     * SUBSCRIBE 이벤트 처리를 과도하게 지연시키지 않기 위해 재시도는 1회로 제한합니다.
+     */
+    private static final int ENTER_SCRIPT_MAX_ATTEMPTS = 2;
+
+    /** Lua 결과가 null인 경우의 실패 사유. */
+    private static final String ENTER_FAILURE_NULL_RESULT = "Lua result is null";
+
+    /** Redis 또는 Lua 실행 중 예외가 발생한 경우의 실패 사유. */
+    private static final String ENTER_FAILURE_EXCEPTION = "Lua execution exception";
+
+    /** 예상하지 못한 Lua 반환값을 받은 경우의 실패 사유. */
+    private static final String ENTER_FAILURE_UNKNOWN_RESULT = "Unknown Lua result";
+
+    /** 존재하지 않는 로비 코드로 구독한 경우의 실패 메시지. */
+    private static final String ENTER_FAILED_LOBBY_NOT_FOUND_MESSAGE =
+            "존재하지 않는 로비입니다. 로비 목록을 새로고침해주세요.";
+
+    /** 시스템 오류로 입장 처리가 실패한 경우의 실패 메시지. */
+    private static final String ENTER_FAILED_SYSTEM_MESSAGE =
+            "로비 입장 처리에 실패했습니다. 새로고침 후 다시 시도해주세요.";
 
     // =========================================================
     // 메시지/TTL 상수
@@ -78,7 +115,7 @@ public class WebSocketEventListener {
      * ws:connection:{wsSessionId} 매핑 TTL.
      *
      * 정상 종료 시 DISCONNECT 이벤트에서 즉시 삭제한다.
-     * TTL은 서버 장애, 이벤트 누락, 비정상 종료에 대비한 안전장치
+     * TTL은 서버 장애, 이벤트 누락, 비정상 종료에 대비한 안전장치다.
      */
     private static final Duration WS_CONNECTION_TTL = Duration.ofHours(2);
 
@@ -97,15 +134,15 @@ public class WebSocketEventListener {
 
     /**
      * Redis Pub/Sub 기반 시스템 메시지 발행자.
-     * ENTER/LEAVE 메시지를 로비 채팅 채널로 브로드캐스트할 때 사용
+     * ENTER/LEAVE 메시지를 로비 채팅 채널로 브로드캐스트할 때 사용한다.
      */
     private final RedisPublisher redisPublisher;
 
     /**
-     * 로비 refresh 신호를 현재 서버에 연결된 WebSocket 클라이언트에게 전송한다.
+     * 로비 refresh 신호와 입장 실패 메시지를 현재 서버에 연결된 WebSocket 클라이언트에게 전송한다.
      *
-     * 기존 LobbyEventService도 SimpMessagingTemplate으로 refresh 신호를 보내고 있으므로,
-     * 동일한 방식으로 로비 내부 갱신 신호를 전송한다.
+     * ENTER_FAILED 메시지는 Redis 장애 가능성을 고려하여 Redis Pub/Sub을 거치지 않고
+     * 현재 서버의 Simple Broker로 직접 전송한다.
      */
     private final SimpMessagingTemplate messagingTemplate;
 
@@ -127,7 +164,7 @@ public class WebSocketEventListener {
      * 로비 입장 원자 처리 Lua 스크립트.
      *
      * RedisScript<String> Bean이 여러 개(create/leave/enter) 존재하므로
-     * @Qualifier로 명확하게 주입
+     * @Qualifier로 명확하게 주입한다.
      */
     @Qualifier("enterLobbyScript")
     private final RedisScript<String> enterLobbyScript;
@@ -164,7 +201,7 @@ public class WebSocketEventListener {
 
         String lobbyCode = StompDestinations.extractLobbyCode(destination);
 
-        // 세션 속성에도 현재 로비 코드를 저장
+        // 세션 속성에도 현재 로비 코드를 저장한다.
         // 동일 연결 내 후속 메시지 처리에서 roomId를 빠르게 참조할 수 있다.
         sessionAttributes.put(WebSocketHeaders.ROOM_ID, lobbyCode);
 
@@ -259,31 +296,20 @@ public class WebSocketEventListener {
      * - lobby:{code}:order
      * - ws:connection:{wsSessionId}
      *
-     * [브로드캐스트]
-     * 신규 입장인 경우에만 ENTER 메시지와 refresh 신호를 보낸다.
-     * 이미 입장한 사용자의 중복 구독에는 불필요한 시스템 메시지를 보내지 않는다.
+     * [실패 처리]
+     * SUBSCRIBE 프레임은 이미 처리되어 클라이언트가 구독 상태가 될 수 있다.
+     * 따라서 Lua 실행 실패, null 반환, 알 수 없는 반환값이 발생하면
+     * ENTER_FAILED 메시지를 전송하여 클라이언트가 재시도 또는 로비 이탈을 수행할 수 있게 한다.
      */
     private void processLobbyEnter(
             String lobbyCode,
             String userIdentifier,
             String wsSessionId
     ) {
-        List<String> keys = List.of(
-                RedisKeys.lobbyKey(lobbyCode),
-                RedisKeys.lobbyParticipantsKey(lobbyCode),
-                RedisKeys.lobbyOrderKey(lobbyCode),
-                RedisKeys.wsConnectionKey(wsSessionId)
-        );
+        EnterLobbyExecutionResult executionResult =
+                executeEnterLobbyScriptWithRetry(lobbyCode, userIdentifier, wsSessionId);
 
-        String result = stringRedisTemplate.execute(
-                enterLobbyScript,
-                keys,
-                userIdentifier,
-                lobbyCode,
-                String.valueOf(WS_CONNECTION_TTL.toMillis()),
-                WebSocketHeaders.SESSION_USER_ID,
-                WebSocketHeaders.SESSION_LOBBY_CODE
-        );
+        String result = executionResult.result();
 
         if (ENTER_RESULT_ENTERED.equals(result)) {
             log.info("로비 입장 처리 완료 - 로비: {}, 식별자: {}, wsSessionId: {}",
@@ -301,17 +327,134 @@ public class WebSocketEventListener {
         }
 
         if (ENTER_RESULT_LOBBY_NOT_FOUND.equals(result)) {
-            log.warn("로비 입장 거부 - 존재하지 않는 로비입니다. 로비: {}, 식별자: {}",
-                    lobbyCode, userIdentifier);
+            log.warn("로비 입장 거부 - 존재하지 않는 로비입니다. 로비: {}, 식별자: {}, wsSessionId: {}",
+                    lobbyCode, userIdentifier, wsSessionId);
+
+            publishEnterFailedMessage(lobbyCode, userIdentifier, ENTER_FAILED_LOBBY_NOT_FOUND_MESSAGE);
+            cleanupWsConnection(wsSessionId);
             return;
         }
 
-        log.error("로비 입장 처리 실패 - 알 수 없는 Lua 반환값. 로비: {}, 식별자: {}, 반환값: {}",
-                lobbyCode, userIdentifier, result);
+        handleLobbyEnterFailure(
+                lobbyCode,
+                userIdentifier,
+                wsSessionId,
+                executionResult.failureReason() != null
+                        ? executionResult.failureReason()
+                        : ENTER_FAILURE_UNKNOWN_RESULT,
+                result,
+                executionResult.exception()
+        );
     }
 
     /**
-     * wsSessionId 기준으로 Redis에 저장된 lobbyCode를 역추적합니다.
+     * enter_lobby.lua를 최대 ENTER_SCRIPT_MAX_ATTEMPTS만큼 실행한다.
+     *
+     * [재시도 대상]
+     * - Redis 예외 발생
+     * - Lua 결과가 null
+     *
+     * [재시도하지 않는 대상]
+     * - ENTERED
+     * - ALREADY_JOINED
+     * - LOBBY_NOT_FOUND
+     *
+     * LOBBY_NOT_FOUND는 일시 장애라기보다 잘못된 로비 코드 또는 이미 삭제된 로비 상태이므로
+     * 재시도하지 않고 즉시 반환한다.
+     */
+    private EnterLobbyExecutionResult executeEnterLobbyScriptWithRetry(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId
+    ) {
+        RuntimeException lastException = null;
+
+        for (int attempt = 1; attempt <= ENTER_SCRIPT_MAX_ATTEMPTS; attempt++) {
+            try {
+                String result = executeEnterLobbyScript(lobbyCode, userIdentifier, wsSessionId);
+
+                if (result != null) {
+                    return EnterLobbyExecutionResult.success(result);
+                }
+
+                log.warn("로비 입장 Lua 결과 null - 재시도 여부 확인. attempt: {}/{}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                        attempt, ENTER_SCRIPT_MAX_ATTEMPTS, lobbyCode, userIdentifier, wsSessionId);
+
+            } catch (RuntimeException e) {
+                lastException = e;
+                log.warn("로비 입장 Lua 실행 예외 - 재시도 여부 확인. attempt: {}/{}, 로비: {}, 식별자: {}, wsSessionId: {}, message: {}",
+                        attempt, ENTER_SCRIPT_MAX_ATTEMPTS, lobbyCode, userIdentifier, wsSessionId, e.getMessage());
+            }
+        }
+
+        if (lastException != null) {
+            return EnterLobbyExecutionResult.failure(ENTER_FAILURE_EXCEPTION, lastException);
+        }
+
+        return EnterLobbyExecutionResult.failure(ENTER_FAILURE_NULL_RESULT, null);
+    }
+
+    /**
+     * enter_lobby.lua를 1회 실행한다.
+     *
+     * 재시도 정책은 executeEnterLobbyScriptWithRetry()에서만 관리한다.
+     */
+    private String executeEnterLobbyScript(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId
+    ) {
+        List<String> keys = List.of(
+                RedisKeys.lobbyKey(lobbyCode),
+                RedisKeys.lobbyParticipantsKey(lobbyCode),
+                RedisKeys.lobbyOrderKey(lobbyCode),
+                RedisKeys.wsConnectionKey(wsSessionId)
+        );
+
+        return stringRedisTemplate.execute(
+                enterLobbyScript,
+                keys,
+                userIdentifier,
+                lobbyCode,
+                String.valueOf(WS_CONNECTION_TTL.toMillis()),
+                WebSocketHeaders.SESSION_USER_ID,
+                WebSocketHeaders.SESSION_LOBBY_CODE
+        );
+    }
+
+    /**
+     * 로비 입장 처리 최종 실패를 처리한다.
+     *
+     * [처리 내용]
+     * - ERROR 로그 기록
+     * - ENTER_FAILED 메시지 전송
+     * - ws:connection 보상 삭제
+     *
+     * SUBSCRIBE 자체는 이미 완료되었을 수 있으므로,
+     * 클라이언트는 ENTER_FAILED 메시지를 수신하면 로비 화면에서 이탈하거나 재시도해야 한다.
+     */
+    private void handleLobbyEnterFailure(
+            String lobbyCode,
+            String userIdentifier,
+            String wsSessionId,
+            String reason,
+            String result,
+            Exception exception
+    ) {
+        if (exception == null) {
+            log.error("로비 입장 처리 최종 실패 - reason: {}, result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                    reason, result, lobbyCode, userIdentifier, wsSessionId);
+        } else {
+            log.error("로비 입장 처리 최종 실패 - reason: {}, result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
+                    reason, result, lobbyCode, userIdentifier, wsSessionId, exception);
+        }
+
+        publishEnterFailedMessage(lobbyCode, userIdentifier, ENTER_FAILED_SYSTEM_MESSAGE);
+        cleanupWsConnection(wsSessionId);
+    }
+
+    /**
+     * wsSessionId 기준으로 Redis에 저장된 lobbyCode를 역추적한다.
      */
     private String findLobbyCodeByWsSessionId(String wsSessionId) {
         if (wsSessionId == null || wsSessionId.isBlank()) {
@@ -333,7 +476,7 @@ public class WebSocketEventListener {
     }
 
     /**
-     * 로비 채팅 채널에 ENTER 시스템 메시지를 발행합니다.
+     * 로비 채팅 채널에 ENTER 시스템 메시지를 발행한다.
      */
     private void publishEnterMessage(String lobbyCode, String userIdentifier) {
         redisPublisher.publish(
@@ -349,7 +492,7 @@ public class WebSocketEventListener {
     }
 
     /**
-     * 로비 채팅 채널에 LEAVE 시스템 메시지를 발행합니다.
+     * 로비 채팅 채널에 LEAVE 시스템 메시지를 발행한다.
      */
     private void publishLeaveMessage(String lobbyCode, String userIdentifier) {
         redisPublisher.publish(
@@ -365,10 +508,33 @@ public class WebSocketEventListener {
     }
 
     /**
-     * 로비 내부 정보 새로고침 신호를 브로드캐스트합니다.
+     * 로비 입장 실패 메시지를 해당 로비 채널로 전송한다.
+     *
+     * Redis 장애 때문에 enter_lobby.lua가 실패했을 수 있으므로
+     * 실패 알림은 Redis Pub/Sub을 거치지 않고 현재 서버의 WebSocket Broker로 직접 전송한다.
+     */
+    private void publishEnterFailedMessage(
+            String lobbyCode,
+            String userIdentifier,
+            String content
+    ) {
+        messagingTemplate.convertAndSend(
+                StompDestinations.subscribeLobbyChat(lobbyCode),
+                ChatMessageDto.builder()
+                        .type(ChatMessageDto.MessageType.ENTER_FAILED)
+                        .roomId(lobbyCode)
+                        .sender(userIdentifier)
+                        .content(content)
+                        .timestamp(LocalDateTime.now().toString())
+                        .build()
+        );
+    }
+
+    /**
+     * 로비 내부 정보 새로고침 신호를 브로드캐스트한다.
      *
      * participants/order가 변경되었으므로,
-     * 로비 화면을 보고 있는 클라이언트가 최신 참여자 목록을 다시 조회하도록 유도합니다.
+     * 로비 화면을 보고 있는 클라이언트가 최신 참여자 목록을 다시 조회하도록 유도한다.
      */
     private void notifyLobbyInfoRefresh(String lobbyCode) {
         messagingTemplate.convertAndSend(
@@ -378,13 +544,51 @@ public class WebSocketEventListener {
     }
 
     /**
-     * DISCONNECT 이후 불필요한 Redis 키를 정리합니다.
+     * 입장 처리 실패 시 ws:connection 키를 보상 삭제한다.
+     *
+     * Redis Lua 스크립트는 원자적으로 실행되므로 일반적으로 부분 성공은 발생하지 않는다.
+     * 다만 재시도 과정 또는 이전 시도에서 남은 ws:connection 키가 있을 수 있으므로 안전하게 정리한다.
+     */
+    private void cleanupWsConnection(String wsSessionId) {
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            return;
+        }
+
+        try {
+            stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
+        } catch (Exception e) {
+            log.error("로비 입장 실패 후 ws:connection 보상 삭제 실패 - wsSessionId: {}", wsSessionId, e);
+        }
+    }
+
+    /**
+     * DISCONNECT 이후 불필요한 Redis 키를 정리한다.
      */
     private void deleteDisconnectKeys(String userIdentifier, String wsSessionId) {
         stringRedisTemplate.delete(RedisKeys.userStatusKey(userIdentifier));
 
         if (wsSessionId != null && !wsSessionId.isBlank()) {
             stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
+        }
+    }
+
+    /**
+     * enter_lobby.lua 실행 결과를 담는 내부 전용 record.
+     *
+     * result가 null이면 실패로 간주한다.
+     * 실패 시 failureReason과 exception을 함께 보관하여 최종 로그에 남긴다.
+     */
+    private record EnterLobbyExecutionResult(
+            String result,
+            String failureReason,
+            Exception exception
+    ) {
+        private static EnterLobbyExecutionResult success(String result) {
+            return new EnterLobbyExecutionResult(result, null, null);
+        }
+
+        private static EnterLobbyExecutionResult failure(String failureReason, Exception exception) {
+            return new EnterLobbyExecutionResult(null, failureReason, exception);
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/dto/ChatMessageDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/dto/ChatMessageDto.java
@@ -34,6 +34,6 @@ public class ChatMessageDto {
      * - LEAVE  : 퇴장 알림 시스템 메시지
      */
     public enum MessageType {
-        CHAT, ANSWER, ENTER, LEAVE
+        CHAT, ANSWER, ENTER, LEAVE, ENTER_FAILED
     }
 }

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -5,66 +5,94 @@
 --
 -- [책임]
 -- 1. 로비 존재 여부 검증
--- 2. participants Set에 userIdentifier 저장
--- 3. order List에 userIdentifier 저장
--- 4. wsSessionId 기준으로 lobbyCode, userIdentifier 매핑 저장
--- 5. userIdentifier 기준 현재 유효 wsSessionId 저장
--- 6. 중복 구독 및 재연결 겹침 상황 처리
+-- 2. 동일 userIdentifier의 세션 sequence 비교
+-- 3. participants Set에 userIdentifier 저장
+-- 4. order List에 userIdentifier 저장
+-- 5. wsSessionId 기준 lobbyCode, userIdentifier 매핑 저장
+-- 6. userIdentifier 기준 현재 유효 wsSessionId 저장
+-- 7. userIdentifier 기준 현재 유효 sessionSequence 저장
 --
 -- [동일 userIdentifier 다중 세션 정책]
--- 같은 userIdentifier가 같은 로비에 다시 입장하면 최신 wsSessionId를 현재 유효 세션으로 본다.
--- 이전 wsSessionId는 Java에서 stale 세션으로 처리하여 DISCONNECT 시 퇴장 처리하지 않는다.
+-- 같은 userIdentifier가 같은 로비에 다시 입장하면 sessionSequence가 더 큰 세션을
+-- 현재 유효 세션으로 본다.
+--
+-- Redis Lua는 원자적으로 실행되지만, 네트워크 지연으로 오래된 SUBSCRIBE 요청이
+-- 더 늦게 도착할 수 있다. 이를 막기 위해 sessionSequence를 비교하여
+-- 더 오래된 세션은 user_session을 덮어쓰지 않고 STALE_SESSION으로 거부한다.
 -- ============================================================================
 
-local lobbyKey              = KEYS[1] -- lobby:{code}
-local participantsKey       = KEYS[2] -- lobby:{code}:participants
-local orderKey              = KEYS[3] -- lobby:{code}:order
-local wsConnectionKey       = KEYS[4] -- ws:connection:{wsSessionId}
-local lobbyUserSessionKey   = KEYS[5] -- lobby:{code}:user_session:{userIdentifier}
+local lobbyKey                  = KEYS[1] -- lobby:{code}
+local participantsKey           = KEYS[2] -- lobby:{code}:participants
+local orderKey                  = KEYS[3] -- lobby:{code}:order
+local wsConnectionKey           = KEYS[4] -- ws:connection:{wsSessionId}
+local lobbyUserSessionKey       = KEYS[5] -- lobby:{code}:user_session:{userIdentifier}
+local lobbyUserSessionSeqKey    = KEYS[6] -- lobby:{code}:user_session_seq:{userIdentifier}
 
-local userIdentifier        = ARGV[1] -- 사용자 식별자(UUID)
-local lobbyCode             = ARGV[2] -- 로비 초대 코드
-local connectionTtlMs       = ARGV[3] -- ws:connection TTL(ms)
-local userField             = ARGV[4] -- WebSocketHeaders.SESSION_USER_ID
-local lobbyField            = ARGV[5] -- WebSocketHeaders.SESSION_LOBBY_CODE
-local wsSessionId           = ARGV[6] -- 현재 WebSocket 세션 ID
+local userIdentifier            = ARGV[1] -- 사용자 식별자(UUID)
+local lobbyCode                 = ARGV[2] -- 로비 초대 코드
+local connectionTtlMs           = ARGV[3] -- ws:connection TTL(ms)
+local userField                 = ARGV[4] -- WebSocketHeaders.SESSION_USER_ID
+local lobbyField                = ARGV[5] -- WebSocketHeaders.SESSION_LOBBY_CODE
+local wsSessionId               = ARGV[6] -- 현재 WebSocket 세션 ID
+local sessionSequence           = tonumber(ARGV[7]) -- 현재 WebSocket 세션 sequence
 
 -- 1. 로비가 존재하지 않으면 입장 상태를 만들지 않는다.
 if redis.call('EXISTS', lobbyKey) == 0 then
     return "LOBBY_NOT_FOUND"
 end
 
--- 2. 기존에 같은 userIdentifier로 등록된 현재 유효 wsSessionId를 조회한다.
-local previousWsSessionId = redis.call('GET', lobbyUserSessionKey)
+-- 2. sessionSequence가 숫자가 아니면 잘못된 서버 상태로 본다.
+if sessionSequence == nil then
+    return "INVALID_SEQUENCE"
+end
 
--- 3. 참여자 Set에 추가한다.
+-- 3. 기존 현재 유효 세션과 sequence를 조회한다.
+local previousWsSessionId = redis.call('GET', lobbyUserSessionKey)
+local previousSequence = redis.call('GET', lobbyUserSessionSeqKey)
+
+-- 4. 이미 더 최신 세션이 존재하면 현재 요청은 stale로 간주한다.
+-- 이 경우 participants/order/user_session/ws:connection을 변경하지 않는다.
+if previousSequence ~= false and tonumber(previousSequence) > sessionSequence then
+    local currentWsSessionId = previousWsSessionId
+
+    if currentWsSessionId == false then
+        currentWsSessionId = ""
+    end
+
+    return "STALE_SESSION:" .. currentWsSessionId
+end
+
+-- 5. 참여자 Set에 추가한다.
 -- SADD 반환값:
 -- - 1: 신규 참여자
 -- - 0: 이미 참여 중인 사용자
 local added = redis.call('SADD', participantsKey, userIdentifier)
 
--- 4. 신규 참여자일 때만 order List에 추가한다.
+-- 6. 신규 참여자일 때만 order List에 추가한다.
 -- 이미 참여 중인 사용자의 재연결/중복 구독은 order를 중복 저장하지 않는다.
 if added == 1 then
     redis.call('RPUSH', orderKey, userIdentifier)
 end
 
--- 5. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
+-- 7. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
 redis.call('HSET', wsConnectionKey,
     userField,  userIdentifier,
     lobbyField, lobbyCode
 )
 redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
 
--- 6. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
+-- 8. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
 redis.call('SET', lobbyUserSessionKey, wsSessionId, 'PX', connectionTtlMs)
 
--- 7. 반환값 결정
+-- 9. userIdentifier 기준 현재 유효 세션 sequence도 함께 저장한다.
+redis.call('SET', lobbyUserSessionSeqKey, tostring(sessionSequence), 'PX', connectionTtlMs)
+
+-- 10. 반환값 결정
 if added == 1 then
     return "ENTERED"
 end
 
-if previousWsSessionId and previousWsSessionId ~= wsSessionId then
+if previousWsSessionId ~= false and previousWsSessionId ~= wsSessionId then
     return "SESSION_REPLACED:" .. previousWsSessionId
 end
 

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -8,60 +8,64 @@
 -- 2. participants Set에 userIdentifier 저장
 -- 3. order List에 userIdentifier 저장
 -- 4. wsSessionId 기준으로 lobbyCode, userIdentifier 매핑 저장
--- 5. 중복 구독 시 participants/order 중복 저장 방지
+-- 5. userIdentifier 기준 현재 유효 wsSessionId 저장
+-- 6. 중복 구독 및 재연결 겹침 상황 처리
 --
--- [원자성]
--- Redis Lua 스크립트는 싱글 스레드로 실행되므로,
--- 아래의 입장 상태 변경 작업은 중간에 다른 Redis 명령이 끼어들 수 없다.
---
--- [중복 구독 처리]
--- SADD 결과가 1이면 신규 입장자
--- SADD 결과가 0이면 이미 participants에 존재하는 사용자이므로,
--- order List에는 다시 넣지 않는다.
--- 단, WebSocket 세션은 새로 열렸을 수 있으므로 ws:connection 매핑은 항상 갱신한다.
+-- [동일 userIdentifier 다중 세션 정책]
+-- 같은 userIdentifier가 같은 로비에 다시 입장하면 최신 wsSessionId를 현재 유효 세션으로 본다.
+-- 이전 wsSessionId는 Java에서 stale 세션으로 처리하여 DISCONNECT 시 퇴장 처리하지 않는다.
 -- ============================================================================
 
-local lobbyKey        = KEYS[1] -- lobby:{code}
-local participantsKey = KEYS[2] -- lobby:{code}:participants
-local orderKey        = KEYS[3] -- lobby:{code}:order
-local wsConnectionKey = KEYS[4] -- ws:connection:{wsSessionId}
+local lobbyKey              = KEYS[1] -- lobby:{code}
+local participantsKey       = KEYS[2] -- lobby:{code}:participants
+local orderKey              = KEYS[3] -- lobby:{code}:order
+local wsConnectionKey       = KEYS[4] -- ws:connection:{wsSessionId}
+local lobbyUserSessionKey   = KEYS[5] -- lobby:{code}:user_session:{userIdentifier}
 
-local userIdentifier  = ARGV[1] -- 사용자 식별자(UUID)
-local lobbyCode       = ARGV[2] -- 로비 초대 코드
-local connectionTtlMs = ARGV[3] -- ws:connection TTL(ms)
-local userField       = ARGV[4] -- WebSocketHeaders.SESSION_USER_ID
-local lobbyField      = ARGV[5] -- WebSocketHeaders.SESSION_LOBBY_CODE
+local userIdentifier        = ARGV[1] -- 사용자 식별자(UUID)
+local lobbyCode             = ARGV[2] -- 로비 초대 코드
+local connectionTtlMs       = ARGV[3] -- ws:connection TTL(ms)
+local userField             = ARGV[4] -- WebSocketHeaders.SESSION_USER_ID
+local lobbyField            = ARGV[5] -- WebSocketHeaders.SESSION_LOBBY_CODE
+local wsSessionId           = ARGV[6] -- 현재 WebSocket 세션 ID
 
 -- 1. 로비가 존재하지 않으면 입장 상태를 만들지 않는다.
--- 존재하지 않는 로비에 participants/order가 생기는 고스트 데이터 방지용
 if redis.call('EXISTS', lobbyKey) == 0 then
     return "LOBBY_NOT_FOUND"
 end
 
--- 2. 참여자 Set에 추가
+-- 2. 기존에 같은 userIdentifier로 등록된 현재 유효 wsSessionId를 조회한다.
+local previousWsSessionId = redis.call('GET', lobbyUserSessionKey)
+
+-- 3. 참여자 Set에 추가한다.
 -- SADD 반환값:
--- - 1: 새로 추가됨
--- - 0: 이미 존재함
+-- - 1: 신규 참여자
+-- - 0: 이미 참여 중인 사용자
 local added = redis.call('SADD', participantsKey, userIdentifier)
 
--- 3. 신규 입장자일 때만 order List에 추가한다.
--- 중복 구독 또는 새로고침으로 같은 사용자가 다시 구독해도 방장 위임 순서가 중복되지 않는다.
+-- 4. 신규 참여자일 때만 order List에 추가한다.
+-- 이미 참여 중인 사용자의 재연결/중복 구독은 order를 중복 저장하지 않는다.
 if added == 1 then
     redis.call('RPUSH', orderKey, userIdentifier)
 end
 
--- 4. WebSocket 세션 ID 기준 역추적 정보를 저장한다.
--- DISCONNECT 이벤트에서 wsSessionId만으로 lobbyCode를 찾기 위해 필요하다.
+-- 5. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
 redis.call('HSET', wsConnectionKey,
     userField,  userIdentifier,
     lobbyField, lobbyCode
 )
-
--- 5. 비정상 종료 또는 서버 장애 시 좀비 ws:connection 키가 남지 않도록 TTL을 설정한다.
 redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
 
+-- 6. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
+redis.call('SET', lobbyUserSessionKey, wsSessionId, 'PX', connectionTtlMs)
+
+-- 7. 반환값 결정
 if added == 1 then
     return "ENTERED"
+end
+
+if previousWsSessionId and previousWsSessionId ~= wsSessionId then
+    return "SESSION_REPLACED:" .. previousWsSessionId
 end
 
 return "ALREADY_JOINED"

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -19,6 +19,9 @@
 -- Redis Lua는 원자적으로 실행되지만, 네트워크 지연으로 오래된 SUBSCRIBE 요청이
 -- 더 늦게 도착할 수 있다. 이를 막기 위해 sessionSequence를 비교하여
 -- 더 오래된 세션은 user_session을 덮어쓰지 않고 STALE_SESSION으로 거부한다.
+--
+-- 단, 같은 wsSessionId가 다시 들어온 경우에는 동일 세션의 재구독/중복 구독으로 보고
+-- STALE_SESSION으로 거부하지 않고 TTL만 갱신한다.
 -- ============================================================================
 
 local lobbyKey                  = KEYS[1] -- lobby:{code}
@@ -30,7 +33,7 @@ local lobbyUserSessionSeqKey    = KEYS[6] -- lobby:{code}:user_session_seq:{user
 
 local userIdentifier            = ARGV[1] -- 사용자 식별자(UUID)
 local lobbyCode                 = ARGV[2] -- 로비 초대 코드
-local connectionTtlMs           = ARGV[3] -- ws:connection TTL(ms)
+local connectionTtlMs           = ARGV[3] -- ws/user_session TTL(ms)
 local userField                 = ARGV[4] -- WebSocketHeaders.SESSION_USER_ID
 local lobbyField                = ARGV[5] -- WebSocketHeaders.SESSION_LOBBY_CODE
 local wsSessionId               = ARGV[6] -- 현재 WebSocket 세션 ID
@@ -42,6 +45,9 @@ if redis.call('EXISTS', lobbyKey) == 0 then
 end
 
 -- 2. sessionSequence가 숫자가 아니면 잘못된 서버 상태로 본다.
+-- sessionSequence는 CONNECT 단계에서 Redis INCR로 발급되고 Java에서 검증 후 전달된다.
+-- 따라서 nil 또는 숫자 변환 실패는 재시도 가능한 사용자 입력 오류가 아니라
+-- Java-Lua 계약 위반에 가까우므로 입장을 허용하지 않는다.
 if sessionSequence == nil then
     return "INVALID_SEQUENCE"
 end
@@ -51,8 +57,21 @@ local previousWsSessionId = redis.call('GET', lobbyUserSessionKey)
 local previousSequence = redis.call('GET', lobbyUserSessionSeqKey)
 
 -- 4. 이미 더 최신 세션이 존재하면 현재 요청은 stale로 간주한다.
--- 이 경우 participants/order/user_session/ws:connection을 변경하지 않는다.
+-- 다만 동일 wsSessionId가 다시 들어온 경우에는 같은 세션의 재구독/중복 구독으로 보고
+-- stale 거부 대신 TTL을 갱신한다.
 if previousSequence ~= false and tonumber(previousSequence) > sessionSequence then
+    if previousWsSessionId ~= false and previousWsSessionId == wsSessionId then
+        redis.call('HSET', wsConnectionKey,
+            userField,  userIdentifier,
+            lobbyField, lobbyCode
+        )
+        redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
+        redis.call('PEXPIRE', lobbyUserSessionKey, connectionTtlMs)
+        redis.call('PEXPIRE', lobbyUserSessionSeqKey, connectionTtlMs)
+
+        return "ALREADY_JOINED"
+    end
+
     local currentWsSessionId = previousWsSessionId
 
     if currentWsSessionId == false then

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -1,0 +1,67 @@
+---@diagnostic disable: undefined-global
+
+-- ============================================================================
+-- 로비 입장 원자적 처리 스크립트
+--
+-- [책임]
+-- 1. 로비 존재 여부 검증
+-- 2. participants Set에 userIdentifier 저장
+-- 3. order List에 userIdentifier 저장
+-- 4. wsSessionId 기준으로 lobbyCode, userIdentifier 매핑 저장
+-- 5. 중복 구독 시 participants/order 중복 저장 방지
+--
+-- [원자성]
+-- Redis Lua 스크립트는 싱글 스레드로 실행되므로,
+-- 아래의 입장 상태 변경 작업은 중간에 다른 Redis 명령이 끼어들 수 없다.
+--
+-- [중복 구독 처리]
+-- SADD 결과가 1이면 신규 입장자
+-- SADD 결과가 0이면 이미 participants에 존재하는 사용자이므로,
+-- order List에는 다시 넣지 않는다.
+-- 단, WebSocket 세션은 새로 열렸을 수 있으므로 ws:connection 매핑은 항상 갱신한다.
+-- ============================================================================
+
+local lobbyKey        = KEYS[1] -- lobby:{code}
+local participantsKey = KEYS[2] -- lobby:{code}:participants
+local orderKey        = KEYS[3] -- lobby:{code}:order
+local wsConnectionKey = KEYS[4] -- ws:connection:{wsSessionId}
+
+local userIdentifier  = ARGV[1] -- 사용자 식별자(UUID)
+local lobbyCode       = ARGV[2] -- 로비 초대 코드
+local connectionTtlMs = ARGV[3] -- ws:connection TTL(ms)
+local userField       = ARGV[4] -- WebSocketHeaders.SESSION_USER_ID
+local lobbyField      = ARGV[5] -- WebSocketHeaders.SESSION_LOBBY_CODE
+
+-- 1. 로비가 존재하지 않으면 입장 상태를 만들지 않는다.
+-- 존재하지 않는 로비에 participants/order가 생기는 고스트 데이터 방지용
+if redis.call('EXISTS', lobbyKey) == 0 then
+    return "LOBBY_NOT_FOUND"
+end
+
+-- 2. 참여자 Set에 추가
+-- SADD 반환값:
+-- - 1: 새로 추가됨
+-- - 0: 이미 존재함
+local added = redis.call('SADD', participantsKey, userIdentifier)
+
+-- 3. 신규 입장자일 때만 order List에 추가한다.
+-- 중복 구독 또는 새로고침으로 같은 사용자가 다시 구독해도 방장 위임 순서가 중복되지 않는다.
+if added == 1 then
+    redis.call('RPUSH', orderKey, userIdentifier)
+end
+
+-- 4. WebSocket 세션 ID 기준 역추적 정보를 저장한다.
+-- DISCONNECT 이벤트에서 wsSessionId만으로 lobbyCode를 찾기 위해 필요하다.
+redis.call('HSET', wsConnectionKey,
+    userField,  userIdentifier,
+    lobbyField, lobbyCode
+)
+
+-- 5. 비정상 종료 또는 서버 장애 시 좀비 ws:connection 키가 남지 않도록 TTL을 설정한다.
+redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
+
+if added == 1 then
+    return "ENTERED"
+end
+
+return "ALREADY_JOINED"


### PR DESCRIPTION
## 📣 Related Issue

- #51

## 📝 Summary

- WebSocket 로비 채팅 채널 구독 시 로비 입장 상태가 Redis에 일관되게 저장되도록 수정했습니다.
- `enter_lobby.lua`를 추가하여 로비 입장 처리를 Redis Lua 스크립트로 원자적으로 처리했습니다.
  - `lobby:{code}:participants` Set 저장
  - `lobby:{code}:order` List 저장
  - `ws:connection:{wsSessionId}` Hash 저장
  - 중복 구독 시 `order` 중복 저장 방지
- 로비 채팅 채널(`/topic/lobby/{code}`)과 refresh 채널(`/topic/lobby/{code}/refresh`)을 명확히 분리하여, 실제 입장 처리는 채팅 채널 구독 시점에만 수행되도록 수정했습니다.
- `RedisTemplate<String, Object>` 사용으로 인해 Pub/Sub 메시지에 클래스 타입 정보가 포함되던 문제를 수정했습니다.
  - Pub/Sub 전용 `JsonMapper`를 분리했습니다.
  - `RedisPublisher`는 `StringRedisTemplate`으로 순수 JSON 문자열을 발행하도록 변경했습니다.
  - `RedisSubscriber`는 Redis 메시지를 역직렬화하지 않고 JSON 문자열 그대로 WebSocket 클라이언트에 전달하도록 변경했습니다.
- DISCONNECT 시 `wsSessionId` 기반으로 `lobbyCode`를 역추적하여 자동 퇴장 처리가 정상 수행되도록 했습니다.
- 마지막 유저 퇴장 시 로비 관련 Redis 키가 정상 삭제되는 것을 확인했습니다.

## 🙏PR point

- 로비 입장 상태 저장은 Java 코드에서 Redis 명령을 여러 번 호출하지 않고, `enter_lobby.lua`에서 단일 원자 연산으로 처리합니다.
  - 중간 실패로 인해 `participants`, `order`, `ws:connection` 간 상태가 불일치하는 문제를 방지하기 위함입니다.
- 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행됩니다.
  - `/topic/lobby/{code}/refresh` 구독은 입장 처리 대상이 아닙니다.
  - refresh 채널까지 입장 처리 대상으로 보면 동일 유저가 `order` List에 중복 저장될 수 있습니다.
- Redis 문자열 데이터(`participants`, `order`, `ws:connection`)는 `StringRedisTemplate` 기준으로 처리합니다.
  - `RedisTemplate<String, Object>`를 사용하면 JSON 직렬화로 인해 Lua 스크립트의 `SREM`, `LREM` 비교가 실패할 수 있습니다.
- Pub/Sub 메시지는 프론트에서 바로 `JSON.parse()` 가능한 순수 JSON 형태로 전달됩니다.
  - 기존 문제 형태: `["io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto", {...}]`
  - 수정 후 형태: `{"type":"ENTER","roomId":"...","sender":"...","content":"...","timestamp":"..."}`

### 검증 내용

- STOMP CONNECT 성공 확인
- `/topic/lobby/{code}` SUBSCRIBE 성공 확인
- ENTER 메시지 순수 JSON 수신 확인
- Redis `participants` 저장 확인
- Redis `order` 저장 확인
- Redis `ws:connection:{wsSessionId}` 저장 확인
- DISCONNECT 시 `ws:connection`, `participants`, `order`, `lobby` 정리 확인
- 중복 구독 시 `order` List에 동일 `userIdentifier`가 중복 저장되지 않는 것 확인

## 📬 Reference
