### PR TITLE
[Feat/#35] 로그인 - ID/PW 검증 및 세션 발급

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -90,6 +90,48 @@ POST /api/auth/register
 
 ---
 
+#### 자체 로그인
+
+```http
+POST /api/auth/login
+```
+
+가입한 로그인 ID/비밀번호로 인증 후 Access/Refresh 토큰을 발급합니다.  
+로그인 성공 시 `user_sessions`에 세션 추적 정보를 저장하며, Refresh Token은 Redis에 저장됩니다.
+
+**Request**
+
+```json
+{
+  "loginId": "member01",
+  "password": "password123"
+}
+```
+
+**Response `200 OK`**
+
+```json
+{
+  "userId": 2,
+  "loginId": "member01",
+  "nickname": "registered-user",
+  "userType": "REGISTERED",
+  "userIdentifier": "b17f7ee0-614f-4f5f-b770-83f6d4b85f4a",
+  "accessToken": "eyJhbGciOi...",
+  "accessTokenExpiresAt": "2026-05-03T07:45:00Z",
+  "refreshToken": "eyJhbGciOi...",
+  "refreshTokenExpiresAt": "2026-06-02T07:30:00Z"
+}
+```
+
+**Error**
+
+- `400 Bad Request`: 필수값 누락 / 공백 포함
+- `401 Unauthorized`: 로그인 ID 또는 비밀번호 불일치
+- `423 Locked`: 로그인 실패 5회 누적 계정 잠금 (15분)
+
+---
+
 ### 로비 (Lobby)
 
 #### 로비 생성
@@ -656,7 +698,6 @@ SEND /app/lobby/{code}/kick
 
 | 분류 | 설명 |
 |---|---|
-| 로그인 | `POST /api/auth/login` |
 | 맵 아이템(문제) CRUD | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |
 | YouTube URL 유효성 검증 | `POST /api/youtube/validate` |
 | 로비 맵 변경 | `PATCH /api/lobbies/{inviteCode}/map` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,9 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   └── AuthController.java                 # REST 인증 엔드포인트 (/api/auth/**)
 │   │   ├── dto/
 │   │   │   ├── GuestLoginRequest.java              # 게스트 로그인 요청 DTO
-│   │   │   └── GuestLoginResponse.java             # 게스트 로그인 응답 DTO (JWT 포함)
+│   │   │   ├── GuestLoginResponse.java             # 게스트 로그인 응답 DTO (JWT 포함)
+│   │   │   ├── LoginRequest.java                   # 자체 로그인 요청 DTO
+│   │   │   └── LoginResponse.java                  # 자체 로그인 응답 DTO (JWT + 세션 식별자)
 │   │   ├── entity/
 │   │   │   ├── User.java                           # 사용자 엔티티 (게스트/회원 통합)
 │   │   │   ├── GuestSession.java                   # 게스트 세션 엔티티
@@ -24,7 +26,9 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   ├── UserCredentialRepository.java
 │   │   │   └── UserSessionRepository.java
 │   │   └── service/
-│   │       └── GuestAuthService.java               # 게스트 로그인/세션 발급 로직
+│   │       ├── GuestAuthService.java               # 게스트 로그인/세션 발급 로직
+│   │       ├── RegisterAuthService.java            # 회원가입 로직
+│   │       └── LoginAuthService.java               # 자체 로그인/잠금 정책/세션 발급 로직
 │   │
 │   ├── chat/                                       # 채팅 도메인
 │   │   ├── controller/
@@ -662,7 +666,7 @@ JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
 
 ### 정식 회원 (Member)
 
-로그인 성공 시 JWT 또는 Redis 세션을 발급받아 인증합니다.  
+로그인 성공 시 JWT를 발급하고 `user_sessions`에 서버 세션 추적 정보를 저장합니다.  
 맵 생성, 로비 호스팅 등 전체 기능에 접근할 수 있습니다.
 
 ### 게스트 (Guest)
@@ -673,7 +677,7 @@ JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
 ### WebSocket 인증 흐름
 
 ```text
-STOMP CONNECT 헤더: { userIdentifier: "UUID 또는 회원 ID" }
+STOMP CONNECT 헤더: { userIdentifier: "UUID" }
     │
     ▼
 StompChannelInterceptor.handleConnect()

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
@@ -2,11 +2,15 @@ package io.github.ascrew.monomatbe.domain.auth.controller;
 
 import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginResponse;
+import io.github.ascrew.monomatbe.domain.auth.dto.LoginRequest;
+import io.github.ascrew.monomatbe.domain.auth.dto.LoginResponse;
 import io.github.ascrew.monomatbe.domain.auth.dto.RegisterRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
 import io.github.ascrew.monomatbe.domain.auth.service.GuestAuthService;
+import io.github.ascrew.monomatbe.domain.auth.service.LoginAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.RegisterAuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +27,7 @@ public class AuthController {
 
     private final GuestAuthService guestAuthService;
     private final RegisterAuthService registerAuthService;
+    private final LoginAuthService loginAuthService;
 
     /**
      * 게스트 로그인 엔드포인트
@@ -47,5 +52,31 @@ public class AuthController {
                 request.nickname()
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 자체 로그인 엔드포인트.
+     */
+    @Operation(summary = "자체 로그인", description = "로그인 ID/비밀번호로 인증하고 토큰/세션 정보를 발급합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        LoginResponse response = loginAuthService.login(
+                request.loginId(),
+                request.password(),
+                resolveClientIp(httpServletRequest),
+                httpServletRequest.getHeader("User-Agent")
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,21 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 자체 로그인 요청 DTO.
+ */
+public record LoginRequest(
+        @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "로그인 ID는 50자를 초과할 수 없습니다.")
+        @Pattern(regexp = "^\\S+$", message = "로그인 ID에는 공백을 포함할 수 없습니다.")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
+        @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
+        @Pattern(regexp = "^\\S+$", message = "비밀번호에는 공백을 포함할 수 없습니다.")
+        String password
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,23 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import lombok.Builder;
+
+import java.time.Instant;
+
+/**
+ * 자체 로그인 응답 DTO.
+ */
+@Builder
+public record LoginResponse(
+        Long userId,
+        String loginId,
+        String nickname,
+        UserType userType,
+        String userIdentifier,
+        String accessToken,
+        Instant accessTokenExpiresAt,
+        String refreshToken,
+        Instant refreshTokenExpiresAt
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
@@ -79,4 +79,24 @@ public class UserCredential {
         // 인증정보 변경 시각 자동 갱신
         this.updatedAt = LocalDateTime.now();
     }
+
+    public boolean isLockedAt(LocalDateTime now) {
+        return this.lockedUntil != null && this.lockedUntil.isAfter(now);
+    }
+
+    public void increaseFailedLoginCount() {
+        if (this.failedLoginCount == null) {
+            this.failedLoginCount = 0;
+        }
+        this.failedLoginCount += 1;
+    }
+
+    public void resetFailedLoginState() {
+        this.failedLoginCount = 0;
+        this.lockedUntil = null;
+    }
+
+    public void lockUntil(LocalDateTime lockedUntil) {
+        this.lockedUntil = lockedUntil;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
@@ -1,0 +1,151 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.LoginResponse;
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
+import io.github.ascrew.monomatbe.global.security.jwt.TokenWithExpiry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class LoginAuthService {
+
+    private static final int LOCK_THRESHOLD = 5;
+    private static final Duration LOCK_DURATION = Duration.ofMinutes(15);
+
+    private static final String ERR_INVALID_CREDENTIALS = "로그인 ID 또는 비밀번호가 올바르지 않습니다.";
+    private static final String ERR_ACCOUNT_LOCKED = "로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.";
+
+    private final UserCredentialRepository userCredentialRepository;
+    private final UserSessionRepository userSessionRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${auth.redis.refresh-store-enabled:true}")
+    private boolean refreshStoreEnabled;
+
+    @Transactional(noRollbackFor = ResponseStatusException.class)
+    public LoginResponse login(String rawLoginId, String rawPassword, String ipAddress, String userAgent) {
+        String loginId = normalizeRequiredWithTrim(rawLoginId, "로그인 ID");
+        validateNoWhitespace(loginId, "로그인 ID");
+
+        String password = validateNoWhitespace(rawPassword, "비밀번호");
+
+        UserCredential credential = userCredentialRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_CREDENTIALS));
+
+        LocalDateTime now = LocalDateTime.now();
+        if (credential.isLockedAt(now)) {
+            throw new ResponseStatusException(HttpStatus.LOCKED, ERR_ACCOUNT_LOCKED);
+        }
+
+        if (!passwordEncoder.matches(password, credential.getPasswordHash())) {
+            credential.increaseFailedLoginCount();
+            if (credential.getFailedLoginCount() >= LOCK_THRESHOLD) {
+                credential.lockUntil(now.plus(LOCK_DURATION));
+            }
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_CREDENTIALS);
+        }
+
+        credential.resetFailedLoginState();
+        User user = credential.getUser();
+        user.updateLastLoginAt(now);
+
+        String userIdentifier = UUID.randomUUID().toString();
+        TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(
+                user.getId(),
+                user.getUserType(),
+                userIdentifier
+        );
+        TokenWithExpiry refreshToken = jwtTokenProvider.createRefreshToken(
+                user.getId(),
+                user.getUserType(),
+                userIdentifier
+        );
+
+        userSessionRepository.save(UserSession.builder()
+                .user(user)
+                .sessionToken(refreshToken.token())
+                .ipAddress(normalizeOptionalLength(ipAddress, 45))
+                .userAgent(normalizeOptionalLength(userAgent, 500))
+                .expiresAt(LocalDateTime.ofInstant(refreshToken.expiresAt(), ZoneId.systemDefault()))
+                .createdAt(now)
+                .build());
+
+        if (refreshStoreEnabled) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    String refreshTokenKey = RedisKeys.refreshTokenKey(userIdentifier);
+                    redisTemplate.opsForValue().set(refreshTokenKey, refreshToken.token(), jwtTokenProvider.refreshTokenTtl());
+                }
+            });
+        }
+
+        return LoginResponse.builder()
+                .userId(user.getId())
+                .loginId(credential.getLoginId())
+                .nickname(user.getUsername())
+                .userType(user.getUserType())
+                .userIdentifier(userIdentifier)
+                .accessToken(accessToken.token())
+                .accessTokenExpiresAt(accessToken.expiresAt())
+                .refreshToken(refreshToken.token())
+                .refreshTokenExpiresAt(refreshToken.expiresAt())
+                .build();
+    }
+
+    private String normalizeRequiredWithTrim(String value, String fieldName) {
+        if (value == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+        }
+        String normalized = value.trim();
+        if (normalized.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+        }
+        return normalized;
+    }
+
+    private String validateNoWhitespace(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+        }
+        if (value.chars().anyMatch(Character::isWhitespace)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "에는 공백을 포함할 수 없습니다.");
+        }
+        return value;
+    }
+
+    private String normalizeOptionalLength(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return normalized.length() > maxLength
+                ? normalized.substring(0, maxLength)
+                : normalized;
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
@@ -1,0 +1,163 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.LoginResponse;
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LoginAuthServiceTest {
+
+    @Autowired
+    private LoginAuthService loginAuthService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserCredentialRepository userCredentialRepository;
+
+    @Autowired
+    private UserSessionRepository userSessionRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void login_success() {
+        String loginId = "member_" + System.nanoTime();
+        String password = "password123";
+        String nickname = "n" + (System.nanoTime() % 1_000_000);
+        long sessionCountBefore = userSessionRepository.count();
+
+        UserCredential credential = createCredential(loginId, password, nickname);
+
+        LoginResponse response = loginAuthService.login(
+                loginId,
+                password,
+                "127.0.0.1",
+                "JUnit-Agent"
+        );
+
+        assertEquals(credential.getUser().getId(), response.userId());
+        assertEquals(loginId, response.loginId());
+        assertEquals(nickname, response.nickname());
+        assertEquals(UserType.REGISTERED, response.userType());
+        assertNotNull(response.accessToken());
+        assertNotNull(response.refreshToken());
+        assertNotNull(response.accessTokenExpiresAt());
+        assertNotNull(response.refreshTokenExpiresAt());
+        assertNotNull(response.userIdentifier());
+        assertEquals(UUID.fromString(response.userIdentifier()).toString(), response.userIdentifier());
+
+        UserCredential savedCredential = userCredentialRepository.findByLoginId(loginId).orElseThrow();
+        assertEquals(0, savedCredential.getFailedLoginCount());
+        assertNull(savedCredential.getLockedUntil());
+
+        User savedUser = userRepository.findById(response.userId()).orElseThrow();
+        assertNotNull(savedUser.getLastLoginAt());
+
+        assertEquals(sessionCountBefore + 1, userSessionRepository.count());
+    }
+
+    @Test
+    void login_wrongPassword_incrementsFailedCount() {
+        String loginId = "member_" + System.nanoTime();
+        createCredential(loginId, "password123", "n" + (System.nanoTime() % 1_000_000));
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                loginAuthService.login(loginId, "wrong-password", null, null));
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertEquals("로그인 ID 또는 비밀번호가 올바르지 않습니다.", exception.getReason());
+
+        UserCredential savedCredential = userCredentialRepository.findByLoginId(loginId).orElseThrow();
+        assertEquals(1, savedCredential.getFailedLoginCount());
+        assertNull(savedCredential.getLockedUntil());
+    }
+
+    @Test
+    void login_fiveFailures_locksAccount() {
+        String loginId = "member_" + System.nanoTime();
+        createCredential(loginId, "password123", "n" + (System.nanoTime() % 1_000_000));
+
+        for (int i = 0; i < 5; i++) {
+            assertThrows(ResponseStatusException.class, () ->
+                    loginAuthService.login(loginId, "wrong-password", null, null));
+        }
+
+        UserCredential savedCredential = userCredentialRepository.findByLoginId(loginId).orElseThrow();
+        assertEquals(5, savedCredential.getFailedLoginCount());
+        assertNotNull(savedCredential.getLockedUntil());
+        assertTrue(savedCredential.getLockedUntil().isAfter(LocalDateTime.now()));
+
+        ResponseStatusException lockedException = assertThrows(ResponseStatusException.class, () ->
+                loginAuthService.login(loginId, "password123", null, null));
+        assertEquals(HttpStatus.LOCKED, lockedException.getStatusCode());
+    }
+
+    @Test
+    void login_lockedAccount_returnsLocked() {
+        String loginId = "member_" + System.nanoTime();
+        UserCredential credential = createCredential(loginId, "password123", "n" + (System.nanoTime() % 1_000_000));
+        credential.lockUntil(LocalDateTime.now().plusMinutes(10));
+        userCredentialRepository.saveAndFlush(credential);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                loginAuthService.login(loginId, "password123", null, null));
+        assertEquals(HttpStatus.LOCKED, exception.getStatusCode());
+        assertEquals("로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.", exception.getReason());
+    }
+
+    @Test
+    void login_success_resetsFailedState() {
+        String loginId = "member_" + System.nanoTime();
+        String password = "password123";
+        UserCredential credential = createCredential(loginId, password, "n" + (System.nanoTime() % 1_000_000));
+        credential.increaseFailedLoginCount();
+        credential.increaseFailedLoginCount();
+        credential.lockUntil(LocalDateTime.now().minusMinutes(1));
+        userCredentialRepository.saveAndFlush(credential);
+
+        loginAuthService.login(loginId, password, null, null);
+
+        UserCredential savedCredential = userCredentialRepository.findByLoginId(loginId).orElseThrow();
+        assertEquals(0, savedCredential.getFailedLoginCount());
+        assertNull(savedCredential.getLockedUntil());
+    }
+
+    private UserCredential createCredential(String loginId, String rawPassword, String nickname) {
+        User savedUser = userRepository.saveAndFlush(User.builder()
+                .username(nickname)
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        return userCredentialRepository.saveAndFlush(UserCredential.builder()
+                .user(savedUser)
+                .loginId(loginId)
+                .passwordHash(passwordEncoder.encode(rawPassword))
+                .build());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #32 
- #35 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `/api/auth/login` 자체 로그인 엔드포인트를 추가했습니다.
- 로그인 요청/응답 DTO인 `LoginRequest`, `LoginResponse`를 추가했습니다.
- `LoginAuthService`를 구현해 로그인 ID/PW 검증 및 BCrypt 비교 로직을 반영했습니다.
- 로그인 실패 횟수(`failed_login_count`)를 누적하고, 5회 실패 시 15분 잠금(`locked_until`) 처리하도록 구현했습니다.
- 잠금 상태 로그인 시 `423 Locked`를 반환하도록 처리했습니다.
- 로그인 성공 시 실패 카운트/잠금 상태를 초기화하고 `users.lastLoginAt`을 갱신하도록 구현했습니다.
- 로그인 성공 시 UUID 기반 `userIdentifier`를 발급해 Access/Refresh JWT를 생성하도록 구현했습니다.
- Refresh Token을 Redis(`auth:refresh:{sessionId}`)에 저장하고, `user_sessions` 테이블에 세션 추적 정보를 저장하도록 구현했습니다.

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 로그인 세션 전략은 `JWT 발급 + user_sessions 저장 병행`으로 확정해 구현했습니다.
- 잠금 정책은 `로그인 실패 5회 시 15분 잠금`으로 반영했습니다.
- 현재 WebSocket 인터셉터가 `userIdentifier` UUID 형식을 강제하므로, 회원 로그인도 UUID 기반 `userIdentifier` 발급으로 통일했습니다.
- 이번 PR 범위는 로그인 구현까지이며, Refresh Token 재발급/로그아웃/세션 정리 정책을 위한 후속 이슈 생성이 필요해 보입니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
