### PR TITLE
[Fix/#55] WebSocket 온라인 상태 다중 세션 정합성 개선

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -93,7 +93,7 @@ POST /api/auth/register
 
 **Error**
 
-- `400 Bad Request`: 필수값 누락/비밀번호 길이 조건 불만족
+- `400 Bad Request`: 필수값 누락/비밀번호 길이 조건 불만족/비밀번호 공백 포함/닉네임 8자 초과
 - `409 Conflict`: 로그인 ID 또는 닉네임 중복
 
 ### 로비 (Lobby)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.Size;
  */
 public record GuestLoginRequest(
         @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+        @Size(max = 8, message = "닉네임은 8자를 초과할 수 없습니다.")
         String nickname
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 /**
@@ -9,14 +10,16 @@ import jakarta.validation.constraints.Size;
 public record RegisterRequest(
         @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
         @Size(max = 50, message = "로그인 ID는 50자를 초과할 수 없습니다.")
+        @Pattern(regexp = "^\\S+$", message = "로그인 ID에는 공백을 포함할 수 없습니다.")
         String loginId,
 
         @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
         @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
+        @Pattern(regexp = "^\\S+$", message = "비밀번호에는 공백을 포함할 수 없습니다.")
         String password,
 
         @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+        @Size(max = 8, message = "닉네임은 8자를 초과할 수 없습니다.")
         String nickname
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -24,6 +24,7 @@ public class RegisterAuthService {
 
     private static final String ERR_DUPLICATE_LOGIN_ID = "이미 사용 중인 로그인 ID입니다.";
     private static final String ERR_DUPLICATE_NICKNAME = "이미 사용 중인 닉네임입니다.";
+    private static final int MAX_NICKNAME_LENGTH = 8;
 
     private final UserRepository userRepository;
     private final UserCredentialRepository userCredentialRepository;
@@ -31,10 +32,13 @@ public class RegisterAuthService {
 
     @Transactional
     public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
-        String loginId = normalizeRequiredAtServiceBoundary(rawLoginId, "로그인 ID");
-        String password = normalizeRequiredAtServiceBoundary(rawPassword, "비밀번호");
-        String nickname = normalizeRequiredAtServiceBoundary(rawNickname, "닉네임");
+        String loginId = normalizeRequiredWithTrim(rawLoginId, "로그인 ID");
+        validateNoWhitespace(loginId, "로그인 ID");
 
+        String password = validateNoWhitespace(rawPassword, "비밀번호");
+
+        String nickname = normalizeRequiredWithTrim(rawNickname, "닉네임");
+        validateNicknameLength(nickname);
         validateDuplicate(loginId, nickname);
 
         User savedUser;
@@ -81,7 +85,7 @@ public class RegisterAuthService {
     /**
      * 서비스 직접 호출 경로를 위한 최소 방어선: trim + null/blank 차단.
      */
-    private String normalizeRequiredAtServiceBoundary(String value, String fieldName) {
+    private String normalizeRequiredWithTrim(String value, String fieldName) {
         if (value == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
         }
@@ -90,5 +94,21 @@ public class RegisterAuthService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
         }
         return normalized;
+    }
+
+    private String validateNoWhitespace(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는(은) 비어 있을 수 없습니다.");
+        }
+        if (value.chars().anyMatch(Character::isWhitespace)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "에는 공백을 포함할 수 없습니다.");
+        }
+        return value;
+    }
+
+    private void validateNicknameLength(String nickname) {
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 8자를 초과할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -183,13 +183,31 @@ public final class RedisKeys {
     /**
      * 사용자 온라인 상태 키를 반환합니다.
      * 저장 구조: String "ONLINE"
-     * TTL: WebSocketEventListener에서 2시간으로 설정
      *
      * @param userIdentifier 사용자 식별자 (게스트 UUID 또는 회원 ID)
      * @return "user_status:{userIdentifier}"
      */
     public static String userStatusKey(String userIdentifier) {
         return USER_STATUS_PREFIX + userIdentifier;
+    }
+
+    /**
+     * 사용자 온라인 상태를 구성하는 WebSocket 세션 Set 키를 반환한다.
+     *
+     * 저장 구조:
+     * - Key   : user_status:{userIdentifier}:sessions
+     * - Type  : Set
+     * - Value : wsSessionId 목록
+     *
+     * [사용 목적]
+     * 동일 userIdentifier가 여러 WebSocket 세션을 가질 수 있으므로,
+     * 마지막 세션이 종료되기 전까지 user_status:{userIdentifier}를 ONLINE으로 유지하기 위해 사용한다.
+     *
+     * @param userIdentifier 사용자 식별자
+     * @return "user_status:{userIdentifier}:sessions"
+     */
+    public static String userStatusSessionsKey(String userIdentifier) {
+        return USER_STATUS_PREFIX + userIdentifier + ":sessions";
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -72,16 +71,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     // =========================================================
 
     /**
-     * 사용자 온라인 상태 TTL.
-     *
-     * 비정상 종료 시 Redis 좀비 키 방지용입니다.
-     * 정상 종료 시 WebSocketEventListener에서 즉시 삭제한다.
-     *
-     * user_status 다중 세션 정합성은 후속 이슈 #55에서 개선합니다.
-     */
-    private static final long USER_STATUS_TTL_HOURS = 2;
-
-    /**
      * ws:connection:{wsSessionId}, lobby:{code}:user_session:{userIdentifier},
      * lobby:{code}:user_session_seq:{userIdentifier} 매핑 TTL.
      *
@@ -90,8 +79,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
      * 기존 2시간은 장시간 로비 대기 또는 게임 진행 중 TTL 만료 타이밍 이슈가 생길 수 있어
      * 6시간으로 늘린다.
      *
-     * 추후 #55에서 사용자 온라인 상태 다중 세션 관리와 함께
-     * WebSocket heartbeat 기반 TTL 연장 구조를 검토한다.
+     * 사용자 온라인 상태 TTL은 userStatusTtl 설정값을 사용한다.
      */
     private static final Duration WS_CONNECTION_TTL = Duration.ofHours(6);
 
@@ -102,6 +90,21 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final StringRedisTemplate stringRedisTemplate;
     private final WebSocketMetric webSocketMetric;
     private final RedisScript<String> enterLobbyScript;
+
+    /**
+     * 사용자 온라인 상태 TTL.
+     *
+     * [기본값]
+     * - PT2H: 2시간
+     *
+     * [설정 예시]
+     * monomat.websocket.user-status.ttl=PT2H
+     *
+     * [설계 의도]
+     * CONNECT 시점과 DISCONNECT 후 TTL 연장 시점이 동일한 정책을 따르도록
+     * WebSocketEventListener와 같은 설정 키를 사용한다.
+     */
+    private final Duration userStatusTtl;
 
     /**
      * 로비 입장 Lua 재시도 횟수.
@@ -120,11 +123,13 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     public StompChannelInterceptor(
             StringRedisTemplate stringRedisTemplate,
             WebSocketMetric webSocketMetric,
-            @Qualifier("enterLobbyScript") RedisScript<String> enterLobbyScript
+            @Qualifier("enterLobbyScript") RedisScript<String> enterLobbyScript,
+            @Value("${monomat.websocket.user-status.ttl:PT2H}") Duration userStatusTtl
     ) {
         this.stringRedisTemplate = stringRedisTemplate;
         this.webSocketMetric = webSocketMetric;
         this.enterLobbyScript = enterLobbyScript;
+        this.userStatusTtl = userStatusTtl;
     }
 
     @Override
@@ -314,21 +319,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     }
 
                     case INVALID_SEQUENCE -> {
-                        /*
-                         * INVALID_SEQUENCE는 재시도 대상이 아니다.
-                         *
-                         * sessionSequence는 CONNECT 단계에서 Redis INCR로 발급되고,
-                         * SUBSCRIBE 처리 전에 Java의 extractSessionSequence()에서 검증된 뒤 Lua에 전달된다.
-                         *
-                         * 따라서 Lua에서 INVALID_SEQUENCE가 반환된다는 것은 일시적인 Redis 장애라기보다
-                         * Java-Lua 인자 계약이 깨졌거나 세션 속성 저장 흐름이 깨진 서버 내부 오류에 가깝다.
-                         *
-                         * fallback 값(예: 0)을 사용하면 sequence가 없는 세션이 정상 입장될 수 있어
-                         * stale 세션 방지 정책이 약해진다.
-                         *
-                         * 또한 같은 잘못된 ARGV로 재시도해도 결과가 반복될 가능성이 높으므로
-                         * 즉시 STOMP ERROR로 실패시키고 클라이언트가 새 연결을 생성하도록 유도한다.
-                         */
                         cleanupWsConnection(wsSessionId);
                         throw new IllegalStateException("로비 입장 실패: 세션 상태가 유효하지 않습니다. 새로고침 후 다시 시도해주세요.");
                     }
@@ -366,7 +356,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         }
 
         cleanupWsConnection(wsSessionId);
-        throw new IllegalStateException("일시적으로 로비 입장 상태를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.");    }
+        throw new IllegalStateException("일시적으로 로비 입장 상태를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.");
+    }
 
     /**
      * STOMP 세션 속성에서 sessionSequence를 추출한다.
@@ -386,7 +377,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     }
 
     /**
-     * enter_lobby.lua를 1회 실행
+     * enter_lobby.lua를 1회 실행한다.
      */
     private String executeEnterLobbyScript(
             String lobbyCode,
@@ -482,6 +473,32 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         return sanitized.length() > 50 ? sanitized.substring(0, 50) + "..." : sanitized;
     }
 
+    /**
+     * 사용자 온라인 상태와 현재 WebSocket 세션을 Redis에 저장한다.
+     *
+     * [저장 구조]
+     * - user_status:{userIdentifier}:sessions = Set<wsSessionId>
+     * - user_status:{userIdentifier} = ONLINE
+     *
+     * [중요]
+     * CONNECT 시점과 DISCONNECT 후 TTL 연장 시점이 서로 다른 TTL 정책을 사용하면
+     * 분산 환경에서 온라인 상태 만료 기준이 달라질 수 있다.
+     * 따라서 userStatusTtl 설정값 하나로 온라인 상태 TTL을 통일한다.
+     */
+    private void saveUserOnlineSession(String userIdentifier, String wsSessionId) {
+        String userStatusKey = RedisKeys.userStatusKey(userIdentifier);
+        String userStatusSessionsKey = RedisKeys.userStatusSessionsKey(userIdentifier);
+
+        stringRedisTemplate.opsForSet().add(userStatusSessionsKey, wsSessionId);
+        stringRedisTemplate.expire(userStatusSessionsKey, userStatusTtl);
+
+        stringRedisTemplate.opsForValue().set(
+                userStatusKey,
+                WebSocketHeaders.STATUS_ONLINE,
+                userStatusTtl
+        );
+    }
+
     private enum LobbyEnterResultType {
         ENTERED,
         ALREADY_JOINED,
@@ -490,32 +507,5 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         LOBBY_NOT_FOUND,
         INVALID_SEQUENCE,
         UNKNOWN
-    }
-
-    /**
-     * 사용자 온라인 상태와 현재 WebSocket 세션을 Redis에 저장한다.
-     *
-     * [저장 구조]
-     * - user_status:{userIdentifier}:sessions = Set<wsSessionId>
-     * - user_status:{userIdentifier} = ONLINE
-     */
-    private void saveUserOnlineSession(String userIdentifier, String wsSessionId) {
-        String userStatusKey = RedisKeys.userStatusKey(userIdentifier);
-        String userStatusSessionsKey = RedisKeys.userStatusSessionsKey(userIdentifier);
-
-        stringRedisTemplate.opsForSet().add(userStatusSessionsKey, wsSessionId);
-
-        stringRedisTemplate.expire(
-                userStatusSessionsKey,
-                USER_STATUS_TTL_HOURS,
-                TimeUnit.HOURS
-        );
-
-        stringRedisTemplate.opsForValue().set(
-                userStatusKey,
-                WebSocketHeaders.STATUS_ONLINE,
-                USER_STATUS_TTL_HOURS,
-                TimeUnit.HOURS
-        );
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -101,8 +101,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
      * monomat.websocket.user-status.ttl=PT2H
      *
      * [설계 의도]
-     * CONNECT 시점과 DISCONNECT 후 TTL 연장 시점이 동일한 정책을 따르도록
-     * WebSocketEventListener와 같은 설정 키를 사용한다.
+     * 사용자 온라인 상태 생성 시점의 TTL 정책을 설정값으로 관리한다.
+     * DISCONNECT에서는 TTL을 연장하지 않고 세션 제거 및 마지막 세션 여부만 판단한다.
      */
     private final Duration userStatusTtl;
 
@@ -197,11 +197,14 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             throw new IllegalStateException("STOMP CONNECT: WebSocket 세션 ID가 없습니다.");
         }
 
+        log.debug("STOMP CONNECT 온라인 상태 저장 시작 - userIdentifier: {}, wsSessionId: {}, sessionSequence: {}",
+                userIdentifier, wsSessionId, sessionSequence);
+
         saveUserOnlineSession(userIdentifier, wsSessionId);
 
         webSocketMetric.increment();
 
-        log.info("STOMP CONNECT 성공: {}, wsSessionId: {}, sessionSequence: {}",
+        log.info("STOMP CONNECT 성공 - userIdentifier: {}, wsSessionId: {}, sessionSequence: {}",
                 userIdentifier, wsSessionId, sessionSequence);
     }
 
@@ -481,22 +484,27 @@ public class StompChannelInterceptor implements ChannelInterceptor {
      * - user_status:{userIdentifier} = ONLINE
      *
      * [중요]
-     * CONNECT 시점과 DISCONNECT 후 TTL 연장 시점이 서로 다른 TTL 정책을 사용하면
-     * 분산 환경에서 온라인 상태 만료 기준이 달라질 수 있다.
-     * 따라서 userStatusTtl 설정값 하나로 온라인 상태 TTL을 통일한다.
+     * 온라인 상태 TTL은 CONNECT 시점의 생존 신호를 기준으로 설정한다.
+     * DISCONNECT는 세션 정리 이벤트이므로 TTL 연장 기준으로 사용하지 않는다.
      */
     private void saveUserOnlineSession(String userIdentifier, String wsSessionId) {
         String userStatusKey = RedisKeys.userStatusKey(userIdentifier);
         String userStatusSessionsKey = RedisKeys.userStatusSessionsKey(userIdentifier);
 
-        stringRedisTemplate.opsForSet().add(userStatusSessionsKey, wsSessionId);
-        stringRedisTemplate.expire(userStatusSessionsKey, userStatusTtl);
+        try {
+            stringRedisTemplate.opsForSet().add(userStatusSessionsKey, wsSessionId);
+            stringRedisTemplate.expire(userStatusSessionsKey, userStatusTtl);
 
-        stringRedisTemplate.opsForValue().set(
-                userStatusKey,
-                WebSocketHeaders.STATUS_ONLINE,
-                userStatusTtl
-        );
+            stringRedisTemplate.opsForValue().set(
+                    userStatusKey,
+                    WebSocketHeaders.STATUS_ONLINE,
+                    userStatusTtl
+            );
+        } catch (RuntimeException e) {
+            log.error("STOMP CONNECT 온라인 상태 저장 실패 - userIdentifier: {}, wsSessionId: {}, userStatusKey: {}, userStatusSessionsKey: {}",
+                    userIdentifier, wsSessionId, userStatusKey, userStatusSessionsKey, e);
+            throw new IllegalStateException("STOMP CONNECT: 사용자 온라인 상태 저장에 실패했습니다.", e);
+        }
     }
 
     private enum LobbyEnterResultType {

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -185,16 +185,19 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             sessionAttributes.put(WebSocketHeaders.SESSION_SEQUENCE, sessionSequence);
         }
 
-        stringRedisTemplate.opsForValue().set(
-                RedisKeys.userStatusKey(userIdentifier),
-                WebSocketHeaders.STATUS_ONLINE,
-                USER_STATUS_TTL_HOURS,
-                TimeUnit.HOURS
-        );
+        String wsSessionId = accessor.getSessionId();
+
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            log.warn("STOMP CONNECT 거부: WebSocket 세션 ID 없음 - userIdentifier: {}", userIdentifier);
+            throw new IllegalStateException("STOMP CONNECT: WebSocket 세션 ID가 없습니다.");
+        }
+
+        saveUserOnlineSession(userIdentifier, wsSessionId);
 
         webSocketMetric.increment();
 
-        log.info("STOMP CONNECT 성공: {}, sessionSequence: {}", userIdentifier, sessionSequence);
+        log.info("STOMP CONNECT 성공: {}, wsSessionId: {}, sessionSequence: {}",
+                userIdentifier, wsSessionId, sessionSequence);
     }
 
     /**
@@ -487,5 +490,32 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         LOBBY_NOT_FOUND,
         INVALID_SEQUENCE,
         UNKNOWN
+    }
+
+    /**
+     * 사용자 온라인 상태와 현재 WebSocket 세션을 Redis에 저장한다.
+     *
+     * [저장 구조]
+     * - user_status:{userIdentifier}:sessions = Set<wsSessionId>
+     * - user_status:{userIdentifier} = ONLINE
+     */
+    private void saveUserOnlineSession(String userIdentifier, String wsSessionId) {
+        String userStatusKey = RedisKeys.userStatusKey(userIdentifier);
+        String userStatusSessionsKey = RedisKeys.userStatusSessionsKey(userIdentifier);
+
+        stringRedisTemplate.opsForSet().add(userStatusSessionsKey, wsSessionId);
+
+        stringRedisTemplate.expire(
+                userStatusSessionsKey,
+                USER_STATUS_TTL_HOURS,
+                TimeUnit.HOURS
+        );
+
+        stringRedisTemplate.opsForValue().set(
+                userStatusKey,
+                WebSocketHeaders.STATUS_ONLINE,
+                USER_STATUS_TTL_HOURS,
+                TimeUnit.HOURS
+        );
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -24,6 +24,7 @@ import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -34,6 +35,7 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -73,6 +75,25 @@ public class WebSocketEventListener {
 
     /** 퇴장 시스템 메시지 포맷 */
     private static final String LEAVE_MESSAGE_FORMAT = "%s님이 퇴장하셨습니다.";
+
+    // =========================================================
+    // 설정값
+    // =========================================================
+
+    /**
+     * 사용자 온라인 상태 TTL.
+     *
+     * [기본값]
+     * - PT2H: 2시간
+     *
+     * [설정 예시]
+     * monomat.websocket.user-status.ttl=PT2H
+     *
+     * [설계 의도]
+     * WebSocket DISCONNECT 이벤트 누락 또는 서버 비정상 종료 시
+     * user_status 및 sessions Set이 Redis에 영구적으로 남지 않도록 TTL을 적용한다.
+     */
+    private final Duration userStatusTtl;
 
     // =========================================================
     // 의존성
@@ -118,7 +139,8 @@ public class WebSocketEventListener {
             SimpMessagingTemplate messagingTemplate,
             ApplicationEventPublisher eventPublisher,
             WebSocketMetric webSocketMetric,
-            @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper
+            @Qualifier("pubSubJsonMapper") JsonMapper pubSubJsonMapper,
+            @Value("${monomat.websocket.user-status.ttl:PT2H}") Duration userStatusTtl
     ) {
         this.stringRedisTemplate = stringRedisTemplate;
         this.redisPublisher = redisPublisher;
@@ -126,6 +148,7 @@ public class WebSocketEventListener {
         this.eventPublisher = eventPublisher;
         this.webSocketMetric = webSocketMetric;
         this.pubSubJsonMapper = pubSubJsonMapper;
+        this.userStatusTtl = userStatusTtl;
     }
 
     /**
@@ -203,6 +226,7 @@ public class WebSocketEventListener {
             log.info("stale WebSocket 세션 연결 해제 감지 - 실제 퇴장 처리 생략. 로비: {}, 식별자: {}, wsSessionId: {}",
                     lobbyCode, userIdentifier, wsSessionId);
 
+            removeUserOnlineSessionOnly(userIdentifier, wsSessionId);
             deleteStaleConnectionKey(wsSessionId);
             webSocketMetric.decrement();
             return;
@@ -495,17 +519,17 @@ public class WebSocketEventListener {
     /**
      * DISCONNECT 이후 불필요한 Redis 키를 정리한다.
      *
-     * 현재 유효 세션의 DISCONNECT에서만 user_status, lobbyUserSessionKey,
-     * lobbyUserSessionSequenceKey를 삭제한다.
-     *
-     * stale 세션은 deleteStaleConnectionKey()에서 ws:connection만 삭제한다.
+     * [중요]
+     * user_status:{userIdentifier}는 무조건 삭제하지 않는다.
+     * 현재 wsSessionId를 user_status:{userIdentifier}:sessions Set에서 제거한 뒤,
+     * 남은 세션이 없을 때만 사용자를 오프라인으로 처리한다.
      */
     private void deleteDisconnectKeys(
             String userIdentifier,
             String wsSessionId,
             String lobbyCode
     ) {
-        stringRedisTemplate.delete(RedisKeys.userStatusKey(userIdentifier));
+        deleteUserOnlineSession(userIdentifier, wsSessionId);
 
         if (wsSessionId != null && !wsSessionId.isBlank()) {
             stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
@@ -515,5 +539,90 @@ public class WebSocketEventListener {
             stringRedisTemplate.delete(RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier));
             stringRedisTemplate.delete(RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, userIdentifier));
         }
+    }
+
+    /**
+     * DISCONNECT 된 WebSocket 세션을 사용자 온라인 세션 Set에서 제거한다.
+     *
+     * 마지막 세션이 종료된 경우에만 user_status:{userIdentifier}를 삭제한다.
+     * 아직 다른 WebSocket 세션이 남아 있다면 사용자는 온라인 상태로 유지한다.
+     */
+    private void deleteUserOnlineSession(String userIdentifier, String wsSessionId) {
+        if (!hasValidUserIdentifier(userIdentifier)) {
+            return;
+        }
+
+        String userStatusKey = RedisKeys.userStatusKey(userIdentifier);
+        String userStatusSessionsKey = RedisKeys.userStatusSessionsKey(userIdentifier);
+
+        removeUserOnlineSession(userStatusSessionsKey, wsSessionId);
+
+        Long remainingSessionCount = stringRedisTemplate.opsForSet().size(userStatusSessionsKey);
+
+        if (remainingSessionCount == null || remainingSessionCount == 0) {
+            deleteUserOnlineStatus(userStatusKey, userStatusSessionsKey, userIdentifier, wsSessionId);
+            return;
+        }
+
+        refreshUserOnlineStatusTtl(userStatusKey, userStatusSessionsKey);
+
+        log.info("사용자 온라인 상태 유지 - 남은 WebSocket 세션 수: {}, userIdentifier: {}, disconnectedWsSessionId: {}",
+                remainingSessionCount, userIdentifier, wsSessionId);
+    }
+
+    /**
+     * stale WebSocket 세션을 사용자 온라인 세션 Set에서만 제거한다.
+     *
+     * stale 세션은 로비 기준 최신 유효 세션이 아니므로,
+     * 로비 퇴장 처리와 user_status 삭제 판단은 수행하지 않는다.
+     */
+    private void removeUserOnlineSessionOnly(String userIdentifier, String wsSessionId) {
+        if (!hasValidUserIdentifier(userIdentifier)) {
+            return;
+        }
+
+        String userStatusSessionsKey = RedisKeys.userStatusSessionsKey(userIdentifier);
+        removeUserOnlineSession(userStatusSessionsKey, wsSessionId);
+
+        log.info("stale WebSocket 세션을 온라인 세션 Set에서 제거 - userIdentifier: {}, wsSessionId: {}",
+                userIdentifier, wsSessionId);
+    }
+
+    /**
+     * 사용자 온라인 세션 Set에서 특정 wsSessionId를 제거한다.
+     */
+    private void removeUserOnlineSession(String userStatusSessionsKey, String wsSessionId) {
+        if (wsSessionId == null || wsSessionId.isBlank()) {
+            return;
+        }
+
+        stringRedisTemplate.opsForSet().remove(userStatusSessionsKey, wsSessionId);
+    }
+
+    /**
+     * 사용자 온라인 상태 관련 Redis 키를 삭제한다.
+     */
+    private void deleteUserOnlineStatus(
+            String userStatusKey,
+            String userStatusSessionsKey,
+            String userIdentifier,
+            String wsSessionId
+    ) {
+        stringRedisTemplate.delete(userStatusKey);
+        stringRedisTemplate.delete(userStatusSessionsKey);
+
+        log.info("사용자 온라인 상태 삭제 - 마지막 WebSocket 세션 종료. userIdentifier: {}, wsSessionId: {}",
+                userIdentifier, wsSessionId);
+    }
+
+    /**
+     * 사용자 온라인 상태 관련 Redis 키의 TTL을 갱신한다.
+     *
+     * 일부 세션만 종료된 경우에도 다른 세션이 살아 있으므로,
+     * user_status와 sessions Set의 TTL을 다시 연장하여 온라인 상태가 조기 만료되지 않도록 한다.
+     */
+    private void refreshUserOnlineStatusTtl(String userStatusKey, String userStatusSessionsKey) {
+        stringRedisTemplate.expire(userStatusKey, userStatusTtl);
+        stringRedisTemplate.expire(userStatusSessionsKey, userStatusTtl);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -564,8 +564,6 @@ public class WebSocketEventListener {
             return;
         }
 
-        refreshUserOnlineStatusTtl(userStatusKey, userStatusSessionsKey);
-
         log.info("사용자 온라인 상태 유지 - 남은 WebSocket 세션 수: {}, userIdentifier: {}, disconnectedWsSessionId: {}",
                 remainingSessionCount, userIdentifier, wsSessionId);
     }
@@ -613,16 +611,5 @@ public class WebSocketEventListener {
 
         log.info("사용자 온라인 상태 삭제 - 마지막 WebSocket 세션 종료. userIdentifier: {}, wsSessionId: {}",
                 userIdentifier, wsSessionId);
-    }
-
-    /**
-     * 사용자 온라인 상태 관련 Redis 키의 TTL을 갱신한다.
-     *
-     * 일부 세션만 종료된 경우에도 다른 세션이 살아 있으므로,
-     * user_status와 sessions Set의 TTL을 다시 연장하여 온라인 상태가 조기 만료되지 않도록 한다.
-     */
-    private void refreshUserOnlineStatusTtl(String userStatusKey, String userStatusSessionsKey) {
-        stringRedisTemplate.expire(userStatusKey, userStatusTtl);
-        stringRedisTemplate.expire(userStatusSessionsKey, userStatusTtl);
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -4,13 +4,13 @@ import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
-import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 class RegisterAuthServiceTest {
 
     @Autowired
@@ -27,13 +28,14 @@ class RegisterAuthServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserCredentialRepository userCredentialRepository;
+    private String uniqueNickname() {
+        return "n" + (System.nanoTime() % 1_000_000);
+    }
 
     @Test
     void register_success() {
         String uniqueLoginId = "member_" + System.nanoTime();
-        String uniqueNickname = "nick_" + System.nanoTime();
+        String uniqueNickname = uniqueNickname();
 
         RegisterResponse response = registerAuthService.register(
                 uniqueLoginId,
@@ -48,13 +50,13 @@ class RegisterAuthServiceTest {
     }
 
     @Test
-    void register_trimsInputValues() {
+    void register_trimsLoginIdAndNickname() {
         String uniqueLoginId = "member_" + System.nanoTime();
-        String uniqueNickname = "nick_" + System.nanoTime();
+        String uniqueNickname = uniqueNickname();
 
         RegisterResponse response = registerAuthService.register(
                 "  " + uniqueLoginId + "  ",
-                "  password123  ",
+                "password123",
                 "  " + uniqueNickname + "  "
         );
 
@@ -63,20 +65,32 @@ class RegisterAuthServiceTest {
     }
 
     @Test
+    void register_passwordWithWhitespace_throwsBadRequest() {
+        String uniqueLoginId = "member_" + System.nanoTime();
+        String uniqueNickname = uniqueNickname();
+        String rawPassword = "  password123  ";
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register(uniqueLoginId, rawPassword, uniqueNickname));
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("비밀번호에는 공백을 포함할 수 없습니다.", exception.getReason());
+    }
+
+    @Test
     void register_duplicateLoginId_throwsConflict() {
         String loginId = "dup_login_" + System.nanoTime();
 
-        registerAuthService.register(loginId, "password123", "dupNick_" + System.nanoTime());
+        registerAuthService.register(loginId, "password123", uniqueNickname());
 
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register(loginId, "password123", "anotherNick_" + System.nanoTime()));
+                registerAuthService.register(loginId, "password123", uniqueNickname()));
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
         assertEquals("이미 사용 중인 로그인 ID입니다.", exception.getReason());
     }
 
     @Test
     void register_duplicateNickname_throwsConflict() {
-        String nickname = "dup_nick_" + System.nanoTime();
+        String nickname = uniqueNickname();
         userRepository.saveAndFlush(User.builder()
                 .username(nickname)
                 .userType(UserType.REGISTERED)
@@ -92,7 +106,7 @@ class RegisterAuthServiceTest {
     @Test
     void register_nullPassword_throwsBadRequest() {
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("login_" + System.nanoTime(), null, "nick_" + System.nanoTime()));
+                registerAuthService.register("login_" + System.nanoTime(), null, uniqueNickname()));
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
         assertEquals("비밀번호는 비어 있을 수 없습니다.", exception.getReason());
     }
@@ -100,8 +114,29 @@ class RegisterAuthServiceTest {
     @Test
     void register_blankLoginId_throwsBadRequest() {
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("   ", "password123", "nick_" + System.nanoTime()));
+                registerAuthService.register("   ", "password123", uniqueNickname()));
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
         assertEquals("로그인 ID는 비어 있을 수 없습니다.", exception.getReason());
+    }
+
+    @Test
+    void register_nicknameTooLong_throwsBadRequest() {
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register("login_" + System.nanoTime(), "password123", "123456789"));
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("닉네임은 8자를 초과할 수 없습니다.", exception.getReason());
+    }
+
+    @Test
+    void register_loginIdWithWhitespace_throwsBadRequest() {
+        // given
+        String loginIdWithWhitespace = "abc def";
+        String uniqueNickname = uniqueNickname();
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                registerAuthService.register(loginIdWithWhitespace, "password123", uniqueNickname));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("로그인 ID에는 공백을 포함할 수 없습니다.", exception.getReason());
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #55

## 📝 Summary

- WebSocket 사용자 온라인 상태를 단일 Redis 키가 아닌 세션 Set 기반으로 관리하도록 개선했습니다.
- 동일 사용자가 여러 탭 또는 여러 WebSocket 세션으로 접속한 상태에서 일부 세션만 종료되어도 온라인 상태가 잘못 삭제되지 않도록 수정했습니다.
- `user_status:{userIdentifier}:sessions` Set을 추가하여 현재 연결 중인 `wsSessionId` 목록을 관리합니다.
- DISCONNECT 시 현재 `wsSessionId`만 Set에서 제거하고, 남은 세션이 없을 때만 `user_status:{userIdentifier}`를 삭제하도록 변경했습니다.
- stale WebSocket 세션 disconnect 시에도 온라인 세션 Set에서 해당 `wsSessionId`만 제거하도록 정리했습니다.
- 사용자 온라인 상태 TTL을 설정값 기반으로 관리할 수 있도록 개선했습니다.

## 🙏PR point

- 기존 구조에서는 `user_status:{userIdentifier}` 단일 키만 사용했기 때문에, 동일 사용자가 여러 WebSocket 세션을 가진 상태에서 하나의 세션만 disconnect되어도 온라인 상태가 삭제될 수 있었습니다.
- 이번 수정 후에는 `user_status:{userIdentifier}:sessions` Set의 남은 세션 수를 기준으로 마지막 세션 종료 여부를 판단합니다.
- 다중 탭 환경에서 다음 흐름이 정상 동작하는지 중점적으로 확인 부탁드립니다.
  - 같은 `userIdentifier`로 탭 A, 탭 B 연결
  - 탭 A만 종료
  - `user_status:{userIdentifier}`는 유지
  - 탭 B까지 종료
  - `user_status:{userIdentifier}` 삭제

## 📬 Reference

- `RedisKeys.java`
  - `userStatusSessionsKey()` 추가
- `StompChannelInterceptor.java`
  - CONNECT 시 `user_status:{userIdentifier}:sessions`에 `wsSessionId` 추가
  - CONNECT 시 `user_status:{userIdentifier}` ONLINE 저장 유지
- `WebSocketEventListener.java`
  - DISCONNECT 시 `user_status:{userIdentifier}` 무조건 삭제 로직 제거
  - sessions Set이 비었을 때만 온라인 상태 삭제
  - stale 세션 disconnect 시 sessions Set에서 해당 `wsSessionId`만 제거