### PR TITLE
[Feat/#37] 맵 생성 및 DB저장

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -180,21 +180,34 @@ GET /api/maps
 ```
 
 공개(`is_public=true`) 상태이면서 삭제되지 않은 맵만 반환합니다.
+페이지네이션 파라미터를 지원합니다.
+
+| 쿼리 파라미터 | 기본값 | 설명 |
+|---|---:|---|
+| `page` | `0` | 0-based 페이지 번호 |
+| `size` | `20` | 페이지 크기 (최대 100) |
 
 **Response `200 OK`**
 
 ```json
-[
-  {
-    "id": 1,
-    "title": "K-POP 2세대",
-    "category": "kpop",
-    "numOfSong": 20,
-    "totalPlayTime": 600,
-    "isPublic": true,
-    "ownerId": 10
-  }
-]
+{
+  "content": [
+    {
+      "id": 1,
+      "title": "K-POP 2세대",
+      "category": "kpop",
+      "numOfSong": 20,
+      "totalPlayTime": 600,
+      "isPublic": true,
+      "ownerId": 10
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1,
+  "hasNext": false
+}
 ```
 
 #### 공개 맵 단건 조회

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,22 @@ POST /api/auth/guest
 - 정식 회원 닉네임과 충돌: `정식 회원이 이미 사용 중인 닉네임입니다.`
 - 기존 사용자 닉네임과 충돌: `이미 사용 중인 닉네임입니다.`
 
+#### (dev 전용) REGISTERED 토큰 발급
+
+```
+POST /api/auth/dev/registered-token
+```
+
+dev 프로필에서만 노출됩니다. 입력한 username으로 REGISTERED 사용자를 만들거나 재사용해 Access/Refresh 토큰을 발급합니다.
+
+**Request**
+
+```json
+{
+  "username": "dev-registered-user"
+}
+```
+
 ### 로비 (Lobby)
 
 ### 로비 생성
@@ -152,6 +168,89 @@ Redis에서 직접 필터링하여 고속 반환합니다.
 | `maxPlayers` | Integer | 최대 참여 인원 |
 | `isPrivate` | Boolean | 비공개 여부 (`true` = 비공개) |
 | `status` | String | 로비 상태 (`WAITING` \| `PLAYING`) |
+
+---
+
+### 맵 (Map)
+
+#### 공개 맵 목록 조회
+
+```
+GET /api/maps
+```
+
+공개(`is_public=true`) 상태이면서 삭제되지 않은 맵만 반환합니다.
+
+**Response `200 OK`**
+
+```json
+[
+  {
+    "id": 1,
+    "title": "K-POP 2세대",
+    "category": "kpop",
+    "numOfSong": 20,
+    "totalPlayTime": 600,
+    "isPublic": true,
+    "ownerId": 10
+  }
+]
+```
+
+#### 공개 맵 단건 조회
+
+```
+GET /api/maps/{mapId}
+```
+
+공개(`is_public=true`) 상태이면서 삭제되지 않은 맵만 조회할 수 있습니다.
+
+**Response `200 OK`**
+
+```json
+{
+  "id": 1,
+  "ownerId": 10,
+  "title": "K-POP 2세대",
+  "description": "추억의 명곡 모음",
+  "category": "kpop",
+  "numOfSong": 20,
+  "totalPlayTime": 600,
+  "isPublic": true,
+  "createdAt": "2026-05-06T10:00:00",
+  "updatedAt": "2026-05-06T10:00:00"
+}
+```
+
+#### 맵 생성
+
+```
+POST /api/maps
+```
+
+정식 회원(`REGISTERED`)만 생성할 수 있습니다.
+
+`category`는 아래 enum 값만 허용합니다.
+- `kpop`
+- `jpop`
+- `pop`
+
+#### 맵 수정
+
+```
+PUT /api/maps/{mapId}
+```
+
+맵 소유자만 수정 가능하며, `isPublic` 필드로 공개/비공개 전환을 지원합니다.
+수정 시 Redis 맵 캐시를 무효화합니다.
+
+#### 맵 삭제
+
+```
+DELETE /api/maps/{mapId}
+```
+
+맵 소유자만 삭제할 수 있으며, 물리 삭제 대신 Soft Delete(`is_deleted=true`) 처리합니다.
 
 ---
 
@@ -324,7 +423,6 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 | 회원가입 | `POST /api/auth/register` |
 | 로그인 | `POST /api/auth/login` |
 | 로비 초대 코드 입장 | `POST /api/lobbies/join` |
-| 맵 CRUD | `GET/POST/PUT/DELETE /api/maps` |
 | 맵 아이템(문제) CRUD | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |
 | YouTube URL 유효성 검증 | `POST /api/youtube/validate` |
 | 인게임 WebSocket | `/app/game/{code}/**` |

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
@@ -1,0 +1,79 @@
+package io.github.ascrew.monomatbe.domain.map.controller;
+
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.service.MapService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Map", description = "맵 관련 REST API")
+@RestController
+@RequestMapping("/api/maps")
+@RequiredArgsConstructor
+public class MapController {
+
+    private final MapService mapService;
+
+    @Operation(summary = "공개 맵 목록 조회")
+    @GetMapping
+    public ResponseEntity<List<MapSummaryResponse>> getPublicMaps() {
+        return ResponseEntity.ok(mapService.getPublicMaps());
+    }
+
+    @Operation(summary = "공개 맵 단건 조회")
+    @GetMapping("/{mapId}")
+    public ResponseEntity<MapDetailResponse> getPublicMap(@PathVariable Long mapId) {
+        return ResponseEntity.ok(mapService.getPublicMap(mapId));
+    }
+
+    @Operation(summary = "맵 생성", description = "정식 회원(REGISTERED)만 생성 가능합니다.")
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MapDetailResponse> createMap(
+            @Valid @RequestBody CreateMapRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(mapService.createMap(request, principal));
+    }
+
+    @Operation(summary = "맵 수정", description = "맵 소유자만 수정 가능합니다.")
+    @PutMapping("/{mapId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MapDetailResponse> updateMap(
+            @PathVariable Long mapId,
+            @Valid @RequestBody UpdateMapRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        return ResponseEntity.ok(mapService.updateMap(mapId, request, principal));
+    }
+
+    @Operation(summary = "맵 삭제", description = "맵 소유자만 삭제 가능하며 Soft Delete 처리됩니다.")
+    @DeleteMapping("/{mapId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteMap(
+            @PathVariable Long mapId,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        mapService.deleteMap(mapId, principal);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
@@ -2,7 +2,7 @@ package io.github.ascrew.monomatbe.domain.map.controller;
 
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
-import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.PublicMapPageResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.service.MapService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
@@ -21,9 +21,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "Map", description = "맵 관련 REST API")
 @RestController
@@ -35,8 +34,11 @@ public class MapController {
 
     @Operation(summary = "공개 맵 목록 조회")
     @GetMapping
-    public ResponseEntity<List<MapSummaryResponse>> getPublicMaps() {
-        return ResponseEntity.ok(mapService.getPublicMaps());
+    public ResponseEntity<PublicMapPageResponse> getPublicMaps(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        return ResponseEntity.ok(mapService.getPublicMaps(page, size));
     }
 
     @Operation(summary = "공개 맵 단건 조회")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapRequest.java
@@ -1,0 +1,21 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateMapRequest(
+        @NotBlank(message = "맵 제목은 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "맵 제목은 50자를 초과할 수 없습니다.")
+        String title,
+
+        @Size(max = 255, message = "맵 설명은 255자를 초과할 수 없습니다.")
+        String description,
+
+        @NotNull(message = "카테고리는 비어 있을 수 없습니다.")
+        MapCategory category,
+
+        boolean isPublic
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapDetailResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapDetailResponse.java
@@ -1,0 +1,21 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record MapDetailResponse(
+        Long id,
+        Long ownerId,
+        String title,
+        String description,
+        MapCategory category,
+        int numOfSong,
+        int totalPlayTime,
+        boolean isPublic,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapSummaryResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapSummaryResponse.java
@@ -1,0 +1,16 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import lombok.Builder;
+
+@Builder
+public record MapSummaryResponse(
+        Long id,
+        String title,
+        MapCategory category,
+        int numOfSong,
+        int totalPlayTime,
+        boolean isPublic,
+        Long ownerId
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/PublicMapPageResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/PublicMapPageResponse.java
@@ -1,0 +1,16 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PublicMapPageResponse(
+        List<MapSummaryResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/UpdateMapRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/UpdateMapRequest.java
@@ -1,0 +1,21 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMapRequest(
+        @NotBlank(message = "맵 제목은 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "맵 제목은 50자를 초과할 수 없습니다.")
+        String title,
+
+        @Size(max = 255, message = "맵 설명은 255자를 초과할 수 없습니다.")
+        String description,
+
+        @NotNull(message = "카테고리는 비어 있을 수 없습니다.")
+        MapCategory category,
+
+        boolean isPublic
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategory.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategory.java
@@ -1,0 +1,44 @@
+package io.github.ascrew.monomatbe.domain.map.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum MapCategory {
+    KPOP("kpop"),
+    JPOP("jpop"),
+    POP("pop");
+
+    private final String value;
+
+    MapCategory(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+
+    @JsonCreator
+    public static MapCategory from(String rawValue) {
+        if (rawValue == null) {
+            throw new IllegalArgumentException("category는 null일 수 없습니다.");
+        }
+
+        String normalized = rawValue
+                .trim()
+                .toLowerCase(Locale.ROOT)
+                .replace("-", "")
+                .replace("_", "")
+                .replace(" ", "");
+
+        return switch (normalized) {
+            case "kpop" -> KPOP;
+            case "jpop" -> JPOP;
+            case "pop" -> POP;
+            default -> throw new IllegalArgumentException("지원하지 않는 category입니다: " + rawValue);
+        };
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/QuizMap.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/QuizMap.java
@@ -1,0 +1,105 @@
+package io.github.ascrew.monomatbe.domain.map.entity;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "map")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class QuizMap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
+
+    @Column(name = "title", nullable = false, length = 50)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 20)
+    private MapCategory category;
+
+    @Column(name = "num_of_song", nullable = false)
+    private Integer numOfSong;
+
+    @Column(name = "total_play_time", nullable = false)
+    private Integer totalPlayTime;
+
+    @Column(name = "is_public", nullable = false)
+    private Boolean isPublic;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        if (this.createdAt == null) {
+            this.createdAt = now;
+        }
+        this.updatedAt = now;
+        if (this.numOfSong == null) {
+            this.numOfSong = 0;
+        }
+        if (this.totalPlayTime == null) {
+            this.totalPlayTime = 0;
+        }
+        if (this.isPublic == null) {
+            this.isPublic = false;
+        }
+        if (this.isDeleted == null) {
+            this.isDeleted = false;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void update(String title, String description, MapCategory category, boolean isPublic) {
+        this.title = title;
+        this.description = description;
+        this.category = category;
+        this.isPublic = isPublic;
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/QuizMap.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/QuizMap.java
@@ -41,7 +41,7 @@ public class QuizMap {
     @Column(name = "title", nullable = false, length = 50)
     private String title;
 
-    @Column(name = "description", columnDefinition = "TEXT")
+    @Column(name = "description", length = 255)
     private String description;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
@@ -1,0 +1,16 @@
+package io.github.ascrew.monomatbe.domain.map.repository;
+
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuizMapJpaRepository extends JpaRepository<QuizMap, Long> {
+
+    List<QuizMap> findAllByIsDeletedFalseAndIsPublicTrueOrderByUpdatedAtDesc();
+
+    Optional<QuizMap> findByIdAndIsDeletedFalseAndIsPublicTrue(Long id);
+
+    Optional<QuizMap> findByIdAndIsDeletedFalse(Long id);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
@@ -1,14 +1,15 @@
 package io.github.ascrew.monomatbe.domain.map.repository;
 
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface QuizMapJpaRepository extends JpaRepository<QuizMap, Long> {
 
-    List<QuizMap> findAllByIsDeletedFalseAndIsPublicTrueOrderByUpdatedAtDesc();
+    Page<QuizMap> findAllByIsDeletedFalseAndIsPublicTrue(Pageable pageable);
 
     Optional<QuizMap> findByIdAndIsDeletedFalseAndIsPublicTrue(Long id);
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -6,12 +6,18 @@ import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.PublicMapPageResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,11 +28,15 @@ import tools.jackson.databind.json.JsonMapper;
 import java.time.Duration;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MapService {
 
     private static final Duration MAP_CACHE_TTL = Duration.ofMinutes(5);
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
 
     private static final String ERROR_INVALID_PRINCIPAL = "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
     private static final String ERROR_REGISTERED_ONLY = "정식 회원만 맵을 생성할 수 있습니다.";
@@ -38,29 +48,72 @@ public class MapService {
     private final StringRedisTemplate redisTemplate;
     private final JsonMapper jsonMapper;
 
+    // 공개된 맵 목록을 페이징하여 조회 (Redis 캐싱 적용)
     @Transactional(readOnly = true)
-    public List<MapSummaryResponse> getPublicMaps() {
-        String cacheKey = RedisKeys.mapPublicListKey();
-        String cachedValue = redisTemplate.opsForValue().get(cacheKey);
-        if (cachedValue != null) {
-            return jsonMapper.readValue(cachedValue, new TypeReference<List<MapSummaryResponse>>() {});
+    public PublicMapPageResponse getPublicMaps(Integer page, Integer size) {
+        // 파라미터 정규화 및 유효성 검사
+        int normalizedPage = page == null || page < 0 ? DEFAULT_PAGE : page;
+        int normalizedSize = size == null || size <= 0 ? DEFAULT_SIZE : Math.min(size, MAX_SIZE);
+
+        // 캐시 키 생성 및 조회
+        String version = getPublicListCacheVersion();
+        String cacheKey = RedisKeys.mapPublicListKey(version, normalizedPage, normalizedSize);
+        // 캐시 조회/역직렬화 실패는 DB fallback으로 처리한다.
+        try {
+            String cachedValue = redisTemplate.opsForValue().get(cacheKey);
+            if (cachedValue != null) {
+                try {
+                    return jsonMapper.readValue(cachedValue, new TypeReference<PublicMapPageResponse>() {});
+                } catch (Exception e) {
+                    log.warn("공개 맵 목록 캐시 역직렬화 실패 - key: {}. 캐시 삭제 후 DB fallback", cacheKey, e);
+                    safeDeleteCache(cacheKey);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("공개 맵 목록 캐시 조회 실패 - key: {}. DB fallback", cacheKey, e);
         }
 
-        List<MapSummaryResponse> response = quizMapJpaRepository.findAllByIsDeletedFalseAndIsPublicTrueOrderByUpdatedAtDesc()
+        // 캐시 미스시 DB에서 데이터 조회
+        Pageable pageable = PageRequest.of(
+                normalizedPage,
+                normalizedSize,
+                Sort.by(Sort.Direction.DESC, "updatedAt")
+        );
+        Page<QuizMap> pageResult = quizMapJpaRepository.findAllByIsDeletedFalseAndIsPublicTrue(pageable);
+        List<MapSummaryResponse> content = pageResult.getContent()
                 .stream()
                 .map(this::toSummaryResponse)
                 .toList();
 
-        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(response), MAP_CACHE_TTL);
+        PublicMapPageResponse response = PublicMapPageResponse.builder()
+                .content(content)
+                .page(pageResult.getNumber())
+                .size(pageResult.getSize())
+                .totalElements(pageResult.getTotalElements())
+                .totalPages(pageResult.getTotalPages())
+                .hasNext(pageResult.hasNext())
+                .build();
+
+        safeWriteCache(cacheKey, response);
         return response;
     }
 
     @Transactional(readOnly = true)
     public MapDetailResponse getPublicMap(Long mapId) {
         String cacheKey = RedisKeys.mapPublicDetailKey(mapId);
-        String cachedValue = redisTemplate.opsForValue().get(cacheKey);
-        if (cachedValue != null) {
-            return jsonMapper.readValue(cachedValue, MapDetailResponse.class);
+        // 캐시 조회/역직렬화 실패는 DB fallback으로 처리한다.
+        try {
+            String cachedValue = redisTemplate.opsForValue().get(cacheKey);
+            if (cachedValue != null) {
+                try {
+                    return jsonMapper.readValue(cachedValue, MapDetailResponse.class);
+                } catch (Exception e) {
+                    log.warn("공개 맵 단건 캐시 역직렬화 실패 - key: {}. 캐시 삭제 후 DB fallback", cacheKey, e);
+                    safeDeleteCache(cacheKey);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("공개 맵 단건 캐시 조회 실패 - key: {}. DB fallback", cacheKey, e);
         }
 
         QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalseAndIsPublicTrue(mapId)
@@ -68,7 +121,7 @@ public class MapService {
                         HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
 
         MapDetailResponse response = toDetailResponse(quizMap);
-        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(response), MAP_CACHE_TTL);
+        safeWriteCache(cacheKey, response);
         return response;
     }
 
@@ -147,10 +200,46 @@ public class MapService {
     }
 
     private void evictMapCache(Long mapId) {
-        redisTemplate.delete(List.of(
-                RedisKeys.mapPublicListKey(),
-                RedisKeys.mapPublicDetailKey(mapId)
-        ));
+        redisTemplate.opsForValue().increment(RedisKeys.mapPublicListVersionKey());
+        redisTemplate.delete(RedisKeys.mapPublicDetailKey(mapId));
+    }
+
+    private String getPublicListCacheVersion() {
+        String key = RedisKeys.mapPublicListVersionKey();
+        try {
+            String version = redisTemplate.opsForValue().get(key);
+            if (version != null) {
+                return version;
+            }
+
+            Boolean set = redisTemplate.opsForValue().setIfAbsent(key, "1");
+            if (Boolean.TRUE.equals(set)) {
+                return "1";
+            }
+
+            String fallback = redisTemplate.opsForValue().get(key);
+            return fallback != null ? fallback : "1";
+        } catch (Exception e) {
+            log.warn("공개 맵 목록 캐시 버전 조회/초기화 실패 - key: {}. 기본 버전으로 진행", key, e);
+            return "1";
+        }
+    }
+
+    private void safeWriteCache(String key, Object payload) {
+        try {
+            String serialized = jsonMapper.writeValueAsString(payload);
+            redisTemplate.opsForValue().set(key, serialized, MAP_CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("맵 캐시 저장 실패 - key: {}. 응답은 정상 반환", key, e);
+        }
+    }
+
+    private void safeDeleteCache(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.warn("손상 캐시 삭제 실패 - key: {}", key, e);
+        }
     }
 
     private MapSummaryResponse toSummaryResponse(QuizMap quizMap) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -145,7 +145,7 @@ public class MapService {
                 .isPublic(request.isPublic())
                 .build());
 
-        evictMapCache(created.getId());
+        safeEvictMapCache(created.getId());
         return toDetailResponse(created);
     }
 
@@ -160,7 +160,7 @@ public class MapService {
         validateOwnership(quizMap, principal);
         quizMap.update(request.title(), request.description(), request.category(), request.isPublic());
 
-        evictMapCache(quizMap.getId());
+        safeEvictMapCache(quizMap.getId());
         return toDetailResponse(quizMap);
     }
 
@@ -174,7 +174,7 @@ public class MapService {
 
         validateOwnership(quizMap, principal);
         quizMap.softDelete();
-        evictMapCache(quizMap.getId());
+        safeEvictMapCache(quizMap.getId());
     }
 
     private void validatePrincipal(CustomPrincipal principal) {
@@ -199,9 +199,20 @@ public class MapService {
         }
     }
 
-    private void evictMapCache(Long mapId) {
-        redisTemplate.opsForValue().increment(RedisKeys.mapPublicListVersionKey());
-        redisTemplate.delete(RedisKeys.mapPublicDetailKey(mapId));
+    private void safeEvictMapCache(Long mapId) {
+        try {
+            redisTemplate.opsForValue().increment(RedisKeys.mapPublicListVersionKey());
+        } catch (Exception e) {
+            log.warn("공개 맵 목록 캐시 버전 무효화 실패 - key: {}",
+                    RedisKeys.mapPublicListVersionKey(), e);
+        }
+
+        String detailKey = RedisKeys.mapPublicDetailKey(mapId);
+        try {
+            redisTemplate.delete(detailKey);
+        } catch (Exception e) {
+            log.warn("공개 맵 단건 캐시 무효화 실패 - key: {}", detailKey, e);
+        }
     }
 
     private String getPublicListCacheVersion() {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -1,0 +1,182 @@
+package io.github.ascrew.monomatbe.domain.map.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MapService {
+
+    private static final Duration MAP_CACHE_TTL = Duration.ofMinutes(5);
+
+    private static final String ERROR_INVALID_PRINCIPAL = "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
+    private static final String ERROR_REGISTERED_ONLY = "정식 회원만 맵을 생성할 수 있습니다.";
+    private static final String ERROR_MAP_NOT_FOUND = "맵을 찾을 수 없습니다.";
+    private static final String ERROR_MAP_FORBIDDEN = "본인 소유의 맵만 수정/삭제할 수 있습니다.";
+    private static final String ERROR_USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
+    private final QuizMapJpaRepository quizMapJpaRepository;
+    private final UserRepository userRepository;
+    private final StringRedisTemplate redisTemplate;
+    private final JsonMapper jsonMapper;
+
+    @Transactional(readOnly = true)
+    public List<MapSummaryResponse> getPublicMaps() {
+        String cacheKey = RedisKeys.mapPublicListKey();
+        String cachedValue = redisTemplate.opsForValue().get(cacheKey);
+        if (cachedValue != null) {
+            return jsonMapper.readValue(cachedValue, new TypeReference<List<MapSummaryResponse>>() {});
+        }
+
+        List<MapSummaryResponse> response = quizMapJpaRepository.findAllByIsDeletedFalseAndIsPublicTrueOrderByUpdatedAtDesc()
+                .stream()
+                .map(this::toSummaryResponse)
+                .toList();
+
+        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(response), MAP_CACHE_TTL);
+        return response;
+    }
+
+    @Transactional(readOnly = true)
+    public MapDetailResponse getPublicMap(Long mapId) {
+        String cacheKey = RedisKeys.mapPublicDetailKey(mapId);
+        String cachedValue = redisTemplate.opsForValue().get(cacheKey);
+        if (cachedValue != null) {
+            return jsonMapper.readValue(cachedValue, MapDetailResponse.class);
+        }
+
+        QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalseAndIsPublicTrue(mapId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
+
+        MapDetailResponse response = toDetailResponse(quizMap);
+        redisTemplate.opsForValue().set(cacheKey, jsonMapper.writeValueAsString(response), MAP_CACHE_TTL);
+        return response;
+    }
+
+    @Transactional
+    public MapDetailResponse createMap(CreateMapRequest request, CustomPrincipal principal) {
+        validateRegisteredPrincipal(principal);
+
+        User owner = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        HttpStatus.NOT_FOUND, ERROR_USER_NOT_FOUND));
+        if (owner.getUserType() != UserType.REGISTERED) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    HttpStatus.FORBIDDEN, ERROR_REGISTERED_ONLY);
+        }
+
+        QuizMap created = quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title(request.title())
+                .description(request.description())
+                .category(request.category())
+                .isPublic(request.isPublic())
+                .build());
+
+        evictMapCache(created.getId());
+        return toDetailResponse(created);
+    }
+
+    @Transactional
+    public MapDetailResponse updateMap(Long mapId, UpdateMapRequest request, CustomPrincipal principal) {
+        validatePrincipal(principal);
+
+        QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalse(mapId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
+
+        validateOwnership(quizMap, principal);
+        quizMap.update(request.title(), request.description(), request.category(), request.isPublic());
+
+        evictMapCache(quizMap.getId());
+        return toDetailResponse(quizMap);
+    }
+
+    @Transactional
+    public void deleteMap(Long mapId, CustomPrincipal principal) {
+        validatePrincipal(principal);
+
+        QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalse(mapId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
+
+        validateOwnership(quizMap, principal);
+        quizMap.softDelete();
+        evictMapCache(quizMap.getId());
+    }
+
+    private void validatePrincipal(CustomPrincipal principal) {
+        if (principal == null || principal.userId() == null) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+        }
+    }
+
+    private void validateRegisteredPrincipal(CustomPrincipal principal) {
+        validatePrincipal(principal);
+        if (principal.userType() != UserType.REGISTERED) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    HttpStatus.FORBIDDEN, ERROR_REGISTERED_ONLY);
+        }
+    }
+
+    private void validateOwnership(QuizMap quizMap, CustomPrincipal principal) {
+        if (!quizMap.getOwner().getId().equals(principal.userId())) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    HttpStatus.FORBIDDEN, ERROR_MAP_FORBIDDEN);
+        }
+    }
+
+    private void evictMapCache(Long mapId) {
+        redisTemplate.delete(List.of(
+                RedisKeys.mapPublicListKey(),
+                RedisKeys.mapPublicDetailKey(mapId)
+        ));
+    }
+
+    private MapSummaryResponse toSummaryResponse(QuizMap quizMap) {
+        return MapSummaryResponse.builder()
+                .id(quizMap.getId())
+                .title(quizMap.getTitle())
+                .category(quizMap.getCategory())
+                .numOfSong(quizMap.getNumOfSong())
+                .totalPlayTime(quizMap.getTotalPlayTime())
+                .isPublic(Boolean.TRUE.equals(quizMap.getIsPublic()))
+                .ownerId(quizMap.getOwner().getId())
+                .build();
+    }
+
+    private MapDetailResponse toDetailResponse(QuizMap quizMap) {
+        return MapDetailResponse.builder()
+                .id(quizMap.getId())
+                .ownerId(quizMap.getOwner().getId())
+                .title(quizMap.getTitle())
+                .description(quizMap.getDescription())
+                .category(quizMap.getCategory())
+                .numOfSong(quizMap.getNumOfSong())
+                .totalPlayTime(quizMap.getTotalPlayTime())
+                .isPublic(Boolean.TRUE.equals(quizMap.getIsPublic()))
+                .createdAt(quizMap.getCreatedAt())
+                .updatedAt(quizMap.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -58,6 +58,12 @@ public final class RedisKeys {
     /** 초대 코드 중복 방지 SETNX 락 키 접두사 */
     private static final String LOBBY_CODE_LOCK_PREFIX = "lobby:code:lock:";
 
+    /** 공개 맵 목록 캐시 키 */
+    private static final String MAP_PUBLIC_LIST = "map:public:list";
+
+    /** 공개 맵 단건 캐시 키 접두사 */
+    private static final String MAP_PUBLIC_DETAIL_PREFIX = "map:public:";
+
     // =========================================================
     // Redis Hash 필드 키 상수 (auth:guest:session:{token} Hash 내부 필드명)
     // =========================================================
@@ -223,5 +229,13 @@ public final class RedisKeys {
      */
     public static String lobbyCodeLockKey(String inviteCode) {
         return LOBBY_CODE_LOCK_PREFIX + inviteCode;
+    }
+
+    public static String mapPublicListKey() {
+        return MAP_PUBLIC_LIST;
+    }
+
+    public static String mapPublicDetailKey(Long mapId) {
+        return MAP_PUBLIC_DETAIL_PREFIX + mapId;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -59,7 +59,10 @@ public final class RedisKeys {
     private static final String LOBBY_CODE_LOCK_PREFIX = "lobby:code:lock:";
 
     /** 공개 맵 목록 캐시 키 */
-    private static final String MAP_PUBLIC_LIST = "map:public:list";
+    private static final String MAP_PUBLIC_LIST_PREFIX = "map:public:list";
+
+    /** 공개 맵 목록 캐시 버전 키 */
+    private static final String MAP_PUBLIC_LIST_VERSION = "map:public:list:version";
 
     /** 공개 맵 단건 캐시 키 접두사 */
     private static final String MAP_PUBLIC_DETAIL_PREFIX = "map:public:";
@@ -231,8 +234,12 @@ public final class RedisKeys {
         return LOBBY_CODE_LOCK_PREFIX + inviteCode;
     }
 
-    public static String mapPublicListKey() {
-        return MAP_PUBLIC_LIST;
+    public static String mapPublicListVersionKey() {
+        return MAP_PUBLIC_LIST_VERSION;
+    }
+
+    public static String mapPublicListKey(String version, int page, int size) {
+        return MAP_PUBLIC_LIST_PREFIX + ":v:" + version + ":p:" + page + ":s:" + size;
     }
 
     public static String mapPublicDetailKey(Long mapId) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategoryTest.java
@@ -1,0 +1,24 @@
+package io.github.ascrew.monomatbe.domain.map.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MapCategoryTest {
+
+    @Test
+    void from_acceptsLowercaseAndHyphenVariants() {
+        assertThat(MapCategory.from("kpop")).isEqualTo(MapCategory.KPOP);
+        assertThat(MapCategory.from("jpop")).isEqualTo(MapCategory.JPOP);
+        assertThat(MapCategory.from("pop")).isEqualTo(MapCategory.POP);
+        assertThat(MapCategory.from("K-POP")).isEqualTo(MapCategory.KPOP);
+    }
+
+    @Test
+    void from_rejectsUnsupportedCategory() {
+        assertThatThrownBy(() -> MapCategory.from("rock"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("지원하지 않는 category");
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
@@ -1,0 +1,162 @@
+package io.github.ascrew.monomatbe.domain.map.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MapServiceTest {
+
+    @Mock
+    private QuizMapJpaRepository quizMapJpaRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private JsonMapper jsonMapper;
+
+    private MapService mapService;
+
+    @BeforeEach
+    void setUp() {
+        mapService = new MapService(quizMapJpaRepository, userRepository, redisTemplate, jsonMapper);
+    }
+
+    @Test
+    void createMap_guestUser_forbidden() {
+        CreateMapRequest request = new CreateMapRequest("title", "desc", MapCategory.KPOP, true);
+        CustomPrincipal guest = new CustomPrincipal(1L, "guest-uuid", UserType.GUEST);
+
+        assertThatThrownBy(() -> mapService.createMap(request, guest))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("정식 회원만 맵을 생성할 수 있습니다.");
+
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    void createMap_registeredUser_success() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        when(userRepository.findById(10L)).thenReturn(Optional.of(owner));
+        when(quizMapJpaRepository.save(any(QuizMap.class))).thenAnswer(invocation -> {
+            QuizMap input = invocation.getArgument(0);
+            return QuizMap.builder()
+                    .id(300L)
+                    .owner(input.getOwner())
+                    .title(input.getTitle())
+                    .description(input.getDescription())
+                    .category(input.getCategory())
+                    .isPublic(input.getIsPublic())
+                    .numOfSong(0)
+                    .totalPlayTime(0)
+                    .build();
+        });
+
+        CreateMapRequest request = new CreateMapRequest("new map", "desc", MapCategory.KPOP, true);
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        var response = mapService.createMap(request, principal);
+
+        assertThat(response.id()).isEqualTo(300L);
+        assertThat(response.ownerId()).isEqualTo(10L);
+        assertThat(response.title()).isEqualTo("new map");
+        assertThat(response.isPublic()).isTrue();
+        verify(redisTemplate).delete(argThat((java.util.Collection<String> keys) ->
+                keys.contains(RedisKeys.mapPublicListKey())
+                        && keys.contains(RedisKeys.mapPublicDetailKey(300L))
+        ));
+    }
+
+    @Test
+    void updateMap_notOwner_forbidden() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(100L)
+                .owner(owner)
+                .title("old")
+                .description("old")
+                .category(MapCategory.POP)
+                .isPublic(true)
+                .build();
+
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(100L)).thenReturn(Optional.of(quizMap));
+
+        UpdateMapRequest request = new UpdateMapRequest("new", "new", MapCategory.JPOP, false);
+        CustomPrincipal anotherUser = new CustomPrincipal(11L, "u-11", UserType.REGISTERED);
+
+        assertThatThrownBy(() -> mapService.updateMap(100L, request, anotherUser))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("본인 소유의 맵만 수정/삭제할 수 있습니다.");
+    }
+
+    @Test
+    void updateMap_owner_evictsPublicMapCaches() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(200L)
+                .owner(owner)
+                .title("old")
+                .description("old")
+                .category(MapCategory.POP)
+                .isPublic(true)
+                .numOfSong(0)
+                .totalPlayTime(0)
+                .build();
+
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(200L)).thenReturn(Optional.of(quizMap));
+
+        UpdateMapRequest request = new UpdateMapRequest("new", "new", MapCategory.KPOP, false);
+        CustomPrincipal ownerPrincipal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        mapService.updateMap(200L, request, ownerPrincipal);
+
+        verify(redisTemplate).delete(argThat((java.util.Collection<String> keys) ->
+                keys.contains(RedisKeys.mapPublicListKey())
+                        && keys.contains(RedisKeys.mapPublicDetailKey(200L))
+        ));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Optional;
@@ -25,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +42,8 @@ class MapServiceTest {
     @Mock
     private StringRedisTemplate redisTemplate;
     @Mock
+    private ValueOperations<String, String> valueOperations;
+    @Mock
     private JsonMapper jsonMapper;
 
     private MapService mapService;
@@ -46,6 +51,8 @@ class MapServiceTest {
     @BeforeEach
     void setUp() {
         mapService = new MapService(quizMapJpaRepository, userRepository, redisTemplate, jsonMapper);
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(valueOperations.increment(anyString())).thenReturn(1L);
     }
 
     @Test
@@ -93,10 +100,8 @@ class MapServiceTest {
         assertThat(response.ownerId()).isEqualTo(10L);
         assertThat(response.title()).isEqualTo("new map");
         assertThat(response.isPublic()).isTrue();
-        verify(redisTemplate).delete(argThat((java.util.Collection<String> keys) ->
-                keys.contains(RedisKeys.mapPublicListKey())
-                        && keys.contains(RedisKeys.mapPublicDetailKey(300L))
-        ));
+        verify(valueOperations).increment(RedisKeys.mapPublicListVersionKey());
+        verify(redisTemplate).delete(RedisKeys.mapPublicDetailKey(300L));
     }
 
     @Test
@@ -154,9 +159,7 @@ class MapServiceTest {
 
         mapService.updateMap(200L, request, ownerPrincipal);
 
-        verify(redisTemplate).delete(argThat((java.util.Collection<String> keys) ->
-                keys.contains(RedisKeys.mapPublicListKey())
-                        && keys.contains(RedisKeys.mapPublicDetailKey(200L))
-        ));
+        verify(valueOperations).increment(RedisKeys.mapPublicListVersionKey());
+        verify(redisTemplate).delete(RedisKeys.mapPublicDetailKey(200L));
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
- #37 

## 📝 Summary
   <!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
   - `domain/map` 신규 도메인 추가 및 맵 CRUD API 구현
     - `GET /api/maps`, `GET /api/maps/{id}`, `POST /api/maps`, `PUT /api/maps/{id}`, `DELETE
  /api/maps/{id}`
   - 권한/인가 정책 반영
     - 생성: `REGISTERED`만 허용
     - 수정/삭제: 맵 소유자만 허용
     - 조회: 공개 맵(`isPublic=true`)만 노출
   - Soft Delete 적용
     - 삭제 시 물리 삭제 대신 `is_deleted=true` 처리
   - Redis 캐시 무효화 적용
     - 맵 생성/수정/삭제 시 공개 목록/단건 캐시 제거
   - 맵 카테고리 enum 전환
     - `MapCategory` 도입 (`KPOP`, `JPOP`, `POP`)
     - 엔티티/DTO/응답 계약을 enum 기반으로 정리
   - 테스트/문서 업데이트
     - `MapServiceTest`, `MapCategoryTest` 추가/보완
     - `docs/API.md` 맵 API 및 카테고리 규격 반영

   ## 🙏PR point
   <!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - `MapCategory`는 현재 `KPOP/JPOP/POP`만 허용하며, 확장 시 enum 상수 추가가 필요합니다.
   - 카테고리 JSON 입력은 `kpop`, `jpop`, `pop`(및 `K-POP` 형태)을 허용하고 응답은 소문자
  문자열로 직렬화됩니다.
   - `DELETE /api/maps/{id}`는 hard delete가 아닌 soft delete입니다.
   - 공개 맵 조회 정책으로 인해 비공개 맵은 목록/단건 조회에서 제외됩니다.

   ## 📬 Reference
   <!-- 참고한 코드의 출처를 작성해주세요 -->
   - `.github/running/Monomat_ERD.sql`
   - `docs/API.md`
   - `src/main/java/io/github/ascrew/monomatbe/domain/lobby/*` (기존 도메인 구조/패턴 참고)