### PR TITLE
[Feat/#49] 초대 코드 기반 로비 입장 API 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,30 +50,21 @@ POST /api/auth/guest
 - 정식 회원 닉네임과 충돌: `정식 회원이 이미 사용 중인 닉네임입니다.`
 - 기존 사용자 닉네임과 충돌: `이미 사용 중인 닉네임입니다.`
 
-#### (dev 전용) REGISTERED 토큰 발급
+---
 
-```
-POST /api/auth/dev/registered-token
-```
-
-dev 프로필에서만 노출됩니다. 입력한 username으로 REGISTERED 사용자를 만들거나 재사용해 Access/Refresh 토큰을 발급합니다.
 #### 회원가입
 
 ```
 POST /api/auth/register
 ```
 
-로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.  
+로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.
 회원가입 API는 계정 생성만 수행하며 토큰 발급은 로그인 API에서 처리됩니다.
 
 **Request**
 
 ```json
 {
-  "username": "dev-registered-user"
-}
-```
-
   "loginId": "member01",
   "password": "password123",
   "nickname": "registered-user"
@@ -93,12 +84,14 @@ POST /api/auth/register
 
 **Error**
 
-- `400 Bad Request`: 필수값 누락/비밀번호 길이 조건 불만족/비밀번호 공백 포함/닉네임 8자 초과
+- `400 Bad Request`: 필수값 누락 / 비밀번호 길이 조건 불만족 / 비밀번호 공백 포함 / 닉네임 8자 초과
 - `409 Conflict`: 로그인 ID 또는 닉네임 중복
+
+---
 
 ### 로비 (Lobby)
 
-### 로비 생성
+#### 로비 생성
 
 ```
 POST /api/lobbies
@@ -164,6 +157,75 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
 
 ---
 
+#### 초대 코드 기반 로비 입장
+
+```
+POST /api/lobbies/join
+```
+
+초대 코드로 로비 입장 가능 여부를 검증하고 로비 기본 정보를 반환합니다.
+JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 가능합니다.
+
+> **중요:** 이 API는 입장 허가 사전 검증만 수행합니다.
+> 실제 참여자 등록은 응답 수신 후 WebSocket `/topic/lobby/{inviteCode}` 구독 시점에 처리됩니다.
+>
+> 클라이언트 처리 순서:
+> 1. `POST /api/lobbies/join` 호출 → 입장 가능 여부 확인
+> 2. WebSocket `SUBSCRIBE /topic/lobby/{inviteCode}` → 실제 입장 처리
+
+**Request Header**
+
+| 헤더 | 필수 | 설명 |
+|---|---|---|
+| `Authorization` | ✅ | `Bearer {accessToken}` |
+
+**Request Body**
+
+```json
+{
+  "inviteCode": "ABC123"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `inviteCode` | String | ✅ | 6자리 초대 코드 (영문 대문자 + 숫자) |
+
+**Response `200 OK`**
+
+```json
+{
+  "inviteCode": "ABC123",
+  "title": "K-POP 퀴즈방",
+  "hostId": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+  "maxPlayers": 8,
+  "currentPlayers": 3,
+  "status": "WAITING",
+  "mapCategory": "kpop"
+}
+```
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `inviteCode` | String | 로비 초대 코드 (WebSocket 구독 경로에 사용) |
+| `title` | String | 로비 제목 |
+| `hostId` | String | 방장 사용자 식별자 |
+| `maxPlayers` | Integer | 최대 참여 인원 |
+| `currentPlayers` | Integer | 현재 참여 인원 (응답 시점 스냅샷) |
+| `status` | String | 로비 상태 (`WAITING`) |
+| `mapCategory` | String | 선택된 맵의 카테고리 (미선택 시 `null`) |
+
+**Error**
+
+| 상태 코드 | 설명 |
+|---|---|
+| `400 Bad Request` | 초대 코드 형식 오류 (6자리 영문 대문자 + 숫자 조합이 아닌 경우) |
+| `401 Unauthorized` | JWT 토큰 없음 또는 만료 |
+| `404 Not Found` | 존재하지 않는 초대 코드 |
+| `409 Conflict` | 게임이 이미 시작된 로비 또는 최대 인원 초과 |
+
+---
+
 #### 공개 로비 목록 조회
 
 ```
@@ -182,6 +244,7 @@ Redis에서 직접 필터링하여 고속 반환합니다.
     "hostId": "uuid-xxxx-xxxx",
     "title": "K-POP 퀴즈방",
     "mapId": 1,
+    "mapCategory": "kpop",
     "maxPlayers": 8,
     "isPrivate": false,
     "status": "WAITING"
@@ -194,7 +257,8 @@ Redis에서 직접 필터링하여 고속 반환합니다.
 | `code` | String | 로비 초대 코드 (6자리) |
 | `hostId` | String | 방장 사용자 식별자 |
 | `title` | String | 로비 제목 |
-| `mapId` | Long | 선택된 맵 ID (미선택 시 null) |
+| `mapId` | Long | 선택된 맵 ID (미선택 시 `null`) |
+| `mapCategory` | String | 선택된 맵의 카테고리 (미선택 시 `null`) |
 | `maxPlayers` | Integer | 최대 참여 인원 |
 | `isPrivate` | Boolean | 비공개 여부 (`true` = 비공개) |
 | `status` | String | 로비 상태 (`WAITING` \| `PLAYING`) |
@@ -454,6 +518,7 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 | `userIdentifier` 헤더 누락 | `STOMP CONNECT: 사용자 식별자가 없습니다. 연결이 거부되었습니다.` |
 | 유효하지 않은 `userIdentifier` 형식 | `STOMP CONNECT: 유효하지 않은 식별자 형식입니다. 연결이 거부되었습니다.` |
 | 인증 없이 SEND/SUBSCRIBE 시도 | `인증 정보가 존재하지 않습니다.` |
+| 최대 인원 초과 로비 구독 시도 | `로비 입장 실패: 최대 인원에 도달했습니다.` |
 
 ---
 
@@ -464,7 +529,6 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 | 분류 | 설명 |
 |---|---|
 | 로그인 | `POST /api/auth/login` |
-| 로비 초대 코드 입장 | `POST /api/lobbies/join` |
 | 맵 아이템(문제) CRUD | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |
 | YouTube URL 유효성 검증 | `POST /api/youtube/validate` |
 | 인게임 WebSocket | `/app/game/{code}/**` |

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -98,14 +98,14 @@ public class RegisterAuthService {
 
     private String validateNoWhitespace(String value, String fieldName) {
         if (value == null || value.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는(은) 비어 있을 수 없습니다.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
         }
         if (value.chars().anyMatch(Character::isWhitespace)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "에는 공백을 포함할 수 없습니다.");
         }
         return value;
     }
-
+    
     private void validateNicknameLength(String nickname) {
         if (nickname.length() > MAX_NICKNAME_LENGTH) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 8자를 초과할 수 없습니다.");

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -105,7 +105,7 @@ public class RegisterAuthService {
         }
         return value;
     }
-    
+
     private void validateNicknameLength(String nickname) {
         if (nickname.length() > MAX_NICKNAME_LENGTH) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 8자를 초과할 수 없습니다.");

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -82,7 +82,10 @@ public class LobbyController {
             @Valid @RequestBody CreateLobbyRequest request,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        log.info(LOG_CREATE_LOBBY_REQUEST, principal.userIdentifier());
+        log.info(
+                LOG_CREATE_LOBBY_REQUEST,
+                principal != null ? principal.userIdentifier() : "null"
+        );
 
         CreateLobbyResponse response = lobbyService.createLobby(request, principal);
 
@@ -100,7 +103,7 @@ public class LobbyController {
      *
      * [처리 흐름]
      * 이 API는 입장 허가 사전 검증만 수행한다.
-     * 실제 참여자 등록은 클라이언트가 읍답을 받은 뒤
+     * 실제 참여자 등록은 클라이언트가 응답을 받은 뒤
      * WebSocket /topic/lobby/{inviteCode}를 구독하는 시점에 처리된다.
      *
      * 클라이언트 처리 순서:
@@ -129,7 +132,11 @@ public class LobbyController {
             @Valid @RequestBody JoinLobbyRequest request,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        log.info(LOG_JOIN_LOBBY_REQUEST, request.inviteCode(), principal.userIdentifier());
+        log.info(
+                LOG_JOIN_LOBBY_REQUEST,
+                request.inviteCode(),
+                principal != null ? principal.userIdentifier() : "null"
+        );
 
         JoinLobbyResponse response = lobbyService.joinLobby(request.inviteCode(), principal);
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -9,6 +9,8 @@ package io.github.ascrew.monomatbe.domain.lobby.controller;
 
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyRequest;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
@@ -48,6 +50,10 @@ public class LobbyController {
             "요청 수신: 공개 로비 목록 조회 [GET /api/lobbies]";
     private static final String LOG_GET_PUBLIC_LOBBIES_RESPONSE =
             "조회 완료: 공개 로비 {}개 반환";
+    private static final String LOG_JOIN_LOBBY_REQUEST =
+            "요청 수신: 로비 입장 [POST /api/lobbies/join] - 초대 코드: {}, 식별자: {}";
+    private static final String LOG_JOIN_LOBBY_RESPONSE =
+            "로비 입장 사전 검증 완료 - 초대 코드: {}";
 
     private final LobbyService lobbyService;
 
@@ -83,6 +89,53 @@ public class LobbyController {
         log.info(LOG_CREATE_LOBBY_RESPONSE, response.inviteCode());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 초대 코드 기반 로비 입장 API
+     *
+     * [인증]
+     * JWT Access Token이 필요하다.
+     * 게스트도 로그인 후 발급받은 토큰으로 입장할 수 있다.
+     *
+     * [처리 흐름]
+     * 이 API는 입장 허가 사전 검증만 수행한다.
+     * 실제 참여자 등록은 클라이언트가 읍답을 받은 뒤
+     * WebSocket /topic/lobby/{inviteCode}를 구독하는 시점에 처리된다.
+     *
+     * 클라이언트 처리 순서:
+     * 1. POST /api/lobbies/join 호출 -> 입장 가능 여부 확인
+     * 2. WebSocket SUBSCRIBE /topic/lobby/{inviteCode} -> 실제 입장 처리
+     *
+     * [에러 응답]
+     * - 404 Not Found : 존재하지 않는 초대 코드
+     * - 409 Conflict : 게임 진행 중인 로비 또는 최대 인원 초과
+     *
+     * @param request 로비 입장 요청 DTO (초대 코드 포함, @Valid 검증 적용)
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 200 OK + 로비 기본 정보
+     */
+    @Operation(
+            summary = "초대 코드 기반 로비 입장",
+            description = """
+                    초대 코드로 로비 입장 가능 여부를 검증하고 로비 기본 정보를 반환합니다.
+                    실제 참여자 등록은 이후 WebSocket 구독 시점에 처리됩니다.
+                    JWT 인증이 필요합니다.
+                    """
+    )
+    @PostMapping("/join")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<JoinLobbyResponse> joinLobby(
+            @Valid @RequestBody JoinLobbyRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(LOG_JOIN_LOBBY_REQUEST, request.inviteCode(), principal.userIdentifier());
+
+        JoinLobbyResponse response = lobbyService.joinLobby(request.inviteCode(), principal);
+
+        log.info(LOG_JOIN_LOBBY_RESPONSE, response.inviteCode());
+
+        return ResponseEntity.ok(response);
     }
 
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyRequest.java
@@ -1,0 +1,24 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 초대 코드 기반 로비 입장 요청 DTO
+ * 검증 규칙 :
+ * - inviteCode : 필수, 영문 대문자 + 숫자 조합 6가지
+ * inviteCode 형식 검증 이유 :
+ * 형식이 맞지 않는 코드는 Redis 조회 전에 즉시 거부하여 불필요한 외부 요청을 차단한다.
+ */
+public record JoinLobbyRequest(
+
+        @NotBlank(message = "초대 코드는 비어 있을 수 없습니다.")
+        @Size(min = 6, max = 6, message = "초대 코드는 6자리여야 합니다.")
+        @Pattern(
+                regexp = "^[A-Z0-9]{6}$",
+                message = "초대 코드는 영문 대문자와 숫자만 허용됩니다."
+        )
+        String inviteCode
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyResponse.java
@@ -1,0 +1,33 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import lombok.Builder;
+
+/**
+ * 초대 코드 기반 로비 입장 응답 DTO
+ *
+ * [currentPlayers]
+ * REST 응답 시점의 스냅샷이며, WebSocket 연결 후 REFRESH_LOBBY_INFO 신호로
+ * 최신 상태를 다시 조회하므로 일시적 불일치는 허용한다.
+ *
+ * [mapCategory]
+ * 맵 선택 이슈에서 반정규화 방식으로 Redis Hash에 저장될 예정이다.
+ * 현재는 맵 선택 기능이 구현되지 않았으므로 null로 내려간다.
+ */
+@Builder
+public record JoinLobbyResponse(
+        // 로비 초대 코드 (WebSocket 구독 경로에 사용)
+        String inviteCode,
+        // 로비 제목
+        String title,
+        // 방장 사용자 식별자
+        String hostId,
+        // 최대 참여 인원
+        int maxPlayers,
+        // 현재 참여 인원 (응답 시점 스냅샷)
+        int currentPlayers,
+        // 로비 상태 (WAITING | PLAYING)
+        String status,
+        // 선택된 맵의 카테고리 (미선택 시 null)
+        String mapCategory
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
@@ -19,6 +19,7 @@ public class LobbyRedisDto {
     private String hostId;        // 현재 방장의 사용자 식별자
     private String title;         // 로비 제목
     private Long mapId;           // 선택된 맵 세트 ID
+    private String mapCategory;   // 선택된 맵의 카테고리 (미선택 시 null)
     private Integer maxPlayers;   // 최대 참여 가능 인원
     private Boolean isPrivate;    // 공개(false) / 비공개(true) 여부
     private String status;        // 로비 상태 (WAITING, PLAYING)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -6,9 +6,11 @@ package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LobbyRepository {
 
@@ -25,18 +27,6 @@ public interface LobbyRepository {
 
   /**
    * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
-   *
-   * [보상 삭제 대상]
-   * - lobby:{code} Hash
-   * - lobby:{code}:participants Set
-   * - lobby:{code}:order List
-   * - lobby:public Set에서 코드 제거
-   * - lobby:code:lock:{code} 락 키
-   *
-   * 반환 타입을 void → boolean으로 변경
-   * 보상 삭제 성공 여부를 서비스 레이어에서 확인하여
-   * 실패 시 모니터링 가능한 로그/알림 처리를 가능하게 한다.
-   *
    * @param inviteCode 삭제할 로비 초대 코드
    * @return 보상 삭제 성공 여부 (true: 성공, false: 실패)
    */
@@ -44,11 +34,29 @@ public interface LobbyRepository {
 
   /**
    * Lua 스크립트를 실행하여 퇴장 처리를 원자적으로 수행한다.
-   *
    * @return LeaveLobbyResult (Destroyed | Delegated | Left | Error)
    */
   LeaveLobbyResult executeLeaveLobbyProcess(String code, String userId);
 
   /** Redis에서 공개 로비 목록을 필터링하여 반환한다. */
   List<LobbyRedisDto> getPublicLobbies();
+
+  /**
+   * 초대 코드로 로비 입장에 필요한 정보를 조회한다.
+   *
+   * [반환 전략]
+   * 로비가 존재하지 않으면 Optinal.empty()를 반환한다.
+   * 서비스 레이어에서 empty 여부로 404를 처리 하므로, Repository는 존재 여부 판단을 서비스에 위임한다.
+   *
+   * @param inviteCode 로비 초대 코드
+   * @return 로비 정보 Optional (로비 미존재 시 empty)
+   */
+  Optional<JoinLobbyResponse> findByInviteCode(String inviteCode);
+
+  /**
+   * 해당 로비의 현재 참여 인원 수를 반환한다.
+   * @param inviteCode 로비 초대 코드
+   * @return 현재 참여 인원 수
+   */
+  int getCurrentPlayerCount(String inviteCode);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -45,7 +45,7 @@ public interface LobbyRepository {
    * 초대 코드로 로비 입장에 필요한 정보를 조회한다.
    *
    * [반환 전략]
-   * 로비가 존재하지 않으면 Optinal.empty()를 반환한다.
+   * 로비가 존재하지 않으면 Optional.empty()를 반환한다.
    * 서비스 레이어에서 empty 여부로 404를 처리 하므로, Repository는 존재 여부 판단을 서비스에 위임한다.
    *
    * @param inviteCode 로비 초대 코드

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
@@ -18,6 +19,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 @Slf4j
@@ -68,6 +70,16 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   /** Lua 스크립트 null 반환 시 에러 메시지 */
   private static final String ERROR_REDIS_SCRIPT_NULL =
           "Redis 스크립트 실행 결과가 null입니다. Redis 연결 상태를 확인해주세요.";
+
+  // =========================================================
+  // findByInviteCode 관련 상수
+  // =========================================================
+
+  /**
+   * 로비가 존재하지 않거나 TTL이 만료된 경우 반환할 빈 Optional.
+   * 매번 새 객체를 생성하지 않기 위해 상수로 관리한다.
+   */
+  private static final Optional<JoinLobbyResponse> EMPTY_LOBBY = Optional.empty();
 
   // =========================================================
   // 공개 메서드
@@ -204,15 +216,73 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     return result;
   }
 
+  /**
+   * 초대 코드로 로비 입장에 필요한 정보를 조회한다.
+   *
+   * [조회 전략]
+   * HGETALL로 lobby:{code} Hash를 한 번에 읽어 응답 객체를 구성한다.
+   * currentPlayers는 participants Set의 SCARD로 별도 조회한다.
+   *
+   * [mapCategory]
+   * 맵 선택 기능 구현 전까지 null로 반환한다.
+   * 맵 선택 이슈에서 Redis Hash에 map_category 필드가 추가되면
+   * FIELD_MAP_CATEGORY 상수로 조회한다.
+   *
+   * @param inviteCode 로비 초대 코드
+   * @return 로비 정보 Optional (로비 미존재 시 empty)
+   */
+  @Override
+  public Optional<JoinLobbyResponse> findByInviteCode(String inviteCode) {
+    // HGETALL로 Hash 전체를 한 번에 읽어 네트워크 왕복 횟수를 최소화한다.
+    Map<Object, Object> data =
+            redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(inviteCode));
+
+    // 로비가 존재하지 않거나 TTL이 만료된 경우
+    if (data.isEmpty()) {
+      return EMPTY_LOBBY;
+    }
+
+    // 현재 참여 인원은 participants Set의 SCARD로 조회한다.
+    int currentPlayers = getCurrentPlayerCount(inviteCode);
+
+    return Optional.of(JoinLobbyResponse.builder()
+            .inviteCode(inviteCode)
+            .title((String) data.get(RedisKeys.FIELD_TITLE))
+            .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
+            .maxPlayers(parseNullableIntOrDefault(data.get(RedisKeys.FIELD_MAX_PLAYERS), 0))
+            .currentPlayers(currentPlayers)
+            .status((String) data.get(RedisKeys.FIELD_STATUS))
+            // 맵 선택 이슈 구현 전까지 null로 반환한다.
+            .mapCategory(null)
+            .build());
+  }
+
+  /**
+   * 해당 로비의 현재 참여 인원 수를 반환한다.
+   *
+   * [구현 방식]
+   * lobby:{code}:participants Set의 SCARD 명령으로 조회한다.
+   * null 반환 시 Redis 연결 이상이므로 0으로 폴백하여 NPE를 방지한다.
+   *
+   * @param inviteCode 로비 초대 코드
+   * @return 현재 참여 인원 수 (Redis 오류 시 0)
+   */
+  @Override
+  public int getCurrentPlayerCount(String inviteCode) {
+    Long count = redisTemplate.opsForSet()
+            .size(RedisKeys.lobbyParticipantsKey(inviteCode));
+
+    // null은 Redis 연결 이상을 의미한다.
+    // 0으로 폴백하여 NPE를 방지하고, 서비스 레이어에서 정상 흐름을 유지한다.
+    return count != null ? count.intValue() : 0;
+  }
+
   // =========================================================
   // private 메서드
   // =========================================================
 
   /**
    * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행한다.
-   *
-   * participants, order 관련 키 제거 이유:
-   * 입장 처리는 WebSocketEventListener.processLobbyEnter()에서 담당하므로, 생성 시점에서는 방장을 추가하지 않는다.
    *
    * @return "OK" (성공) | "LOCK_FAILED" (코드 충돌) | null (Redis 오류)
    */
@@ -248,9 +318,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    *
    * [정규화 이유]
    * Lua 스크립트(create_lobby.lua)에서 isPrivate 값을
-   * if isPrivate == "false" then 으로 비교합니다.
+   * if isPrivate == "false" then 으로 비교한다.
    * IS_PRIVATE_TRUE / IS_PRIVATE_FALSE 상수를 사용하여
-   * 대소문자 불일치나 예상치 못한 값이 전달되는 것을 방지합니다.
+   * 대소문자 불일치나 예상치 못한 값이 전달되는 것을 방지한다.
    *
    * @param isPrivate 로비 비공개 여부
    * @return "true" (비공개) 또는 "false" (공개)
@@ -310,6 +380,31 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     } catch (NumberFormatException e) {
       log.warn("Redis Hash 필드 Integer 파싱 실패 - 값: {}", value);
       return null;
+    }
+  }
+
+  /**
+   * Redis Hash 필드값을 Integer로 파싱한다.
+   * null이거나 파싱 실패 시 defaultValue를 반환한다.
+   *
+   * [parseNullableInt()와의 차이]
+   * parseNullableInt()는 null을 그대로 반환하지만,
+   * 이 메서드는 primitive int 필드에 대입할 때 NullPointerException이 발생하지 않도록 반드시 기본값을 반환한다.
+   *
+   * @param value        Redis Hash에서 조회한 원시값
+   * @param defaultValue 파싱 실패 시 반환할 기본값
+   * @return 파싱된 정수 또는 defaultValue
+   */
+  private int parseNullableIntOrDefault(Object value, int defaultValue) {
+    if (value == null) {
+      return defaultValue;
+    }
+    try {
+      return Integer.parseInt((String) value);
+    } catch (NumberFormatException e) {
+      log.warn("Redis Hash 필드 Integer 파싱 실패 - 값: {}, 기본값 {} 사용",
+              value, defaultValue);
+      return defaultValue;
     }
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -262,8 +262,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             .maxPlayers(maxPlayers)
             .currentPlayers(currentPlayers)
             .status((String) data.get(RedisKeys.FIELD_STATUS))
-            // 맵 선택 이슈 구현 전까지 null로 반환한다.
-            .mapCategory(null)
+            .mapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY))
             .build());
   }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -81,6 +81,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    */
   private static final Optional<JoinLobbyResponse> EMPTY_LOBBY = Optional.empty();
 
+  private static final String ERROR_INVALID_LOBBY_DATA =
+          "로비 정보가 유효하지 않습니다.";
+
   // =========================================================
   // 공개 메서드
   // =========================================================
@@ -246,11 +249,17 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     // 현재 참여 인원은 participants Set의 SCARD로 조회한다.
     int currentPlayers = getCurrentPlayerCount(inviteCode);
 
+    int maxPlayers = parseRequiredPositiveInt(
+            data.get(RedisKeys.FIELD_MAX_PLAYERS),
+            RedisKeys.FIELD_MAX_PLAYERS,
+            inviteCode
+    );
+
     return Optional.of(JoinLobbyResponse.builder()
             .inviteCode(inviteCode)
             .title((String) data.get(RedisKeys.FIELD_TITLE))
             .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
-            .maxPlayers(parseNullableIntOrDefault(data.get(RedisKeys.FIELD_MAX_PLAYERS), 0))
+            .maxPlayers(maxPlayers)
             .currentPlayers(currentPlayers)
             .status((String) data.get(RedisKeys.FIELD_STATUS))
             // 맵 선택 이슈 구현 전까지 null로 반환한다.
@@ -385,27 +394,55 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   /**
-   * Redis Hash 필드값을 Integer로 파싱한다.
-   * null이거나 파싱 실패 시 defaultValue를 반환한다.
+   * Redis Hash의 필수 양수 정수 필드를 파싱한다.
    *
-   * [parseNullableInt()와의 차이]
-   * parseNullableInt()는 null을 그대로 반환하지만,
-   * 이 메서드는 primitive int 필드에 대입할 때 NullPointerException이 발생하지 않도록 반드시 기본값을 반환한다.
+   * [사용 목적]
+   * max_players처럼 로비 입장 검증에 반드시 필요한 필드는
+   * 누락되거나 잘못된 값일 때 기본값으로 폴백하면 안 된다.
    *
-   * @param value        Redis Hash에서 조회한 원시값
-   * @param defaultValue 파싱 실패 시 반환할 기본값
-   * @return 파싱된 정수 또는 defaultValue
+   * [실패 처리]
+   * - null
+   * - 숫자 파싱 실패
+   * - 0 이하
+   *
+   * 위 경우는 Redis 로비 데이터 손상으로 보고 500을 반환한다.
+   *
+   * @param value      Redis Hash에서 조회한 원시값
+   * @param fieldName  Redis Hash 필드명
+   * @param inviteCode 로비 초대 코드
+   * @return 파싱된 양수 정수
    */
-  private int parseNullableIntOrDefault(Object value, int defaultValue) {
+  private int parseRequiredPositiveInt(Object value, String fieldName, String inviteCode) {
     if (value == null) {
-      return defaultValue;
+      log.error("Redis 로비 필수 필드 누락 - inviteCode: {}, field: {}",
+              inviteCode, fieldName);
+      throw new ResponseStatusException(
+              HttpStatus.INTERNAL_SERVER_ERROR,
+              ERROR_INVALID_LOBBY_DATA
+      );
     }
+
     try {
-      return Integer.parseInt((String) value);
+      int parsed = Integer.parseInt((String) value);
+
+      if (parsed <= 0) {
+        log.error("Redis 로비 필수 필드 값이 유효하지 않음 - inviteCode: {}, field: {}, value: {}",
+                inviteCode, fieldName, value);
+        throw new ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ERROR_INVALID_LOBBY_DATA
+        );
+      }
+
+      return parsed;
+
     } catch (NumberFormatException e) {
-      log.warn("Redis Hash 필드 Integer 파싱 실패 - 값: {}, 기본값 {} 사용",
-              value, defaultValue);
-      return defaultValue;
+      log.error("Redis 로비 필수 필드 숫자 파싱 실패 - inviteCode: {}, field: {}, value: {}",
+              inviteCode, fieldName, value, e);
+      throw new ResponseStatusException(
+              HttpStatus.INTERNAL_SERVER_ERROR,
+              ERROR_INVALID_LOBBY_DATA
+      );
     }
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -208,6 +208,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               .title((String) data.get(RedisKeys.FIELD_TITLE))
               .status((String) data.get(RedisKeys.FIELD_STATUS))
               .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
+              .mapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY))
               .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
               .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
               .build());

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -171,23 +171,27 @@ public class LobbyService {
      * @return 로비 응답 DTO
      */
     public JoinLobbyResponse joinLobby(String inviteCode, CustomPrincipal principal) {
+        if (principal == null || principal.userId() == null) {
+            log.warn("로비 입장 요청 거부 - principal 또는 userId가 null. inviteCode: {}", inviteCode);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+        }
+
         log.info(LOG_JOIN_LOBBY_REQUEST, inviteCode, principal.userIdentifier());
 
-        // 1. 로비 존재 여부 확인
-        // findByInviteCode()는 HGETALL로 로비 Hash 전체를 읽는다.
-        // 로비가 없으면 404를 반환하고 이후 검증을 진행하지 않는다.
         JoinLobbyResponse lobbyInfo = lobbyRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, ERROR_LOBBY_NOT_FOUND));
 
-        // 2. 로비 상태 확인
-        // PLAYING, FINISHED 상태의 로비에는 입장할 수 없다.
         if (!LOBBY_STATUS_WAITING.equals(lobbyInfo.status())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
         }
 
-        // 3. 인원 초과 확인
-        if (lobbyInfo.currentPlayers() >= lobbyInfo.maxPlayers()) {
+        boolean alreadyParticipant = lobbyRepository.isParticipant(
+                inviteCode,
+                principal.userIdentifier()
+        );
+
+        if (!alreadyParticipant && lobbyInfo.currentPlayers() >= lobbyInfo.maxPlayers()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_FULL);
         }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -7,8 +7,10 @@ import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
@@ -36,6 +38,12 @@ public class LobbyService {
             "사용자를 찾을 수 없습니다.";
     private static final String ERROR_CREATE_LOBBY_FAILED =
             "로비 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    private static final String ERROR_LOBBY_NOT_FOUND =
+            "존재하지 않는 로비입니다.";
+    private static final String ERROR_LOBBY_NOT_WAITING =
+            "게임이 이미 시작된 로비에는 입장할 수 없습니다.";
+    private static final String ERROR_LOBBY_FULL =
+            "최대 인원에 도달한 로비입니다.";
 
     // =========================================================
     // 로그 메시지 상수
@@ -49,6 +57,22 @@ public class LobbyService {
             "Redis 보상 삭제 완료 - 코드: {}";
     private static final String LOG_COMPENSATION_FAILED =
             "Redis 보상 삭제 실패 - 코드: {}. 수동 정리 필요. [모니터링 필요]";
+    private static final String LOG_JOIN_LOBBY_REQUEST =
+            "로비 입장 요청 - 초대 코드: {}, 식별자: {}";
+    private static final String LOG_JOIN_LOBBY_SUCCESS =
+            "로비 입장 사전 검증 통과 - 초대 코드: {}, 식별자: {}, 현재 인원: {}/{}";
+
+    // =========================================================
+    // 비즈니스 규칙 상수
+    // =========================================================
+
+    /**
+     * 입장 가능한 로비 상태
+     * PLAYING, FINISHED 상태의 로비에는 입장할 수 없다.
+     * LobbyStatus enum을 직접 비교하지 않고 Redis에서 읽은 문자열과 비교하므로
+     * name()으로 변환하여 상수로 관리한다.
+     */
+    private static final String LOBBY_STATUS_WAITING = LobbyStatus.WAITING.name();
 
     private final LobbyRepository lobbyRepository;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
@@ -125,6 +149,55 @@ public class LobbyService {
             throw new ResponseStatusException(
                     HttpStatus.INTERNAL_SERVER_ERROR, ERROR_CREATE_LOBBY_FAILED);
         }
+    }
+
+    /**
+     * 초대 코드 기반 로비 입장 사전 검증을 수행하고 로비 정보를 반환한다.
+     *
+     * [책임 범위]
+     * 이 메서드는 입장 허가 검증만 담당한다.
+     * 실제 Redis 참여자 등록은 클라이언트가 WebSocket을 연결하고,
+     * /topic/lobby/{code}를 구독하는 시점에 enter_lobby.lua로 처리된다.
+     *
+     * [검증 순서]
+     * Redis 조회 횟수를 최소화하기 위해 HGETALL (1회)로 로비 존재 여부와
+     * 상태를 동시에 확인하고, 이후 SCARD (1회)로 인원을 확인한다.
+     * 1. 로비 존재 여부 확인 -> 없으면 404
+     * 2. 로비 상태 확인 -> WAITING이 아니면 409
+     * 3. 인원 초과 확인 -> 초과면 409
+     *
+     * @param inviteCode 로비 초대 코드
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 로비 응답 DTO
+     */
+    public JoinLobbyResponse joinLobby(String inviteCode, CustomPrincipal principal) {
+        log.info(LOG_JOIN_LOBBY_REQUEST, inviteCode, principal.userIdentifier());
+
+        // 1. 로비 존재 여부 확인
+        // findByInviteCode()는 HGETALL로 로비 Hash 전체를 읽는다.
+        // 로비가 없으면 404를 반환하고 이후 검증을 진행하지 않는다.
+        JoinLobbyResponse lobbyInfo = lobbyRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, ERROR_LOBBY_NOT_FOUND));
+
+        // 2. 로비 상태 확인
+        // PLAYING, FINISHED 상태의 로비에는 입장할 수 없다.
+        if (!LOBBY_STATUS_WAITING.equals(lobbyInfo.status())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
+        }
+
+        // 3. 인원 초과 확인
+        if (lobbyInfo.currentPlayers() >= lobbyInfo.maxPlayers()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_FULL);
+        }
+
+        log.info(LOG_JOIN_LOBBY_SUCCESS,
+                inviteCode,
+                principal.userIdentifier(),
+                lobbyInfo.currentPlayers(),
+                lobbyInfo.maxPlayers());
+
+        return lobbyInfo;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -124,6 +124,9 @@ public final class RedisKeys {
     /** 로비 Hash의 선택된 맵 ID 필드 (null 가능 — 맵 미선택 상태) */
     public static final String FIELD_MAP_ID = "map_id";
 
+    /** 로비 Hash의 선택된 맵 카테고리 필드 */
+    public static final String FIELD_MAP_CATEGORY = "map_category";
+
     /** 로비 Hash의 최대 참여 인원 필드 */
     public static final String FIELD_MAX_PLAYERS = "max_players";
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -58,6 +58,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private static final String ENTER_RESULT_STALE_SESSION_PREFIX = "STALE_SESSION:";
     private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
     private static final String ENTER_RESULT_INVALID_SEQUENCE = "INVALID_SEQUENCE";
+    private static final String ENTER_RESULT_FULL = "FULL"; // 로비 최대 인원 초과 반환값
 
     // =========================================================
     // 실패 사유 상수
@@ -311,6 +312,12 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         return result;
                     }
 
+                    // 최대 인원 초과 : ws:connection 정리 후 즉시 거부
+                    case FULL -> {
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalStateException("로비 입장 실패: 최대 인원에 도달했습니다.");
+                    }
+
                     case STALE_SESSION -> {
                         cleanupWsConnection(wsSessionId);
                         throw new IllegalStateException("로비 입장 실패: 더 최신 WebSocket 세션이 이미 존재합니다.");
@@ -441,6 +448,11 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             return LobbyEnterResultType.INVALID_SEQUENCE;
         }
 
+        // 최대 인원 초과 반환값
+        if (ENTER_RESULT_FULL.equals(result)) {
+            return LobbyEnterResultType.FULL;
+        }
+
         return LobbyEnterResultType.UNKNOWN;
     }
 
@@ -514,6 +526,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         STALE_SESSION,
         LOBBY_NOT_FOUND,
         INVALID_SEQUENCE,
+        FULL, //최대 인원 초과
         UNKNOWN
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -60,6 +60,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private static final String ENTER_RESULT_INVALID_SEQUENCE = "INVALID_SEQUENCE";
     private static final String ENTER_RESULT_FULL = "FULL";
     private static final String ENTER_RESULT_LOBBY_NOT_WAITING = "LOBBY_NOT_WAITING";
+    private static final String ENTER_RESULT_INVALID_LOBBY_CAPACITY = "INVALID_LOBBY_CAPACITY";
 
     // =========================================================
     // 실패 사유 상수
@@ -323,6 +324,11 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         throw new IllegalStateException("로비 입장 실패: 게임이 이미 시작된 로비입니다.");
                     }
 
+                    case INVALID_LOBBY_CAPACITY -> {
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalStateException("로비 입장 실패: 로비 정원 정보가 유효하지 않습니다.");
+                    }
+
                     case STALE_SESSION -> {
                         cleanupWsConnection(wsSessionId);
                         throw new IllegalStateException("로비 입장 실패: 더 최신 WebSocket 세션이 이미 존재합니다.");
@@ -461,6 +467,10 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             return LobbyEnterResultType.LOBBY_NOT_WAITING;
         }
 
+        if (ENTER_RESULT_INVALID_LOBBY_CAPACITY.equals(result)) {
+            return LobbyEnterResultType.INVALID_LOBBY_CAPACITY;
+        }
+
         return LobbyEnterResultType.UNKNOWN;
     }
 
@@ -536,6 +546,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         INVALID_SEQUENCE,
         FULL,
         LOBBY_NOT_WAITING,
+        INVALID_LOBBY_CAPACITY,
         UNKNOWN
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -58,7 +58,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private static final String ENTER_RESULT_STALE_SESSION_PREFIX = "STALE_SESSION:";
     private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
     private static final String ENTER_RESULT_INVALID_SEQUENCE = "INVALID_SEQUENCE";
-    private static final String ENTER_RESULT_FULL = "FULL"; // 로비 최대 인원 초과 반환값
+    private static final String ENTER_RESULT_FULL = "FULL";
+    private static final String ENTER_RESULT_LOBBY_NOT_WAITING = "LOBBY_NOT_WAITING";
 
     // =========================================================
     // 실패 사유 상수
@@ -312,10 +313,14 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         return result;
                     }
 
-                    // 최대 인원 초과 : ws:connection 정리 후 즉시 거부
                     case FULL -> {
                         cleanupWsConnection(wsSessionId);
                         throw new IllegalStateException("로비 입장 실패: 최대 인원에 도달했습니다.");
+                    }
+
+                    case LOBBY_NOT_WAITING -> {
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalStateException("로비 입장 실패: 게임이 이미 시작된 로비입니다.");
                     }
 
                     case STALE_SESSION -> {
@@ -448,9 +453,12 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             return LobbyEnterResultType.INVALID_SEQUENCE;
         }
 
-        // 최대 인원 초과 반환값
         if (ENTER_RESULT_FULL.equals(result)) {
             return LobbyEnterResultType.FULL;
+        }
+
+        if (ENTER_RESULT_LOBBY_NOT_WAITING.equals(result)) {
+            return LobbyEnterResultType.LOBBY_NOT_WAITING;
         }
 
         return LobbyEnterResultType.UNKNOWN;
@@ -526,7 +534,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         STALE_SESSION,
         LOBBY_NOT_FOUND,
         INVALID_SEQUENCE,
-        FULL, //최대 인원 초과
+        FULL,
+        LOBBY_NOT_WAITING,
         UNKNOWN
     }
 }

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -6,22 +6,24 @@
 -- [책임]
 -- 1. 로비 존재 여부 검증
 -- 2. 동일 userIdentifier의 세션 sequence 비교
--- 3. participants Set에 userIdentifier 저장
--- 4. order List에 userIdentifier 저장
--- 5. wsSessionId 기준 lobbyCode, userIdentifier 매핑 저장
--- 6. userIdentifier 기준 현재 유효 wsSessionId 저장
--- 7. userIdentifier 기준 현재 유효 sessionSequence 저장
+-- 3. 최대 인원 초과 여부 검증 (Race Condition 방어용 최종 검증)
+-- 4. participants Set에 userIdentifier 저장
+-- 5. order List에 userIdentifier 저장
+-- 6. wsSessionId 기준 lobbyCode, userIdentifier 매핑 저장
+-- 7. userIdentifier 기준 현재 유효 wsSessionId 저장
+-- 8. userIdentifier 기준 현재 유효 sessionSequence 저장
+--
+-- [인원 검증 설계 의도]
+-- REST API (/api/lobbies/join)의 인원 체크는 UX용 사전 검증이고,
+-- 이 스크립트의 인원 체크는 Race Condition 방어용 원자적 최종 검증이다.
+-- 두 레이어가 역할이 다르므로 둘 다 존재해야 한다.
+--
+-- [이미 참여 중인 유저 처리]
+-- 재접속 (ALREADY_JOINED, SESSION_REPLACED)인 경우에는 인원 초과 검증을 건너뛴다.
+-- 이미 participants Set에 존재하므로 SCARD가 증가하지 않기 때문
 --
 -- [동일 userIdentifier 다중 세션 정책]
--- 같은 userIdentifier가 같은 로비에 다시 입장하면 sessionSequence가 더 큰 세션을
--- 현재 유효 세션으로 본다.
---
--- Redis Lua는 원자적으로 실행되지만, 네트워크 지연으로 오래된 SUBSCRIBE 요청이
--- 더 늦게 도착할 수 있다. 이를 막기 위해 sessionSequence를 비교하여
--- 더 오래된 세션은 user_session을 덮어쓰지 않고 STALE_SESSION으로 거부한다.
---
--- 단, 같은 wsSessionId가 다시 들어온 경우에는 동일 세션의 재구독/중복 구독으로 보고
--- STALE_SESSION으로 거부하지 않고 TTL만 갱신한다.
+-- 같은 userIdentifier가 같은 로비에 다시 입장하면 sessionSequence가 더 큰 세션을 현재 유효 세션으로 본다.
 -- ============================================================================
 
 local lobbyKey                  = KEYS[1] -- lobby:{code}
@@ -45,9 +47,6 @@ if redis.call('EXISTS', lobbyKey) == 0 then
 end
 
 -- 2. sessionSequence가 숫자가 아니면 잘못된 서버 상태로 본다.
--- sessionSequence는 CONNECT 단계에서 Redis INCR로 발급되고 Java에서 검증 후 전달된다.
--- 따라서 nil 또는 숫자 변환 실패는 재시도 가능한 사용자 입력 오류가 아니라
--- Java-Lua 계약 위반에 가까우므로 입장을 허용하지 않는다.
 if sessionSequence == nil then
     return "INVALID_SEQUENCE"
 end
@@ -57,56 +56,60 @@ local previousWsSessionId = redis.call('GET', lobbyUserSessionKey)
 local previousSequence = redis.call('GET', lobbyUserSessionSeqKey)
 
 -- 4. 이미 더 최신 세션이 존재하면 현재 요청은 stale로 간주한다.
--- 다만 동일 wsSessionId가 다시 들어온 경우에는 같은 세션의 재구독/중복 구독으로 보고
--- stale 거부 대신 TTL을 갱신한다.
 if previousSequence ~= false and tonumber(previousSequence) > sessionSequence then
     if previousWsSessionId ~= false and previousWsSessionId == wsSessionId then
         redis.call('HSET', wsConnectionKey,
             userField,  userIdentifier,
             lobbyField, lobbyCode
         )
-        redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
-        redis.call('PEXPIRE', lobbyUserSessionKey, connectionTtlMs)
+        redis.call('PEXPIRE', wsConnectionKey,       connectionTtlMs)
+        redis.call('PEXPIRE', lobbyUserSessionKey,    connectionTtlMs)
         redis.call('PEXPIRE', lobbyUserSessionSeqKey, connectionTtlMs)
-
         return "ALREADY_JOINED"
     end
 
-    local currentWsSessionId = previousWsSessionId
-
-    if currentWsSessionId == false then
-        currentWsSessionId = ""
-    end
-
+    local currentWsSessionId = previousWsSessionId ~= false and previousWsSessionId or ""
     return "STALE_SESSION:" .. currentWsSessionId
 end
 
--- 5. 참여자 Set에 추가한다.
--- SADD 반환값:
--- - 1: 신규 참여자
--- - 0: 이미 참여 중인 사용자
+
+-- 5. 이미 참여 중인 유저인지 먼저 확인한다.
+--    재접속(SESSION_REPLACED, ALREADY_JOINED)인 경우에는 인원 초과 검증을 건너뛴다.
+--    participants Set에 이미 존재하므로 SADD 결과가 0이 되어 SCARD가 증가하지 않기 때문이다.
+local alreadyInLobby = redis.call('SISMEMBER', participantsKey, userIdentifier)
+
+-- 6. 신규 입장자에 한해서만 최대 인원 초과를 검증한다.
+--    [Race Condition 방어]
+--    REST API의 인원 검증과 달리, SADD 직전에 검증하므로 원자적으로 처리된다.
+if alreadyInLobby == 0 then
+    local currentCount = redis.call('SCARD', participantsKey)
+    local maxPlayers   = tonumber(redis.call('HGET', lobbyKey, 'max_players'))
+
+    if maxPlayers ~= nil and currentCount >= maxPlayers then
+        return "FULL"
+    end
+end
+
+-- 7. 참여자 Set에 추가한다.
 local added = redis.call('SADD', participantsKey, userIdentifier)
 
--- 6. 신규 참여자일 때만 order List에 추가한다.
--- 이미 참여 중인 사용자의 재연결/중복 구독은 order를 중복 저장하지 않는다.
+-- 8. 신규 참여자일 때만 order List에 추가한다.
 if added == 1 then
     redis.call('RPUSH', orderKey, userIdentifier)
 end
 
--- 7. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
+-- 9. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
 redis.call('HSET', wsConnectionKey,
     userField,  userIdentifier,
     lobbyField, lobbyCode
 )
 redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
 
--- 8. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
-redis.call('SET', lobbyUserSessionKey, wsSessionId, 'PX', connectionTtlMs)
+-- 10. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
+redis.call('SET', lobbyUserSessionKey,    wsSessionId,                 'PX', connectionTtlMs)
+redis.call('SET', lobbyUserSessionSeqKey, tostring(sessionSequence),  'PX', connectionTtlMs)
 
--- 9. userIdentifier 기준 현재 유효 세션 sequence도 함께 저장한다.
-redis.call('SET', lobbyUserSessionSeqKey, tostring(sessionSequence), 'PX', connectionTtlMs)
-
--- 10. 반환값 결정
+-- 11. 반환값 결정
 if added == 1 then
     return "ENTERED"
 end

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -46,16 +46,25 @@ if redis.call('EXISTS', lobbyKey) == 0 then
     return "LOBBY_NOT_FOUND"
 end
 
--- 2. sessionSequence가 숫자가 아니면 잘못된 서버 상태로 본다.
+-- 2. WAITING 상태의 로비만 입장을 허용한다.
+-- REST join API는 UX용 사전 검증이고, 실제 입장 확정은 이 Lua에서 수행되므로
+-- PLAYING / FINISHED 상태 로비는 여기서 최종 차단해야 한다.
+local lobbyStatus = redis.call('HGET', lobbyKey, 'status')
+
+if lobbyStatus ~= 'WAITING' then
+    return "LOBBY_NOT_WAITING"
+end
+
+-- 3. sessionSequence가 숫자가 아니면 잘못된 서버 상태로 본다.
 if sessionSequence == nil then
     return "INVALID_SEQUENCE"
 end
 
--- 3. 기존 현재 유효 세션과 sequence를 조회한다.
+-- 4. 기존 현재 유효 세션과 sequence를 조회한다.
 local previousWsSessionId = redis.call('GET', lobbyUserSessionKey)
 local previousSequence = redis.call('GET', lobbyUserSessionSeqKey)
 
--- 4. 이미 더 최신 세션이 존재하면 현재 요청은 stale로 간주한다.
+-- 5. 이미 더 최신 세션이 존재하면 현재 요청은 stale로 간주한다.
 if previousSequence ~= false and tonumber(previousSequence) > sessionSequence then
     if previousWsSessionId ~= false and previousWsSessionId == wsSessionId then
         redis.call('HSET', wsConnectionKey,
@@ -73,12 +82,12 @@ if previousSequence ~= false and tonumber(previousSequence) > sessionSequence th
 end
 
 
--- 5. 이미 참여 중인 유저인지 먼저 확인한다.
+-- 6. 이미 참여 중인 유저인지 먼저 확인한다.
 --    재접속(SESSION_REPLACED, ALREADY_JOINED)인 경우에는 인원 초과 검증을 건너뛴다.
 --    participants Set에 이미 존재하므로 SADD 결과가 0이 되어 SCARD가 증가하지 않기 때문이다.
 local alreadyInLobby = redis.call('SISMEMBER', participantsKey, userIdentifier)
 
--- 6. 신규 입장자에 한해서만 최대 인원 초과를 검증한다.
+-- 7. 신규 입장자에 한해서만 최대 인원 초과를 검증한다.
 --    [Race Condition 방어]
 --    REST API의 인원 검증과 달리, SADD 직전에 검증하므로 원자적으로 처리된다.
 if alreadyInLobby == 0 then
@@ -90,26 +99,26 @@ if alreadyInLobby == 0 then
     end
 end
 
--- 7. 참여자 Set에 추가한다.
+-- 8. 참여자 Set에 추가한다.
 local added = redis.call('SADD', participantsKey, userIdentifier)
 
--- 8. 신규 참여자일 때만 order List에 추가한다.
+-- 9. 신규 참여자일 때만 order List에 추가한다.
 if added == 1 then
     redis.call('RPUSH', orderKey, userIdentifier)
 end
 
--- 9. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
+-- 10. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
 redis.call('HSET', wsConnectionKey,
     userField,  userIdentifier,
     lobbyField, lobbyCode
 )
 redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
 
--- 10. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
+-- 11. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
 redis.call('SET', lobbyUserSessionKey,    wsSessionId,                 'PX', connectionTtlMs)
 redis.call('SET', lobbyUserSessionSeqKey, tostring(sessionSequence),  'PX', connectionTtlMs)
 
--- 11. 반환값 결정
+-- 12. 반환값 결정
 if added == 1 then
     return "ENTERED"
 end

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -94,7 +94,11 @@ if alreadyInLobby == 0 then
     local currentCount = redis.call('SCARD', participantsKey)
     local maxPlayers   = tonumber(redis.call('HGET', lobbyKey, 'max_players'))
 
-    if maxPlayers ~= nil and currentCount >= maxPlayers then
+    if maxPlayers == nil or maxPlayers <= 0 then
+        return "INVALID_LOBBY_CAPACITY"
+    end
+
+    if currentCount >= maxPlayers then
         return "FULL"
     end
 end


### PR DESCRIPTION
## 📣 Related Issue

- #49

## 📝 Summary

- `POST /api/lobbies/join` API를 추가하여 초대 코드 기반 로비 입장 사전 검증을 구현했습니다.
- 초대 코드 형식 검증을 위한 `JoinLobbyRequest`와 로비 기본 정보 반환을 위한 `JoinLobbyResponse`를 추가했습니다.
- Redis의 `lobby:{code}` Hash와 `participants` Set을 기준으로 로비 존재 여부, 상태, 현재 인원을 검증하도록 구현했습니다.
- 실제 참여자 등록은 기존 구조대로 WebSocket `/topic/lobby/{code}` 구독 시점에 처리되도록 역할을 분리했습니다.
- `enter_lobby.lua`에 최대 인원 초과 및 로비 상태 검증을 추가하여 REST 우회 입장도 차단하도록 보완했습니다.
- `StompChannelInterceptor`에서 `FULL`, `LOBBY_NOT_WAITING` 반환값을 처리하도록 확장했습니다.
- API 문서에 초대 코드 입장 API 명세를 반영했습니다.

## 🙏PR point

- `POST /api/lobbies/join`은 실제 입장 처리가 아니라 입장 가능 여부를 확인하는 사전 검증 API입니다.
- 최종 참여자 등록은 WebSocket 구독 시점의 `enter_lobby.lua`에서 원자적으로 수행됩니다.
- 정원 초과와 `PLAYING` 상태 로비 입장은 REST와 WebSocket Lua 양쪽에서 모두 차단되도록 구현했습니다.
- 이미 참여 중인 유저의 재접속/새로고침은 정원 초과 상태에서도 허용되도록 처리했습니다.

## 📬 Reference

- Swagger로 `POST /api/auth/guest`, `POST /api/lobbies`, `POST /api/lobbies/join` 테스트
- `ws-test.html`로 `/topic/lobby/{inviteCode}` 구독 및 ENTER 메시지 수신 확인
- Redis CLI로 `participants`, `order`, `user_session`, `ws:connection` 저장/삭제 흐름 확인