### PR TITLE
[Feat/#62] 로비 생성 시 맵 연결 기능 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,8 @@
 - **Base URL** : `http://{서버 도메인}:8080`
 - **WebSocket Endpoint** : `ws://{서버 도메인}:8080/ws` (SockJS 폴백 지원)
 - **Content-Type** : `application/json`
-- **인증** : WebSocket 연결 시 STOMP CONNECT 헤더에 `userIdentifier` 포함 필요
+- **REST 인증** : `Authorization: Bearer {accessToken}`
+- **WebSocket 인증** : STOMP CONNECT 헤더에 `userIdentifier` 포함 필요
 
 ---
 
@@ -15,11 +16,11 @@
 
 #### 게스트 로그인
 
-```
+```http
 POST /api/auth/guest
 ```
 
-닉네임 입력만으로 게스트 계정을 생성하고 `UUID(userIdentifier)` 기반 세션을 발급합니다.
+닉네임 입력만으로 게스트 계정을 생성하고 `UUID(userIdentifier)` 기반 세션을 발급합니다.  
 응답으로 Access/Refresh 토큰이 함께 반환되며, 게스트 세션 정보는 Redis에 30일 TTL로 저장됩니다.
 
 **Request**
@@ -54,11 +55,11 @@ POST /api/auth/guest
 
 #### 회원가입
 
-```
+```http
 POST /api/auth/register
 ```
 
-로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.
+로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.  
 회원가입 API는 계정 생성만 수행하며 토큰 발급은 로그인 API에서 처리됩니다.
 
 **Request**
@@ -93,12 +94,16 @@ POST /api/auth/register
 
 #### 로비 생성
 
-```
+```http
 POST /api/lobbies
 ```
 
-로비를 생성하고 6자리 초대 코드를 발급합니다.
+로비를 생성하고 6자리 초대 코드를 발급합니다.  
 JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 가능합니다.
+
+`mapId`는 선택 사항입니다.  
+로비는 맵 없이 먼저 생성할 수 있으며, 게임 시작 시점에는 선택된 맵이 있어야 합니다.  
+`mapId`가 전달된 경우 백엔드에서 맵 존재 여부, 삭제 여부, 접근 권한을 검증합니다.
 
 **Request Header**
 
@@ -106,7 +111,33 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
 |---|---|---|
 | `Authorization` | ✅ | `Bearer {accessToken}` |
 
-**Request Body**
+**Request Body — 맵 선택 로비**
+
+```json
+{
+  "title": "K-POP 퀴즈방",
+  "maxPlayers": 8,
+  "isPrivate": false,
+  "mapId": 1,
+  "roundCount": 5,
+  "timeLimitSeconds": 30
+}
+```
+
+**Request Body — 맵 미선택 로비**
+
+```json
+{
+  "title": "K-POP 퀴즈방",
+  "maxPlayers": 8,
+  "isPrivate": false,
+  "mapId": null,
+  "roundCount": 5,
+  "timeLimitSeconds": 30
+}
+```
+
+`mapId` 필드는 생략할 수도 있습니다.
 
 ```json
 {
@@ -123,10 +154,11 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
 | `title` | String | ✅ | 로비 제목 (최대 255자) |
 | `maxPlayers` | Integer | ✅ | 최대 참여 인원 (2~8) |
 | `isPrivate` | Boolean | ✅ | 비공개 여부 |
+| `mapId` | Long | ❌ | 로비에 연결할 맵 ID. 미선택 시 `null` 또는 생략 가능 |
 | `roundCount` | Integer | ❌ | 라운드 수 (1~20, 기본값 5) |
 | `timeLimitSeconds` | Integer | ❌ | 제한 시간 초 (10~120, 기본값 30) |
 
-**Response `201 Created`**
+**Response `201 Created` — 맵 선택 로비**
 
 ```json
 {
@@ -135,7 +167,26 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
   "title": "K-POP 퀴즈방",
   "maxPlayers": 8,
   "isPrivate": false,
-  "status": "WAITING"
+  "status": "WAITING",
+  "mapId": 1,
+  "mapTitle": "K-POP 2세대",
+  "mapCategory": "kpop"
+}
+```
+
+**Response `201 Created` — 맵 미선택 로비**
+
+```json
+{
+  "lobbyId": 1,
+  "inviteCode": "ABC123",
+  "title": "K-POP 퀴즈방",
+  "maxPlayers": 8,
+  "isPrivate": false,
+  "status": "WAITING",
+  "mapId": null,
+  "mapTitle": null,
+  "mapCategory": null
 }
 ```
 
@@ -147,26 +198,44 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
 | `maxPlayers` | Integer | 최대 참여 인원 |
 | `isPrivate` | Boolean | 비공개 여부 |
 | `status` | String | 로비 상태 (`WAITING`) |
+| `mapId` | Long | 선택된 맵 ID (미선택 시 `null`) |
+| `mapTitle` | String | 선택된 맵 제목 (미선택 시 `null`) |
+| `mapCategory` | String | 선택된 맵 카테고리 (미선택 시 `null`) |
+
+**맵 검증 정책**
+
+| 상황 | 결과 |
+|---|---|
+| `mapId` 없음 | 맵 미선택 로비로 생성 허용 |
+| 공개 맵 | 로비 연결 허용 |
+| 본인 소유 비공개 맵 | 로비 연결 허용 |
+| 타인 소유 비공개 맵 | 로비 연결 거부 |
+| 삭제된 맵 | 로비 연결 거부 |
+| 존재하지 않는 맵 | 로비 연결 거부 |
 
 **Error**
 
 | 상태 코드 | 설명 |
 |---|---|
+| `400 Bad Request` | 요청 검증 실패 (`mapId`가 양수가 아닌 경우 등) |
 | `401 Unauthorized` | JWT 토큰 없음 또는 만료 |
+| `403 Forbidden` | 타인 소유 비공개 맵을 로비에 연결하려는 경우 |
+| `404 Not Found` | 존재하지 않는 사용자 또는 존재하지 않는 맵 |
+| `409 Conflict` | 삭제된 맵을 로비에 연결하려는 경우 |
 | `503 Service Unavailable` | 초대 코드 생성 실패 (재시도 초과) |
 
 ---
 
 #### 초대 코드 기반 로비 입장
 
-```
+```http
 POST /api/lobbies/join
 ```
 
-초대 코드로 로비 입장 가능 여부를 검증하고 로비 기본 정보를 반환합니다.
+초대 코드로 로비 입장 가능 여부를 검증하고 로비 기본 정보를 반환합니다.  
 JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 가능합니다.
 
-> **중요:** 이 API는 입장 허가 사전 검증만 수행합니다.
+> **중요:** 이 API는 입장 허가 사전 검증만 수행합니다.  
 > 실제 참여자 등록은 응답 수신 후 WebSocket `/topic/lobby/{inviteCode}` 구독 시점에 처리됩니다.
 >
 > 클라이언트 처리 순서:
@@ -191,7 +260,7 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 |---|---|---|---|
 | `inviteCode` | String | ✅ | 6자리 초대 코드 (영문 대문자 + 숫자) |
 
-**Response `200 OK`**
+**Response `200 OK` — 맵 선택 로비**
 
 ```json
 {
@@ -201,7 +270,25 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
   "maxPlayers": 8,
   "currentPlayers": 3,
   "status": "WAITING",
+  "mapId": 1,
+  "mapTitle": "K-POP 2세대",
   "mapCategory": "kpop"
+}
+```
+
+**Response `200 OK` — 맵 미선택 로비**
+
+```json
+{
+  "inviteCode": "ABC123",
+  "title": "K-POP 퀴즈방",
+  "hostId": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+  "maxPlayers": 8,
+  "currentPlayers": 3,
+  "status": "WAITING",
+  "mapId": null,
+  "mapTitle": null,
+  "mapCategory": null
 }
 ```
 
@@ -213,6 +300,8 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 | `maxPlayers` | Integer | 최대 참여 인원 |
 | `currentPlayers` | Integer | 현재 참여 인원 (응답 시점 스냅샷) |
 | `status` | String | 로비 상태 (`WAITING`) |
+| `mapId` | Long | 선택된 맵 ID (미선택 시 `null`) |
+| `mapTitle` | String | 선택된 맵 제목 (미선택 시 `null`) |
 | `mapCategory` | String | 선택된 맵의 카테고리 (미선택 시 `null`) |
 
 **Error**
@@ -228,11 +317,11 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 
 #### 공개 로비 목록 조회
 
-```
+```http
 GET /api/lobbies
 ```
 
-현재 활성화된 공개(`isPrivate = false`) 로비 목록을 반환합니다.
+현재 활성화된 공개(`isPrivate = false`) 로비 목록을 반환합니다.  
 Redis에서 직접 필터링하여 고속 반환합니다.
 
 **Response `200 OK`**
@@ -244,8 +333,20 @@ Redis에서 직접 필터링하여 고속 반환합니다.
     "hostId": "uuid-xxxx-xxxx",
     "title": "K-POP 퀴즈방",
     "mapId": 1,
+    "mapTitle": "K-POP 2세대",
     "mapCategory": "kpop",
     "maxPlayers": 8,
+    "isPrivate": false,
+    "status": "WAITING"
+  },
+  {
+    "code": "DEF456",
+    "hostId": "uuid-yyyy-yyyy",
+    "title": "맵 미선택 퀴즈방",
+    "mapId": null,
+    "mapTitle": null,
+    "mapCategory": null,
+    "maxPlayers": 6,
     "isPrivate": false,
     "status": "WAITING"
   }
@@ -258,6 +359,7 @@ Redis에서 직접 필터링하여 고속 반환합니다.
 | `hostId` | String | 방장 사용자 식별자 |
 | `title` | String | 로비 제목 |
 | `mapId` | Long | 선택된 맵 ID (미선택 시 `null`) |
+| `mapTitle` | String | 선택된 맵 제목 (미선택 시 `null`) |
 | `mapCategory` | String | 선택된 맵의 카테고리 (미선택 시 `null`) |
 | `maxPlayers` | Integer | 최대 참여 인원 |
 | `isPrivate` | Boolean | 비공개 여부 (`true` = 비공개) |
@@ -269,11 +371,11 @@ Redis에서 직접 필터링하여 고속 반환합니다.
 
 #### 공개 맵 목록 조회
 
-```
+```http
 GET /api/maps
 ```
 
-공개(`is_public=true`) 상태이면서 삭제되지 않은 맵만 반환합니다.
+공개(`is_public=true`) 상태이면서 삭제되지 않은 맵만 반환합니다.  
 페이지네이션 파라미터를 지원합니다.
 
 | 쿼리 파라미터 | 기본값 | 설명 |
@@ -306,7 +408,7 @@ GET /api/maps
 
 #### 공개 맵 단건 조회
 
-```
+```http
 GET /api/maps/{mapId}
 ```
 
@@ -331,29 +433,30 @@ GET /api/maps/{mapId}
 
 #### 맵 생성
 
-```
+```http
 POST /api/maps
 ```
 
 정식 회원(`REGISTERED`)만 생성할 수 있습니다.
 
 `category`는 아래 enum 값만 허용합니다.
+
 - `kpop`
 - `jpop`
 - `pop`
 
 #### 맵 수정
 
-```
+```http
 PUT /api/maps/{mapId}
 ```
 
-맵 소유자만 수정 가능하며, `isPublic` 필드로 공개/비공개 전환을 지원합니다.
+맵 소유자만 수정 가능하며, `isPublic` 필드로 공개/비공개 전환을 지원합니다.  
 수정 시 Redis 맵 캐시를 무효화합니다.
 
 #### 맵 삭제
 
-```
+```http
 DELETE /api/maps/{mapId}
 ```
 
@@ -363,12 +466,12 @@ DELETE /api/maps/{mapId}
 
 ## WebSocket API (STOMP)
 
-WebSocket 연결 후 STOMP 프로토콜로 통신합니다.
+WebSocket 연결 후 STOMP 프로토콜로 통신합니다.  
 SockJS를 통해 WebSocket 연결 실패 시 HTTP 폴링으로 자동 대체됩니다.
 
 ### 연결
 
-```
+```text
 CONNECT
 userIdentifier: {UUID 또는 회원 ID}
 ```
@@ -385,7 +488,7 @@ userIdentifier: {UUID 또는 회원 ID}
 
 #### 전체 채팅 송신
 
-```
+```text
 SEND /app/chat/global
 ```
 
@@ -400,7 +503,7 @@ SEND /app/chat/global
 
 #### 전체 채팅 수신 구독
 
-```
+```text
 SUBSCRIBE /topic/chat/global
 ```
 
@@ -418,7 +521,7 @@ SUBSCRIBE /topic/chat/global
 
 #### 로비 채팅 송신
 
-```
+```text
 SEND /app/chat/lobby/{code}
 ```
 
@@ -433,7 +536,7 @@ SEND /app/chat/lobby/{code}
 
 #### 로비 채팅 수신 구독
 
-```
+```text
 SUBSCRIBE /topic/lobby/{code}
 ```
 
@@ -457,6 +560,7 @@ SUBSCRIBE /topic/lobby/{code}
 | `ANSWER` | 정답 제출 메시지 (인게임 전용) |
 | `ENTER` | 입장 알림 시스템 메시지 |
 | `LEAVE` | 퇴장 알림 시스템 메시지 |
+| `KICK` | 강퇴 알림 시스템 메시지 |
 
 > `sender` 필드는 클라이언트 전송값을 무시하고 서버 세션에서 추출한 값으로 교체됩니다. (발신자 위변조 방지)
 
@@ -466,28 +570,28 @@ SUBSCRIBE /topic/lobby/{code}
 
 #### 로비 생성 알림 송신
 
-```
+```text
 SEND /app/lobby/create
 ```
 
-로비 생성 후 클라이언트가 호출합니다.
+로비 생성 후 클라이언트가 호출합니다.  
 로비 리스트를 보고 있는 모든 클라이언트에게 새로고침 신호를 전송합니다.
 
 #### 로비 리스트 새로고침 구독
 
-```
+```text
 SUBSCRIBE /topic/lobby/refresh
 ```
 
 **수신 메시지**
 
-```
+```text
 "REFRESH_LOBBY_LIST"
 ```
 
 #### 로비 정보 변경 알림 송신
 
-```
+```text
 SEND /app/lobby/{code}/update
 ```
 
@@ -495,15 +599,39 @@ SEND /app/lobby/{code}/update
 
 #### 로비 내부 새로고침 구독
 
-```
+```text
 SUBSCRIBE /topic/lobby/{code}/refresh
 ```
 
 **수신 메시지**
 
-```
+```text
 "REFRESH_LOBBY_INFO"
 ```
+
+#### 로비 유저 강퇴 송신
+
+```text
+SEND /app/lobby/{code}/kick
+```
+
+방장이 특정 유저를 로비에서 강퇴합니다.
+
+**Body**
+
+```json
+{
+  "targetUserIdentifier": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc"
+}
+```
+
+**처리 결과**
+
+- 요청자가 방장이 아니면 거부됩니다.
+- 자기 자신은 강퇴할 수 없습니다.
+- 강퇴 대상이 로비 참여자가 아니면 거부됩니다.
+- 강퇴 성공 시 로비 채팅 채널로 `KICK` 메시지가 브로드캐스트됩니다.
+- 강퇴 성공 후 로비 내부 새로고침 신호가 브로드캐스트됩니다.
 
 ---
 
@@ -531,4 +659,7 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 | 로그인 | `POST /api/auth/login` |
 | 맵 아이템(문제) CRUD | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |
 | YouTube URL 유효성 검증 | `POST /api/youtube/validate` |
+| 로비 맵 변경 | `PATCH /api/lobbies/{inviteCode}/map` |
+| 로비 준비 상태 변경 | `PATCH /api/lobbies/{inviteCode}/ready` |
+| 로비 게임 시작 | `POST /api/lobbies/{inviteCode}/start` |
 | 인게임 WebSocket | `/app/game/{code}/**` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,8 +16,8 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   ├── entity/
 │   │   │   ├── User.java                           # 사용자 엔티티 (게스트/회원 통합)
 │   │   │   ├── GuestSession.java                   # 게스트 세션 엔티티
-│   │   │   ├── UserCredential.java                 # 회원 인증정보 엔티티 (후속 이슈 대비)
-│   │   │   └── UserSession.java                    # 회원 세션 엔티티 (후속 이슈 대비)
+│   │   │   ├── UserCredential.java                 # 회원 인증정보 엔티티
+│   │   │   └── UserSession.java                    # 회원 세션 엔티티
 │   │   ├── repository/
 │   │   │   ├── UserRepository.java
 │   │   │   ├── GuestSessionRepository.java
@@ -32,31 +32,51 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   └── service/
 │   │       └── ChatService.java                    # 채팅 메시지 처리 및 발행
 │   │
-│   └── lobby/                                      # 로비 도메인
-│       ├── LeaveLobbyResult.java                   # 퇴장 처리 결과 (sealed interface)
-│       ├── controller/
-│       │   ├── LobbyController.java                # HTTP REST API (로비 생성, 목록 조회)
-│       │   └── LobbyEventController.java           # STOMP 로비 이벤트 수신
-│       ├── dto/
-│       │   ├── CreateLobbyRequest.java             # 로비 생성 요청 DTO
-│       │   ├── CreateLobbyResponse.java            # 로비 생성 응답 DTO (inviteCode 포함)
-│       │   └── LobbyRedisDto.java                  # 로비 목록 조회 응답 DTO
-│       ├── entity/
-│       │   ├── GameLobby.java                      # GAME_LOBBY 테이블 엔티티
-│       │   ├── LobbyDefaults.java                  # 로비 생성 기본값 및 상수
-│       │   └── LobbyStatus.java                    # 로비 상태 열거형 (WAITING, PLAYING, FINISHED)
-│       ├── repository/
-│       │   ├── GameLobbyJpaRepository.java         # GAME_LOBBY JPA 리포지토리
-│       │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
-│       │   └── LobbyRepositoryImpl.java            # Redis 기반 구현체 (SETNX, Lua 스크립트 활용)
-│       └── service/
-│           ├── LobbyEventService.java              # 로비 이벤트 처리 및 STOMP 브로드캐스트
-│           └── LobbyService.java                   # 로비 생성/조회 비즈니스 로직
+│   ├── lobby/                                      # 로비 도메인
+│   │   ├── KickLobbyResult.java                    # 강퇴 처리 결과 (sealed interface)
+│   │   ├── LeaveLobbyResult.java                   # 퇴장 처리 결과 (sealed interface)
+│   │   ├── controller/
+│   │   │   ├── LobbyController.java                # HTTP REST API (로비 생성, 입장, 목록 조회)
+│   │   │   └── LobbyEventController.java           # STOMP 로비 이벤트 수신
+│   │   ├── dto/
+│   │   │   ├── CreateLobbyRequest.java             # 로비 생성 요청 DTO (선택적 mapId 포함)
+│   │   │   ├── CreateLobbyResponse.java            # 로비 생성 응답 DTO (inviteCode + 맵 정보 포함)
+│   │   │   ├── JoinLobbyRequest.java               # 초대 코드 기반 로비 입장 요청 DTO
+│   │   │   ├── JoinLobbyResponse.java              # 초대 코드 기반 로비 입장 응답 DTO (맵 정보 포함)
+│   │   │   ├── KickLobbyPlayerRequest.java         # 로비 유저 강퇴 요청 DTO
+│   │   │   ├── LobbyMapMetadata.java               # Redis 저장용 로비 맵 메타데이터 DTO
+│   │   │   └── LobbyRedisDto.java                  # 공개 로비 목록 조회 응답 DTO (맵 정보 포함)
+│   │   ├── entity/
+│   │   │   ├── GameLobby.java                      # GAME_LOBBY 테이블 엔티티
+│   │   │   ├── LobbyDefaults.java                  # 로비 생성 기본값 및 상수
+│   │   │   └── LobbyStatus.java                    # 로비 상태 열거형 (WAITING, PLAYING, FINISHED)
+│   │   ├── repository/
+│   │   │   ├── GameLobbyJpaRepository.java         # GAME_LOBBY JPA 리포지토리
+│   │   │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
+│   │   │   └── LobbyRepositoryImpl.java            # Redis 기반 구현체 (SETNX, Lua 스크립트 활용)
+│   │   └── service/
+│   │       ├── LobbyEventService.java              # 로비 이벤트 처리 및 STOMP 브로드캐스트
+│   │       └── LobbyService.java                   # 로비 생성/입장/조회 비즈니스 로직
+│   │
+│   ├── map/                                        # 퀴즈 맵 도메인
+│   │   ├── controller/
+│   │   │   └── QuizMapController.java              # 맵 REST API
+│   │   ├── dto/
+│   │   │   └── ...                                 # 맵 생성/수정/조회 DTO
+│   │   ├── entity/
+│   │   │   ├── QuizMap.java                        # map 테이블 엔티티
+│   │   │   └── MapCategory.java                    # 맵 카테고리 enum (kpop, jpop, pop)
+│   │   ├── repository/
+│   │   │   └── QuizMapJpaRepository.java           # 맵 JPA 리포지토리
+│   │   └── service/
+│   │       └── QuizMapService.java                 # 맵 생성/수정/삭제/조회 비즈니스 로직
+│   │
+│   └── ...
 │
 └── global/                                         # 전역 인프라 레이어
     ├── config/                                     # 애플리케이션 설정
     │   ├── RedisConfig.java                        # Redis 연결, 직렬화, Pub/Sub 설정
-    │   ├── RedisScriptConfig.java                  # create/enter/leave Lua 스크립트 Bean 등록
+    │   ├── RedisScriptConfig.java                  # create/enter/leave/kick Lua 스크립트 Bean 등록
     │   ├── WebSocketConfig.java                    # STOMP 엔드포인트 및 브로커 설정
     │   └── SecurityConfig/
     │       ├── SecurityConfigDev.java              # 개발 환경 (인증 없이 전체 허용)
@@ -121,6 +141,25 @@ global/WebSocketEventListener → ApplicationEventPublisher.publishEvent(PlayerL
 
 `PlayerLeaveEvent`는 `global/websocket/event`에 위치하여 `domain → global` 단방향 의존을 유지합니다.
 
+### 도메인 간 의존 규칙
+
+동일한 `domain` 하위 도메인 간 참조는 비즈니스 흐름상 허용하지만, 직접 엔티티 결합은 최소화합니다.
+
+예를 들어 로비 생성 시 맵을 연결할 때 `LobbyService`는 `QuizMapJpaRepository`로 맵 접근 권한을 검증합니다.  
+하지만 Redis 저장 계층인 `LobbyRepositoryImpl`은 `QuizMap` 엔티티에 직접 의존하지 않고, `LobbyMapMetadata`라는 최소 DTO만 전달받습니다.
+
+```text
+LobbyService
+    ├── QuizMapJpaRepository 조회
+    ├── 맵 존재/삭제/권한 검증
+    └── LobbyMapMetadata 생성
+            ↓
+LobbyRepositoryImpl
+    └── Redis 저장에 필요한 mapId, mapTitle, mapCategory만 사용
+```
+
+이 구조를 통해 맵 도메인의 영속성 모델 변경이 Redis 저장 계층으로 직접 전파되는 것을 방지합니다.
+
 ---
 
 ## 🔄 실시간 메시지 흐름
@@ -172,6 +211,8 @@ enter_lobby.lua
     │
     ├── lobby:{code}:participants Set에 userIdentifier 저장
     ├── lobby:{code}:order List에 userIdentifier 저장
+    ├── lobby:{code}:user_session:{userIdentifier}에 현재 wsSessionId 저장
+    ├── lobby:{code}:user_session_seq:{userIdentifier}에 현재 세션 sequence 저장
     ├── ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
     └── 중복 구독 시 order List 중복 저장 방지
     │
@@ -214,27 +255,96 @@ leave_lobby.lua
     └── LEFT      → 로비 내부 새로고침
 ```
 
+### 로비 강퇴 흐름
+
+```text
+방장 클라이언트
+    │ STOMP SEND /app/lobby/{code}/kick
+    ▼
+LobbyEventController.kickLobbyPlayer()
+    │ 세션에서 requesterIdentifier 추출
+    ▼
+LobbyEventService.kickLobbyPlayer()
+    │ 1. 로비 코드 형식 검증
+    │ 2. 요청자 인증 정보 검증
+    │ 3. 강퇴 대상 식별자 검증
+    ▼
+kick_lobby.lua
+    │ Redis Lua 스크립트로 강퇴 상태를 원자적으로 변경
+    │
+    ├── 방장 권한 검증
+    ├── 자기 자신 강퇴 방지
+    ├── 참여자 여부 검증
+    ├── participants/order에서 대상 제거
+    ├── kicked Set에 대상 추가
+    └── 대상의 현재 wsSessionId 반환
+    │
+    ▼
+LobbyEventService.handleKickSuccess()
+    │ 1. 대상 ws:connection 키 삭제
+    │ 2. KICK 메시지 로비 채팅 채널로 브로드캐스트
+    │ 3. 로비 내부 refresh 브로드캐스트
+```
+
 ---
 
 ## 🗄️ Redis 데이터 구조
 
 | 키 패턴 | 타입 | 설명 |
 |---|---|---|
-| `lobby:{code}` | Hash | 로비 메타 정보 (title, status, host_user_id 등) |
+| `lobby:{code}` | Hash | 로비 메타 정보 (title, status, host_user_id, map_id, map_title, map_category 등) |
 | `lobby:{code}:participants` | Set | 로비 참여자 식별자 목록 |
 | `lobby:{code}:order` | List | 입장 순서 (방장 위임 시 LINDEX 0 사용) |
+| `lobby:{code}:kicked` | Set | 강퇴된 사용자 식별자 목록 |
+| `lobby:{code}:user_session:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence |
 | `lobby:public` | Set | 공개 로비 코드 목록 (고속 필터링용) |
 | `auth:guest:session:{token}` | Hash | 게스트 세션 정보 (userId, username, userType, TTL 30일) |
 | `auth:refresh:{sessionId}` | String | Refresh Token (TTL 30일) |
 | `user_status:{userIdentifier}` | String | 사용자 온라인 상태 (`ONLINE`, TTL 2시간) |
+| `user_status:{userIdentifier}:sessions` | Set | 사용자별 활성 WebSocket 세션 목록 |
 | `ws:connection:{wsSessionId}` | Hash | WebSocket 세션 → userId, lobbyCode 매핑 |
+| `map:public:list:v:{version}:p:{page}:s:{size}` | String | 공개 맵 목록 페이지 캐시 |
+| `map:public:{mapId}` | String | 공개 맵 단건 캐시 |
+| `map:public:list:version` | String | 공개 맵 목록 캐시 버전 |
 
-> ⚠️ `host_user_id` 필드명은 `leave_lobby.lua`에 하드코딩되어 있습니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
+> ⚠️ `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`에 하드코딩되어 있습니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
+
+### `lobby:{code}` Hash 구조
+
+로비 메타 정보는 Redis Hash로 저장합니다.
+
+| 필드 | 값 예시 | 설명 |
+|---|---|---|
+| `code` | `ABC123` | 로비 초대 코드 |
+| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier |
+| `title` | `K-POP 퀴즈방` | 로비 제목 |
+| `max_players` | `8` | 최대 참여 인원 |
+| `is_private` | `false` | 비공개 여부. `true` = 비공개 |
+| `status` | `WAITING` | 로비 상태 |
+| `map_id` | `1` | 선택된 맵 ID |
+| `map_title` | `K-POP 2세대` | 선택된 맵 제목 |
+| `map_category` | `kpop` | 선택된 맵 카테고리 |
+
+`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.  
+맵이 선택되지 않은 로비는 위 세 필드를 저장하지 않습니다.
+
+Redis에 `"null"` 문자열을 저장하지 않고, 응답 DTO에서만 `null`로 표현합니다.
 
 ### Redis Hash 필드 상수 (`RedisKeys.FIELD_*`)
 
 로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.  
 문자열 리터럴 직접 사용 시 오타가 런타임에서야 발견되는 문제를 컴파일 타임에 방지합니다.
+
+로비 맵 연결 기능에서 사용하는 주요 필드는 다음과 같습니다.
+
+| 필드 상수 | Redis Hash 필드명 | 설명 |
+|---|---|---|
+| `FIELD_MAP_ID` | `map_id` | 선택된 맵 ID |
+| `FIELD_MAP_TITLE` | `map_title` | 선택된 맵 제목 |
+| `FIELD_MAP_CATEGORY` | `map_category` | 선택된 맵 카테고리 |
+
+맵 미선택 로비에서는 위 필드를 저장하지 않습니다.
 
 ### WebSocket 로비 입장 저장 구조
 
@@ -244,6 +354,8 @@ leave_lobby.lua
 |---|---|---|---|
 | `lobby:{code}:participants` | Set | `/topic/lobby/{code}` 구독 시 | 현재 로비에 참여 중인 userIdentifier 목록 |
 | `lobby:{code}:order` | List | `/topic/lobby/{code}` 구독 시 | 입장 순서. 방장 퇴장 시 다음 방장 위임 기준 |
+| `lobby:{code}:user_session:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 wsSessionId |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 세션 sequence |
 | `ws:connection:{wsSessionId}` | Hash | `/topic/lobby/{code}` 구독 시 | WebSocket 세션 ID로 userIdentifier와 lobbyCode를 역추적하기 위한 매핑 |
 
 `ws:connection:{wsSessionId}` Hash 필드:
@@ -261,6 +373,12 @@ SMEMBERS lobby:R2VJW5:participants
 
 LRANGE lobby:R2VJW5:order 0 -1
 1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
+
+GET lobby:R2VJW5:user_session:9746cc76-f8f2-4859-b602-df6e1032fea4
+"mhrg4it0"
+
+GET lobby:R2VJW5:user_session_seq:9746cc76-f8f2-4859-b602-df6e1032fea4
+"1"
 
 HGETALL ws:connection:mhrg4it0
 1) "userId"
@@ -281,6 +399,73 @@ HGETALL ws:connection:mhrg4it0
 Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,  
 Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
 
+### 로비 생성 시 맵 연결 정책
+
+로비 생성 시 `mapId`는 선택 사항입니다.
+
+```text
+로비 생성: mapId 선택 사항
+게임 시작: mapId 필수
+```
+
+이 구조를 선택한 이유는 로비가 게임 시작 전 대기실 역할을 하기 때문입니다.  
+방장은 먼저 로비를 만들고 참여자를 모은 뒤, 로비 내부에서 맵을 선택하거나 변경할 수 있습니다.
+
+`mapId`가 전달된 경우 `LobbyService`에서 다음 순서로 검증합니다.
+
+```text
+1. 맵 존재 여부 확인
+2. 삭제된 맵 여부 확인
+3. 공개 맵이면 허용
+4. 비공개 맵이면 소유자만 허용
+```
+
+검증 결과에 따른 HTTP 상태 코드는 다음과 같습니다.
+
+| 상황 | 상태 코드 |
+|---|---|
+| 존재하지 않는 맵 | `404 Not Found` |
+| 삭제된 맵 | `409 Conflict` |
+| 타인 소유 비공개 맵 | `403 Forbidden` |
+| 공개 맵 또는 본인 소유 비공개 맵 | 로비 생성 허용 |
+
+검증이 끝난 맵 정보는 `LobbyMapMetadata`로 변환하여 Redis 저장 계층에 전달합니다.  
+이를 통해 `LobbyRepositoryImpl`이 `QuizMap` 엔티티에 직접 의존하지 않도록 분리합니다.
+
+### Lua 스크립트 기반 원자적 로비 생성
+
+`create_lobby.lua`는 초대 코드 선점과 로비 Hash 저장을 원자적으로 처리합니다.
+
+처리 대상:
+
+```text
+lobby:code:lock:{code}
+lobby:{code}
+lobby:public
+```
+
+로비 생성 시 아래 정보를 저장합니다.
+
+```text
+code
+host_user_id
+title
+max_players
+is_private
+status
+```
+
+이슈 #62 이후 선택된 맵이 있는 경우 아래 필드도 같은 Lua 스크립트 안에서 함께 저장합니다.
+
+```text
+map_id
+map_title
+map_category
+```
+
+맵 미선택 로비의 경우 Java에서 빈 문자열을 전달하고, Lua 스크립트는 `mapId`가 빈 문자열이면 맵 관련 필드를 저장하지 않습니다.  
+이 방식으로 Redis Hash에 `"null"` 문자열이 저장되는 것을 방지합니다.
+
 ### Lua 스크립트 기반 원자적 입장 처리
 
 `enter_lobby.lua`는 WebSocket 로비 입장 시 필요한 Redis 상태 변경을 단일 원자 연산으로 처리합니다.
@@ -290,6 +475,8 @@ Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
 ```text
 lobby:{code}:participants
 lobby:{code}:order
+lobby:{code}:user_session:{userIdentifier}
+lobby:{code}:user_session_seq:{userIdentifier}
 ws:connection:{wsSessionId}
 ```
 
@@ -308,15 +495,17 @@ ws:connection은 있지만 participants에는 없음
 2. participants Set에 userIdentifier 추가
 3. 신규 입장자인 경우에만 order List에 userIdentifier 추가
 4. ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
-5. ws:connection:{wsSessionId} TTL 설정
+5. 로비 내 유저별 현재 유효 wsSessionId 저장
+6. 로비 내 유저별 현재 유효 세션 sequence 저장
+7. 관련 키 TTL 설정
 ```
 
 반환값은 다음과 같습니다.
 
 | 반환값 | 의미 |
 |---|---|
-| `ENTERED` | 신규 입장 처리 완료 |
-| `ALREADY_JOINED` | 이미 참여 중인 유저의 중복 구독. order 중복 저장 없음 |
+| `ENTERED:{sequence}` | 신규 입장 처리 완료 |
+| `ALREADY_JOINED:{sequence}` | 이미 참여 중인 유저의 중복 구독. order 중복 저장 없음 |
 | `LOBBY_NOT_FOUND` | 존재하지 않는 로비 코드로 구독 요청 |
 
 입장 처리는 반드시 `/topic/lobby/{code}` 구독 시점에만 수행합니다.  
@@ -330,6 +519,48 @@ Redis는 싱글 스레드로 Lua 스크립트를 실행하므로 다수의 동�
 반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,  
 `LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여  
 서비스 레이어가 Redis 반환 포맷을 알 필요 없도록 캡슐화합니다.
+
+### Lua 스크립트 기반 원자적 강퇴 처리
+
+`kick_lobby.lua`는 방장의 강퇴 요청을 원자적으로 처리합니다.
+
+처리 대상:
+
+```text
+lobby:{code}
+lobby:{code}:participants
+lobby:{code}:order
+lobby:{code}:kicked
+lobby:{code}:user_session:{targetUserIdentifier}
+lobby:{code}:user_session_seq:{targetUserIdentifier}
+```
+
+처리 순서:
+
+```text
+1. 로비 존재 여부 확인
+2. 방장 정보 존재 여부 확인
+3. 요청자가 방장인지 검증
+4. 자기 자신 강퇴 요청인지 검증
+5. 강퇴 대상이 참여자인지 검증
+6. participants/order에서 강퇴 대상 제거
+7. kicked Set에 강퇴 대상 추가
+8. 강퇴 대상의 현재 wsSessionId 반환
+9. 강퇴 대상의 user_session / user_session_seq 키 삭제
+```
+
+반환값은 다음과 같습니다.
+
+| 반환값 | 의미 |
+|---|---|
+| `KICKED:{targetWsSessionId}` | 강퇴 성공 |
+| `LOBBY_NOT_FOUND` | 존재하지 않는 로비 |
+| `HOST_NOT_FOUND` | 로비 방장 정보 없음 |
+| `FORBIDDEN` | 요청자가 방장이 아님 |
+| `CANNOT_KICK_SELF` | 자기 자신 강퇴 시도 |
+| `TARGET_NOT_PARTICIPANT` | 강퇴 대상이 로비 참여자가 아님 |
+
+강퇴 성공 후 `LobbyEventService`는 `KICK` 메시지를 로비 채팅 채널로 브로드캐스트하고, 로비 내부 refresh 이벤트를 발행합니다.
 
 ### ChatMessageDto 위치
 
@@ -383,14 +614,14 @@ WebSocket 클라이언트가 ["클래스명", {...}] 형태의 메시지를 받�
 기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로  
 동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.  
 `lobby:{code}:participants`를 단일 진실의 원천으로 통일하여  
-입장(Lua) → 퇴장(Lua) 모두 동일한 키를 사용합니다.
+입장(Lua) → 퇴장(Lua) → 강퇴(Lua) 모두 동일한 키를 사용합니다.
 
 ### SETNX 기반 초대 코드 중복 방지
 
-`LobbyRepositoryImpl.acquireInviteCode()`는 6자리 초대 코드를 생성할 때  
+`LobbyRepositoryImpl`은 6자리 초대 코드를 생성할 때  
 `lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.  
-선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`(5회)까지 재시도합니다.  
-락 TTL은 10초로 설정하여 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
+선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`까지 재시도합니다.  
+락 TTL은 `LobbyDefaults.INVITE_CODE_LOCK_TTL`을 따르며, 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
 
 ### JWT 인증 구조
 
@@ -416,6 +647,7 @@ JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
 | 클라이언트 → 서버 | `/app/chat/lobby/{code}` | 로비 채팅 메시지 송신 |
 | 클라이언트 → 서버 | `/app/lobby/create` | 로비 생성 이벤트 송신 |
 | 클라이언트 → 서버 | `/app/lobby/{code}/update` | 로비 정보 변경 이벤트 송신 |
+| 클라이언트 → 서버 | `/app/lobby/{code}/kick` | 방장의 로비 유저 강퇴 요청 |
 | 서버 → 클라이언트 | `/topic/chat/global` | 전체 채팅 메시지 수신 |
 | 서버 → 클라이언트 | `/topic/lobby/{code}` | 로비 채팅 메시지 수신 및 로비 입장 처리 트리거 |
 | 서버 → 클라이언트 | `/topic/lobby/{code}/refresh` | 로비 내부 정보 새로고침 신호 |
@@ -470,3 +702,131 @@ Controller
     ▼
 Service
 ```
+
+---
+
+## 🧩 로비 생성 시 맵 연결 흐름
+
+```text
+클라이언트
+    │ POST /api/lobbies
+    │ Body: { title, maxPlayers, isPrivate, mapId?, roundCount?, timeLimitSeconds? }
+    ▼
+LobbyController.createLobby()
+    │ @AuthenticationPrincipal CustomPrincipal 주입
+    ▼
+LobbyService.createLobby()
+    │ 1. principal 검증
+    │ 2. host User 조회
+    │ 3. mapId가 있으면 QuizMap 조회 및 권한 검증
+    │ 4. LobbyMapMetadata 생성
+    ▼
+LobbyRepository.saveToRedis()
+    │ create_lobby.lua 실행
+    │ 초대 코드 선점 + Redis Hash 저장
+    ▼
+GameLobbyJpaRepository.save()
+    │ GAME_LOBBY 스냅샷 저장
+    ▼
+CreateLobbyResponse 반환
+```
+
+### 맵 미선택 로비
+
+`mapId`가 없으면 맵 검증을 수행하지 않습니다.
+
+```json
+{
+  "mapId": null,
+  "mapTitle": null,
+  "mapCategory": null
+}
+```
+
+Redis Hash에는 `map_id`, `map_title`, `map_category` 필드를 저장하지 않습니다.
+
+### 맵 선택 로비
+
+`mapId`가 있으면 검증 후 Redis Hash와 DB 스냅샷에 반영합니다.
+
+```json
+{
+  "mapId": 1,
+  "mapTitle": "K-POP 2세대",
+  "mapCategory": "kpop"
+}
+```
+
+Redis Hash에는 아래 필드를 저장합니다.
+
+```text
+map_id
+map_title
+map_category
+```
+
+---
+
+## 🧪 주요 검증 시나리오
+
+### 로비 생성
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| `mapId` 없이 로비 생성 | `201 Created`, 맵 정보 `null` |
+| 공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함 |
+| 본인 소유 비공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함 |
+| 타인 소유 비공개 맵 `mapId`로 로비 생성 | `403 Forbidden` |
+| 삭제된 맵 `mapId`로 로비 생성 | `409 Conflict` |
+| 존재하지 않는 `mapId`로 로비 생성 | `404 Not Found` |
+| 음수 또는 0 `mapId`로 로비 생성 | `400 Bad Request` |
+
+### Redis 저장
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| 맵 미선택 로비 | `map_id`, `map_title`, `map_category` 필드 없음 |
+| 맵 선택 로비 | `map_id`, `map_title`, `map_category` 필드 있음 |
+| 맵 미선택 로비 | `"null"` 문자열 저장 없음 |
+
+---
+
+## 📌 향후 확장 포인트
+
+### 로비 내부 맵 변경
+
+현재 이슈 #62는 로비 생성 시점의 선택적 맵 연결만 처리합니다.  
+향후 로비 대기실에서 방장이 맵을 변경하는 API를 추가할 수 있습니다.
+
+예상 API:
+
+```http
+PATCH /api/lobbies/{inviteCode}/map
+```
+
+예상 정책:
+
+```text
+1. 방장만 변경 가능
+2. WAITING 상태에서만 변경 가능
+3. 삭제된 맵 선택 불가
+4. 비공개 맵은 소유자만 선택 가능
+5. 변경 후 /topic/lobby/{code}/refresh 브로드캐스트
+```
+
+### 게임 시작 조건 검증
+
+게임 시작 시점에는 반드시 유효한 맵이 선택되어 있어야 합니다.
+
+예상 조건:
+
+```text
+1. 요청자가 방장이어야 함
+2. 로비 상태가 WAITING이어야 함
+3. 선택된 맵이 있어야 함
+4. 선택된 맵이 삭제되지 않아야 함
+5. 맵의 문제 수가 roundCount 이상이어야 함
+6. 모든 참여자가 준비 완료 상태여야 함
+```
+
+이 검증은 로비 준비 상태 관리 및 게임 시작 이슈에서 처리하는 것이 적절합니다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyRequest.java
@@ -1,13 +1,14 @@
 package io.github.ascrew.monomatbe.domain.lobby.dto;
 
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 /**
  * 로비 생성 요청 DTO.
+ *
+ * [맵 선택 정책]
+ * mapId는 선택 사항이다.
+ * 로비는 맵 없이 먼저 생성될 수 있으며, 게임 시작 시점에 맵 선택 여부를 검증한다.
  *
  * [기본값 처리]
  * roundCount, timeLimitSeconds는 클라이언트가 null로 생략하면 LobbyDefaults 상수값으로 자동 적용된다.
@@ -15,6 +16,7 @@ import jakarta.validation.constraints.Size;
  * [검증 규칙 — 기능명세서 기준]
  * - title      : 필수, 최대 255자
  * - maxPlayers : 2~8명
+ * - mapId      : 선택 사항 (맵 없는 로비 허용), 전달 시 양수
  * - roundCount : 1~20 (생략 시 기본값 5)
  * - timeLimitSeconds : 10~120초 (생략 시 기본값 30)
  */
@@ -29,6 +31,15 @@ public record CreateLobbyRequest(
         int maxPlayers,
 
         boolean isPrivate,
+
+        /**
+         * 로비에 연결할 맵 ID
+         *
+         * null이면 맵 미선택 로비로 생성한다.
+         * 실제 맵 존재 여부, 삭제 여부, 접근 권한은 LobbyService에서 검증한다.
+         */
+        @Positive(message = "맵 ID는 양수여야 합니다.")
+        Long mapId,
 
         @Min(value = 1, message = "라운드 수는 1 이상이어야 합니다.")
         @Max(value = 20, message = "라운드 수는 20 이하이어야 합니다.")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyResponse.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 /**
  * 로비 생성 응답 DTO.
  *
+ * [맵 정보]
+ * mapId, mapTitle, mapCategory는 로비 생성 시 맵을 선택하지 않은 경우 null이다.
+ *
  * [딥링크 설계]
  * 프론트엔드가 /lobby/{inviteCode} 경로로 바로 이동할 수 있도록 inviteCode를 응답에 포함한다.
  *
@@ -15,6 +18,9 @@ import lombok.Builder;
  * - maxPlayers : 최대 참여 인원
  * - isPrivate  : 공개/비공개 여부
  * - status     : 로비 상태 (생성 직후 WAITING)
+ * - mapId      : 선택된 맵 ID (맵 미선택 시 null)
+ * - mapTitle   : 선택된 맵 제목 (맵 미선택 시 null)
+ * - mapCategory: 선택된 맵 카테고리 (맵 미선택 시 null)
  */
 @Builder
 public record CreateLobbyResponse(
@@ -23,5 +29,9 @@ public record CreateLobbyResponse(
         String title,
         int maxPlayers,
         boolean isPrivate,
-        String status
-) {}
+        String status,
+        Long mapId,
+        String mapTitle,
+        String mapCategory
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyResponse.java
@@ -9,9 +9,8 @@ import lombok.Builder;
  * REST 응답 시점의 스냅샷이며, WebSocket 연결 후 REFRESH_LOBBY_INFO 신호로
  * 최신 상태를 다시 조회하므로 일시적 불일치는 허용한다.
  *
- * [mapCategory]
- * 맵 선택 이슈에서 반정규화 방식으로 Redis Hash에 저장될 예정이다.
- * 현재는 맵 선택 기능이 구현되지 않았으므로 null로 내려간다.
+ * [맵 정보]
+ * mapId, mapTitle, mapCategory는 로비에 맵이 선택되지 않은 경우 null
  */
 @Builder
 public record JoinLobbyResponse(
@@ -27,6 +26,10 @@ public record JoinLobbyResponse(
         int currentPlayers,
         // 로비 상태 (WAITING | PLAYING)
         String status,
+        //선택된 맵 ID (미선택 시 null)
+        Long mapId,
+        // 선택된 맵 제목 (미선택 시 null)
+        String mapTitle,
         // 선택된 맵의 카테고리 (미선택 시 null)
         String mapCategory
 ) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyMapMetadata.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyMapMetadata.java
@@ -1,0 +1,15 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+/**
+ * 로비에 연결된 맵의 최소 메타데이터
+ *
+ * [설계 의도]
+ * LobbyRepository는 Redis 저장 책임만 가지므로 QuizMap 엔티티에 직접 의존하지 않는다.
+ * LobbyService가 맵 접근 권한을 검증한 뒤, Redis Hash에 필요한 최소 정보만 이 DTO로 전달한다.
+ */
+public record LobbyMapMetadata(
+        Long mapId,
+        String mapTitle,
+        String mapCategory
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
@@ -24,6 +24,7 @@ public class LobbyRedisDto {
     private String mapCategory;   // 선택된 맵의 카테고리 (미선택 시 null)
 
     private Integer maxPlayers;   // 최대 참여 가능 인원
+    private Integer currentPlayers; // 현재 참여 인원 수
     private Boolean isPrivate;    // 공개(false) / 비공개(true) 여부
     private String status;        // 로비 상태 (WAITING, PLAYING)
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
@@ -18,8 +18,11 @@ public class LobbyRedisDto {
     private String code;          // 로비 초대 코드 (6자리 고유 코드)
     private String hostId;        // 현재 방장의 사용자 식별자
     private String title;         // 로비 제목
-    private Long mapId;           // 선택된 맵 세트 ID
+
+    private Long mapId;           // 선택된 맵 세트 ID (미선택 시 null)
+    private String mapTitle;      // 선택된 맵 제목 (미선택 시 null)
     private String mapCategory;   // 선택된 맵의 카테고리 (미선택 시 null)
+
     private Integer maxPlayers;   // 최대 참여 가능 인원
     private Boolean isPrivate;    // 공개(false) / 비공개(true) 여부
     private String status;        // 로비 상태 (WAITING, PLAYING)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -5,9 +5,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
-import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
-import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
-import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.*;
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 
 import java.util.List;
@@ -23,8 +21,16 @@ public interface LobbyRepository {
 
   /**
    * Redis에 로비 데이터를 저장하고 초대 코드를 반환한다.
+   *
+   * @param request 로비 생성 요청
+   * @param userIdentifier 방장 사용자 식별자
+   * @param mapMetadata 선택된 맵 메타데이터 (맵 미선택 시 null)
    */
-  String saveToRedis(CreateLobbyRequest request, String userIdentifier);
+  String saveToRedis(
+          CreateLobbyRequest request,
+          String userIdentifier,
+          LobbyMapMetadata mapMetadata
+  );
 
   /**
    * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -8,6 +8,7 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -27,6 +28,12 @@ import java.util.Set;
 @Repository
 @RequiredArgsConstructor
 public class LobbyRepositoryImpl implements LobbyRepository {
+
+  /**
+   * Lua 스크립트에 선택 값이 없음을 표현하기 위한 값.
+   * Redis Hash에 "null" 문자열이 저장되는 것을 방지하기 위해 빈 문자열을 사용합니다.
+   */
+  private static final String EMPTY_REDIS_VALUE = "";
 
   private final StringRedisTemplate redisTemplate;
   private final RedisScript<String> leaveLobbyScript;
@@ -49,8 +56,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String RESULT_DELEGATED_PREFIX = "DELEGATED:";
 
   // =========================================================
-// kick_lobby.lua 반환값 상수
-// =========================================================
+  // kick_lobby.lua 반환값 상수
+  // =========================================================
 
   private static final String RESULT_KICKED_PREFIX = "KICKED:";
   private static final String RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
@@ -128,12 +135,15 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    * - 최대 재시도 횟수 초과 시 503 반환
    */
   @Override
-  public String saveToRedis(CreateLobbyRequest request, String userIdentifier) {
+  public String saveToRedis(
+          CreateLobbyRequest request,
+          String userIdentifier,
+          LobbyMapMetadata mapMetadata
+  ) {
     for (int attempt = 0; attempt < LobbyDefaults.INVITE_CODE_MAX_RETRY; attempt++) {
       String candidate = generateInviteCode();
-      String result = executeCreateLobbyScript(candidate, request, userIdentifier);
+      String result = executeCreateLobbyScript(candidate, request, userIdentifier, mapMetadata);
 
-      // null 반환은 코드 충돌이 아닌 Redis 오류이므로 즉시 503 반환
       if (result == null) {
         log.error("Lua 스크립트 null 반환 - Redis 연결 오류 가능성. 코드: {}", candidate);
         throw new ResponseStatusException(
@@ -141,11 +151,15 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       }
 
       if (RESULT_OK.equals(result)) {
-        log.info("로비 Redis 저장 완료 - 코드: {}, 방장: {}", candidate, userIdentifier);
+        log.info(
+                "로비 Redis 저장 완료 - 코드: {}, 방장: {}, mapId: {}",
+                candidate,
+                userIdentifier,
+                mapMetadata != null ? mapMetadata.mapId() : null
+        );
         return candidate;
       }
 
-      // LOCK_FAILED: 코드 충돌 → 새 코드로 재시도
       log.warn("초대 코드 충돌 - 재시도 {}/{}: {}",
               attempt + 1, LobbyDefaults.INVITE_CODE_MAX_RETRY, candidate);
     }
@@ -267,6 +281,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               .title((String) data.get(RedisKeys.FIELD_TITLE))
               .status((String) data.get(RedisKeys.FIELD_STATUS))
               .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
+              .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
               .mapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY))
               .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
               .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
@@ -318,6 +333,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             .maxPlayers(maxPlayers)
             .currentPlayers(currentPlayers)
             .status((String) data.get(RedisKeys.FIELD_STATUS))
+            .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
+            .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
             .mapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY))
             .build());
   }
@@ -347,19 +364,24 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   // =========================================================
 
   /**
-   * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행한다.
+   * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행합니다.
    *
-   * @return "OK" (성공) | "LOCK_FAILED" (코드 충돌) | null (Redis 오류)
+   * [맵 정보 저장 정책]
+   * mapMetadata가 null이면 빈 문자열을 Lua에 전달합니다.
+   * Lua는 mapId가 빈 문자열인 경우 map_id, map_title, map_category 필드를 저장하지 않습니다.
+   *
+   * @return "OK" | "LOCK_FAILED" | null
    */
   private String executeCreateLobbyScript(
           String inviteCode,
           CreateLobbyRequest request,
-          String userIdentifier
+          String userIdentifier,
+          LobbyMapMetadata mapMetadata
   ) {
     List<String> keys = List.of(
-            RedisKeys.lobbyCodeLockKey(inviteCode), // KEYS[1]
-            RedisKeys.lobbyKey(inviteCode),         // KEYS[2]
-            RedisKeys.LOBBY_PUBLIC                  // KEYS[3]
+            RedisKeys.lobbyCodeLockKey(inviteCode),
+            RedisKeys.lobbyKey(inviteCode),
+            RedisKeys.LOBBY_PUBLIC
     );
 
     String lockTtlMs = String.valueOf(LobbyDefaults.INVITE_CODE_LOCK_TTL.toMillis());
@@ -368,13 +390,18 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     return redisTemplate.execute(
             createLobbyScript,
             keys,
-            userIdentifier,                         // ARGV[1]
-            lockTtlMs,                              // ARGV[2]
-            inviteCode,                             // ARGV[3]
-            request.title(),                        // ARGV[4]
-            String.valueOf(request.maxPlayers()),   // ARGV[5]
-            isPrivateValue,                         // ARGV[6]
-            LobbyStatus.WAITING.name()              // ARGV[7]
+            userIdentifier,
+            lockTtlMs,
+            inviteCode,
+            request.title(),
+            String.valueOf(request.maxPlayers()),
+            isPrivateValue,
+            LobbyStatus.WAITING.name(),
+
+            // 맵 미선택 시 빈 문자열을 전달하여 Redis에 "null" 문자열이 저장되지 않게 합니다.
+            mapMetadata != null ? String.valueOf(mapMetadata.mapId()) : EMPTY_REDIS_VALUE,
+            mapMetadata != null ? mapMetadata.mapTitle() : EMPTY_REDIS_VALUE,
+            mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE
     );
   }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -284,6 +284,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
               .mapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY))
               .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
+              .currentPlayers(getCurrentPlayerCount(code))
               .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
               .build());
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -148,7 +148,7 @@ public class LobbyService {
                     .build());
 
             log.info(
-                    "로비 생성 완료 - 코드: {}, 방장: {}",
+                    "로비 생성 완료 - 코드: {}, 방장: {}, mapId: {}",
                     inviteCode,
                     principal.userIdentifier(),
                     mapMetadata != null ? mapMetadata.mapId() : null

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -14,6 +14,9 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -44,6 +47,12 @@ public class LobbyService {
             "게임이 이미 시작된 로비에는 입장할 수 없습니다.";
     private static final String ERROR_LOBBY_FULL =
             "최대 인원에 도달한 로비입니다.";
+    private static final String ERROR_MAP_NOT_FOUND =
+            "존재하지 않는 맵입니다.";
+    private static final String ERROR_MAP_DELETED =
+            "삭제된 맵은 로비에 연결할 수 없습니다.";
+    private static final String ERROR_PRIVATE_MAP_FORBIDDEN =
+            "비공개 맵은 소유자만 로비에 연결할 수 있습니다.";
 
     // =========================================================
     // 로그 메시지 상수
@@ -77,6 +86,7 @@ public class LobbyService {
     private final LobbyRepository lobbyRepository;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final UserRepository userRepository;
+    private final QuizMapJpaRepository quizMapJpaRepository;
 
     /**
      * 로비를 생성한다.
@@ -108,11 +118,27 @@ public class LobbyService {
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, ERROR_USER_NOT_FOUND));
 
-        String inviteCode = lobbyRepository.saveToRedis(request, principal.userIdentifier());
+        /**
+         * 맵 연결 정책 :
+         * - mapId가 없으면 맵 미선택 로비로 생성한다.
+         * - mapId가 있으면 존재 여부, 삭제 여부, 접근 권한을 검증한다.
+         * - 검증된 최소 맵 정보만 Redis 저장 계층으로 전달한다.
+         */
+        LobbyMapMetadata mapMetadata = resolveLobbyMapMetadata(
+                request.mapId(),
+                principal.userId()
+        );
+
+        String inviteCode = lobbyRepository.saveToRedis(
+                request,
+                principal.userIdentifier(),
+                mapMetadata
+        );
 
         try {
             GameLobby gameLobby = gameLobbyJpaRepository.save(GameLobby.builder()
                     .host(host)
+                    .mapId(mapMetadata != null ? mapMetadata.mapId() : null)
                     .inviteCode(inviteCode)
                     .title(request.title())
                     .maxPlayers(request.maxPlayers())
@@ -121,7 +147,12 @@ public class LobbyService {
                     .isPrivate(request.isPrivate())
                     .build());
 
-            log.info("로비 생성 완료 - 코드: {}, 방장: {}", inviteCode, principal.userIdentifier());
+            log.info(
+                    "로비 생성 완료 - 코드: {}, 방장: {}",
+                    inviteCode,
+                    principal.userIdentifier(),
+                    mapMetadata != null ? mapMetadata.mapId() : null
+            );
 
             return CreateLobbyResponse.builder()
                     .lobbyId(gameLobby.getId())
@@ -130,19 +161,19 @@ public class LobbyService {
                     .maxPlayers(gameLobby.getMaxPlayers())
                     .isPrivate(gameLobby.getIsPrivate())
                     .status(gameLobby.getStatus().name())
+                    .mapId(mapMetadata != null ? mapMetadata.mapId() : null)
+                    .mapTitle(mapMetadata != null ? mapMetadata.mapTitle() : null)
+                    .mapCategory(mapMetadata != null ? mapMetadata.mapCategory() : null)
                     .build();
 
         } catch (Exception e) {
-            // 보상 삭제 성공/실패를 구분하여 모니터링 가능한 로그 기록
             log.error(LOG_DB_SAVE_FAILED, inviteCode, e);
 
             boolean compensationSuccess = lobbyRepository.deleteFromRedis(inviteCode);
 
             if (compensationSuccess) {
-                // 보상 삭제 성공: 데이터 정합성 유지됨
                 log.info(LOG_COMPENSATION_SUCCESS, inviteCode);
             } else {
-                // 보상 삭제 실패: Redis에 좀비 로비 데이터가 남아있을 수 있음
                 log.error(LOG_COMPENSATION_FAILED, inviteCode);
             }
 
@@ -212,5 +243,66 @@ public class LobbyService {
      */
     public List<LobbyRedisDto> getPublicLobbies() {
         return lobbyRepository.getPublicLobbies();
+    }
+
+    /**
+     * 로비 생성 시 선택된 맵의 접근 가능 여부를 검증하고,
+     * Redis 저장에 필요한 최소 메타데이터로 변환합니다.
+     *
+     * [정책]
+     * - mapId가 null이면 맵 미선택 로비로 생성한다.
+     * - 삭제된 맵은 선택할 수 없다.
+     * - 공개 맵은 누구나 로비에 연결할 수 있다.
+     * - 비공개 맵은 소유자만 로비에 연결할 수 있다.
+     *
+     * @param mapId 요청으로 전달된 맵 ID
+     * @param requesterUserId 로비 생성 요청자의 DB userId
+     * @return 선택된 맵 메타데이터. 맵 미선택 시 null.
+     */
+    private LobbyMapMetadata resolveLobbyMapMetadata(Long mapId, Long requesterUserId) {
+        if (mapId == null) {
+            return null;
+        }
+
+        QuizMap quizMap = quizMapJpaRepository.findById(mapId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_MAP_NOT_FOUND
+                ));
+
+        if (Boolean.TRUE.equals(quizMap.getIsDeleted())) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_MAP_DELETED
+            );
+        }
+
+        if (!canUseMap(quizMap, requesterUserId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_PRIVATE_MAP_FORBIDDEN
+            );
+        }
+
+        return new LobbyMapMetadata(
+                quizMap.getId(),
+                quizMap.getTitle(),
+                quizMap.getCategory().value()
+        );
+    }
+
+    /**
+     * 요청자가 해당 맵을 로비에 연결할 수 있는지 검증한다.
+     *
+     * 공개 맵은 누구나 사용할 수 있고, 비공개 맵은 맵 소유자만 사용할 수 있다.
+     */
+    private boolean canUseMap(QuizMap quizMap, Long requesterUserId) {
+        if (Boolean.TRUE.equals(quizMap.getIsPublic())) {
+            return true;
+        }
+
+        return quizMap.getOwner() != null
+                && quizMap.getOwner().getId() != null
+                && quizMap.getOwner().getId().equals(requesterUserId);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -127,6 +127,9 @@ public final class RedisKeys {
     /** 로비 Hash의 선택된 맵 ID 필드 (null 가능 — 맵 미선택 상태) */
     public static final String FIELD_MAP_ID = "map_id";
 
+    /** 로비 Hash의 선택된 맵 제목 필드 (맵 미선택 시 필드가 없을 수 있음) */
+    public static final String FIELD_MAP_TITLE = "map_title";
+
     /** 로비 Hash의 선택된 맵 카테고리 필드 */
     public static final String FIELD_MAP_CATEGORY = "map_category";
 

--- a/src/main/resources/scripts/create_lobby.lua
+++ b/src/main/resources/scripts/create_lobby.lua
@@ -23,7 +23,22 @@ local inviteCode      = ARGV[3]   -- 초대 코드
 local title           = ARGV[4]   -- 로비 제목
 local maxPlayers      = ARGV[5]   -- 최대 인원
 local isPrivate       = ARGV[6]   -- "true" | "false"
-local status          = ARGV[7]   -- "WAITING"
+local status         = ARGV[7]  -- "WAITING"
+
+local mapId           = ARGV[8]   -- 선택된 맵 ID. 미선택 시 ""
+local mapTitle        = ARGV[9]   -- 선택된 맵 제목. 미선택 시 ""
+local mapCategory    = ARGV[10]  -- 선택된 맵 카테고리. 미선택 시 ""
+
+-- Redis Hash 필드명은 스크립트 상단에서 중앙 관리합니다.
+local FIELD_CODE         = 'code'
+local FIELD_HOST_USER_ID = 'host_user_id'
+local FIELD_TITLE        = 'title'
+local FIELD_MAX_PLAYERS  = 'max_players'
+local FIELD_IS_PRIVATE   = 'is_private'
+local FIELD_STATUS       = 'status'
+local FIELD_MAP_ID       = 'map_id'
+local FIELD_MAP_TITLE    = 'map_title'
+local FIELD_MAP_CATEGORY = 'map_category'
 
 -- 1. SETNX 선점 시도
 --    이미 동일한 코드가 선점되어 있으면 LOCK_FAILED 반환
@@ -43,7 +58,16 @@ redis.call('HSET', lobbyKey,
     'status',       status
 )
 
--- 3. 공개 로비인 경우 전역 공개 목록 Set에 코드 추가 (lobby:public)
+-- 3. 맵이 선택된 경우에만 맵 메타 정보 저장
+if mapId ~= "" then
+    redis.call('HSET', lobbyKey,
+        FIELD_MAP_ID,       mapId,
+        FIELD_MAP_TITLE,    mapTitle,
+        FIELD_MAP_CATEGORY, mapCategory
+    )
+end
+
+-- 4. 공개 로비인 경우 전역 공개 목록 Set에 코드 추가 (lobby:public)
 -- [isPrivate 값 보장]
 -- Java LobbyRepositoryImpl.normalizeIsPrivate()에서 반드시 소문자 "true"/"false"로
 -- 정규화하여 전달하므로, 이 비교는 항상 일관되게 동작한다.


### PR DESCRIPTION
## 📣 Related Issue

- #62

## 📝 Summary

- 로비 생성 요청에 `mapId`를 선택적으로 전달할 수 있도록 추가했습니다.
- `mapId`가 전달된 경우 맵 존재 여부, 삭제 여부, 접근 권한을 검증하도록 구현했습니다.
- 공개 맵은 누구나 로비에 연결할 수 있고, 비공개 맵은 소유자만 연결할 수 있도록 제한했습니다.
- 로비 Redis 데이터에 선택된 맵의 `mapId`, `mapTitle`, `mapCategory`를 저장하도록 확장했습니다.
- 로비 생성 응답에 맵 정보를 포함하도록 수정했습니다.
- 초대 코드 기반 로비 입장 응답에 맵 정보를 포함하도록 수정했습니다.
- 공개 로비 목록 응답에 맵 제목과 카테고리 정보를 포함하도록 수정했습니다.
- 맵이 선택되지 않은 로비는 `mapId`, `mapTitle`, `mapCategory`를 `null`로 응답하도록 처리했습니다.
- 맵 미선택 상태에서는 Redis Hash에 `map_*` 필드를 저장하지 않도록 처리하여 `"null"` 문자열 저장을 방지했습니다.

## 🙏 PR point

- 로비 생성 시 `mapId`는 필수가 아니라 선택 사항으로 처리했습니다.
  - 로비는 맵 없이 생성할 수 있습니다.
  - 게임 시작 시점에는 선택된 맵이 있는지 별도로 검증하는 구조를 의도했습니다.
- 맵 검증 정책은 다음과 같습니다.
  - 존재하지 않는 맵: `404 Not Found`
  - 삭제된 맵: `409 Conflict`
  - 타인 소유 비공개 맵: `403 Forbidden`
  - 공개 맵 또는 본인 소유 비공개 맵: 연결 가능
- Redis에는 맵이 선택된 경우에만 `map_id`, `map_title`, `map_category`를 저장합니다.
- 맵 미선택 로비의 경우 Redis에 `"null"` 문자열을 저장하지 않고, 응답 DTO에서만 `null`로 표현합니다.
- 이번 PR에서는 게임 시작 조건 검증은 포함하지 않았습니다.
  - `mapId` 필수 여부는 이후 `[Feat] 로비 준비 상태 관리 및 게임 시작 조건 검증` 이슈에서 처리하는 것이 적절합니다.

## 📬 Reference

- 기능명세서
  - 로비 만들기 — 로비 생성
  - 로비 — 맵 및 룰 설정
  - 로비 목록 조회 — 목록 조회 및 필터링