### PR TITLE
[Feat/#50] 방장의 로비 유저 강퇴 및 재입장 차단 구현

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/KickLobbyResult.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/KickLobbyResult.java
@@ -1,0 +1,59 @@
+package io.github.ascrew.monomatbe.domain.lobby;
+
+/**
+ * 로비 강퇴 Lua 스크립트 실행 결과
+ *
+ * [설계 의도]
+ * kick_lobby.lua의 문자열 반환값을 서비스 레이어까지 직접 노출하지 않고,
+ * 도메인 의미를 가진 타입으로 반환하여 처리한다.
+ */
+public sealed interface KickLobbyResult permits
+        KickLobbyResult.Kicked,
+        KickLobbyResult.LobbyNotFound,
+        KickLobbyResult.HostNotFound,
+        KickLobbyResult.Forbidden,
+        KickLobbyResult.CannotKickSelf,
+        KickLobbyResult.TargetNotParticipant,
+        KickLobbyResult.Error {
+
+    /**
+     * 강퇴 성공.
+     *
+     * @param lobbyCode             로비 초대 코드
+     * @param targetUserIdentifier  강퇴 대상 사용자 식별자
+     * @param targetWsSessionId     강퇴 대상의 현재 유효 WebSocket 세션 ID. 없을 수 있음.
+     */
+    record Kicked(
+            String lobbyCode,
+            String targetUserIdentifier,
+            String targetWsSessionId
+    ) implements KickLobbyResult {
+    }
+
+    /** 로비가 Redis에 존재하지 않음. */
+    record LobbyNotFound(String lobbyCode) implements KickLobbyResult {
+    }
+
+    /** 로비의 방장 정보가 유효하지 않음. */
+    record HostNotFound(String lobbyCode) implements KickLobbyResult {
+    }
+
+    /** 요청자가 방장이 아님. */
+    record Forbidden(String lobbyCode, String requesterIdentifier) implements KickLobbyResult {
+    }
+
+    /** 방장이 자기 자신을 강퇴하려고 함. */
+    record CannotKickSelf(String lobbyCode, String requesterIdentifier) implements KickLobbyResult {
+    }
+
+    /** 강퇴 대상이 현재 로비 참여자가 아님. */
+    record TargetNotParticipant(
+            String lobbyCode,
+            String targetUserIdentifier
+    ) implements KickLobbyResult {
+    }
+
+    /** Lua 실행 실패 또는 알 수 없는 반환값. */
+    record Error(String reason) implements KickLobbyResult {
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyEventController.java
@@ -3,14 +3,18 @@
  *
  * [책임]
  * - 로비 생성 및 로비 내부 정보 변경 이벤트를 수신하여 LobbyEventService에 위임
+ * - 방장의 유저 강퇴 이벤트를 수신하여 LobbyEventService에 위임
  * - 컨트롤러는 수신 경로 정의와 서비스 위임만 담당
  */
 package io.github.ascrew.monomatbe.domain.lobby.controller;
 
+import io.github.ascrew.monomatbe.domain.lobby.dto.KickLobbyPlayerRequest;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyEventService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
@@ -49,5 +53,31 @@ public class LobbyEventController {
           Principal principal
   ) {
     lobbyEventService.notifyLobbyInfoRefresh(code, principal);
+  }
+
+  /**
+   * 방장의 로비 유저 강퇴 이벤트 수신.
+   *
+   * 클라이언트 송신 경로: /app/lobby/{code}/kick
+   *
+   * 요청 payload 예시:
+   * {
+   *   "targetUserIdentifier": "강퇴 대상 UUID"
+   * }
+   *
+   * [처리 내용]
+   * - 요청자가 현재 로비 방장인지 검증
+   * - 강퇴 대상이 현재 로비 참여자인지 검증
+   * - Redis participants/order에서 강퇴 대상 제거
+   * - 강퇴 알림 메시지 브로드캐스트
+   * - 로비 정보 refresh 신호 브로드캐스트
+   */
+  @MessageMapping("/lobby/{code}/kick")
+  public void kickLobbyPlayer(
+          @DestinationVariable String code,
+          @Valid @Payload KickLobbyPlayerRequest request,
+          Principal principal
+  ) {
+    lobbyEventService.kickLobbyPlayer(code, request, principal);
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyEventController.java
@@ -10,14 +10,18 @@ package io.github.ascrew.monomatbe.domain.lobby.controller;
 
 import io.github.ascrew.monomatbe.domain.lobby.dto.KickLobbyPlayerRequest;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyEventService;
+import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
 
 import java.security.Principal;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -50,9 +54,10 @@ public class LobbyEventController {
   @MessageMapping("/lobby/{code}/update")
   public void notifyLobbyInfoRefresh(
           @DestinationVariable String code,
-          Principal principal
+          SimpMessageHeaderAccessor accessor
   ) {
-    lobbyEventService.notifyLobbyInfoRefresh(code, principal);
+    String userIdentifier = extractUserIdentifier(accessor);
+    lobbyEventService.notifyLobbyInfoRefresh(code, userIdentifier);
   }
 
   /**
@@ -76,8 +81,37 @@ public class LobbyEventController {
   public void kickLobbyPlayer(
           @DestinationVariable String code,
           @Valid @Payload KickLobbyPlayerRequest request,
-          Principal principal
+          SimpMessageHeaderAccessor accessor
   ) {
-    lobbyEventService.kickLobbyPlayer(code, request, principal);
+    String requesterIdentifier = extractUserIdentifier(accessor);
+    lobbyEventService.kickLobbyPlayer(code, request, requesterIdentifier);
+  }
+
+  /**
+   * STOMP 세션 속성에서 인증된 userIdentifier를 추출합니다.
+   *
+   * [설계 의도]
+   * StompChannelInterceptor가 CONNECT 시점에 검증한 userIdentifier를
+   * sessionAttributes에 저장하므로, MessageMapping에서는 Principal 대신
+   * 해당 세션 속성을 신뢰 기준으로 사용합니다.
+   */
+  private String extractUserIdentifier(SimpMessageHeaderAccessor accessor) {
+    if (accessor == null) {
+      return null;
+    }
+
+    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+
+    if (sessionAttributes == null) {
+      return null;
+    }
+
+    Object value = sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER);
+
+    if (value instanceof String userIdentifier && StringUtils.hasText(userIdentifier)) {
+      return userIdentifier;
+    }
+
+    return null;
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/KickLobbyPlayerRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/KickLobbyPlayerRequest.java
@@ -1,0 +1,21 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 로비 유저 강퇴 요청 DTO
+ *
+ * [전송 경로]
+ * 클라이언트 -> 서버 : /app/lobby/{code}/kick
+ *
+ * [targetUserIdentifier]
+ * 강퇴 대상 사용자의 Redis 기준 사용자 식별자이다.
+ * 현재 로비 참여자 Set에는 DB userId가 아니라 userIdentifier (UUID)가 저장되므로,
+ * 강퇴 대상도 동일 식별자를 사용한다.
+ */
+public record KickLobbyPlayerRequest(
+
+        @NotBlank(message = "강퇴 대상 식별자는 비어 있을 수 없습니다.")
+        String targetUserIdentifier
+){
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/KickLobbyPlayerRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/KickLobbyPlayerRequest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * 로비 유저 강퇴 요청 DTO
@@ -16,6 +17,10 @@ import jakarta.validation.constraints.NotBlank;
 public record KickLobbyPlayerRequest(
 
         @NotBlank(message = "강퇴 대상 식별자는 비어 있을 수 없습니다.")
+        @Pattern(
+                regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                message = "강퇴 대상 식별자 형식이 올바르지 않습니다."
+        )
         String targetUserIdentifier
-){
+) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -8,6 +8,7 @@ import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,20 @@ public interface LobbyRepository {
    * @return LeaveLobbyResult (Destroyed | Delegated | Left | Error)
    */
   LeaveLobbyResult executeLeaveLobbyProcess(String code, String userId);
+
+  /**
+   * Lua 스크립트를 실행하여 방장의 로비 유저 강퇴를 원자적으로 수행한다.
+   *
+   * @param code 로비 초대 코드
+   * @param requesterIdentifier 강퇴 요청자 식별자
+   * @param targetUserIdentifier 강퇴 대상 식별자
+   * @return KickLobbyResult
+   */
+  KickLobbyResult executeKickLobbyProcess(
+          String code,
+          String requesterIdentifier,
+          String targetUserIdentifier
+  );
 
   /** Redis에서 공개 로비 목록을 필터링하여 반환한다. */
   List<LobbyRedisDto> getPublicLobbies();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -190,6 +190,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             RedisKeys.lobbyKey(code),
             RedisKeys.lobbyParticipantsKey(code),
             RedisKeys.lobbyOrderKey(code),
+            RedisKeys.lobbyKickedKey(code),
             RedisKeys.LOBBY_PUBLIC
     );
 
@@ -211,6 +212,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             RedisKeys.lobbyKey(code),
             RedisKeys.lobbyParticipantsKey(code),
             RedisKeys.lobbyOrderKey(code),
+            RedisKeys.lobbyKickedKey(code),
             RedisKeys.lobbyUserSessionKey(code, targetUserIdentifier),
             RedisKeys.lobbyUserSessionSequenceKey(code, targetUserIdentifier)
     );

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -7,6 +7,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -30,6 +31,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private final StringRedisTemplate redisTemplate;
   private final RedisScript<String> leaveLobbyScript;
   private final RedisScript<String> createLobbyScript;
+  private final RedisScript<String> kickLobbyScript;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -45,6 +47,17 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String RESULT_DESTROYED = "DESTROYED";
   private static final String RESULT_LEFT = "LEFT";
   private static final String RESULT_DELEGATED_PREFIX = "DELEGATED:";
+
+  // =========================================================
+// kick_lobby.lua 반환값 상수
+// =========================================================
+
+  private static final String RESULT_KICKED_PREFIX = "KICKED:";
+  private static final String RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
+  private static final String RESULT_HOST_NOT_FOUND = "HOST_NOT_FOUND";
+  private static final String RESULT_FORBIDDEN = "FORBIDDEN";
+  private static final String RESULT_CANNOT_KICK_SELF = "CANNOT_KICK_SELF";
+  private static final String RESULT_TARGET_NOT_PARTICIPANT = "TARGET_NOT_PARTICIPANT";
 
   // =========================================================
   // isPrivate 정규화 상수
@@ -185,6 +198,47 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       return parseLuaResult(result, code, userId);
     } catch (Exception e) {
       return new LeaveLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
+    }
+  }
+
+  @Override
+  public KickLobbyResult executeKickLobbyProcess(
+          String code,
+          String requesterIdentifier,
+          String targetUserIdentifier
+  ) {
+    List<String> keys = List.of(
+            RedisKeys.lobbyKey(code),
+            RedisKeys.lobbyParticipantsKey(code),
+            RedisKeys.lobbyOrderKey(code),
+            RedisKeys.lobbyUserSessionKey(code, targetUserIdentifier),
+            RedisKeys.lobbyUserSessionSequenceKey(code, targetUserIdentifier)
+    );
+
+    try {
+      String result = redisTemplate.execute(
+              kickLobbyScript,
+              keys,
+              requesterIdentifier,
+              targetUserIdentifier
+      );
+
+      return parseKickLuaResult(
+              result,
+              code,
+              requesterIdentifier,
+              targetUserIdentifier
+      );
+    } catch (Exception e) {
+      log.error(
+              "강퇴 Lua 스크립트 실행 중 예외 발생 - lobbyCode: {}, requester: {}, target: {}",
+              code,
+              requesterIdentifier,
+              targetUserIdentifier,
+              e
+      );
+
+      return new KickLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
     }
   }
 
@@ -370,6 +424,49 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       return new LeaveLobbyResult.Delegated(code, newHostId);
     }
     return new LeaveLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+  }
+
+  private KickLobbyResult parseKickLuaResult(
+          String result,
+          String code,
+          String requesterIdentifier,
+          String targetUserIdentifier
+  ) {
+    if (result == null) {
+      return new KickLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
+    }
+
+    if (result.startsWith(RESULT_KICKED_PREFIX)) {
+      String targetWsSessionId = result.substring(RESULT_KICKED_PREFIX.length());
+
+      return new KickLobbyResult.Kicked(
+              code,
+              targetUserIdentifier,
+              targetWsSessionId
+      );
+    }
+
+    if (RESULT_LOBBY_NOT_FOUND.equals(result)) {
+      return new KickLobbyResult.LobbyNotFound(code);
+    }
+
+    if (RESULT_HOST_NOT_FOUND.equals(result)) {
+      return new KickLobbyResult.HostNotFound(code);
+    }
+
+    if (RESULT_FORBIDDEN.equals(result)) {
+      return new KickLobbyResult.Forbidden(code, requesterIdentifier);
+    }
+
+    if (RESULT_CANNOT_KICK_SELF.equals(result)) {
+      return new KickLobbyResult.CannotKickSelf(code, requesterIdentifier);
+    }
+
+    if (RESULT_TARGET_NOT_PARTICIPANT.equals(result)) {
+      return new KickLobbyResult.TargetNotParticipant(code, targetUserIdentifier);
+    }
+
+    return new KickLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
   }
 
   private Long parseNullableLong(Object value) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
@@ -8,18 +8,26 @@
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
+import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.dto.KickLobbyPlayerRequest;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 
 @Slf4j
@@ -30,8 +38,24 @@ public class LobbyEventService {
   // 로비 코드 검증 패턴: 영문 대문자 및 숫자 조합 6~12자리
   private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
 
+  // =========================================================
+  // 강퇴 메시지 상수
+  // =========================================================
+
+  private static final String KICK_MESSAGE_FORMAT = "%s님이 강퇴되었습니다.";
+  private static final String ERROR_INVALID_LOBBY_CODE = "유효하지 않은 로비 코드입니다.";
+  private static final String ERROR_INVALID_PRINCIPAL = "인증 정보가 유효하지 않습니다.";
+  private static final String ERROR_INVALID_KICK_TARGET = "강퇴 대상 식별자가 유효하지 않습니다.";
+  private static final String ERROR_LOBBY_NOT_FOUND = "존재하지 않는 로비입니다.";
+  private static final String ERROR_HOST_NOT_FOUND = "로비 방장 정보가 유효하지 않습니다.";
+  private static final String ERROR_FORBIDDEN = "방장만 유저를 강퇴할 수 있습니다.";
+  private static final String ERROR_CANNOT_KICK_SELF = "자기 자신은 강퇴할 수 없습니다.";
+  private static final String ERROR_TARGET_NOT_PARTICIPANT = "강퇴 대상이 로비 참여자가 아닙니다.";
+  private static final String ERROR_KICK_FAILED = "강퇴 처리에 실패했습니다.";
+
   private final SimpMessagingTemplate messagingTemplate;
   private final LobbyRepository lobbyRepository;
+  private final StringRedisTemplate stringRedisTemplate;
 
   /**
    * 전역 로비 리스트를 보고 있는 클라이언트들에게 새로고침 신호를 전송합니다.
@@ -40,7 +64,8 @@ public class LobbyEventService {
   public void notifyLobbyListRefresh() {
     messagingTemplate.convertAndSend(
             StompDestinations.SUBSCRIBE_LOBBY_LIST_REFRESH,
-            StompDestinations.MSG_REFRESH_LOBBY_LIST);
+            StompDestinations.MSG_REFRESH_LOBBY_LIST
+    );
   }
 
   /**
@@ -76,7 +101,79 @@ public class LobbyEventService {
 
     messagingTemplate.convertAndSend(
             StompDestinations.subscribeLobbyRefresh(code),
-            StompDestinations.MSG_REFRESH_LOBBY_INFO);
+            StompDestinations.MSG_REFRESH_LOBBY_INFO
+    );
+  }
+
+  /**
+   * 방장의 로비 유저 강퇴 요청을 처리한다.
+   *
+   * [처리 흐름]
+   * 1. 로비 코드 형식 검증
+   * 2. 요청자 인증 정보 검증
+   * 3. 강퇴 대상 식별자 검증
+   * 4. kick_lobby.lua로 방장 권한 검증 및 Redis 참여자 상태 원자 변경
+   * 5. 강퇴 대상의 ws:connection 키 정리
+   * 6. 강퇴 알림 브로드캐스트
+   * 7. 로비 정보 refresh 브로드캐스트
+   *
+   * [주의]
+   * 현재 구조에서는 서버가 특정 WebSocketSession 객체를 직접 close하지 않는다.
+   * 대신 Redis 참여자 상태에서 제거하고 KICK 메시지를 전송하여,
+   * 클라이언트가 구독 해제 및 로비 리스트 이동을 수행하도록 한다.
+   */
+  public void kickLobbyPlayer(
+          String code,
+          KickLobbyPlayerRequest request,
+          Principal principal
+  ) {
+    validateKickRequest(code, request, principal);
+
+    String requesterIdentifier = principal.getName();
+    String targetUserIdentifier = request.targetUserIdentifier().trim();
+
+    KickLobbyResult result = lobbyRepository.executeKickLobbyProcess(
+            code,
+            requesterIdentifier,
+            targetUserIdentifier
+    );
+
+    switch (result) {
+      case KickLobbyResult.Kicked kicked -> handleKickSuccess(kicked);
+
+      case KickLobbyResult.LobbyNotFound ignored -> throw new ResponseStatusException(
+              HttpStatus.NOT_FOUND,
+              ERROR_LOBBY_NOT_FOUND
+      );
+
+      case KickLobbyResult.HostNotFound ignored -> throw new ResponseStatusException(
+              HttpStatus.CONFLICT,
+              ERROR_HOST_NOT_FOUND
+      );
+
+      case KickLobbyResult.Forbidden ignored -> throw new ResponseStatusException(
+              HttpStatus.FORBIDDEN,
+              ERROR_FORBIDDEN
+      );
+
+      case KickLobbyResult.CannotKickSelf ignored -> throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST,
+              ERROR_CANNOT_KICK_SELF
+      );
+
+      case KickLobbyResult.TargetNotParticipant ignored -> throw new ResponseStatusException(
+              HttpStatus.CONFLICT,
+              ERROR_TARGET_NOT_PARTICIPANT
+      );
+
+      case KickLobbyResult.Error error -> {
+        log.error("강퇴 처리 실패 - reason: {}", error.reason());
+        throw new ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ERROR_KICK_FAILED
+        );
+      }
+    }
   }
 
   /**
@@ -96,7 +193,9 @@ public class LobbyEventService {
     String userIdentifier = event.userIdentifier();
 
     // 입력값 방어: 비어있는 코드나 식별자는 처리하지 않음
-    if (!StringUtils.hasText(code) || !StringUtils.hasText(userIdentifier)) return;
+    if (!StringUtils.hasText(code) || !StringUtils.hasText(userIdentifier)) {
+      return;
+    }
 
     // Lua 스크립트로 원자적 퇴장 처리 후 결과를 도메인 객체로 수신
     LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(code, userIdentifier);
@@ -107,29 +206,121 @@ public class LobbyEventService {
     switch (result) {
       case LeaveLobbyResult.Destroyed d -> {
         log.info("[handlePlayerLeave] 로비 폭파 - 로비: {}", d.lobbyCode());
+
         // 로비가 사라졌으므로 전역 로비 리스트를 보고 있는 클라이언트에게 새로고침 신호
         notifyLobbyListRefresh();
       }
+
       case LeaveLobbyResult.Delegated d -> {
-        log.info("[handlePlayerLeave] 방장 위임 - 로비: {}, 새 방장: {}",
-                d.lobbyCode(), d.newHostId());
+        log.info(
+                "[handlePlayerLeave] 방장 위임 - 로비: {}, 새 방장: {}",
+                d.lobbyCode(),
+                d.newHostId()
+        );
+
         // 방장이 바뀌었으므로 로비 내부 클라이언트에게 새로고침 신호
         messagingTemplate.convertAndSend(
                 StompDestinations.subscribeLobbyRefresh(d.lobbyCode()),
-                StompDestinations.MSG_REFRESH_LOBBY_INFO);
+                StompDestinations.MSG_REFRESH_LOBBY_INFO
+        );
       }
+
       case LeaveLobbyResult.Left l -> {
-        log.info("[handlePlayerLeave] 일반 퇴장 - 로비: {}, 식별자: {}",
-                l.lobbyCode(), l.userId());
+        log.info(
+                "[handlePlayerLeave] 일반 퇴장 - 로비: {}, 식별자: {}",
+                l.lobbyCode(),
+                l.userId()
+        );
+
         // 참여자가 줄었으므로 로비 내부 클라이언트에게 새로고침 신호
         messagingTemplate.convertAndSend(
                 StompDestinations.subscribeLobbyRefresh(l.lobbyCode()),
-                StompDestinations.MSG_REFRESH_LOBBY_INFO);
+                StompDestinations.MSG_REFRESH_LOBBY_INFO
+        );
       }
+
       case LeaveLobbyResult.Error e -> {
         // 정상 흐름이 아니므로 브로드캐스트 없이 에러 로그만 남깁니다.
         log.error("[handlePlayerLeave] 퇴장 처리 실패 - 사유: {}", e.reason());
       }
     }
+  }
+
+  private void validateKickRequest(
+          String code,
+          KickLobbyPlayerRequest request,
+          Principal principal
+  ) {
+    if (!StringUtils.hasText(code) || !LOBBY_CODE_PATTERN.matcher(code).matches()) {
+      throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST,
+              ERROR_INVALID_LOBBY_CODE
+      );
+    }
+
+    if (principal == null || !StringUtils.hasText(principal.getName())) {
+      throw new ResponseStatusException(
+              HttpStatus.UNAUTHORIZED,
+              ERROR_INVALID_PRINCIPAL
+      );
+    }
+
+    if (request == null || !StringUtils.hasText(request.targetUserIdentifier())) {
+      throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST,
+              ERROR_INVALID_KICK_TARGET
+      );
+    }
+  }
+
+  private void handleKickSuccess(KickLobbyResult.Kicked result) {
+    String lobbyCode = result.lobbyCode();
+    String targetUserIdentifier = result.targetUserIdentifier();
+
+    deleteTargetWsConnection(result.targetWsSessionId());
+    publishKickMessage(lobbyCode, targetUserIdentifier);
+
+    messagingTemplate.convertAndSend(
+            StompDestinations.subscribeLobbyRefresh(lobbyCode),
+            StompDestinations.MSG_REFRESH_LOBBY_INFO
+    );
+
+    log.info(
+            "로비 유저 강퇴 완료 - lobbyCode: {}, targetUserIdentifier: {}, targetWsSessionId: {}",
+            lobbyCode,
+            targetUserIdentifier,
+            result.targetWsSessionId()
+    );
+  }
+
+  private void deleteTargetWsConnection(String targetWsSessionId) {
+    if (!StringUtils.hasText(targetWsSessionId)) {
+      return;
+    }
+
+    try {
+      stringRedisTemplate.delete(RedisKeys.wsConnectionKey(targetWsSessionId));
+    } catch (Exception e) {
+      log.warn(
+              "강퇴 대상 ws:connection 키 삭제 실패 - targetWsSessionId: {}",
+              targetWsSessionId,
+              e
+      );
+    }
+  }
+
+  private void publishKickMessage(String lobbyCode, String targetUserIdentifier) {
+    ChatMessageDto message = ChatMessageDto.builder()
+            .type(ChatMessageDto.MessageType.KICK)
+            .roomId(lobbyCode)
+            .sender(targetUserIdentifier)
+            .content(String.format(KICK_MESSAGE_FORMAT, targetUserIdentifier))
+            .timestamp(LocalDateTime.now().toString())
+            .build();
+
+    messagingTemplate.convertAndSend(
+            StompDestinations.subscribeLobbyChat(lobbyCode),
+            message
+    );
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
@@ -25,8 +25,9 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import tools.jackson.databind.json.JsonMapper;
 
-import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 
@@ -57,6 +58,9 @@ public class LobbyEventService {
   private final LobbyRepository lobbyRepository;
   private final StringRedisTemplate stringRedisTemplate;
 
+  @Qualifier("pubSubJsonMapper")
+  private final JsonMapper pubSubJsonMapper;
+
   /**
    * 전역 로비 리스트를 보고 있는 클라이언트들에게 새로고침 신호를 전송합니다.
    * 로비 생성 또는 삭제(폭파) 이벤트 발생 시 호출됩니다.
@@ -76,20 +80,15 @@ public class LobbyEventService {
    * 2. 요청자 인증 확인
    * 3. Redis에서 로비 존재 여부 확인
    * 4. 요청자가 해당 로비의 참여자인지 확인
-   *
-   * @param code      로비 초대 코드
-   * @param principal 요청자 인증 정보
    */
-  public void notifyLobbyInfoRefresh(String code, Principal principal) {
+  public void notifyLobbyInfoRefresh(String code, String userIdentifier) {
     if (!StringUtils.hasText(code) || !LOBBY_CODE_PATTERN.matcher(code).matches()) {
       return;
     }
 
-    if (principal == null || !StringUtils.hasText(principal.getName())) {
+    if (!StringUtils.hasText(userIdentifier)) {
       return;
     }
-
-    String userIdentifier = principal.getName();
 
     if (!lobbyRepository.existsByCode(code)) {
       return;
@@ -125,11 +124,10 @@ public class LobbyEventService {
   public void kickLobbyPlayer(
           String code,
           KickLobbyPlayerRequest request,
-          Principal principal
+          String requesterIdentifier
   ) {
-    validateKickRequest(code, request, principal);
+    validateKickRequest(code, request, requesterIdentifier);
 
-    String requesterIdentifier = principal.getName();
     String targetUserIdentifier = request.targetUserIdentifier().trim();
 
     KickLobbyResult result = lobbyRepository.executeKickLobbyProcess(
@@ -249,7 +247,7 @@ public class LobbyEventService {
   private void validateKickRequest(
           String code,
           KickLobbyPlayerRequest request,
-          Principal principal
+          String requesterIdentifier
   ) {
     if (!StringUtils.hasText(code) || !LOBBY_CODE_PATTERN.matcher(code).matches()) {
       throw new ResponseStatusException(
@@ -258,7 +256,7 @@ public class LobbyEventService {
       );
     }
 
-    if (principal == null || !StringUtils.hasText(principal.getName())) {
+    if (!StringUtils.hasText(requesterIdentifier)) {
       throw new ResponseStatusException(
               HttpStatus.UNAUTHORIZED,
               ERROR_INVALID_PRINCIPAL
@@ -318,9 +316,20 @@ public class LobbyEventService {
             .timestamp(LocalDateTime.now().toString())
             .build();
 
-    messagingTemplate.convertAndSend(
-            StompDestinations.subscribeLobbyChat(lobbyCode),
-            message
-    );
+    try {
+      String payload = pubSubJsonMapper.writeValueAsString(message);
+
+      messagingTemplate.convertAndSend(
+              StompDestinations.subscribeLobbyChat(lobbyCode),
+              payload
+      );
+    } catch (Exception e) {
+      log.error(
+              "KICK 메시지 직렬화 또는 전송 실패 - lobbyCode: {}, targetUserIdentifier: {}",
+              lobbyCode,
+              targetUserIdentifier,
+              e
+      );
+    }
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
@@ -61,6 +61,12 @@ public class LobbyEventService {
   @Qualifier("pubSubJsonMapper")
   private final JsonMapper pubSubJsonMapper;
 
+  private static final Pattern USER_IDENTIFIER_PATTERN =
+          Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+  private static final String ERROR_INVALID_KICK_TARGET_FORMAT =
+          "강퇴 대상 식별자 형식이 올바르지 않습니다.";
+
   /**
    * 전역 로비 리스트를 보고 있는 클라이언트들에게 새로고침 신호를 전송합니다.
    * 로비 생성 또는 삭제(폭파) 이벤트 발생 시 호출됩니다.
@@ -269,6 +275,13 @@ public class LobbyEventService {
               ERROR_INVALID_KICK_TARGET
       );
     }
+
+    if (!USER_IDENTIFIER_PATTERN.matcher(request.targetUserIdentifier().trim()).matches()) {
+      throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST,
+              ERROR_INVALID_KICK_TARGET_FORMAT
+      );
+    }
   }
 
   private void handleKickSuccess(KickLobbyResult.Kicked result) {
@@ -276,7 +289,15 @@ public class LobbyEventService {
     String targetUserIdentifier = result.targetUserIdentifier();
 
     deleteTargetWsConnection(result.targetWsSessionId());
-    publishKickMessage(lobbyCode, targetUserIdentifier);
+    boolean kickMessagePublished = publishKickMessage(lobbyCode, targetUserIdentifier);
+
+    if (!kickMessagePublished) {
+      log.error(
+              "KICK 메시지 전송 실패 - Redis 강퇴 상태는 반영되었으나 클라이언트 알림이 누락될 수 있음. lobbyCode: {}, targetUserIdentifier: {}",
+              lobbyCode,
+              targetUserIdentifier
+      );
+    }
 
     messagingTemplate.convertAndSend(
             StompDestinations.subscribeLobbyRefresh(lobbyCode),
@@ -307,7 +328,7 @@ public class LobbyEventService {
     }
   }
 
-  private void publishKickMessage(String lobbyCode, String targetUserIdentifier) {
+  private boolean publishKickMessage(String lobbyCode, String targetUserIdentifier) {
     ChatMessageDto message = ChatMessageDto.builder()
             .type(ChatMessageDto.MessageType.KICK)
             .roomId(lobbyCode)
@@ -323,6 +344,8 @@ public class LobbyEventService {
               StompDestinations.subscribeLobbyChat(lobbyCode),
               payload
       );
+
+      return true;
     } catch (Exception e) {
       log.error(
               "KICK 메시지 직렬화 또는 전송 실패 - lobbyCode: {}, targetUserIdentifier: {}",
@@ -330,6 +353,7 @@ public class LobbyEventService {
               targetUserIdentifier,
               e
       );
+      return false;
     }
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -54,4 +54,24 @@ public class RedisScriptConfig {
         redisScript.setResultType(String.class);
         return redisScript;
     }
+
+    /**
+     * 로비 유저 강퇴 처리 Lua 스크립트
+     *
+     * [처리 내용]
+     * - 로비 존재 여부 확인
+     * - 방장 권한 검증
+     * - 자기 자신 강퇴 방지
+     * - 강퇴 대상 참여 여부 확인
+     * - participants Set에서 대상 제거
+     * - order List에서 대상 제거
+     * - 대상자의 로비 WebSocket 세션 매핑 제거
+     */
+    @Bean
+    public RedisScript<String> kickLobbyScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/kick_lobby.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -34,6 +34,9 @@ public final class RedisKeys {
     /** 로비별 입장 순서 List 키 접미사 */
     private static final String ORDER_SUFFIX = ":order";
 
+    /** 로비별 강퇴 유저 Set 키 접미사 */
+    private static final String KICKED_SUFFIX = ":kicked";
+
     /** 로비 내 사용자별 현재 유효 WebSocket 세션 키 접미사 */
     private static final String USER_SESSION_SUFFIX = ":user_session:";
 
@@ -182,6 +185,8 @@ public final class RedisKeys {
     public static String lobbyOrderKey(String code) {
         return LOBBY_PREFIX + code + ORDER_SUFFIX;
     }
+
+    public static String lobbyKickedKey(String code) { return LOBBY_PREFIX + code + KICKED_SUFFIX; }
 
     /**
      * 사용자 온라인 상태 키를 반환합니다.

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -61,6 +61,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private static final String ENTER_RESULT_FULL = "FULL";
     private static final String ENTER_RESULT_LOBBY_NOT_WAITING = "LOBBY_NOT_WAITING";
     private static final String ENTER_RESULT_INVALID_LOBBY_CAPACITY = "INVALID_LOBBY_CAPACITY";
+    private static final String ENTER_RESULT_KICKED_USER = "KICKED_USER";
 
     // =========================================================
     // 실패 사유 상수
@@ -334,6 +335,11 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         throw new IllegalStateException("로비 입장 실패: 더 최신 WebSocket 세션이 이미 존재합니다.");
                     }
 
+                    case KICKED_USER -> {
+                        cleanupWsConnection(wsSessionId);
+                        throw new IllegalStateException("로비 입장 실패 : 강퇴된 로비에는 재입장할 수 없습니다.");
+                    }
+
                     case LOBBY_NOT_FOUND -> {
                         cleanupWsConnection(wsSessionId);
                         throw new IllegalArgumentException("로비 입장 실패: 존재하지 않는 로비입니다.");
@@ -410,6 +416,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                 RedisKeys.lobbyKey(lobbyCode),
                 RedisKeys.lobbyParticipantsKey(lobbyCode),
                 RedisKeys.lobbyOrderKey(lobbyCode),
+                RedisKeys.lobbyKickedKey(lobbyCode),
                 RedisKeys.wsConnectionKey(wsSessionId),
                 RedisKeys.lobbyUserSessionKey(lobbyCode, userIdentifier),
                 RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, userIdentifier)
@@ -469,6 +476,10 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
         if (ENTER_RESULT_INVALID_LOBBY_CAPACITY.equals(result)) {
             return LobbyEnterResultType.INVALID_LOBBY_CAPACITY;
+        }
+
+        if (ENTER_RESULT_KICKED_USER.equals(result)) {
+            return LobbyEnterResultType.KICKED_USER;
         }
 
         return LobbyEnterResultType.UNKNOWN;
@@ -547,6 +558,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         FULL,
         LOBBY_NOT_WAITING,
         INVALID_LOBBY_CAPACITY,
+        KICKED_USER,
         UNKNOWN
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/dto/ChatMessageDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/dto/ChatMessageDto.java
@@ -28,12 +28,19 @@ public class ChatMessageDto {
 
     /**
      * 메시지 유형 열거형.
-     * - CHAT   : 일반 채팅 메시지
-     * - ANSWER : 정답 제출 메시지 (인게임 전용)
-     * - ENTER  : 입장 알림 시스템 메시지
-     * - LEAVE  : 퇴장 알림 시스템 메시지
+     * - CHAT         : 일반 채팅 메시지
+     * - ANSWER       : 정답 제출 메시지 (인게임 전용)
+     * - ENTER        : 입장 알림 시스템 메시지
+     * - LEAVE        : 퇴장 알림 시스템 메시지
+     * - KICK         : 강퇴 알림 시스템 메시지
+     * - ENTER_FAILED : 입장 실패 알림 메시지
      */
     public enum MessageType {
-        CHAT, ANSWER, ENTER, LEAVE, ENTER_FAILED
+        CHAT,
+        ANSWER,
+        ENTER,
+        LEAVE,
+        KICK,
+        ENTER_FAILED
     }
 }

--- a/src/main/resources/scripts/enter_lobby.lua
+++ b/src/main/resources/scripts/enter_lobby.lua
@@ -29,9 +29,10 @@
 local lobbyKey                  = KEYS[1] -- lobby:{code}
 local participantsKey           = KEYS[2] -- lobby:{code}:participants
 local orderKey                  = KEYS[3] -- lobby:{code}:order
-local wsConnectionKey           = KEYS[4] -- ws:connection:{wsSessionId}
-local lobbyUserSessionKey       = KEYS[5] -- lobby:{code}:user_session:{userIdentifier}
-local lobbyUserSessionSeqKey    = KEYS[6] -- lobby:{code}:user_session_seq:{userIdentifier}
+local kickedKey                 = KEYS[4] -- lobby:{code}:kicked
+local wsConnectionKey           = KEYS[5] -- ws:connection:{wsSessionId}
+local lobbyUserSessionKey       = KEYS[6] -- lobby:{code}:user_session:{userIdentifier}
+local lobbyUserSessionSeqKey    = KEYS[7] -- lobby:{code}:user_session_seq:{userIdentifier}
 
 local userIdentifier            = ARGV[1] -- 사용자 식별자(UUID)
 local lobbyCode                 = ARGV[2] -- 로비 초대 코드
@@ -55,16 +56,21 @@ if lobbyStatus ~= 'WAITING' then
     return "LOBBY_NOT_WAITING"
 end
 
--- 3. sessionSequence가 숫자가 아니면 잘못된 서버 상태로 본다.
+-- 3. 강퇴된 유저는 같은 로비에 재입장할 수 없다.
+if redis.call('SISMEMBER', kickedKey, userIdentifier) == 1 then
+    return "KICKED_USER"
+end
+
+-- 4. sessionSequence가 숫자가 아니면 잘못된 서버 상태로 본다.
 if sessionSequence == nil then
     return "INVALID_SEQUENCE"
 end
 
--- 4. 기존 현재 유효 세션과 sequence를 조회한다.
+-- 5. 기존 현재 유효 세션과 sequence를 조회한다.
 local previousWsSessionId = redis.call('GET', lobbyUserSessionKey)
 local previousSequence = redis.call('GET', lobbyUserSessionSeqKey)
 
--- 5. 이미 더 최신 세션이 존재하면 현재 요청은 stale로 간주한다.
+-- 6. 이미 더 최신 세션이 존재하면 현재 요청은 stale로 간주한다.
 if previousSequence ~= false and tonumber(previousSequence) > sessionSequence then
     if previousWsSessionId ~= false and previousWsSessionId == wsSessionId then
         redis.call('HSET', wsConnectionKey,
@@ -82,12 +88,12 @@ if previousSequence ~= false and tonumber(previousSequence) > sessionSequence th
 end
 
 
--- 6. 이미 참여 중인 유저인지 먼저 확인한다.
+-- 7. 이미 참여 중인 유저인지 먼저 확인한다.
 --    재접속(SESSION_REPLACED, ALREADY_JOINED)인 경우에는 인원 초과 검증을 건너뛴다.
 --    participants Set에 이미 존재하므로 SADD 결과가 0이 되어 SCARD가 증가하지 않기 때문이다.
 local alreadyInLobby = redis.call('SISMEMBER', participantsKey, userIdentifier)
 
--- 7. 신규 입장자에 한해서만 최대 인원 초과를 검증한다.
+-- 8. 신규 입장자에 한해서만 최대 인원 초과를 검증한다.
 --    [Race Condition 방어]
 --    REST API의 인원 검증과 달리, SADD 직전에 검증하므로 원자적으로 처리된다.
 if alreadyInLobby == 0 then
@@ -103,26 +109,26 @@ if alreadyInLobby == 0 then
     end
 end
 
--- 8. 참여자 Set에 추가한다.
+-- 9. 참여자 Set에 추가한다.
 local added = redis.call('SADD', participantsKey, userIdentifier)
 
--- 9. 신규 참여자일 때만 order List에 추가한다.
+-- 10. 신규 참여자일 때만 order List에 추가한다.
 if added == 1 then
     redis.call('RPUSH', orderKey, userIdentifier)
 end
 
--- 10. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
+-- 11. 현재 WebSocket 세션 기준 역추적 정보를 저장한다.
 redis.call('HSET', wsConnectionKey,
     userField,  userIdentifier,
     lobbyField, lobbyCode
 )
 redis.call('PEXPIRE', wsConnectionKey, connectionTtlMs)
 
--- 11. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
+-- 12. userIdentifier 기준 현재 유효 세션을 최신 wsSessionId로 갱신한다.
 redis.call('SET', lobbyUserSessionKey,    wsSessionId,                 'PX', connectionTtlMs)
 redis.call('SET', lobbyUserSessionSeqKey, tostring(sessionSequence),  'PX', connectionTtlMs)
 
--- 12. 반환값 결정
+-- 13. 반환값 결정
 if added == 1 then
     return "ENTERED"
 end

--- a/src/main/resources/scripts/kick_lobby.lua
+++ b/src/main/resources/scripts/kick_lobby.lua
@@ -22,8 +22,9 @@
 local lobbyKey                  = KEYS[1] -- lobby:{code}
 local participantsKey           = KEYS[2] -- lobby:{code}:participants
 local orderKey                  = KEYS[3] -- lobby:{code}:order
-local targetLobbyUserSessionKey = KEYS[4] -- lobby:{code}:user_session:{targetUserIdentifier}
-local targetLobbyUserSeqKey     = KEYS[5] -- lobby:{code}:user_session_seq:{targetUserIdentifier}
+local kickedKey                 = KEYS[4] -- lobby:{code}:kicked
+local targetLobbyUserSessionKey = KEYS[5] -- lobby:{code}:user_session:{targetUserIdentifier}
+local targetLobbyUserSeqKey     = KEYS[6] -- lobby:{code}:user_session_seq:{targetUserIdentifier}
 
 local requesterIdentifier       = ARGV[1] -- 강퇴 요청자 식별자
 local targetUserIdentifier      = ARGV[2] -- 강퇴 대상 식별자
@@ -67,9 +68,12 @@ end
 redis.call('SREM', participantsKey, targetUserIdentifier)
 redis.call('LREM', orderKey, 0, targetUserIdentifier)
 
--- 7. 로비 내 대상 유저 세션 매핑 제거
+-- 7. 강퇴 대상 재입장 차단 등록
+redis.call('SADD', kickedKey, targetUserIdentifier)
+
+-- 8. 로비 내 대상 유저 세션 매핑 제거
 redis.call('DEL', targetLobbyUserSessionKey, targetLobbyUserSeqKey)
 
--- 8. 결과 반환
+-- 9. 결과 반환
 -- Java 레이어에서 targetWsSessionId를 파싱해 ws:connection:{sessionId} 정리 및 알림 처리에 사용한다.
 return "KICKED:" .. targetWsSessionId

--- a/src/main/resources/scripts/kick_lobby.lua
+++ b/src/main/resources/scripts/kick_lobby.lua
@@ -1,0 +1,75 @@
+---@diagnostic disable: undefined-global
+
+-- ============================================================================
+-- 로비 유저 강퇴 원자적 처리 스크립트
+--
+-- [책임]
+-- 1. 로비 존재 여부 검증
+-- 2. 요청자가 현재 방장인지 검증
+-- 3. 강퇴 대상이 로비 참여자인지 검증
+-- 4. 방장 자기 자신 강퇴 방지
+-- 5. participants Set에서 강퇴 대상 제거
+-- 6. order List에서 강퇴 대상 제거
+-- 7. 강퇴 대상의 현재 유효 WebSocket 세션 매핑 조회
+-- 8. 강퇴 대상의 lobby user_session / user_session_seq 키 삭제
+--
+-- [주의]
+-- 실제 WebSocket 물리 close는 이 스크립트에서 수행할 수 없다.
+-- 이 스크립트는 Redis 상태를 원자적으로 변경하고,
+-- Java 레이어가 반환된 wsSessionId를 이용해 강퇴 알림을 전송하도록 한다.
+-- ============================================================================
+
+local lobbyKey                  = KEYS[1] -- lobby:{code}
+local participantsKey           = KEYS[2] -- lobby:{code}:participants
+local orderKey                  = KEYS[3] -- lobby:{code}:order
+local targetLobbyUserSessionKey = KEYS[4] -- lobby:{code}:user_session:{targetUserIdentifier}
+local targetLobbyUserSeqKey     = KEYS[5] -- lobby:{code}:user_session_seq:{targetUserIdentifier}
+
+local requesterIdentifier       = ARGV[1] -- 강퇴 요청자 식별자
+local targetUserIdentifier      = ARGV[2] -- 강퇴 대상 식별자
+
+-- 1. 로비 존재 여부 검증
+if redis.call('EXISTS', lobbyKey) == 0 then
+    return "LOBBY_NOT_FOUND"
+end
+
+-- 2. 방장 권한 검증
+local currentHost = redis.call('HGET', lobbyKey, 'host_user_id')
+
+if currentHost == false or currentHost == nil or currentHost == '' then
+    return "HOST_NOT_FOUND"
+end
+
+if currentHost ~= requesterIdentifier then
+    return "FORBIDDEN"
+end
+
+-- 3. 자기 자신 강퇴 방지
+if requesterIdentifier == targetUserIdentifier then
+    return "CANNOT_KICK_SELF"
+end
+
+-- 4. 강퇴 대상 참여 여부 검증
+local isParticipant = redis.call('SISMEMBER', participantsKey, targetUserIdentifier)
+
+if isParticipant == 0 then
+    return "TARGET_NOT_PARTICIPANT"
+end
+
+-- 5. 강퇴 대상의 현재 유효 WebSocket 세션 ID 조회
+local targetWsSessionId = redis.call('GET', targetLobbyUserSessionKey)
+
+if targetWsSessionId == false or targetWsSessionId == nil then
+    targetWsSessionId = ""
+end
+
+-- 6. participants / order에서 강퇴 대상 제거
+redis.call('SREM', participantsKey, targetUserIdentifier)
+redis.call('LREM', orderKey, 0, targetUserIdentifier)
+
+-- 7. 로비 내 대상 유저 세션 매핑 제거
+redis.call('DEL', targetLobbyUserSessionKey, targetLobbyUserSeqKey)
+
+-- 8. 결과 반환
+-- Java 레이어에서 targetWsSessionId를 파싱해 ws:connection:{sessionId} 정리 및 알림 처리에 사용한다.
+return "KICKED:" .. targetWsSessionId

--- a/src/main/resources/scripts/leave_lobby.lua
+++ b/src/main/resources/scripts/leave_lobby.lua
@@ -9,7 +9,8 @@
 
 local lobbyKey = KEYS[1]         -- 로비 메타 정보 (Hash)
 local participantsKey = KEYS[2]  -- 로비 참여자 명단 (Set)
-local orderKey = KEYS[3]         -- 로비 입장 순서 (List)
+local orderKey = KEYS[3]        -- 로비 입장 순서 (List)
+local kickedKey = KEYS[4]     -- 로비 강퇴 명단 (Set)
 local publicListKey = KEYS[4]    -- 전역 공개 로비 목록 (Set)
 
 local userId = ARGV[1]           -- 퇴장하려는 유저 ID
@@ -25,7 +26,7 @@ local remainCount = redis.call('SCARD', participantsKey)
 if remainCount == 0 then
     -- [Case A: 남은 인원이 0명인 경우 -> 로비 폭파]
     -- 로비와 관련된 모든 키를 일괄 삭제하여 Redis 메모리 누수(좀비 방)를 방지한다.
-    redis.call('DEL', lobbyKey, participantsKey, orderKey)
+    redis.call('DEL', lobbyKey, participantsKey, orderKey, kickedKey)
     redis.call('SREM', publicListKey, lobbyCode) -- 공개 방 목록에서도 제외
     return "DESTROYED"
 else
@@ -46,7 +47,7 @@ else
                 return "DELEGATED:" .. fallbackHost
             else
                 -- 실질적으로 참여자가 없는 상태 -> 로비 폭파
-                redis.call('DEL', lobbyKey, participantsKey, orderKey)
+                redis.call('DEL', lobbyKey, participantsKey, orderKey, kickedKey)
                 redis.call('SREM', publicListKey, lobbyCode)
                 return "DESTROYED"
             end

--- a/src/main/resources/scripts/leave_lobby.lua
+++ b/src/main/resources/scripts/leave_lobby.lua
@@ -9,9 +9,9 @@
 
 local lobbyKey = KEYS[1]         -- 로비 메타 정보 (Hash)
 local participantsKey = KEYS[2]  -- 로비 참여자 명단 (Set)
-local orderKey = KEYS[3]        -- 로비 입장 순서 (List)
-local kickedKey = KEYS[4]     -- 로비 강퇴 명단 (Set)
-local publicListKey = KEYS[4]    -- 전역 공개 로비 목록 (Set)
+local orderKey = KEYS[3]         -- 로비 입장 순서 (List)
+local kickedKey = KEYS[4]        -- 로비 강퇴 명단 (Set)
+local publicListKey = KEYS[5]   -- 전역 공개 로비 목록 (Set)
 
 local userId = ARGV[1]           -- 퇴장하려는 유저 ID
 local lobbyCode = ARGV[2]        -- 퇴장하려는 로비 코드


### PR DESCRIPTION
## 📣 Related Issue

- #50

## 📝 Summary

- 방장이 로비 내 특정 유저를 강퇴할 수 있는 STOMP 이벤트를 추가했습니다.
  - 클라이언트 송신 경로: `/app/lobby/{code}/kick`
  - 요청 payload: `targetUserIdentifier`

- Redis Lua 스크립트 기반으로 강퇴 처리를 원자적으로 수행하도록 구현했습니다.
  - 방장 권한 검증
  - 자기 자신 강퇴 방지
  - 강퇴 대상 참여 여부 검증
  - `participants` Set에서 강퇴 대상 제거
  - `order` List에서 강퇴 대상 제거
  - 대상자의 `user_session`, `user_session_seq` 제거

- 강퇴된 유저의 재입장을 차단하도록 `lobby:{code}:kicked` Set을 추가했습니다.
  - 강퇴 시 대상 userIdentifier를 kicked Set에 저장
  - 로비 재입장 시 `enter_lobby.lua`에서 kicked Set 검사
  - 강퇴된 유저가 재구독하면 `KICKED_USER`로 차단

- 강퇴 이벤트 발생 시 로비 참여자에게 실시간 알림을 전송하도록 구현했습니다.
  - `/topic/lobby/{code}`로 `KICK` 메시지 브로드캐스트
  - `/topic/lobby/{code}/refresh`로 `REFRESH_LOBBY_INFO` 브로드캐스트

- KICK 메시지 직렬화 방식을 정리했습니다.
  - `ChatMessageDto` 객체가 Jackson type metadata 배열 형태로 내려가지 않도록 JSON 문자열로 직렬화하여 전송
  - FE에서 바로 JSON 객체로 파싱 가능하도록 개선

- 로비 폭파 시 `lobby:{code}:kicked` Set도 함께 삭제되도록 정리했습니다.

## 🙏PR point

- 현재 구현은 서버가 WebSocket 세션 객체를 직접 close하는 방식이 아니라, Redis 참여 상태에서 제거하고 `KICK` 메시지를 전송하여 클라이언트가 구독 해제 및 로비 이탈 처리를 수행하도록 하는 구조입니다.
- 강퇴된 유저가 다시 `/topic/lobby/{code}`를 구독하면 서버에서 `KICKED_USER`로 차단하며, STOMP ERROR 응답 후 연결이 종료됩니다.
- `GAME_LOBBY_PLAYER.is_kicked` 업데이트는 현재 로비 참여 상태가 Redis 중심으로 관리되고 있어 이번 구현에서는 직접 반영하지 않았습니다. DB 로비 참여자 영속화 흐름이 명확해지는 시점에 후속 이슈로 분리하는 것이 적절해 보입니다.

## 📬 Reference

- Redis Lua script 기반 원자 처리
- 기존 `leave_lobby.lua`, `enter_lobby.lua` 로비 입퇴장 처리 구조