### PR TITLE
[Fix/#54] 공백 금지

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -93,7 +93,7 @@ POST /api/auth/register
 
 **Error**
 
-- `400 Bad Request`: 필수값 누락/비밀번호 길이 조건 불만족
+- `400 Bad Request`: 필수값 누락/비밀번호 길이 조건 불만족/비밀번호 공백 포함/닉네임 8자 초과
 - `409 Conflict`: 로그인 ID 또는 닉네임 중복
 
 ### 로비 (Lobby)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.Size;
  */
 public record GuestLoginRequest(
         @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+        @Size(max = 8, message = "닉네임은 8자를 초과할 수 없습니다.")
         String nickname
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 /**
@@ -9,14 +10,16 @@ import jakarta.validation.constraints.Size;
 public record RegisterRequest(
         @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
         @Size(max = 50, message = "로그인 ID는 50자를 초과할 수 없습니다.")
+        @Pattern(regexp = "^\\S+$", message = "로그인 ID에는 공백을 포함할 수 없습니다.")
         String loginId,
 
         @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
         @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
+        @Pattern(regexp = "^\\S+$", message = "비밀번호에는 공백을 포함할 수 없습니다.")
         String password,
 
         @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+        @Size(max = 8, message = "닉네임은 8자를 초과할 수 없습니다.")
         String nickname
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -33,10 +33,12 @@ public class RegisterAuthService {
     @Transactional
     public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
         String loginId = normalizeRequiredWithTrim(rawLoginId, "로그인 ID");
-        String password = validatePasswordWithoutWhitespace(rawPassword);
+        validateNoWhitespace(loginId, "로그인 ID");
+
+        String password = validateNoWhitespace(rawPassword, "비밀번호");
+
         String nickname = normalizeRequiredWithTrim(rawNickname, "닉네임");
         validateNicknameLength(nickname);
-
         validateDuplicate(loginId, nickname);
 
         User savedUser;
@@ -94,12 +96,12 @@ public class RegisterAuthService {
         return normalized;
     }
 
-    private String validatePasswordWithoutWhitespace(String value) {
+    private String validateNoWhitespace(String value, String fieldName) {
         if (value == null || value.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호는 비어 있을 수 없습니다.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는(은) 비어 있을 수 없습니다.");
         }
         if (value.chars().anyMatch(Character::isWhitespace)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호에는 공백을 포함할 수 없습니다.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "에는 공백을 포함할 수 없습니다.");
         }
         return value;
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -24,6 +24,7 @@ public class RegisterAuthService {
 
     private static final String ERR_DUPLICATE_LOGIN_ID = "이미 사용 중인 로그인 ID입니다.";
     private static final String ERR_DUPLICATE_NICKNAME = "이미 사용 중인 닉네임입니다.";
+    private static final int MAX_NICKNAME_LENGTH = 8;
 
     private final UserRepository userRepository;
     private final UserCredentialRepository userCredentialRepository;
@@ -31,9 +32,10 @@ public class RegisterAuthService {
 
     @Transactional
     public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
-        String loginId = normalizeRequiredAtServiceBoundary(rawLoginId, "로그인 ID");
-        String password = normalizeRequiredAtServiceBoundary(rawPassword, "비밀번호");
-        String nickname = normalizeRequiredAtServiceBoundary(rawNickname, "닉네임");
+        String loginId = normalizeRequiredWithTrim(rawLoginId, "로그인 ID");
+        String password = validatePasswordWithoutWhitespace(rawPassword);
+        String nickname = normalizeRequiredWithTrim(rawNickname, "닉네임");
+        validateNicknameLength(nickname);
 
         validateDuplicate(loginId, nickname);
 
@@ -81,7 +83,7 @@ public class RegisterAuthService {
     /**
      * 서비스 직접 호출 경로를 위한 최소 방어선: trim + null/blank 차단.
      */
-    private String normalizeRequiredAtServiceBoundary(String value, String fieldName) {
+    private String normalizeRequiredWithTrim(String value, String fieldName) {
         if (value == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
         }
@@ -90,5 +92,21 @@ public class RegisterAuthService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
         }
         return normalized;
+    }
+
+    private String validatePasswordWithoutWhitespace(String value) {
+        if (value == null || value.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호는 비어 있을 수 없습니다.");
+        }
+        if (value.chars().anyMatch(Character::isWhitespace)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호에는 공백을 포함할 수 없습니다.");
+        }
+        return value;
+    }
+
+    private void validateNicknameLength(String nickname) {
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 8자를 초과할 수 없습니다.");
+        }
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -4,13 +4,13 @@ import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
-import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 class RegisterAuthServiceTest {
 
     @Autowired
@@ -27,13 +28,14 @@ class RegisterAuthServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserCredentialRepository userCredentialRepository;
+    private String uniqueNickname() {
+        return "n" + (System.nanoTime() % 1_000_000);
+    }
 
     @Test
     void register_success() {
         String uniqueLoginId = "member_" + System.nanoTime();
-        String uniqueNickname = "nick_" + System.nanoTime();
+        String uniqueNickname = uniqueNickname();
 
         RegisterResponse response = registerAuthService.register(
                 uniqueLoginId,
@@ -48,13 +50,13 @@ class RegisterAuthServiceTest {
     }
 
     @Test
-    void register_trimsInputValues() {
+    void register_trimsLoginIdAndNickname() {
         String uniqueLoginId = "member_" + System.nanoTime();
-        String uniqueNickname = "nick_" + System.nanoTime();
+        String uniqueNickname = uniqueNickname();
 
         RegisterResponse response = registerAuthService.register(
                 "  " + uniqueLoginId + "  ",
-                "  password123  ",
+                "password123",
                 "  " + uniqueNickname + "  "
         );
 
@@ -63,20 +65,32 @@ class RegisterAuthServiceTest {
     }
 
     @Test
+    void register_passwordWithWhitespace_throwsBadRequest() {
+        String uniqueLoginId = "member_" + System.nanoTime();
+        String uniqueNickname = uniqueNickname();
+        String rawPassword = "  password123  ";
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register(uniqueLoginId, rawPassword, uniqueNickname));
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("비밀번호에는 공백을 포함할 수 없습니다.", exception.getReason());
+    }
+
+    @Test
     void register_duplicateLoginId_throwsConflict() {
         String loginId = "dup_login_" + System.nanoTime();
 
-        registerAuthService.register(loginId, "password123", "dupNick_" + System.nanoTime());
+        registerAuthService.register(loginId, "password123", uniqueNickname());
 
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register(loginId, "password123", "anotherNick_" + System.nanoTime()));
+                registerAuthService.register(loginId, "password123", uniqueNickname()));
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
         assertEquals("이미 사용 중인 로그인 ID입니다.", exception.getReason());
     }
 
     @Test
     void register_duplicateNickname_throwsConflict() {
-        String nickname = "dup_nick_" + System.nanoTime();
+        String nickname = uniqueNickname();
         userRepository.saveAndFlush(User.builder()
                 .username(nickname)
                 .userType(UserType.REGISTERED)
@@ -92,7 +106,7 @@ class RegisterAuthServiceTest {
     @Test
     void register_nullPassword_throwsBadRequest() {
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("login_" + System.nanoTime(), null, "nick_" + System.nanoTime()));
+                registerAuthService.register("login_" + System.nanoTime(), null, uniqueNickname()));
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
         assertEquals("비밀번호는 비어 있을 수 없습니다.", exception.getReason());
     }
@@ -100,8 +114,16 @@ class RegisterAuthServiceTest {
     @Test
     void register_blankLoginId_throwsBadRequest() {
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("   ", "password123", "nick_" + System.nanoTime()));
+                registerAuthService.register("   ", "password123", uniqueNickname()));
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
         assertEquals("로그인 ID는 비어 있을 수 없습니다.", exception.getReason());
+    }
+
+    @Test
+    void register_nicknameTooLong_throwsBadRequest() {
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register("login_" + System.nanoTime(), "password123", "123456789"));
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("닉네임은 8자를 초과할 수 없습니다.", exception.getReason());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -126,4 +126,17 @@ class RegisterAuthServiceTest {
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
         assertEquals("닉네임은 8자를 초과할 수 없습니다.", exception.getReason());
     }
+
+    @Test
+    void register_loginIdWithWhitespace_throwsBadRequest() {
+        // given
+        String loginIdWithWhitespace = "abc def";
+        String uniqueNickname = uniqueNickname();
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register(loginIdWithWhitespace, "password123", uniqueNickname));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("로그인 ID에는 공백을 포함할 수 없습니다.", exception.getReason());
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue
- #54 

## 📝 Summary
- 아이디/비밀번호 입력 시 공백 포함 금지 처리 추가
- 닉네임 최대 길이를 8자로 제한
- 관련 검증 로직 및 테스트 케이스 보강
- 문서(API.md) 에러 조건 설명 업데이트

## 🙏PR point
- 서비스 레이어에서도 비밀번호 공백 포함 여부를 방어적으로 검증하도록 추가했습니다.
- 닉네임 길이 제한이 DTO 검증(@Size) + 서비스 검증으로 이중 적용됩니다.

## 📬 Reference