### PR TITLE
[Feat/#63] 로비 준비 상태 관리 및 게임 시작 조건 검증 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,11 +2,11 @@
 
 ## 공통 사항
 
-- **Base URL** : `http://{서버 도메인}:8080`
-- **WebSocket Endpoint** : `ws://{서버 도메인}:8080/ws` (SockJS 폴백 지원)
-- **Content-Type** : `application/json`
-- **REST 인증** : `Authorization: Bearer {accessToken}`
-- **WebSocket 인증** : STOMP CONNECT 헤더에 `userIdentifier` 포함 필요
+* **Base URL** : `http://{서버 도메인}:8080`
+* **WebSocket Endpoint** : `ws://{서버 도메인}:8080/ws` (SockJS 폴백 지원)
+* **Content-Type** : `application/json`
+* **REST 인증** : `Authorization: Bearer {accessToken}`
+* **WebSocket 인증** : STOMP CONNECT 헤더에 `userIdentifier` 포함 필요
 
 ---
 
@@ -20,7 +20,7 @@
 POST /api/auth/guest
 ```
 
-닉네임 입력만으로 게스트 계정을 생성하고 `UUID(userIdentifier)` 기반 세션을 발급합니다.  
+닉네임 입력만으로 게스트 계정을 생성하고 `UUID(userIdentifier)` 기반 세션을 발급합니다.
 응답으로 Access/Refresh 토큰이 함께 반환되며, 게스트 세션 정보는 Redis에 30일 TTL로 저장됩니다.
 
 **Request**
@@ -48,8 +48,8 @@ POST /api/auth/guest
 
 **Error `409 CONFLICT`**
 
-- 정식 회원 닉네임과 충돌: `정식 회원이 이미 사용 중인 닉네임입니다.`
-- 기존 사용자 닉네임과 충돌: `이미 사용 중인 닉네임입니다.`
+* 정식 회원 닉네임과 충돌: `정식 회원이 이미 사용 중인 닉네임입니다.`
+* 기존 사용자 닉네임과 충돌: `이미 사용 중인 닉네임입니다.`
 
 ---
 
@@ -59,7 +59,7 @@ POST /api/auth/guest
 POST /api/auth/register
 ```
 
-로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.  
+로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.
 회원가입 API는 계정 생성만 수행하며 토큰 발급은 로그인 API에서 처리됩니다.
 
 **Request**
@@ -85,8 +85,8 @@ POST /api/auth/register
 
 **Error**
 
-- `400 Bad Request`: 필수값 누락 / 비밀번호 길이 조건 불만족 / 비밀번호 공백 포함 / 닉네임 8자 초과
-- `409 Conflict`: 로그인 ID 또는 닉네임 중복
+* `400 Bad Request`: 필수값 누락 / 비밀번호 길이 조건 불만족 / 비밀번호 공백 포함 / 닉네임 8자 초과
+* `409 Conflict`: 로그인 ID 또는 닉네임 중복
 
 ---
 
@@ -96,7 +96,7 @@ POST /api/auth/register
 POST /api/auth/login
 ```
 
-가입한 로그인 ID/비밀번호로 인증 후 Access/Refresh 토큰을 발급합니다.  
+가입한 로그인 ID/비밀번호로 인증 후 Access/Refresh 토큰을 발급합니다.
 로그인 성공 시 `user_sessions`에 세션 추적 정보를 저장하며, Refresh Token은 Redis에 저장됩니다.
 
 **Request**
@@ -126,9 +126,9 @@ POST /api/auth/login
 
 **Error**
 
-- `400 Bad Request`: 필수값 누락 / 공백 포함
-- `401 Unauthorized`: 로그인 ID 또는 비밀번호 불일치
-- `423 Locked`: 로그인 실패 5회 누적 계정 잠금 (15분)
+* `400 Bad Request`: 필수값 누락 / 공백 포함
+* `401 Unauthorized`: 로그인 ID 또는 비밀번호 불일치
+* `423 Locked`: 로그인 실패 5회 누적 계정 잠금 (15분)
 
 ---
 
@@ -140,18 +140,18 @@ POST /api/auth/login
 POST /api/lobbies
 ```
 
-로비를 생성하고 6자리 초대 코드를 발급합니다.  
+로비를 생성하고 6자리 초대 코드를 발급합니다.
 JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 가능합니다.
 
-`mapId`는 선택 사항입니다.  
-로비는 맵 없이 먼저 생성할 수 있으며, 게임 시작 시점에는 선택된 맵이 있어야 합니다.  
+`mapId`는 선택 사항입니다.
+로비는 맵 없이 먼저 생성할 수 있으며, 게임 시작 시점에는 선택된 맵이 있어야 합니다.
 `mapId`가 전달된 경우 백엔드에서 맵 존재 여부, 삭제 여부, 접근 권한을 검증합니다.
 
 **Request Header**
 
-| 헤더 | 필수 | 설명 |
-|---|---|---|
-| `Authorization` | ✅ | `Bearer {accessToken}` |
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
 
 **Request Body — 맵 선택 로비**
 
@@ -191,14 +191,14 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
 }
 ```
 
-| 필드 | 타입 | 필수 | 설명 |
-|---|---|---|---|
-| `title` | String | ✅ | 로비 제목 (최대 255자) |
-| `maxPlayers` | Integer | ✅ | 최대 참여 인원 (2~8) |
-| `isPrivate` | Boolean | ✅ | 비공개 여부 |
-| `mapId` | Long | ❌ | 로비에 연결할 맵 ID. 미선택 시 `null` 또는 생략 가능 |
-| `roundCount` | Integer | ❌ | 라운드 수 (1~20, 기본값 5) |
-| `timeLimitSeconds` | Integer | ❌ | 제한 시간 초 (10~120, 기본값 30) |
+| 필드                 | 타입      | 필수 | 설명                                  |
+| ------------------ | ------- | -- | ----------------------------------- |
+| `title`            | String  | ✅  | 로비 제목 (최대 255자)                     |
+| `maxPlayers`       | Integer | ✅  | 최대 참여 인원 (2~8)                      |
+| `isPrivate`        | Boolean | ✅  | 비공개 여부                              |
+| `mapId`            | Long    | ❌  | 로비에 연결할 맵 ID. 미선택 시 `null` 또는 생략 가능 |
+| `roundCount`       | Integer | ❌  | 라운드 수 (1~20, 기본값 5)                 |
+| `timeLimitSeconds` | Integer | ❌  | 제한 시간 초 (10~120, 기본값 30)            |
 
 **Response `201 Created` — 맵 선택 로비**
 
@@ -212,7 +212,7 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
   "status": "WAITING",
   "mapId": 1,
   "mapTitle": "K-POP 2세대",
-  "mapCategory": "kpop"
+  "mapCategory": "K-POP"
 }
 ```
 
@@ -232,39 +232,39 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
 }
 ```
 
-| 필드 | 타입 | 설명 |
-|---|---|---|
-| `lobbyId` | Long | DB GAME_LOBBY.id (신고 참조용) |
-| `inviteCode` | String | 6자리 초대 코드 (딥링크: `/lobby/{inviteCode}`) |
-| `title` | String | 로비 제목 |
-| `maxPlayers` | Integer | 최대 참여 인원 |
-| `isPrivate` | Boolean | 비공개 여부 |
-| `status` | String | 로비 상태 (`WAITING`) |
-| `mapId` | Long | 선택된 맵 ID (미선택 시 `null`) |
-| `mapTitle` | String | 선택된 맵 제목 (미선택 시 `null`) |
-| `mapCategory` | String | 선택된 맵 카테고리 (미선택 시 `null`) |
+| 필드            | 타입      | 설명                                                 |
+| ------------- | ------- | -------------------------------------------------- |
+| `lobbyId`     | Long    | DB GAME_LOBBY.id                                   |
+| `inviteCode`  | String  | 6자리 초대 코드                                          |
+| `title`       | String  | 로비 제목                                              |
+| `maxPlayers`  | Integer | 최대 참여 인원                                           |
+| `isPrivate`   | Boolean | 비공개 여부                                             |
+| `status`      | String  | 로비 상태 (`WAITING`)                                  |
+| `mapId`       | Long    | 선택된 맵 ID (미선택 시 `null`)                            |
+| `mapTitle`    | String  | 선택된 맵 제목 (미선택 시 `null`)                            |
+| `mapCategory` | String  | 선택된 맵 카테고리 (`K-POP`, `J-POP`, `POP`, 미선택 시 `null`) |
 
 **맵 검증 정책**
 
-| 상황 | 결과 |
-|---|---|
-| `mapId` 없음 | 맵 미선택 로비로 생성 허용 |
-| 공개 맵 | 로비 연결 허용 |
-| 본인 소유 비공개 맵 | 로비 연결 허용 |
-| 타인 소유 비공개 맵 | 로비 연결 거부 |
-| 삭제된 맵 | 로비 연결 거부 |
-| 존재하지 않는 맵 | 로비 연결 거부 |
+| 상황          | 결과              |
+| ----------- | --------------- |
+| `mapId` 없음  | 맵 미선택 로비로 생성 허용 |
+| 공개 맵        | 로비 연결 허용        |
+| 본인 소유 비공개 맵 | 로비 연결 허용        |
+| 타인 소유 비공개 맵 | 로비 연결 거부        |
+| 삭제된 맵       | 로비 연결 거부        |
+| 존재하지 않는 맵   | 로비 연결 거부        |
 
 **Error**
 
-| 상태 코드 | 설명 |
-|---|---|
-| `400 Bad Request` | 요청 검증 실패 (`mapId`가 양수가 아닌 경우 등) |
-| `401 Unauthorized` | JWT 토큰 없음 또는 만료 |
-| `403 Forbidden` | 타인 소유 비공개 맵을 로비에 연결하려는 경우 |
-| `404 Not Found` | 존재하지 않는 사용자 또는 존재하지 않는 맵 |
-| `409 Conflict` | 삭제된 맵을 로비에 연결하려는 경우 |
-| `503 Service Unavailable` | 초대 코드 생성 실패 (재시도 초과) |
+| 상태 코드                     | 설명                              |
+| ------------------------- | ------------------------------- |
+| `400 Bad Request`         | 요청 검증 실패 (`mapId`가 양수가 아닌 경우 등) |
+| `401 Unauthorized`        | JWT 토큰 없음 또는 만료                 |
+| `403 Forbidden`           | 타인 소유 비공개 맵을 로비에 연결하려는 경우       |
+| `404 Not Found`           | 존재하지 않는 사용자 또는 존재하지 않는 맵        |
+| `409 Conflict`            | 삭제된 맵을 로비에 연결하려는 경우             |
+| `503 Service Unavailable` | 초대 코드 생성 실패 (재시도 초과)            |
 
 ---
 
@@ -274,21 +274,26 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 생성 �
 POST /api/lobbies/join
 ```
 
-초대 코드로 로비 입장 가능 여부를 검증하고 로비 기본 정보를 반환합니다.  
+초대 코드로 로비 입장 가능 여부를 검증하고 로비 기본 정보를 반환합니다.
 JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 가능합니다.
 
-> **중요:** 이 API는 입장 허가 사전 검증만 수행합니다.  
+> 이 API는 입장 허가 사전 검증만 수행합니다.
 > 실제 참여자 등록은 응답 수신 후 WebSocket `/topic/lobby/{inviteCode}` 구독 시점에 처리됩니다.
->
-> 클라이언트 처리 순서:
-> 1. `POST /api/lobbies/join` 호출 → 입장 가능 여부 확인
-> 2. WebSocket `SUBSCRIBE /topic/lobby/{inviteCode}` → 실제 입장 처리
+
+클라이언트 처리 순서:
+
+```text
+1. POST /api/lobbies/join 호출
+2. WebSocket CONNECT
+3. SUBSCRIBE /topic/lobby/{inviteCode}
+4. 실제 Redis participants 등록
+```
 
 **Request Header**
 
-| 헤더 | 필수 | 설명 |
-|---|---|---|
-| `Authorization` | ✅ | `Bearer {accessToken}` |
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
 
 **Request Body**
 
@@ -298,9 +303,9 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 }
 ```
 
-| 필드 | 타입 | 필수 | 설명 |
-|---|---|---|---|
-| `inviteCode` | String | ✅ | 6자리 초대 코드 (영문 대문자 + 숫자) |
+| 필드           | 타입     | 필수 | 설명                      |
+| ------------ | ------ | -- | ----------------------- |
+| `inviteCode` | String | ✅  | 6자리 초대 코드 (영문 대문자 + 숫자) |
 
 **Response `200 OK` — 맵 선택 로비**
 
@@ -314,7 +319,7 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
   "status": "WAITING",
   "mapId": 1,
   "mapTitle": "K-POP 2세대",
-  "mapCategory": "kpop"
+  "mapCategory": "K-POP"
 }
 ```
 
@@ -334,26 +339,26 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 }
 ```
 
-| 필드 | 타입 | 설명 |
-|---|---|---|
-| `inviteCode` | String | 로비 초대 코드 (WebSocket 구독 경로에 사용) |
-| `title` | String | 로비 제목 |
-| `hostId` | String | 방장 사용자 식별자 |
-| `maxPlayers` | Integer | 최대 참여 인원 |
-| `currentPlayers` | Integer | 현재 참여 인원 (응답 시점 스냅샷) |
-| `status` | String | 로비 상태 (`WAITING`) |
-| `mapId` | Long | 선택된 맵 ID (미선택 시 `null`) |
-| `mapTitle` | String | 선택된 맵 제목 (미선택 시 `null`) |
-| `mapCategory` | String | 선택된 맵의 카테고리 (미선택 시 `null`) |
+| 필드               | 타입      | 설명                                                 |
+| ---------------- | ------- | -------------------------------------------------- |
+| `inviteCode`     | String  | 로비 초대 코드                                           |
+| `title`          | String  | 로비 제목                                              |
+| `hostId`         | String  | 방장 사용자 식별자                                         |
+| `maxPlayers`     | Integer | 최대 참여 인원                                           |
+| `currentPlayers` | Integer | 현재 참여 인원 (응답 시점 스냅샷)                               |
+| `status`         | String  | 로비 상태 (`WAITING`)                                  |
+| `mapId`          | Long    | 선택된 맵 ID (미선택 시 `null`)                            |
+| `mapTitle`       | String  | 선택된 맵 제목 (미선택 시 `null`)                            |
+| `mapCategory`    | String  | 선택된 맵 카테고리 (`K-POP`, `J-POP`, `POP`, 미선택 시 `null`) |
 
 **Error**
 
-| 상태 코드 | 설명 |
-|---|---|
-| `400 Bad Request` | 초대 코드 형식 오류 (6자리 영문 대문자 + 숫자 조합이 아닌 경우) |
-| `401 Unauthorized` | JWT 토큰 없음 또는 만료 |
-| `404 Not Found` | 존재하지 않는 초대 코드 |
-| `409 Conflict` | 게임이 이미 시작된 로비 또는 최대 인원 초과 |
+| 상태 코드              | 설명                        |
+| ------------------ | ------------------------- |
+| `400 Bad Request`  | 초대 코드 형식 오류               |
+| `401 Unauthorized` | JWT 토큰 없음 또는 만료           |
+| `404 Not Found`    | 존재하지 않는 초대 코드             |
+| `409 Conflict`     | 게임이 이미 시작된 로비 또는 최대 인원 초과 |
 
 ---
 
@@ -363,8 +368,10 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 GET /api/lobbies
 ```
 
-현재 활성화된 공개(`isPrivate = false`) 로비 목록을 반환합니다.  
+현재 활성화된 공개(`isPrivate = false`) 로비 목록을 반환합니다.
 Redis에서 직접 필터링하여 고속 반환합니다.
+
+Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때문에, 응답은 Jackson 타입 정보가 포함되지 않은 순수 DTO 배열로 반환됩니다.
 
 **Response `200 OK`**
 
@@ -372,40 +379,249 @@ Redis에서 직접 필터링하여 고속 반환합니다.
 [
   {
     "code": "ABC123",
-    "hostId": "uuid-xxxx-xxxx",
+    "hostId": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
     "title": "K-POP 퀴즈방",
     "mapId": 1,
     "mapTitle": "K-POP 2세대",
-    "mapCategory": "kpop",
+    "mapCategory": "K-POP",
     "maxPlayers": 8,
+    "currentPlayers": 3,
     "isPrivate": false,
     "status": "WAITING"
   },
   {
     "code": "DEF456",
-    "hostId": "uuid-yyyy-yyyy",
+    "hostId": "b17f7ee0-614f-4f5f-b770-83f6d4b85f4a",
     "title": "맵 미선택 퀴즈방",
     "mapId": null,
     "mapTitle": null,
     "mapCategory": null,
     "maxPlayers": 6,
+    "currentPlayers": 1,
     "isPrivate": false,
     "status": "WAITING"
   }
 ]
 ```
 
-| 필드 | 타입 | 설명 |
-|---|---|---|
-| `code` | String | 로비 초대 코드 (6자리) |
-| `hostId` | String | 방장 사용자 식별자 |
-| `title` | String | 로비 제목 |
-| `mapId` | Long | 선택된 맵 ID (미선택 시 `null`) |
-| `mapTitle` | String | 선택된 맵 제목 (미선택 시 `null`) |
-| `mapCategory` | String | 선택된 맵의 카테고리 (미선택 시 `null`) |
-| `maxPlayers` | Integer | 최대 참여 인원 |
-| `isPrivate` | Boolean | 비공개 여부 (`true` = 비공개) |
-| `status` | String | 로비 상태 (`WAITING` \| `PLAYING`) |
+| 필드               | 타입      | 설명                                                 |
+| ---------------- | ------- | -------------------------------------------------- |
+| `code`           | String  | 로비 초대 코드                                           |
+| `hostId`         | String  | 방장 사용자 식별자                                         |
+| `title`          | String  | 로비 제목                                              |
+| `mapId`          | Long    | 선택된 맵 ID (미선택 시 `null`)                            |
+| `mapTitle`       | String  | 선택된 맵 제목 (미선택 시 `null`)                            |
+| `mapCategory`    | String  | 선택된 맵 카테고리 (`K-POP`, `J-POP`, `POP`, 미선택 시 `null`) |
+| `maxPlayers`     | Integer | 최대 참여 인원                                           |
+| `currentPlayers` | Integer | 현재 참여 인원                                           |
+| `isPrivate`      | Boolean | 비공개 여부                                             |
+| `status`         | String  | 로비 상태 (`WAITING`, `PLAYING`, `FINISHED`)           |
+
+---
+
+#### 로비 상세 조회
+
+```http
+GET /api/lobbies/{code}
+```
+
+로비 대기실 상세 정보를 조회합니다.
+JWT Access Token이 필요합니다.
+
+응답에는 로비 기본 정보, 선택된 맵 정보, 라운드 설정, 참여자 목록, ready 상태, 게임 시작 가능 여부(`canStart`)가 포함됩니다.
+
+**정책**
+
+* 로비 참여자 또는 방장만 조회할 수 있습니다.
+* 일반 유저는 WebSocket `/topic/lobby/{code}` 구독으로 participants Set에 등록된 이후 조회할 수 있습니다.
+* 방장은 participants Set에 아직 없어도 조회할 수 있습니다.
+* `canStart`는 조회 시점의 snapshot 값입니다.
+* 실제 게임 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 Redis Lua로 최종 검증합니다.
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+
+**Response `200 OK`**
+
+```json
+{
+  "inviteCode": "ABC123",
+  "title": "K-POP 퀴즈방",
+  "hostId": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+  "maxPlayers": 8,
+  "currentPlayers": 2,
+  "status": "WAITING",
+  "mapId": 1,
+  "mapTitle": "K-POP 2세대",
+  "mapCategory": "K-POP",
+  "roundCount": 5,
+  "timeLimitSeconds": 30,
+  "players": [
+    {
+      "userIdentifier": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+      "host": true,
+      "ready": false
+    },
+    {
+      "userIdentifier": "b17f7ee0-614f-4f5f-b770-83f6d4b85f4a",
+      "host": false,
+      "ready": true
+    }
+  ],
+  "canStart": true
+}
+```
+
+| 필드                         | 타입      | 설명                                   |
+| -------------------------- | ------- | ------------------------------------ |
+| `inviteCode`               | String  | 로비 초대 코드                             |
+| `title`                    | String  | 로비 제목                                |
+| `hostId`                   | String  | 방장 userIdentifier                    |
+| `maxPlayers`               | Integer | 최대 참여 인원                             |
+| `currentPlayers`           | Integer | 현재 참여 인원                             |
+| `status`                   | String  | 로비 상태                                |
+| `mapId`                    | Long    | 선택된 맵 ID                             |
+| `mapTitle`                 | String  | 선택된 맵 제목                             |
+| `mapCategory`              | String  | 선택된 맵 카테고리 (`K-POP`, `J-POP`, `POP`) |
+| `roundCount`               | Integer | 게임 라운드 수                             |
+| `timeLimitSeconds`         | Integer | 라운드 제한 시간                            |
+| `players`                  | Array   | 현재 로비 참여자 목록                         |
+| `players[].userIdentifier` | String  | 참여자 식별자                              |
+| `players[].host`           | Boolean | 방장 여부                                |
+| `players[].ready`          | Boolean | ready 여부. 방장은 ready 대상이 아니므로 `false` |
+| `canStart`                 | Boolean | 조회 시점 기준 게임 시작 가능 여부                 |
+
+**canStart 계산 조건**
+
+| 조건                 | 기준                                             |
+| ------------------ | ---------------------------------------------- |
+| 로비 상태가 `WAITING`   | Redis `lobby:{code}.status`                    |
+| 선택된 맵 존재           | Redis `lobby:{code}.map_id`                    |
+| 맵 문제 수가 라운드 수 이상   | DB `map.num_of_song >= GAME_LOBBY.round_count` |
+| 방장 제외 참여자 1명 이상    | Redis `lobby:{code}:participants`              |
+| 방장 제외 모든 참여자 ready | Redis `lobby:{code}:ready`                     |
+
+> `canStart=true` 이후에도 사용자가 퇴장하거나 ready를 해제하면 `/start` 요청은 `409 Conflict`로 실패할 수 있습니다.
+> FE는 `/start` 실패 응답을 버튼 재활성화 및 안내 메시지로 처리해야 합니다.
+
+**Error**
+
+| 상태 코드              | 설명                       |
+| ------------------ | ------------------------ |
+| `401 Unauthorized` | JWT 토큰 없음 또는 만료          |
+| `403 Forbidden`    | 로비 참여자가 아닌 사용자가 상세 조회 시도 |
+| `404 Not Found`    | 존재하지 않는 로비               |
+
+---
+
+#### 로비 ready 상태 변경
+
+```http
+PATCH /api/lobbies/{code}/ready
+```
+
+로비 참여자의 ready 상태를 변경합니다.
+JWT Access Token이 필요합니다.
+
+**정책**
+
+* 로비가 `WAITING` 상태일 때만 변경할 수 있습니다.
+* 로비 참여자만 ready 상태를 변경할 수 있습니다.
+* 방장은 ready 대상에서 제외됩니다.
+* 방장은 ready 버튼이 아니라 게임 시작 버튼을 사용합니다.
+* ready 변경 성공 시 `/topic/lobby/{code}/refresh`로 `REFRESH_LOBBY_INFO`가 브로드캐스트됩니다.
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+
+**Request Body**
+
+```json
+{
+  "ready": true
+}
+```
+
+| 필드      | 타입      | 필수 | 설명                              |
+| ------- | ------- | -- | ------------------------------- |
+| `ready` | Boolean | ✅  | `true` = 준비 완료, `false` = 준비 해제 |
+
+**Response `204 No Content`**
+
+응답 Body 없음.
+
+**Error**
+
+| 상태 코드              | 설명                          |
+| ------------------ | --------------------------- |
+| `400 Bad Request`  | 방장이 ready 변경을 시도한 경우        |
+| `401 Unauthorized` | JWT 토큰 없음 또는 만료             |
+| `403 Forbidden`    | 로비 참여자가 아닌 사용자가 ready 변경 시도 |
+| `404 Not Found`    | 존재하지 않는 로비                  |
+| `409 Conflict`     | `WAITING` 상태가 아닌 로비         |
+
+---
+
+#### 로비 게임 시작
+
+```http
+POST /api/lobbies/{code}/start
+```
+
+로비 게임 시작 조건을 최종 검증하고, 조건 충족 시 로비 상태를 `PLAYING`으로 전환합니다.
+JWT Access Token이 필요하며, 방장만 호출할 수 있습니다.
+
+**정책**
+
+* 요청자는 방장이어야 합니다.
+* 로비 상태는 `WAITING`이어야 합니다.
+* 맵이 선택되어 있어야 합니다.
+* 맵 문제 수가 `roundCount` 이상이어야 합니다.
+* 방장을 제외한 참여자가 1명 이상 있어야 합니다.
+* 방장을 제외한 모든 참여자가 ready 상태여야 합니다.
+* participants Set에 남아 있지만 활성 로비 세션 키가 없는 사용자는 stale participant로 판단해 시작을 거부합니다.
+* 조건 검증은 `start_lobby.lua`에서 Redis 기준으로 원자 처리합니다.
+* 성공 시 Redis와 DB `GAME_LOBBY` 상태를 `PLAYING`으로 동기화합니다.
+* 성공 후 DB 트랜잭션 커밋 이후 `/topic/lobby/{code}/game`으로 `GAME_STARTED` 이벤트를 브로드캐스트합니다.
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+
+**Response `204 No Content`**
+
+응답 Body 없음.
+
+**Error**
+
+| 상태 코드                       | 설명                                                                  |
+| --------------------------- | ------------------------------------------------------------------- |
+| `401 Unauthorized`          | JWT 토큰 없음 또는 만료                                                     |
+| `403 Forbidden`             | 방장이 아닌 사용자가 게임 시작 시도                                                |
+| `404 Not Found`             | 존재하지 않는 로비 또는 맵                                                     |
+| `409 Conflict`              | 로비 상태 불일치, 맵 미선택, 참여자 없음, ready 미완료, stale participant, 맵 문제 수 부족 등 |
+| `500 Internal Server Error` | 게임 시작 상태 동기화 실패                                                     |
+| `503 Service Unavailable`   | Redis Lua 처리 실패 또는 Redis 장애                                         |
+
+**주의**
+
+`GET /api/lobbies/{code}`의 `canStart`는 조회 시점 snapshot입니다.
+실제 시작 가능 여부는 이 API에서 최종 검증됩니다.
+따라서 `canStart=true` 이후에도 다음 상황에서는 `409 Conflict`가 발생할 수 있습니다.
+
+* 참여자가 퇴장한 경우
+* 참여자가 ready를 해제한 경우
+* 로비 상태가 이미 변경된 경우
+* participants Set에 stale 유저가 남아 있는 경우
+* Redis participants/ready/session 정합성이 깨진 경우
 
 ---
 
@@ -417,13 +633,13 @@ Redis에서 직접 필터링하여 고속 반환합니다.
 GET /api/maps
 ```
 
-공개(`is_public=true`) 상태이면서 삭제되지 않은 맵만 반환합니다.  
+공개(`is_public=true`) 상태이면서 삭제되지 않은 맵만 반환합니다.
 페이지네이션 파라미터를 지원합니다.
 
-| 쿼리 파라미터 | 기본값 | 설명 |
-|---|---:|---|
-| `page` | `0` | 0-based 페이지 번호 |
-| `size` | `20` | 페이지 크기 (최대 100) |
+| 쿼리 파라미터 |  기본값 | 설명              |
+| ------- | ---: | --------------- |
+| `page`  |  `0` | 0-based 페이지 번호  |
+| `size`  | `20` | 페이지 크기 (최대 100) |
 
 **Response `200 OK`**
 
@@ -483,9 +699,9 @@ POST /api/maps
 
 `category`는 아래 enum 값만 허용합니다.
 
-- `kpop`
-- `jpop`
-- `pop`
+* `kpop`
+* `jpop`
+* `pop`
 
 #### 맵 수정
 
@@ -493,7 +709,7 @@ POST /api/maps
 PUT /api/maps/{mapId}
 ```
 
-맵 소유자만 수정 가능하며, `isPublic` 필드로 공개/비공개 전환을 지원합니다.  
+맵 소유자만 수정 가능하며, `isPublic` 필드로 공개/비공개 전환을 지원합니다.
 수정 시 Redis 맵 캐시를 무효화합니다.
 
 #### 맵 삭제
@@ -508,7 +724,7 @@ DELETE /api/maps/{mapId}
 
 ## WebSocket API (STOMP)
 
-WebSocket 연결 후 STOMP 프로토콜로 통신합니다.  
+WebSocket 연결 후 STOMP 프로토콜로 통신합니다.
 SockJS를 통해 WebSocket 연결 실패 시 HTTP 폴링으로 자동 대체됩니다.
 
 ### 연결
@@ -518,9 +734,9 @@ CONNECT
 userIdentifier: {UUID 또는 회원 ID}
 ```
 
-| 헤더 | 필수 | 설명 |
-|---|---|---|
-| `userIdentifier` | ✅ | 게스트 UUID(8-4-4-4-12 포맷) 또는 회원 ID |
+| 헤더               | 필수 | 설명                               |
+| ---------------- | -- | -------------------------------- |
+| `userIdentifier` | ✅  | 게스트 UUID(8-4-4-4-12 포맷) 또는 회원 ID |
 
 연결 실패 시 STOMP ERROR 프레임으로 사유를 반환합니다.
 
@@ -596,15 +812,15 @@ SUBSCRIBE /topic/lobby/{code}
 
 **메시지 타입 (`type`)**
 
-| 값 | 설명 |
-|---|---|
-| `CHAT` | 일반 채팅 메시지 |
+| 값        | 설명                 |
+| -------- | ------------------ |
+| `CHAT`   | 일반 채팅 메시지          |
 | `ANSWER` | 정답 제출 메시지 (인게임 전용) |
-| `ENTER` | 입장 알림 시스템 메시지 |
-| `LEAVE` | 퇴장 알림 시스템 메시지 |
-| `KICK` | 강퇴 알림 시스템 메시지 |
+| `ENTER`  | 입장 알림 시스템 메시지      |
+| `LEAVE`  | 퇴장 알림 시스템 메시지      |
+| `KICK`   | 강퇴 알림 시스템 메시지      |
 
-> `sender` 필드는 클라이언트 전송값을 무시하고 서버 세션에서 추출한 값으로 교체됩니다. (발신자 위변조 방지)
+> `sender` 필드는 클라이언트 전송값을 무시하고 서버 세션에서 추출한 값으로 교체됩니다.
 
 ---
 
@@ -616,7 +832,7 @@ SUBSCRIBE /topic/lobby/{code}
 SEND /app/lobby/create
 ```
 
-로비 생성 후 클라이언트가 호출합니다.  
+로비 생성 후 클라이언트가 호출합니다.
 로비 리스트를 보고 있는 모든 클라이언트에게 새로고침 신호를 전송합니다.
 
 #### 로비 리스트 새로고침 구독
@@ -651,6 +867,25 @@ SUBSCRIBE /topic/lobby/{code}/refresh
 "REFRESH_LOBBY_INFO"
 ```
 
+#### 로비 게임 시작 이벤트 구독
+
+```text
+SUBSCRIBE /topic/lobby/{code}/game
+```
+
+방장이 `POST /api/lobbies/{code}/start`를 성공적으로 호출하면, 서버가 DB 트랜잭션 커밋 이후 이 채널로 게임 시작 이벤트를 브로드캐스트합니다.
+
+**수신 메시지**
+
+```text
+"GAME_STARTED"
+```
+
+**FE 처리**
+
+* 이 메시지를 수신하면 로비 대기실에서 인게임 화면으로 전환합니다.
+* 전환 전 필요하다면 `GET /api/lobbies/{code}`를 재조회해 `status=PLAYING`을 확인할 수 있습니다.
+
 #### 로비 유저 강퇴 송신
 
 ```text
@@ -669,11 +904,11 @@ SEND /app/lobby/{code}/kick
 
 **처리 결과**
 
-- 요청자가 방장이 아니면 거부됩니다.
-- 자기 자신은 강퇴할 수 없습니다.
-- 강퇴 대상이 로비 참여자가 아니면 거부됩니다.
-- 강퇴 성공 시 로비 채팅 채널로 `KICK` 메시지가 브로드캐스트됩니다.
-- 강퇴 성공 후 로비 내부 새로고침 신호가 브로드캐스트됩니다.
+* 요청자가 방장이 아니면 거부됩니다.
+* 자기 자신은 강퇴할 수 없습니다.
+* 강퇴 대상이 로비 참여자가 아니면 거부됩니다.
+* 강퇴 성공 시 로비 채팅 채널로 `KICK` 메시지가 브로드캐스트됩니다.
+* 강퇴 성공 후 로비 내부 새로고침 신호가 브로드캐스트됩니다.
 
 ---
 
@@ -683,12 +918,13 @@ SEND /app/lobby/{code}/kick
 
 인증 실패 또는 유효하지 않은 요청 시 STOMP ERROR 프레임으로 응답합니다.
 
-| 상황 | 메시지 |
-|---|---|
-| `userIdentifier` 헤더 누락 | `STOMP CONNECT: 사용자 식별자가 없습니다. 연결이 거부되었습니다.` |
+| 상황                          | 메시지                                              |
+| --------------------------- | ------------------------------------------------ |
+| `userIdentifier` 헤더 누락      | `STOMP CONNECT: 사용자 식별자가 없습니다. 연결이 거부되었습니다.`     |
 | 유효하지 않은 `userIdentifier` 형식 | `STOMP CONNECT: 유효하지 않은 식별자 형식입니다. 연결이 거부되었습니다.` |
-| 인증 없이 SEND/SUBSCRIBE 시도 | `인증 정보가 존재하지 않습니다.` |
-| 최대 인원 초과 로비 구독 시도 | `로비 입장 실패: 최대 인원에 도달했습니다.` |
+| 인증 없이 SEND/SUBSCRIBE 시도     | `인증 정보가 존재하지 않습니다.`                              |
+| 최대 인원 초과 로비 구독 시도           | `로비 입장 실패: 최대 인원에 도달했습니다.`                       |
+| 존재하지 않는 로비 구독 시도            | `로비 입장 실패: 존재하지 않는 로비입니다.`                       |
 
 ---
 
@@ -696,11 +932,9 @@ SEND /app/lobby/{code}/kick
 
 현재 구현된 기능 외에 아래 API가 추가될 예정입니다.
 
-| 분류 | 설명 |
-|---|---|
-| 맵 아이템(문제) CRUD | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |
-| YouTube URL 유효성 검증 | `POST /api/youtube/validate` |
-| 로비 맵 변경 | `PATCH /api/lobbies/{inviteCode}/map` |
-| 로비 준비 상태 변경 | `PATCH /api/lobbies/{inviteCode}/ready` |
-| 로비 게임 시작 | `POST /api/lobbies/{inviteCode}/start` |
-| 인게임 WebSocket | `/app/game/{code}/**` |
+| 분류                 | 설명                                            |
+| ------------------ | --------------------------------------------- |
+| 맵 아이템(문제) CRUD     | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |
+| YouTube URL 유효성 검증 | `POST /api/youtube/validate`                  |
+| 로비 맵 변경            | `PATCH /api/lobbies/{inviteCode}/map`         |
+| 인게임 WebSocket      | `/app/game/{code}/**`                         |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,17 +39,22 @@ src/main/java/io/github/ascrew/monomatbe/
 │   ├── lobby/                                      # 로비 도메인
 │   │   ├── KickLobbyResult.java                    # 강퇴 처리 결과 (sealed interface)
 │   │   ├── LeaveLobbyResult.java                   # 퇴장 처리 결과 (sealed interface)
+│   │   ├── StartLobbyResult.java                   # 게임 시작 처리 결과 (sealed interface)
+│   │   ├── StartLobbyLuaResultCode.java            # start_lobby.lua 반환 문자열 계약 enum
 │   │   ├── controller/
-│   │   │   ├── LobbyController.java                # HTTP REST API (로비 생성, 입장, 목록 조회)
+│   │   │   ├── LobbyController.java                # HTTP REST API (생성, 입장, 목록, 상세, ready, start)
 │   │   │   └── LobbyEventController.java           # STOMP 로비 이벤트 수신
 │   │   ├── dto/
-│   │   │   ├── CreateLobbyRequest.java             # 로비 생성 요청 DTO (선택적 mapId 포함)
-│   │   │   ├── CreateLobbyResponse.java            # 로비 생성 응답 DTO (inviteCode + 맵 정보 포함)
+│   │   │   ├── CreateLobbyRequest.java             # 로비 생성 요청 DTO
+│   │   │   ├── CreateLobbyResponse.java            # 로비 생성 응답 DTO
 │   │   │   ├── JoinLobbyRequest.java               # 초대 코드 기반 로비 입장 요청 DTO
-│   │   │   ├── JoinLobbyResponse.java              # 초대 코드 기반 로비 입장 응답 DTO (맵 정보 포함)
+│   │   │   ├── JoinLobbyResponse.java              # 초대 코드 기반 로비 입장 응답 DTO
 │   │   │   ├── KickLobbyPlayerRequest.java         # 로비 유저 강퇴 요청 DTO
+│   │   │   ├── LobbyDetailResponse.java            # 로비 상세 조회 응답 DTO
+│   │   │   ├── LobbyPlayerResponse.java            # 로비 상세 참여자 응답 DTO
 │   │   │   ├── LobbyMapMetadata.java               # Redis 저장용 로비 맵 메타데이터 DTO
-│   │   │   └── LobbyRedisDto.java                  # 공개 로비 목록 조회 응답 DTO (맵 정보 포함)
+│   │   │   ├── LobbyRedisDto.java                  # 공개 로비 목록 조회 응답 DTO
+│   │   │   └── UpdateLobbyReadyRequest.java        # ready 상태 변경 요청 DTO
 │   │   ├── entity/
 │   │   │   ├── GameLobby.java                      # GAME_LOBBY 테이블 엔티티
 │   │   │   ├── LobbyDefaults.java                  # 로비 생성 기본값 및 상수
@@ -57,10 +62,11 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   ├── repository/
 │   │   │   ├── GameLobbyJpaRepository.java         # GAME_LOBBY JPA 리포지토리
 │   │   │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
-│   │   │   └── LobbyRepositoryImpl.java            # Redis 기반 구현체 (SETNX, Lua 스크립트 활용)
+│   │   │   └── LobbyRepositoryImpl.java            # Redis 기반 구현체 (Lua 스크립트 활용)
 │   │   └── service/
 │   │       ├── LobbyEventService.java              # 로비 이벤트 처리 및 STOMP 브로드캐스트
-│   │       └── LobbyService.java                   # 로비 생성/입장/조회 비즈니스 로직
+│   │       ├── LobbyService.java                   # 로비 생성/입장/상세/ready/start 비즈니스 로직
+│   │       └── LobbyStartReconciliationService.java # 게임 시작 Redis-DB 상태 불일치 재처리 스케줄러
 │   │
 │   ├── map/                                        # 퀴즈 맵 도메인
 │   │   ├── controller/
@@ -80,7 +86,8 @@ src/main/java/io/github/ascrew/monomatbe/
 └── global/                                         # 전역 인프라 레이어
     ├── config/                                     # 애플리케이션 설정
     │   ├── RedisConfig.java                        # Redis 연결, 직렬화, Pub/Sub 설정
-    │   ├── RedisScriptConfig.java                  # create/enter/leave/kick Lua 스크립트 Bean 등록
+    │   ├── RedisScriptConfig.java                  # create/enter/leave/kick/start Lua 스크립트 Bean 등록
+    │   ├── SchedulingConfig.java                   # @Scheduled 기반 재처리 작업 활성화
     │   ├── WebSocketConfig.java                    # STOMP 엔드포인트 및 브로커 설정
     │   └── SecurityConfig/
     │       ├── SecurityConfigDev.java              # 개발 환경 (인증 없이 전체 허용)
@@ -113,7 +120,7 @@ src/main/java/io/github/ascrew/monomatbe/
             ├── JwtClaims.java                      # JWT 클레임 키 상수 (발급/검증 공유)
             ├── JwtTokenProvider.java               # JWT Access/Refresh 토큰 발급
             └── TokenWithExpiry.java                # 토큰 + 만료시각 DTO
-```
+````
 
 ---
 
@@ -126,7 +133,7 @@ domain  →  global  (허용 ✅)
 global  →  domain  (금지 ❌)
 ```
 
-`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.  
+`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.
 `global`이 `domain`을 직접 참조하면 의존 방향이 역전되어 순환 의존 및 결합도 증가 문제가 발생합니다.
 
 ### 의존 방향 역전 해결 사례 — Spring ApplicationEventPublisher
@@ -149,7 +156,7 @@ global/WebSocketEventListener → ApplicationEventPublisher.publishEvent(PlayerL
 
 동일한 `domain` 하위 도메인 간 참조는 비즈니스 흐름상 허용하지만, 직접 엔티티 결합은 최소화합니다.
 
-예를 들어 로비 생성 시 맵을 연결할 때 `LobbyService`는 `QuizMapJpaRepository`로 맵 접근 권한을 검증합니다.  
+예를 들어 로비 생성 시 맵을 연결할 때 `LobbyService`는 `QuizMapJpaRepository`로 맵 접근 권한을 검증합니다.
 하지만 Redis 저장 계층인 `LobbyRepositoryImpl`은 `QuizMap` 엔티티에 직접 의존하지 않고, `LobbyMapMetadata`라는 최소 DTO만 전달받습니다.
 
 ```text
@@ -234,7 +241,7 @@ RedisSubscriber.onMessage()
     │ /topic/lobby/{code} 구독자로 ENTER 메시지 수신
 ```
 
-> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.  
+> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
 > `/topic/lobby/{code}/refresh` 구독은 로비 정보 갱신 신호 수신용이며, 입장 처리 대상이 아닙니다.
 
 ### WebSocket 연결 해제 흐름
@@ -290,84 +297,139 @@ LobbyEventService.handleKickSuccess()
     │ 3. 로비 내부 refresh 브로드캐스트
 ```
 
+### 로비 게임 시작 흐름
+
+```text
+방장 클라이언트
+    │ REST POST /api/lobbies/{code}/start
+    ▼
+LobbyController.startLobbyGame()
+    │ @AuthenticationPrincipal CustomPrincipal 전달
+    ▼
+LobbyService.startLobbyGame()
+    │ 1. 인증 정보 확인
+    │ 2. Redis 로비 존재 여부 확인
+    │ 3. DB GAME_LOBBY 스냅샷 조회
+    │ 4. 선택된 맵 존재/삭제 여부 확인
+    │ 5. 맵 문제 수 >= roundCount 검증
+    ▼
+LobbyRepositoryImpl.executeStartLobbyProcess()
+    │ 1. start_lobby.lua 실행 전 stale ready 데이터 정리
+    │ 2. Redis Lua로 방장 권한, WAITING, mapId, participants, ready, session 상태 원자 검증
+    ▼
+start_lobby.lua
+    ├── 로비 존재 여부 확인
+    ├── 방장 정보 존재 여부 확인
+    ├── 요청자가 방장인지 확인
+    ├── 상태가 WAITING인지 확인
+    ├── map_id 존재 여부 확인
+    ├── 방장 제외 참여자 1명 이상인지 확인
+    ├── 방장 제외 참여자의 활성 로비 세션 키 존재 여부 확인
+    ├── 방장 제외 모든 참여자가 ready 상태인지 확인
+    ├── lobby:{code}.status = PLAYING
+    └── lobby:public에서 code 제거
+    ▼
+LobbyService
+    │ DB GAME_LOBBY.status = PLAYING 저장
+    │ afterCommit에서 GAME_STARTED / REFRESH_LOBBY_INFO 브로드캐스트 등록
+    ▼
+클라이언트
+    │ /topic/lobby/{code}/game에서 GAME_STARTED 수신
+    ▼
+인게임 화면 전환
+```
+
+`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.
+트랜잭션 동기화가 비활성인 경우 즉시 발행하지 않고 서버 오류로 처리하여 DB 커밋 전 이벤트 발행을 방지합니다.
+
 ---
 
 ## 🗄️ Redis 데이터 구조
 
-| 키 패턴 | 타입 | 설명 |
-|---|---|---|
-| `lobby:{code}` | Hash | 로비 메타 정보 (title, status, host_user_id, map_id, map_title, map_category 등) |
-| `lobby:{code}:participants` | Set | 로비 참여자 식별자 목록 |
-| `lobby:{code}:order` | List | 입장 순서 (방장 위임 시 LINDEX 0 사용) |
-| `lobby:{code}:kicked` | Set | 강퇴된 사용자 식별자 목록 |
-| `lobby:{code}:user_session:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID |
-| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence |
-| `lobby:public` | Set | 공개 로비 코드 목록 (고속 필터링용) |
-| `auth:guest:session:{token}` | Hash | 게스트 세션 정보 (userId, username, userType, TTL 30일) |
-| `auth:refresh:{sessionId}` | String | Refresh Token (TTL 30일) |
-| `user_status:{userIdentifier}` | String | 사용자 온라인 상태 (`ONLINE`, TTL 2시간) |
-| `user_status:{userIdentifier}:sessions` | Set | 사용자별 활성 WebSocket 세션 목록 |
-| `ws:connection:{wsSessionId}` | Hash | WebSocket 세션 → userId, lobbyCode 매핑 |
-| `map:public:list:v:{version}:p:{page}:s:{size}` | String | 공개 맵 목록 페이지 캐시 |
-| `map:public:{mapId}` | String | 공개 맵 단건 캐시 |
-| `map:public:list:version` | String | 공개 맵 목록 캐시 버전 |
+| 키 패턴                                             | 타입     | 설명                                                                        |
+| ------------------------------------------------ | ------ | ------------------------------------------------------------------------- |
+| `lobby:{code}`                                   | Hash   | 로비 메타 정보 (title, status, host_user_id, map_id, map_title, map_category 등) |
+| `lobby:{code}:participants`                      | Set    | 로비 참여자 식별자 목록                                                             |
+| `lobby:{code}:ready`                             | Set    | ready 상태인 로비 참여자 userIdentifier 목록                                        |
+| `lobby:{code}:order`                             | List   | 입장 순서 (방장 위임 시 LINDEX 0 사용)                                               |
+| `lobby:{code}:kicked`                            | Set    | 강퇴된 사용자 식별자 목록                                                            |
+| `lobby:{code}:user_session:{userIdentifier}`     | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID                                        |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence                                  |
+| `lobby:public`                                   | Set    | 공개 로비 코드 목록 (고속 필터링용)                                                     |
+| `lobby:start:reconciliation`                     | List   | 게임 시작 Redis-DB 상태 불일치 재처리 큐                                               |
+| `metric:lobby:start:reconciliation:enqueued`     | String | 게임 시작 상태 재처리 큐 적재 횟수                                                      |
+| `metric:lobby:start:reconciliation:success`      | String | 게임 시작 상태 재처리 성공 횟수                                                        |
+| `metric:lobby:start:reconciliation:failed`       | String | 게임 시작 상태 재처리 실패 횟수                                                        |
+| `metric:lobby:start:unknown-result`              | String | `start_lobby.lua` 알 수 없는 반환값 발생 횟수                                        |
+| `metric:lobby:ready:stale-cleanup`               | String | 게임 시작 전 stale ready 데이터 정리 횟수                                             |
+| `metric:lobby:ready:consistency-failure`         | String | 게임 시작 실패 시 ready/participants/session 정합성 진단 발생 횟수                        |
+| `auth:guest:session:{token}`                     | Hash   | 게스트 세션 정보 (userId, username, userType, TTL 30일)                           |
+| `auth:refresh:{sessionId}`                       | String | Refresh Token (TTL 30일)                                                   |
+| `user_status:{userIdentifier}`                   | String | 사용자 온라인 상태 (`ONLINE`, TTL 2시간)                                            |
+| `user_status:{userIdentifier}:sessions`          | Set    | 사용자별 활성 WebSocket 세션 목록                                                   |
+| `ws:connection:{wsSessionId}`                    | Hash   | WebSocket 세션 → userId, lobbyCode 매핑                                       |
+| `map:public:list:v:{version}:p:{page}:s:{size}`  | String | 공개 맵 목록 페이지 캐시                                                            |
+| `map:public:{mapId}`                             | String | 공개 맵 단건 캐시                                                                |
+| `map:public:list:version`                        | String | 공개 맵 목록 캐시 버전                                                             |
 
-> ⚠️ `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`에 하드코딩되어 있습니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
+> ⚠️ `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`, `start_lobby.lua`와 맞춰 관리해야 합니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
 
 ### `lobby:{code}` Hash 구조
 
 로비 메타 정보는 Redis Hash로 저장합니다.
 
-| 필드 | 값 예시 | 설명 |
-|---|---|---|
-| `code` | `ABC123` | 로비 초대 코드 |
-| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier |
-| `title` | `K-POP 퀴즈방` | 로비 제목 |
-| `max_players` | `8` | 최대 참여 인원 |
-| `is_private` | `false` | 비공개 여부. `true` = 비공개 |
-| `status` | `WAITING` | 로비 상태 |
-| `map_id` | `1` | 선택된 맵 ID |
-| `map_title` | `K-POP 2세대` | 선택된 맵 제목 |
-| `map_category` | `kpop` | 선택된 맵 카테고리 |
+| 필드             | 값 예시                                   | 설명                                                          |
+| -------------- | -------------------------------------- | ----------------------------------------------------------- |
+| `code`         | `ABC123`                               | 로비 초대 코드                                                    |
+| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier                                        |
+| `title`        | `K-POP 퀴즈방`                            | 로비 제목                                                       |
+| `max_players`  | `8`                                    | 최대 참여 인원                                                    |
+| `is_private`   | `false`                                | 비공개 여부. `true` = 비공개                                        |
+| `status`       | `WAITING`                              | 로비 상태                                                       |
+| `map_id`       | `1`                                    | 선택된 맵 ID                                                    |
+| `map_title`    | `K-POP 2세대`                            | 선택된 맵 제목                                                    |
+| `map_category` | `jpop`                                 | 선택된 맵 카테고리 원본 값. HTTP 응답 시 `K-POP`, `J-POP`, `POP` 형식으로 정규화 |
 
-`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.  
+`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.
 맵이 선택되지 않은 로비는 위 세 필드를 저장하지 않습니다.
 
 Redis에 `"null"` 문자열을 저장하지 않고, 응답 DTO에서만 `null`로 표현합니다.
 
 ### Redis Hash 필드 상수 (`RedisKeys.FIELD_*`)
 
-로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.  
+로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.
 문자열 리터럴 직접 사용 시 오타가 런타임에서야 발견되는 문제를 컴파일 타임에 방지합니다.
 
 로비 맵 연결 기능에서 사용하는 주요 필드는 다음과 같습니다.
 
-| 필드 상수 | Redis Hash 필드명 | 설명 |
-|---|---|---|
-| `FIELD_MAP_ID` | `map_id` | 선택된 맵 ID |
-| `FIELD_MAP_TITLE` | `map_title` | 선택된 맵 제목 |
-| `FIELD_MAP_CATEGORY` | `map_category` | 선택된 맵 카테고리 |
+| 필드 상수                | Redis Hash 필드명 | 설명                |
+| -------------------- | -------------- | ----------------- |
+| `FIELD_MAP_ID`       | `map_id`       | 선택된 맵 ID          |
+| `FIELD_MAP_TITLE`    | `map_title`    | 선택된 맵 제목          |
+| `FIELD_MAP_CATEGORY` | `map_category` | 선택된 맵 카테고리        |
+| `FIELD_STATUS`       | `status`       | 로비 상태             |
+| `FIELD_HOST_USER_ID` | `host_user_id` | 방장 userIdentifier |
 
-맵 미선택 로비에서는 위 필드를 저장하지 않습니다.
+맵 미선택 로비에서는 맵 관련 필드를 저장하지 않습니다.
 
 ### WebSocket 로비 입장 저장 구조
 
 로비 입장 상태는 `enter_lobby.lua`에서 원자적으로 저장합니다.
 
-| 키 패턴 | 타입 | 저장 시점 | 설명 |
-|---|---|---|---|
-| `lobby:{code}:participants` | Set | `/topic/lobby/{code}` 구독 시 | 현재 로비에 참여 중인 userIdentifier 목록 |
-| `lobby:{code}:order` | List | `/topic/lobby/{code}` 구독 시 | 입장 순서. 방장 퇴장 시 다음 방장 위임 기준 |
-| `lobby:{code}:user_session:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 wsSessionId |
-| `lobby:{code}:user_session_seq:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 세션 sequence |
-| `ws:connection:{wsSessionId}` | Hash | `/topic/lobby/{code}` 구독 시 | WebSocket 세션 ID로 userIdentifier와 lobbyCode를 역추적하기 위한 매핑 |
+| 키 패턴                                             | 타입     | 저장 시점                      | 설명                                                      |
+| ------------------------------------------------ | ------ | -------------------------- | ------------------------------------------------------- |
+| `lobby:{code}:participants`                      | Set    | `/topic/lobby/{code}` 구독 시 | 현재 로비에 참여 중인 userIdentifier 목록                          |
+| `lobby:{code}:order`                             | List   | `/topic/lobby/{code}` 구독 시 | 입장 순서. 방장 퇴장 시 다음 방장 위임 기준                              |
+| `lobby:{code}:user_session:{userIdentifier}`     | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 wsSessionId                                |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 세션 sequence                                |
+| `ws:connection:{wsSessionId}`                    | Hash   | `/topic/lobby/{code}` 구독 시 | WebSocket 세션 ID로 userIdentifier와 lobbyCode를 역추적하기 위한 매핑 |
 
 `ws:connection:{wsSessionId}` Hash 필드:
 
-| 필드 | 값 | 설명 |
-|---|---|---|
-| `userId` | `userIdentifier` | Redis/WebSocket에서 사용하는 사용자 식별자 |
-| `lobbyCode` | `{code}` | 현재 WebSocket 세션이 참여 중인 로비 코드 |
+| 필드          | 값                | 설명                             |
+| ----------- | ---------------- | ------------------------------ |
+| `userId`    | `userIdentifier` | Redis/WebSocket에서 사용하는 사용자 식별자 |
+| `lobbyCode` | `{code}`         | 현재 WebSocket 세션이 참여 중인 로비 코드   |
 
 정상 저장 예시:
 
@@ -393,14 +455,39 @@ HGETALL ws:connection:mhrg4it0
 
 중복 구독 시 `participants`는 Set 구조로 중복 저장되지 않으며, `order` List도 `enter_lobby.lua`에서 신규 입장자일 때만 `RPUSH`하여 중복 저장을 방지합니다.
 
+### 로비 ready 상태 저장 구조
+
+로비 참여자의 ready 상태는 Redis Set으로 관리합니다.
+
+```text
+lobby:{code}:ready
+```
+
+| 키 패턴                 | 타입  | 설명                                  |
+| -------------------- | --- | ----------------------------------- |
+| `lobby:{code}:ready` | Set | ready 상태인 일반 참여자의 userIdentifier 목록 |
+
+정책:
+
+```text
+1. 방장은 ready 대상에서 제외한다.
+2. 일반 참여자만 ready 상태를 변경할 수 있다.
+3. ready 변경은 PATCH /api/lobbies/{code}/ready에서 처리한다.
+4. ready 변경 성공 시 /topic/lobby/{code}/refresh로 REFRESH_LOBBY_INFO를 브로드캐스트한다.
+5. 퇴장/강퇴 시 ready Set에서 해당 userIdentifier를 제거한다.
+6. 게임 시작 직전 ready Set에는 있지만 participants Set에는 없는 stale ready 데이터를 정리한다.
+```
+
+ready 상태는 `canStart` 계산과 `start_lobby.lua`의 최종 시작 조건 검증에 사용됩니다.
+
 ---
 
 ## ⚡ 핵심 설계 결정
 
 ### Java 21 Virtual Thread + Lettuce
 
-가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 **Lettuce**를 사용합니다.  
-Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,  
+가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 **Lettuce**를 사용합니다.
+Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,
 Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
 
 ### 로비 생성 시 맵 연결 정책
@@ -412,7 +499,7 @@ Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
 게임 시작: mapId 필수
 ```
 
-이 구조를 선택한 이유는 로비가 게임 시작 전 대기실 역할을 하기 때문입니다.  
+이 구조를 선택한 이유는 로비가 게임 시작 전 대기실 역할을 하기 때문입니다.
 방장은 먼저 로비를 만들고 참여자를 모은 뒤, 로비 내부에서 맵을 선택하거나 변경할 수 있습니다.
 
 `mapId`가 전달된 경우 `LobbyService`에서 다음 순서로 검증합니다.
@@ -426,14 +513,14 @@ Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
 
 검증 결과에 따른 HTTP 상태 코드는 다음과 같습니다.
 
-| 상황 | 상태 코드 |
-|---|---|
-| 존재하지 않는 맵 | `404 Not Found` |
-| 삭제된 맵 | `409 Conflict` |
-| 타인 소유 비공개 맵 | `403 Forbidden` |
-| 공개 맵 또는 본인 소유 비공개 맵 | 로비 생성 허용 |
+| 상황                  | 상태 코드           |
+| ------------------- | --------------- |
+| 존재하지 않는 맵           | `404 Not Found` |
+| 삭제된 맵               | `409 Conflict`  |
+| 타인 소유 비공개 맵         | `403 Forbidden` |
+| 공개 맵 또는 본인 소유 비공개 맵 | 로비 생성 허용        |
 
-검증이 끝난 맵 정보는 `LobbyMapMetadata`로 변환하여 Redis 저장 계층에 전달합니다.  
+검증이 끝난 맵 정보는 `LobbyMapMetadata`로 변환하여 Redis 저장 계층에 전달합니다.
 이를 통해 `LobbyRepositoryImpl`이 `QuizMap` 엔티티에 직접 의존하지 않도록 분리합니다.
 
 ### Lua 스크립트 기반 원자적 로비 생성
@@ -467,7 +554,7 @@ map_title
 map_category
 ```
 
-맵 미선택 로비의 경우 Java에서 빈 문자열을 전달하고, Lua 스크립트는 `mapId`가 빈 문자열이면 맵 관련 필드를 저장하지 않습니다.  
+맵 미선택 로비의 경우 Java에서 빈 문자열을 전달하고, Lua 스크립트는 `mapId`가 빈 문자열이면 맵 관련 필드를 저장하지 않습니다.
 이 방식으로 Redis Hash에 `"null"` 문자열이 저장되는 것을 방지합니다.
 
 ### Lua 스크립트 기반 원자적 입장 처리
@@ -506,22 +593,22 @@ ws:connection은 있지만 participants에는 없음
 
 반환값은 다음과 같습니다.
 
-| 반환값 | 의미 |
-|---|---|
-| `ENTERED:{sequence}` | 신규 입장 처리 완료 |
+| 반환값                         | 의미                                 |
+| --------------------------- | ---------------------------------- |
+| `ENTERED:{sequence}`        | 신규 입장 처리 완료                        |
 | `ALREADY_JOINED:{sequence}` | 이미 참여 중인 유저의 중복 구독. order 중복 저장 없음 |
-| `LOBBY_NOT_FOUND` | 존재하지 않는 로비 코드로 구독 요청 |
+| `LOBBY_NOT_FOUND`           | 존재하지 않는 로비 코드로 구독 요청               |
 
-입장 처리는 반드시 `/topic/lobby/{code}` 구독 시점에만 수행합니다.  
+입장 처리는 반드시 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
 `/topic/lobby/{code}/refresh`는 입장 처리를 트리거하지 않습니다.
 
 ### Lua 스크립트 기반 원자적 퇴장 처리
 
-`leave_lobby.lua`는 참여자 제거 → 방장 위임 → 로비 폭파를 단일 트랜잭션으로 처리합니다.  
+`leave_lobby.lua`는 참여자 제거 → 방장 위임 → 로비 폭파를 단일 트랜잭션으로 처리합니다.
 Redis는 싱글 스레드로 Lua 스크립트를 실행하므로 다수의 동시 퇴장 시에도 Race Condition이 발생하지 않습니다.
 
-반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,  
-`LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여  
+반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,
+`LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여
 서비스 레이어가 Redis 반환 포맷을 알 필요 없도록 캡슐화합니다.
 
 ### Lua 스크립트 기반 원자적 강퇴 처리
@@ -555,22 +642,175 @@ lobby:{code}:user_session_seq:{targetUserIdentifier}
 
 반환값은 다음과 같습니다.
 
-| 반환값 | 의미 |
-|---|---|
-| `KICKED:{targetWsSessionId}` | 강퇴 성공 |
-| `LOBBY_NOT_FOUND` | 존재하지 않는 로비 |
-| `HOST_NOT_FOUND` | 로비 방장 정보 없음 |
-| `FORBIDDEN` | 요청자가 방장이 아님 |
-| `CANNOT_KICK_SELF` | 자기 자신 강퇴 시도 |
-| `TARGET_NOT_PARTICIPANT` | 강퇴 대상이 로비 참여자가 아님 |
+| 반환값                          | 의미                |
+| ---------------------------- | ----------------- |
+| `KICKED:{targetWsSessionId}` | 강퇴 성공             |
+| `LOBBY_NOT_FOUND`            | 존재하지 않는 로비        |
+| `HOST_NOT_FOUND`             | 로비 방장 정보 없음       |
+| `FORBIDDEN`                  | 요청자가 방장이 아님       |
+| `CANNOT_KICK_SELF`           | 자기 자신 강퇴 시도       |
+| `TARGET_NOT_PARTICIPANT`     | 강퇴 대상이 로비 참여자가 아님 |
 
 강퇴 성공 후 `LobbyEventService`는 `KICK` 메시지를 로비 채팅 채널로 브로드캐스트하고, 로비 내부 refresh 이벤트를 발행합니다.
 
+### Lua 스크립트 기반 원자적 게임 시작 처리
+
+`start_lobby.lua`는 게임 시작 조건 중 Redis 기준으로 원자 검증 가능한 조건을 처리합니다.
+
+처리 대상:
+
+```text
+lobby:{code}
+lobby:{code}:participants
+lobby:{code}:ready
+lobby:public
+```
+
+검증 조건:
+
+```text
+1. 로비가 존재해야 한다.
+2. 방장 정보가 존재해야 한다.
+3. 요청자가 방장이어야 한다.
+4. 로비 상태가 WAITING이어야 한다.
+5. map_id가 존재해야 한다.
+6. 방장 제외 참여자가 1명 이상이어야 한다.
+7. 방장 제외 참여자의 활성 로비 세션 키가 존재해야 한다.
+8. 방장 제외 모든 참여자가 ready 상태여야 한다.
+```
+
+반환값 계약은 `StartLobbyLuaResultCode` enum과 `StartLobbyLuaResultCodeContractTest`로 고정합니다.
+
+| 반환값                                  | 의미                                             |
+| ------------------------------------ | ---------------------------------------------- |
+| `STARTED`                            | 게임 시작 성공                                       |
+| `LOBBY_NOT_FOUND`                    | 로비 없음                                          |
+| `HOST_NOT_FOUND`                     | 방장 정보 없음                                       |
+| `FORBIDDEN`                          | 요청자가 방장이 아님                                    |
+| `LOBBY_NOT_WAITING`                  | 로비 상태가 WAITING이 아님                             |
+| `MAP_NOT_SELECTED`                   | 맵이 선택되지 않음                                     |
+| `NO_PLAYER`                          | 방장 제외 참여자 없음                                   |
+| `NOT_READY:{userIdentifier}`         | 준비하지 않은 참여자 존재                                 |
+| `STALE_PARTICIPANT:{userIdentifier}` | participants에는 있지만 활성 로비 세션 키가 없는 stale 참여자 존재 |
+
+알 수 없는 반환값 또는 `null` 반환값은 generic error로 처리하고, `[MONITORING_REQUIRED]` 로그와 metric을 남깁니다.
+
+### 게임 시작 Redis-DB 상태 불일치 재처리
+
+게임 시작은 Redis Lua가 먼저 원자 검증 및 Redis 상태 전환을 수행하고, 이후 DB `GAME_LOBBY` 상태를 `PLAYING`으로 동기화합니다.
+
+이 구조에서는 아래와 같은 불일치가 발생할 수 있습니다.
+
+```text
+Redis: PLAYING
+DB: WAITING
+```
+
+발생 가능한 상황:
+
+```text
+1. start_lobby.lua 성공
+2. Redis lobby:{code}.status = PLAYING
+3. DB GAME_LOBBY.status 변경 실패
+```
+
+보정 정책:
+
+```text
+1. DB 상태 변경 실패 시 Redis 상태를 WAITING으로 보상 롤백한다.
+2. Redis 롤백 실패 시 lobby:start:reconciliation 큐에 payload를 적재한다.
+3. LobbyStartReconciliationService가 주기적으로 큐를 소비한다.
+4. 실패 시 exponential backoff 기반으로 재시도한다.
+5. 최대 재시도 초과 시 [ALERT_REQUIRED] 로그를 남긴다.
+```
+
+재처리 payload 형식:
+
+```text
+lobbyCode|reason|attempt|nextRetryAtEpochMillis
+```
+
+재처리 사유:
+
+| reason                        | 보정 정책                       |
+| ----------------------------- | --------------------------- |
+| `START_DB_SYNC_FAILED`        | Redis 상태를 `WAITING`으로 롤백    |
+| `START_DB_SNAPSHOT_NOT_FOUND` | DB 스냅샷이 없으므로 Redis 잔존 로비 삭제 |
+
+운영 모니터링 대상:
+
+| 항목                                           | 설명               |
+| -------------------------------------------- | ---------------- |
+| `lobby:start:reconciliation`                 | 재처리 큐 길이         |
+| `[ALERT_REQUIRED]`                           | 즉시 운영 확인이 필요한 로그 |
+| `[MONITORING_REQUIRED]`                      | 모니터링 연계가 필요한 로그  |
+| `metric:lobby:start:reconciliation:enqueued` | 재처리 큐 적재 횟수      |
+| `metric:lobby:start:reconciliation:success`  | 재처리 성공 횟수        |
+| `metric:lobby:start:reconciliation:failed`   | 재처리 실패 횟수        |
+
+### ready / participants 정합성 보정 정책
+
+게임 시작 조건은 `participants`, `ready`, `user_session` 키의 정합성에 영향을 받습니다.
+
+정책:
+
+```text
+1. participants Set을 현재 로비 참여자의 source of truth로 사용한다.
+2. ready Set에는 있지만 participants Set에는 없는 값은 stale ready 데이터로 보고 게임 시작 직전에 제거한다.
+3. participants Set에는 있지만 user_session 키가 없는 값은 stale participant로 보고 게임 시작을 거부한다.
+4. participants Set에 있고 user_session 키도 있지만 ready가 아닌 값은 실제 미준비 유저로 보고 NOT_READY 처리한다.
+5. NOT_READY 또는 STALE_PARTICIPANT 발생 시 ready/participants/session 정합성 진단 로그를 남긴다.
+```
+
+이 정책은 정상 참여자를 임의 삭제하지 않기 위한 선택입니다.
+participants에 남아 있는 유저가 실제 미준비 유저인지 stale 유저인지 Lua 내부에서 완전히 판단하기 어렵기 때문에, user_session 키가 없는 경우만 `STALE_PARTICIPANT`로 분리합니다.
+
+### Redis 직렬화 JsonMapper와 HTTP 응답 JsonMapper 분리
+
+RedisTemplate은 타입 정보가 필요한 `GenericJacksonJsonRedisSerializer`를 사용합니다.
+기존처럼 타입 정보가 포함된 `JsonMapper`를 Spring Bean으로 노출하면 Spring MVC HTTP 응답 직렬화에 해당 Mapper가 개입할 수 있습니다.
+
+그 결과 REST 응답이 아래처럼 Jackson 타입 정보를 포함하는 형태로 내려갈 수 있습니다.
+
+```json
+[
+  "java.util.ArrayList",
+  [
+    [
+      "io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto",
+      {
+        "code": "ABC123",
+        "title": "K-POP 퀴즈방"
+      }
+    ]
+  ]
+]
+```
+
+이를 방지하기 위해 Redis 전용 JsonMapper는 `RedisConfig#createRedisJsonMapper()` private 메서드 내부에서만 생성합니다.
+
+정책:
+
+```text
+1. RedisTemplate 값 직렬화:
+   - 타입 정보 포함 JsonMapper 사용
+   - Spring Bean으로 노출하지 않음
+
+2. Pub/Sub 메시지 직렬화:
+   - 타입 정보 없는 pubSubJsonMapper Bean 사용
+
+3. HTTP 응답 직렬화:
+   - Redis 직렬화용 JsonMapper가 개입하지 않음
+   - 순수 DTO JSON 배열로 반환
+```
+
+기존 `jsonMapper` Bean 직접 주입 사용처는 없어야 하며, JsonMapper가 필요한 신규 코드에서는 목적에 맞는 Bean을 명시적으로 주입해야 합니다.
+
 ### ChatMessageDto 위치
 
-`ChatMessageDto`는 채팅 도메인 전용 객체가 아닌 WebSocket 통신 전반에서 사용되는 메시지 포맷입니다.  
-`domain/chat/dto`가 아닌 `global/websocket/dto`에 위치하여  
-`global` 레이어의 `RedisPublisher`, `RedisSubscriber`, `WebSocketEventListener`가  
+`ChatMessageDto`는 채팅 도메인 전용 객체가 아닌 WebSocket 통신 전반에서 사용되는 메시지 포맷입니다.
+`domain/chat/dto`가 아닌 `global/websocket/dto`에 위치하여
+`global` 레이어의 `RedisPublisher`, `RedisSubscriber`, `WebSocketEventListener`가
 `domain`을 역참조하는 의존 방향 역전을 방지합니다.
 
 ### Redis Pub/Sub 직렬화 분리
@@ -615,49 +855,49 @@ WebSocket 클라이언트가 ["클래스명", {...}] 형태의 메시지를 받�
 
 ### 참여자 키 단일 진실의 원천
 
-기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로  
-동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.  
-`lobby:{code}:participants`를 단일 진실의 원천으로 통일하여  
-입장(Lua) → 퇴장(Lua) → 강퇴(Lua) 모두 동일한 키를 사용합니다.
+기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로
+동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.
+
+`lobby:{code}:participants`를 단일 진실의 원천으로 통일하여
+입장(Lua) → 퇴장(Lua) → 강퇴(Lua) → ready/start 검증 모두 동일한 키를 사용합니다.
 
 ### SETNX 기반 초대 코드 중복 방지
 
-`LobbyRepositoryImpl`은 6자리 초대 코드를 생성할 때  
-`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.  
-선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`까지 재시도합니다.  
+`LobbyRepositoryImpl`은 6자리 초대 코드를 생성할 때
+`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.
+선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`까지 재시도합니다.
+
 락 TTL은 `LobbyDefaults.INVITE_CODE_LOCK_TTL`을 따르며, 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
 
 ### JWT 인증 구조
 
-`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.  
-파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.  
+`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.
+파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.
 컨트롤러에서는 `@AuthenticationPrincipal CustomPrincipal`로 주입받아 사용합니다.
-
-JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여  
-`JwtTokenProvider`(발급)와 `JwtAuthenticationFilter`(검증) 간 키 불일치를 컴파일 타임에 방지합니다.
 
 [식별자 분리]
 
-- `userId` (Long) : DB users.id FK 참조용
-- `userIdentifier` (UUID String) : Redis/WebSocket 식별자
+* `userId` (Long) : DB users.id FK 참조용
+* `userIdentifier` (UUID String) : Redis/WebSocket 식별자
 
 ---
 
 ## 🌐 STOMP 채널 구조
 
-| 방향 | 경로 | 설명 |
-|---|---|---|
-| 클라이언트 → 서버 | `/app/chat/global` | 전체 채팅 메시지 송신 |
-| 클라이언트 → 서버 | `/app/chat/lobby/{code}` | 로비 채팅 메시지 송신 |
-| 클라이언트 → 서버 | `/app/lobby/create` | 로비 생성 이벤트 송신 |
-| 클라이언트 → 서버 | `/app/lobby/{code}/update` | 로비 정보 변경 이벤트 송신 |
-| 클라이언트 → 서버 | `/app/lobby/{code}/kick` | 방장의 로비 유저 강퇴 요청 |
-| 서버 → 클라이언트 | `/topic/chat/global` | 전체 채팅 메시지 수신 |
-| 서버 → 클라이언트 | `/topic/lobby/{code}` | 로비 채팅 메시지 수신 및 로비 입장 처리 트리거 |
-| 서버 → 클라이언트 | `/topic/lobby/{code}/refresh` | 로비 내부 정보 새로고침 신호 |
-| 서버 → 클라이언트 | `/topic/lobby/refresh` | 전역 로비 리스트 새로고침 신호 |
+| 방향         | 경로                            | 설명                          |
+| ---------- | ----------------------------- | --------------------------- |
+| 클라이언트 → 서버 | `/app/chat/global`            | 전체 채팅 메시지 송신                |
+| 클라이언트 → 서버 | `/app/chat/lobby/{code}`      | 로비 채팅 메시지 송신                |
+| 클라이언트 → 서버 | `/app/lobby/create`           | 로비 생성 이벤트 송신                |
+| 클라이언트 → 서버 | `/app/lobby/{code}/update`    | 로비 정보 변경 이벤트 송신             |
+| 클라이언트 → 서버 | `/app/lobby/{code}/kick`      | 방장의 로비 유저 강퇴 요청             |
+| 서버 → 클라이언트 | `/topic/chat/global`          | 전체 채팅 메시지 수신                |
+| 서버 → 클라이언트 | `/topic/lobby/{code}`         | 로비 채팅 메시지 수신 및 로비 입장 처리 트리거 |
+| 서버 → 클라이언트 | `/topic/lobby/{code}/refresh` | 로비 내부 정보 새로고침 신호            |
+| 서버 → 클라이언트 | `/topic/lobby/{code}/game`    | 게임 시작 이벤트 (`GAME_STARTED`)  |
+| 서버 → 클라이언트 | `/topic/lobby/refresh`        | 전역 로비 리스트 새로고침 신호           |
 
-> `/topic/lobby/{code}`는 로비 채팅 메시지 수신 채널이면서 WebSocket 입장 처리 트리거입니다.  
+> `/topic/lobby/{code}`는 로비 채팅 메시지 수신 채널이면서 WebSocket 입장 처리 트리거입니다.
 > `/topic/lobby/{code}/refresh`는 로비 정보 새로고침 신호 수신 전용이며, 입장 처리 트리거가 아닙니다.
 
 ---
@@ -666,12 +906,12 @@ JWT 클레임 키는 `JwtClaims` 상수 클래스로 중앙 관리하여
 
 ### 정식 회원 (Member)
 
-로그인 성공 시 JWT를 발급하고 `user_sessions`에 서버 세션 추적 정보를 저장합니다.  
+로그인 성공 시 JWT를 발급하고 `user_sessions`에 서버 세션 추적 정보를 저장합니다.
 맵 생성, 로비 호스팅 등 전체 기능에 접근할 수 있습니다.
 
 ### 게스트 (Guest)
 
-닉네임 입력만으로 진입하며, 백엔드에서 UUID를 발급하여 `localStorage`에 저장합니다.  
+닉네임 입력만으로 진입하며, 백엔드에서 UUID를 발급하여 `localStorage`에 저장합니다.
 재방문 시 UUID로 자동 복원됩니다. 퀴즈 플레이 참여만 가능합니다.
 
 ### WebSocket 인증 흐름
@@ -757,7 +997,7 @@ Redis Hash에는 `map_id`, `map_title`, `map_category` 필드를 저장하지 �
 {
   "mapId": 1,
   "mapTitle": "K-POP 2세대",
-  "mapCategory": "kpop"
+  "mapCategory": "K-POP"
 }
 ```
 
@@ -771,66 +1011,86 @@ map_category
 
 ---
 
+## 🧩 로비 ready 및 게임 시작 흐름
+
+### ready 상태 변경
+
+```text
+클라이언트
+    │ PATCH /api/lobbies/{code}/ready
+    │ Body: { ready: true }
+    ▼
+LobbyController.updateReadyStatus()
+    │ @AuthenticationPrincipal CustomPrincipal 주입
+    ▼
+LobbyService.updateReadyStatus()
+    │ 1. principal 검증
+    │ 2. Redis 로비 존재 여부 확인
+    │ 3. 로비 상태 WAITING 확인
+    │ 4. 참여자 여부 확인
+    │ 5. 방장 ready 요청 차단
+    ▼
+LobbyRepository.updateReadyStatus()
+    │ ready=true  → SADD lobby:{code}:ready userIdentifier
+    │ ready=false → SREM lobby:{code}:ready userIdentifier
+    ▼
+LobbyEventService.notifyLobbyInfoRefresh()
+    │ /topic/lobby/{code}/refresh 로 REFRESH_LOBBY_INFO 브로드캐스트
+```
+
+### canStart 계산
+
+`GET /api/lobbies/{code}` 응답의 `canStart`는 FE의 게임 시작 버튼 활성화 기준입니다.
+
+계산 조건:
+
+```text
+1. Redis 로비 상태가 WAITING
+2. Redis map_id 존재
+3. DB 기준 맵 문제 수가 roundCount 이상
+4. Redis participants 기준 방장 제외 참여자 1명 이상
+5. Redis ready Set 기준 방장 제외 모든 참여자가 ready
+```
+
+`canStart`는 조회 시점의 snapshot입니다.
+실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 `start_lobby.lua`가 최종 검증합니다.
+
+---
+
 ## 🧪 주요 검증 시나리오
 
 ### 로비 생성
 
-| 시나리오 | 기대 결과 |
-|---|---|
-| `mapId` 없이 로비 생성 | `201 Created`, 맵 정보 `null` |
-| 공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함 |
-| 본인 소유 비공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함 |
-| 타인 소유 비공개 맵 `mapId`로 로비 생성 | `403 Forbidden` |
-| 삭제된 맵 `mapId`로 로비 생성 | `409 Conflict` |
-| 존재하지 않는 `mapId`로 로비 생성 | `404 Not Found` |
-| 음수 또는 0 `mapId`로 로비 생성 | `400 Bad Request` |
+| 시나리오                       | 기대 결과                      |
+| -------------------------- | -------------------------- |
+| `mapId` 없이 로비 생성           | `201 Created`, 맵 정보 `null` |
+| 공개 맵 `mapId`로 로비 생성        | `201 Created`, 맵 정보 포함     |
+| 본인 소유 비공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함     |
+| 타인 소유 비공개 맵 `mapId`로 로비 생성 | `403 Forbidden`            |
+| 삭제된 맵 `mapId`로 로비 생성       | `409 Conflict`             |
+| 존재하지 않는 `mapId`로 로비 생성     | `404 Not Found`            |
+| 음수 또는 0 `mapId`로 로비 생성     | `400 Bad Request`          |
 
 ### Redis 저장
 
-| 시나리오 | 기대 결과 |
-|---|---|
+| 시나리오     | 기대 결과                                       |
+| -------- | ------------------------------------------- |
 | 맵 미선택 로비 | `map_id`, `map_title`, `map_category` 필드 없음 |
-| 맵 선택 로비 | `map_id`, `map_title`, `map_category` 필드 있음 |
-| 맵 미선택 로비 | `"null"` 문자열 저장 없음 |
+| 맵 선택 로비  | `map_id`, `map_title`, `map_category` 필드 있음 |
+| 맵 미선택 로비 | `"null"` 문자열 저장 없음                          |
+| ready 변경 | `lobby:{code}:ready` Set 추가/삭제              |
+| 퇴장/강퇴    | ready Set에서 해당 userIdentifier 제거            |
 
----
+### 로비 상세 / ready / start
 
-## 📌 향후 확장 포인트
-
-### 로비 내부 맵 변경
-
-현재 이슈 #62는 로비 생성 시점의 선택적 맵 연결만 처리합니다.  
-향후 로비 대기실에서 방장이 맵을 변경하는 API를 추가할 수 있습니다.
-
-예상 API:
-
-```http
-PATCH /api/lobbies/{inviteCode}/map
-```
-
-예상 정책:
-
-```text
-1. 방장만 변경 가능
-2. WAITING 상태에서만 변경 가능
-3. 삭제된 맵 선택 불가
-4. 비공개 맵은 소유자만 선택 가능
-5. 변경 후 /topic/lobby/{code}/refresh 브로드캐스트
-```
-
-### 게임 시작 조건 검증
-
-게임 시작 시점에는 반드시 유효한 맵이 선택되어 있어야 합니다.
-
-예상 조건:
-
-```text
-1. 요청자가 방장이어야 함
-2. 로비 상태가 WAITING이어야 함
-3. 선택된 맵이 있어야 함
-4. 선택된 맵이 삭제되지 않아야 함
-5. 맵의 문제 수가 roundCount 이상이어야 함
-6. 모든 참여자가 준비 완료 상태여야 함
-```
-
-이 검증은 로비 준비 상태 관리 및 게임 시작 이슈에서 처리하는 것이 적절합니다.
+| 시나리오                                | 기대 결과                                                |
+| ----------------------------------- | ---------------------------------------------------- |
+| 로비 상세 조회                            | 참여자 목록, ready 상태, canStart 반환                        |
+| 방장이 ready 요청                        | `400 Bad Request`                                    |
+| 일반 참여자가 ready 요청                    | `204 No Content`, refresh 브로드캐스트                     |
+| canStart=true 상태에서 start 요청         | `204 No Content`, `GAME_STARTED` 브로드캐스트              |
+| ready 미완료 상태에서 start 요청             | `409 Conflict`                                       |
+| 맵 미선택 상태에서 start 요청                 | `409 Conflict`                                       |
+| 맵 문제 수 부족 상태에서 start 요청             | `409 Conflict`                                       |
+| stale participant가 있는 상태에서 start 요청 | `409 Conflict`, ready/participants/session 정합성 로그 기록 |
+| Redis Lua 성공 후 DB 동기화 실패            | Redis rollback 또는 reconciliation queue 적재            |

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCode.java
@@ -19,7 +19,8 @@ public enum StartLobbyLuaResultCode {
     LOBBY_NOT_WAITING("LOBBY_NOT_WAITING"),
     MAP_NOT_SELECTED("MAP_NOT_SELECTED"),
     NO_PLAYER("NO_PLAYER"),
-    NOT_READY_PREFIX("NOT_READY:");
+    NOT_READY_PREFIX("NOT_READY:"),
+    STALE_PARTICIPANT_PREFIX("STALE_PARTICIPANT:");
 
     private final String wireValue;
 
@@ -34,6 +35,7 @@ public enum StartLobbyLuaResultCode {
     public static Optional<StartLobbyLuaResultCode> fromExactValue(String value) {
         return Arrays.stream(values())
                 .filter(code -> !code.equals(NOT_READY_PREFIX))
+                .filter(code -> !code.equals(STALE_PARTICIPANT_PREFIX))
                 .filter(code -> code.wireValue.equals(value))
                 .findFirst();
     }
@@ -44,5 +46,13 @@ public enum StartLobbyLuaResultCode {
 
     public static String extractNotReadyUserIdentifier(String value) {
         return value.substring(NOT_READY_PREFIX.wireValue.length());
+    }
+
+    public static boolean isStaleParticipantResult(String value) {
+        return value != null && value.startsWith(STALE_PARTICIPANT_PREFIX.wireValue);
+    }
+
+    public static String extractStaleParticipantUserIdentifier(String value) {
+        return value.substring(STALE_PARTICIPANT_PREFIX.wireValue.length());
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCode.java
@@ -1,0 +1,48 @@
+package io.github.ascrew.monomatbe.domain.lobby;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * start_lobby.lua 반환 문자열 계약
+ *
+ * [중요]
+ * 이 enum의 wireValue는 start_lobby.lua의 return 문자열과 반드시 일치해야 한다.
+ * Lua 스크립트와 Java 파서가 다른 버전으로 배포되면 게임 시작 실패로 이어질 수 있으므로, contract test로 문자열 계약을 고정한다.
+ */
+public enum StartLobbyLuaResultCode {
+
+    STARTED("STARTED"),
+    LOBBY_NOT_FOUND("LOBBY_NOT_FOUND"),
+    HOST_NOT_FOUND("HOST_NOT_FOUND"),
+    FORBIDDEN("FORBIDDEN"),
+    LOBBY_NOT_WAITING("LOBBY_NOT_WAITING"),
+    MAP_NOT_SELECTED("MAP_NOT_SELECTED"),
+    NO_PLAYER("NO_PLAYER"),
+    NOT_READY_PREFIX("NOT_READY:");
+
+    private final String wireValue;
+
+    StartLobbyLuaResultCode(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    public String wireValue() {
+        return wireValue;
+    }
+
+    public static Optional<StartLobbyLuaResultCode> fromExactValue(String value) {
+        return Arrays.stream(values())
+                .filter(code -> !code.equals(NOT_READY_PREFIX))
+                .filter(code -> code.wireValue.equals(value))
+                .findFirst();
+    }
+
+    public static boolean isNotReadyResult(String value) {
+        return value != null && value.startsWith(NOT_READY_PREFIX.wireValue);
+    }
+
+    public static String extractNotReadyUserIdentifier(String value) {
+        return value.substring(NOT_READY_PREFIX.wireValue.length());
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyResult.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyResult.java
@@ -1,0 +1,65 @@
+package io.github.ascrew.monomatbe.domain.lobby;
+
+/**
+ * 로비 게임 시작 Lua 스크립트 실행 결과
+ *
+ * [설계 의도]
+ * start_lobby.lua의 문자열 반환값을 서비스 레이어에 직접 노출하지 않고,
+ * 도메인 의미를 가진 타입으로 변환하여 처리한다.
+ */
+public sealed interface StartLobbyResult permits
+        StartLobbyResult.Started,
+        StartLobbyResult.LobbyNotFound,
+        StartLobbyResult.HostNotFound,
+        StartLobbyResult.Forbidden,
+        StartLobbyResult.LobbyNotWaiting,
+        StartLobbyResult.MapNotSelected,
+        StartLobbyResult.NoPlayer,
+        StartLobbyResult.NotReady,
+        StartLobbyResult.Error {
+
+    /**
+     * 게임 시작 성공.
+     *
+     * @param lobbyCode 로비 초대 코드
+     */
+    record Started(String lobbyCode) implements StartLobbyResult {
+    }
+
+    /** 로비가 Redis에 존재하지 않음 */
+    record LobbyNotFound(String lobbyCode) implements StartLobbyResult {
+    }
+
+    /** 로비의 방장 정보가 유효하지 않음 */
+    record HostNotFound(String lobbyCode) implements StartLobbyResult {
+    }
+
+    /** 요청자가 방장이 아님 */
+    record Forbidden(String lobbyCode, String requesterIdentifier) implements StartLobbyResult {
+    }
+
+    /** 로비 상태가 WAITING이 아님 */
+    record LobbyNotWaiting(String lobbyCode) implements StartLobbyResult {
+    }
+
+    /** 선택된 맵이 없음 */
+    record MapNotSelected(String lobbyCode) implements StartLobbyResult {
+    }
+
+    /** 방장을 제외한 참여자가 없음 */
+    record NoPlayer(String lobbyCode) implements StartLobbyResult {
+    }
+
+    /**
+     * 준비하지 않은 참여자가 있음
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param userIdentifier 준비하지 않은 참여자 식별자
+     */
+    record NotReady(String lobbyCode, String userIdentifier) implements StartLobbyResult {
+    }
+
+    /** Lua 실행 실패 또는 알 수 없는 반환값 */
+    record Error(String reason) implements StartLobbyResult {
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyResult.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyResult.java
@@ -16,6 +16,7 @@ public sealed interface StartLobbyResult permits
         StartLobbyResult.MapNotSelected,
         StartLobbyResult.NoPlayer,
         StartLobbyResult.NotReady,
+        StartLobbyResult.StaleParticipant,
         StartLobbyResult.Error {
 
     /**
@@ -61,5 +62,14 @@ public sealed interface StartLobbyResult permits
 
     /** Lua 실행 실패 또는 알 수 없는 반환값 */
     record Error(String reason) implements StartLobbyResult {
+    }
+
+    /**
+     * participants Set에는 있으나 활성 로비 세션 키가 없는 stale 참여자.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param userIdentifier stale 참여자 식별자
+     */
+    record StaleParticipant(String lobbyCode, String userIdentifier) implements StartLobbyResult {
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -217,7 +217,12 @@ public class LobbyController {
      */
     @Operation(
             summary = "로비 게임 시작",
-            description = "시작 조건을 검증하고 로비 상태를 PLAYING으로 변경한 뒤 게임 시작 이벤트를 브로드캐스트합니다."
+            description = """
+                시작 조건을 최종 검증하고 로비 상태를 PLAYING으로 변경한 뒤 게임 시작 이벤트를 브로드캐스트합니다.
+                로비 상세 응답의 canStart는 조회 시점의 버튼 활성화 기준이며,
+                실제 시작 가능 여부는 이 API에서 Redis Lua로 최종 검증됩니다.
+                따라서 canStart=true 이후에도 참여자 퇴장, ready 해제, 상태 변경이 발생하면 409 Conflict가 반환될 수 있습니다.
+                """
     )
     @PostMapping("/{code}/start")
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -12,6 +12,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyReadyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +25,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,6 +57,10 @@ public class LobbyController {
             "요청 수신: 로비 입장 [POST /api/lobbies/join] - 초대 코드: {}, 식별자: {}";
     private static final String LOG_JOIN_LOBBY_RESPONSE =
             "로비 입장 사전 검증 완료 - 초대 코드: {}";
+    private static final String LOG_UPDATE_READY_REQUEST =
+            "요청 수신: 로비 준비 상태 변경 [PATCH /api/lobbies/{code}/ready] - 코드: {}, 식별자: {}, ready: {}";
+    private static final String LOG_UPDATE_READY_RESPONSE =
+            "로비 준비 상태 변경 완료 - 코드: {}";
 
     private final LobbyService lobbyService;
 
@@ -145,6 +152,44 @@ public class LobbyController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 로비 참여자의 준비 상태 변경 API.
+     *
+     * [정책]
+     * - JWT 인증이 필요하다.
+     * - 로비 참여자만 준비 상태를 변경할 수 있다.
+     * - 방장은 ready 대상에서 제외하고 시작 버튼만 사용한다.
+     * - 준비 상태 변경 후 로비 내부 refresh 신호를 전송한다.
+     *
+     * @param code 로비 초대 코드
+     * @param request 준비 상태 변경 요청 DTO
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 204 No Content
+     */
+    @Operation(
+            summary = "로비 준비 상태 변경",
+            description = "로비 참여자의 ready 상태를 변경합니다. 방장은 ready 대상에서 제외됩니다."
+    )
+    @PatchMapping("/{code}/ready")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> updateReadyStatus(
+            @PathVariable String code,
+            @Valid @RequestBody UpdateLobbyReadyRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(
+                LOG_UPDATE_READY_REQUEST,
+                code,
+                principal != null ? principal.userIdentifier() : "null",
+                request.ready()
+        );
+
+        lobbyService.updateReadyStatus(code, request, principal);
+
+        log.info(LOG_UPDATE_READY_RESPONSE, code);
+
+        return ResponseEntity.noContent().build();
+    }
 
     /**
      * 공개 로비 목록 조회 API.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -11,6 +11,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyReadyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyService;
@@ -53,6 +54,10 @@ public class LobbyController {
             "요청 수신: 공개 로비 목록 조회 [GET /api/lobbies]";
     private static final String LOG_GET_PUBLIC_LOBBIES_RESPONSE =
             "조회 완료: 공개 로비 {}개 반환";
+    private static final String LOG_GET_LOBBY_DETAIL_REQUEST =
+            "요청 수신: 로비 상세 조회 [GET /api/lobbies/{code}] - 코드: {}, 식별자: {}";
+    private static final String LOG_GET_LOBBY_DETAIL_RESPONSE =
+            "로비 상세 조회 완료 - 코드: {}, canStart: {}";
     private static final String LOG_JOIN_LOBBY_REQUEST =
             "요청 수신: 로비 입장 [POST /api/lobbies/join] - 초대 코드: {}, 식별자: {}";
     private static final String LOG_JOIN_LOBBY_RESPONSE =
@@ -189,6 +194,43 @@ public class LobbyController {
         log.info(LOG_UPDATE_READY_RESPONSE, code);
 
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 로비 상세 조회 API
+     *
+     * [용도]
+     * 로비 대기실 화면에서 필요한 참여자 ready 상태와 canStart 값을 조회한다.
+     *
+     * [주의]
+     * 실제 최신 참여자 상태는 WebSocket 구독/해제 흐름에 의해 Redis에서 관리된다.
+     * 클라이언트는 REFRESH_LOBBY_INFO 신호를 받으면 이 API를 다시 호출하여 최신 상태를 동기화한다.
+     *
+     * @param code 로비 초대 코드
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 로비 상세 정보
+     */
+    @Operation(
+            summary = "로비 상세 조회",
+            description = "로비 참여자 ready 상태와 canStart 값을 포함한 대기실 상세 정보를 조회합니다."
+    )
+    @GetMapping("/{code}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<LobbyDetailResponse> getLobbyDetail(
+            @PathVariable String code,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(
+                LOG_GET_LOBBY_DETAIL_REQUEST,
+                code,
+                principal != null ? principal.userIdentifier() : "null"
+        );
+
+        LobbyDetailResponse response = lobbyService.getLobbyDetail(code, principal);
+
+        log.info(LOG_GET_LOBBY_DETAIL_RESPONSE, code, response.canStart());
+
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyController.java
@@ -66,6 +66,10 @@ public class LobbyController {
             "요청 수신: 로비 준비 상태 변경 [PATCH /api/lobbies/{code}/ready] - 코드: {}, 식별자: {}, ready: {}";
     private static final String LOG_UPDATE_READY_RESPONSE =
             "로비 준비 상태 변경 완료 - 코드: {}";
+    private static final String LOG_START_LOBBY_REQUEST =
+            "요청 수신: 게임 시작 [POST /api/lobbies/{code}/start] - 코드: {}, 식별자: {}";
+    private static final String LOG_START_LOBBY_RESPONSE =
+            "게임 시작 처리 완료 - 코드: {}";
 
     private final LobbyService lobbyService;
 
@@ -192,6 +196,44 @@ public class LobbyController {
         lobbyService.updateReadyStatus(code, request, principal);
 
         log.info(LOG_UPDATE_READY_RESPONSE, code);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 로비 게임 시작 API
+     *
+     * [정책]
+     * - JWT 인증이 필요하다.
+     * - 방장만 게임을 시작할 수 있다.
+     * - 로비 상태가 WAITING일 때만 시작할 수 있다.
+     * - 유효한 맵이 선택되어 있어야 한다.
+     * - 맵의 문제 수가 설정된 라운드 수 이상이어야 한다.
+     * - 방장을 제외한 모든 참여자가 ready 상태여야 한다.
+     *
+     * @param code 로비 초대 코드
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 204 No Content
+     */
+    @Operation(
+            summary = "로비 게임 시작",
+            description = "시작 조건을 검증하고 로비 상태를 PLAYING으로 변경한 뒤 게임 시작 이벤트를 브로드캐스트합니다."
+    )
+    @PostMapping("/{code}/start")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> startLobbyGame(
+            @PathVariable String code,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(
+                LOG_START_LOBBY_REQUEST,
+                code,
+                principal != null ? principal.userIdentifier() : "null"
+        );
+
+        lobbyService.startLobbyGame(code, principal);
+
+        log.info(LOG_START_LOBBY_RESPONSE, code);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
@@ -1,0 +1,35 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 로비 대기실 상세 응답 DTO
+ *
+ * 사용 목적 : 로비 대기실 화면에서 필요한 서버 상태를 한 번에 내려준다.
+ *
+ * [포함 정보]
+ * - 로비 기본 정보
+ * - 선택된 맵 정보
+ * - 룰 정보 (roundCount, timeLimitSeconds)
+ * - 참여자별 ready 상태
+ * - 현재 게임 시작 버튼 활성화 가능 여부 (canStart)
+ */
+@Builder
+public record LobbyDetailResponse(
+        String inviteCode,
+        String title,
+        String hostId,
+        int maxPlayers,
+        int currentPlayers,
+        String status,
+        Long mapId,
+        String mapTitle,
+        String mapCategory,
+        Integer roundCount,
+        Integer timeLimitSeconds,
+        List<LobbyPlayerResponse> players,
+        boolean canStart
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyPlayerResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyPlayerResponse.java
@@ -1,0 +1,16 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+/**
+ * 로비 상세 응답에 포함되는 참여자 정보 DTO
+ *
+ * [정책]
+ * - userIdentifier는 Redis와 WebSocket에서 사용하는 사용자 식별자이다.
+ * - 방장은 ready 대상에서 제외되므로 ready=false로 내려갈 수 있다.
+ * - FE는 host=true 여부를 기준으로 방장 UI와 ready UI를 분리한다.
+ */
+public record LobbyPlayerResponse(
+        String userIdentifier,
+        boolean host,
+        boolean ready
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/UpdateLobbyReadyRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/UpdateLobbyReadyRequest.java
@@ -1,0 +1,20 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 로비 참여자의 준비 상태 변경 요청 DTO
+ *
+ * [정책]
+ * - ready=true  : 준비 완료
+ * - ready=false : 준비 해제
+ *
+ * Boolean 타입을 사용하여 클라이언트가 필드를 누락한 경우와 false를 명시한 경우를 구분한다.
+ */
+public record UpdateLobbyReadyRequest(
+
+        @NotNull(message = "준비 상태는 필수입니다.")
+        Boolean ready
+
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -20,6 +20,14 @@ public interface LobbyRepository {
   boolean isParticipant(String code, String userId);
 
   /**
+   * 로비 참여자의 준비 상태를 변경한다.
+   * @param code 로비 초대 코드
+   * @param userIdentifier 준비 상태를 변경할 사용자 식별자
+   * @param ready true면 준비 완료, false면 준비 해제
+   */
+  void updateReadyStatus(String code, String userIdentifier, boolean ready);
+
+  /**
    * Redis에 로비 데이터를 저장하고 초대 코드를 반환한다.
    *
    * @param request 로비 생성 요청

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -5,6 +5,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.*;
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 
@@ -80,6 +81,19 @@ public interface LobbyRepository {
           String code,
           String requesterIdentifier,
           String targetUserIdentifier
+  );
+
+  /**
+   * Lua 스크립트를 실행하여 로비 게임 시작 조건을 원자적으로 검증하고
+   * Redis 로비 상태를 PLAYING으로 변경한다.
+   *
+   * @param code 로비 초대 코드
+   * @param requesterIdentifier 게임 시작 요청자 식별자
+   * @return StartLobbyResult
+   */
+  StartLobbyResult executeStartLobbyProcess(
+          String code,
+          String requesterIdentifier
   );
 
   /** Redis에서 공개 로비 목록을 필터링하여 반환한다. */

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -96,6 +96,12 @@ public interface LobbyRepository {
           String requesterIdentifier
   );
 
+  /**
+   * 게임 시작 처리 중 DB 상태 변경 실패가 발생했을 때, Redis 로비 상태를 WAITING으로 보상 롤백한다.
+   * @param code 로비 초대 코드
+   */
+  void rollbackStartedLobbyStatus(String code);
+
   /** Redis에서 공개 로비 목록을 필터링하여 반환한다. */
   List<LobbyRedisDto> getPublicLobbies();
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -10,6 +10,7 @@ import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface LobbyRepository {
 
@@ -26,6 +27,20 @@ public interface LobbyRepository {
    * @param ready true면 준비 완료, false면 준비 해제
    */
   void updateReadyStatus(String code, String userIdentifier, boolean ready);
+
+  /**
+   * 로비 참여자 목록을 입장 순서를 기준으로 조회한다.
+   * @param code 로비 초대 코드
+   * @return 입장 순서가 반영된 userIdentifier 목록
+   */
+  List<String> getParticipantIdentifiers(String code);
+
+  /**
+   * 로비에서 ready 상태인 참여자 식별자 목록을 조회한다.
+   * @param code 로비 초대 코드
+   * @return ready Set에 저장된 userIdentifier 목록
+   */
+  Set<String> getReadyParticipantIdentifiers(String code);
 
   /**
    * Redis에 로비 데이터를 저장하고 초대 코드를 반환한다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -97,10 +97,40 @@ public interface LobbyRepository {
   );
 
   /**
-   * 게임 시작 처리 중 DB 상태 변경 실패가 발생했을 때, Redis 로비 상태를 WAITING으로 보상 롤백한다.
+   * 게임 시작 처리  DB 상태 변경 실패가 발생했을 때, Redis 로비 상태를 WAITING으로 보상 롤백한다.
    * @param code 로비 초대 코드
+   * @return Redis 보상 롤백 성공 여부
    */
-  void rollbackStartedLobbyStatus(String code);
+  boolean rollbackStartedLobbyStatus(String code);
+
+  /**
+   * Redis-DB 상태 불일치가 발생했을 때 후속 재처리를 위해 Redis 큐에 적재한다.
+   *
+   * @param code 로비 초대 코드
+   * @param reason 재처리 사유
+   */
+  void enqueueStartReconciliation(String code, String reason);
+
+  /**
+   * Redis-DB 상태 불일치 재처리 큐에서 payload를 하나 꺼낸다.
+   *
+   * @return "lobbyCode|reason" 형태의 payload. 없으면 null.
+   */
+  String pollStartReconciliation();
+
+  /**
+   * 재처리에 실패한 payload를 큐에 다시 적재한다.
+   *
+   * @param payload 재처리 payload
+   */
+  void requeueStartReconciliation(String payload);
+
+  /**
+   * 게임 시작 상태 재처리 metric counter를 증가시킨다.
+   *
+   * @param metricKey Redis metric key
+   */
+  void incrementStartReconciliationMetric(String metricKey);
 
   /** Redis에서 공개 로비 목록을 필터링하여 반환한다. */
   List<LobbyRedisDto> getPublicLobbies();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -436,6 +436,73 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
+  /**
+   * Redis 로비 상태를 WAITING으로 보상 롤백한다.
+   *
+   * [필요 이유]
+   * 게임 시작 Lua가 성공하면 Redis 로비 상태는 PLAYING으로 바뀌고,
+   * 공개 로비 목록(lobby:public)에서도 제거된다.
+   *
+   * 이후 DB GAME_LOBBY 상태 변경이 실패하면 Redis는 PLAYING, DB는 WAITING인
+   * 불일치 상태가 될 수 있으므로 가능한 범위에서 Redis 상태를 되돌린다.
+   *
+   * [보상 범위]
+   * - lobby:{code}.status = WAITING
+   * - 공개 로비라면 lobby:public에 code 재등록
+   *
+   * [한계]
+   * Redis 보상 롤백도 실패할 수 있으므로, 실패 시 운영 확인 로그를 남긴다.
+   */
+  @Override
+  public void rollbackStartedLobbyStatus(String code) {
+    String lobbyKey = RedisKeys.lobbyKey(code);
+
+    try {
+      Map<Object, Object> lobbyData = redisTemplate.opsForHash().entries(lobbyKey);
+
+      if (lobbyData.isEmpty()) {
+        log.warn(
+                "{} 게임 시작 Redis 보상 롤백 생략 - 로비 데이터 없음. code: {}, lobbyKey: {}",
+                LOG_MONITORING_REQUIRED,
+                code,
+                lobbyKey
+        );
+        return;
+      }
+
+      redisTemplate.opsForHash().put(
+              lobbyKey,
+              RedisKeys.FIELD_STATUS,
+              LobbyStatus.WAITING.name()
+      );
+
+      boolean isPrivate = Boolean.parseBoolean(
+              (String) lobbyData.get(RedisKeys.FIELD_IS_PRIVATE)
+      );
+
+      if (!isPrivate) {
+        redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, code);
+      }
+
+      log.warn(
+              "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}",
+              code,
+              LobbyStatus.WAITING.name(),
+              !isPrivate
+      );
+
+    } catch (Exception e) {
+      log.error(
+              "{} 게임 시작 Redis 보상 롤백 실패 - code: {}, lobbyKey: {}. "
+                      + "Redis는 PLAYING인데 DB는 WAITING일 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
+              LOG_MONITORING_REQUIRED,
+              code,
+              lobbyKey,
+              e
+      );
+    }
+  }
+
   @Override
   public List<LobbyRedisDto> getPublicLobbies() {
     Set<String> publicLobbyCodes =

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
@@ -41,6 +42,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private final RedisScript<String> leaveLobbyScript;
   private final RedisScript<String> createLobbyScript;
   private final RedisScript<String> kickLobbyScript;
+  private final RedisScript<String> startLobbyScript;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -67,6 +69,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String RESULT_FORBIDDEN = "FORBIDDEN";
   private static final String RESULT_CANNOT_KICK_SELF = "CANNOT_KICK_SELF";
   private static final String RESULT_TARGET_NOT_PARTICIPANT = "TARGET_NOT_PARTICIPANT";
+  private static final String RESULT_STARTED = "STARTED";
+  private static final String RESULT_MAP_NOT_SELECTED = "MAP_NOT_SELECTED";
+  private static final String RESULT_LOBBY_NOT_WAITING = "LOBBY_NOT_WAITING";
+  private static final String RESULT_NO_PLAYER = "NO_PLAYER";
+  private static final String RESULT_NOT_READY_PREFIX = "NOT_READY:";
 
   // =========================================================
   // isPrivate 정규화 상수
@@ -349,6 +356,45 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       );
 
       return new KickLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
+    }
+  }
+
+  @Override
+  public StartLobbyResult executeStartLobbyProcess(
+          String code,
+          String requesterIdentifier
+  ) {
+    List<String> keys = List.of(
+            RedisKeys.lobbyKey(code),
+            RedisKeys.lobbyParticipantsKey(code),
+            RedisKeys.lobbyReadyKey(code),
+            RedisKeys.LOBBY_PUBLIC
+    );
+
+    try {
+      String result = redisTemplate.execute(
+              startLobbyScript,
+              keys,
+              requesterIdentifier,
+              code,
+              RedisKeys.FIELD_HOST_USER_ID,
+              RedisKeys.FIELD_STATUS,
+              RedisKeys.FIELD_MAP_ID,
+              LobbyStatus.WAITING.name(),
+              LobbyStatus.PLAYING.name()
+      );
+
+      return parseStartLuaResult(result, code, requesterIdentifier);
+
+    } catch (Exception e) {
+      log.error(
+              "게임 시작 Lua 스크립트 실행 중 예외 발생 - lobbyCode: {}, requester: {}",
+              code,
+              requesterIdentifier,
+              e
+      );
+
+      return new StartLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
     }
   }
 
@@ -651,6 +697,51 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
 
     return new KickLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+  }
+
+  private StartLobbyResult parseStartLuaResult(
+          String result,
+          String code,
+          String requesterIdentifier
+  ) {
+    if (result == null) {
+      return new StartLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
+    }
+
+    if (RESULT_STARTED.equals(result)) {
+      return new StartLobbyResult.Started(code);
+    }
+
+    if (RESULT_LOBBY_NOT_FOUND.equals(result)) {
+      return new StartLobbyResult.LobbyNotFound(code);
+    }
+
+    if (RESULT_HOST_NOT_FOUND.equals(result)) {
+      return new StartLobbyResult.HostNotFound(code);
+    }
+
+    if (RESULT_FORBIDDEN.equals(result)) {
+      return new StartLobbyResult.Forbidden(code, requesterIdentifier);
+    }
+
+    if (RESULT_LOBBY_NOT_WAITING.equals(result)) {
+      return new StartLobbyResult.LobbyNotWaiting(code);
+    }
+
+    if (RESULT_MAP_NOT_SELECTED.equals(result)) {
+      return new StartLobbyResult.MapNotSelected(code);
+    }
+
+    if (RESULT_NO_PLAYER.equals(result)) {
+      return new StartLobbyResult.NoPlayer(code);
+    }
+
+    if (result.startsWith(RESULT_NOT_READY_PREFIX)) {
+      String notReadyUserIdentifier = result.substring(RESULT_NOT_READY_PREFIX.length());
+      return new StartLobbyResult.NotReady(code, notReadyUserIdentifier);
+    }
+
+    return new StartLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
   }
 
   private Long parseNullableLong(Object value) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -9,6 +9,7 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -282,8 +283,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               .status((String) data.get(RedisKeys.FIELD_STATUS))
               .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
               .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-              .mapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY))
-              .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
+              .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))              .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
               .currentPlayers(getCurrentPlayerCount(code))
               .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
               .build());
@@ -336,8 +336,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             .status((String) data.get(RedisKeys.FIELD_STATUS))
             .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
             .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-            .mapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY))
-            .build());
+            .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))            .build());
   }
 
   /**
@@ -516,6 +515,27 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     } catch (NumberFormatException e) {
       log.warn("Redis Hash 필드 Integer 파싱 실패 - 값: {}", value);
       return null;
+    }
+  }
+
+  /**
+   * Redis에서 문자열을 직접 읽어 DTO에 넣으면 MapCategory의 @JsonValue가 적용되지 않으므로,
+   * 응답 생성 시점에 명시적으로 표시 값을 변환한다.
+   *
+   * [정책]
+   * - null 또는 blank는 맵 미선택 상태로 보고 null로 반환한다.
+   * - 정상 값은 MapCategory의 단일 정규화 규칙을 사용한다.
+   * - 알 수 없는 값은 데이터 손상을 숨기지 않기 위해 원본 값을 반환하고 경고 로그를 남긴다.
+   *
+   * @param rawCategory Redis Hash에서 읽은 원본 카테고리 값
+   * @return FE 응답에 사용할 카테고리 표시 값
+   */
+  private String toDisplayMapCategory(String rawCategory) {
+    try {
+      return MapCategory.toDisplayValue(rawCategory);
+    } catch (IllegalArgumentException e) {
+      log.warn("알 수 없는 맵 카테고리 값 - rawCategory: {}", rawCategory);
+      return rawCategory;
     }
   }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -20,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -131,6 +132,75 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
 
     redisTemplate.opsForSet().remove(readyKey, userIdentifier);
+  }
+
+  /**
+   * 로비 참여자 목록을 입장 순서 기준으로 조회한다.
+   *
+   * [조회 전략]
+   * - lobby:{code}:order List를 우선 사용하여 FE 표시 순서를 안정적으로 유지한다.
+   * - participants Set을 함께 조회하여 이미 퇴장했지만 order에 남은 값은 제거한다.
+   *
+   * @param code 로비 초대 코드
+   * @return 현재 로비에 참여 중인 userIdentifier 목록
+   */
+  @Override
+  public List<String> getParticipantIdentifiers(String code) {
+    Set<String> participantSet = redisTemplate.opsForSet()
+            .members(RedisKeys.lobbyParticipantsKey(code));
+
+    if (participantSet == null || participantSet.isEmpty()) {
+      return new ArrayList<>();
+    }
+
+    List<String> orderedParticipants = redisTemplate.opsForList()
+            .range(RedisKeys.lobbyOrderKey(code), 0, -1);
+
+    if (orderedParticipants == null || orderedParticipants.isEmpty()) {
+      return new ArrayList<>(participantSet);
+    }
+
+    List<String> result = new ArrayList<>();
+
+    for (String userIdentifier : orderedParticipants) {
+      if (participantSet.contains(userIdentifier)) {
+        result.add(userIdentifier);
+      }
+    }
+
+    /*
+     * order List에는 없지만 participants Set에는 존재하는 비정상 데이터를 보정한다.
+     * Redis 장애, 과거 데이터, Lua 계약 변경 상황에서도 상세 응답이 누락되지 않도록 한다.
+     */
+    for (String userIdentifier : participantSet) {
+      if (!result.contains(userIdentifier)) {
+        result.add(userIdentifier);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * ready 상태인 참여자 식별자 목록을 조회한다.
+   *
+   * [반환 정책]
+   * Redis Set 조회 결과가 null이면 빈 Set으로 반환하여
+   * 서비스 레이어에서 null 방어 로직을 반복하지 않도록 한다.
+   *
+   * @param code 로비 초대 코드
+   * @return ready 상태인 userIdentifier Set
+   */
+  @Override
+  public Set<String> getReadyParticipantIdentifiers(String code) {
+    Set<String> readyParticipants = redisTemplate.opsForSet()
+            .members(RedisKeys.lobbyReadyKey(code));
+
+    if (readyParticipants == null || readyParticipants.isEmpty()) {
+      return new HashSet<>();
+    }
+
+    return readyParticipants;
   }
 
   /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -103,6 +103,14 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String ERROR_REDIS_SCRIPT_UNKNOWN_RESULT =
           "Redis 로비 생성 처리 결과가 유효하지 않습니다.";
 
+  /**
+   * 운영 확인이 필요한 Redis 정리 실패 로그 식별자
+   *
+   * 현재 프로젝트에 별도 알림/재처리 큐 인프라가 없으므로,
+   * 운영 로그 수집 시스템에서 이 키워드를 기준으로 알림을 연계할 수 있도록 한다.
+   */
+  private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
+
   // =========================================================
   // findByInviteCode 관련 상수
   // =========================================================
@@ -290,23 +298,32 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    */
   @Override
   public boolean deleteFromRedis(String inviteCode) {
-    try {
-      redisTemplate.delete(List.of(
-              RedisKeys.lobbyKey(inviteCode),
-              RedisKeys.lobbyParticipantsKey(inviteCode),
-              RedisKeys.lobbyOrderKey(inviteCode),
-              RedisKeys.lobbyKickedKey(inviteCode),
-              RedisKeys.lobbyReadyKey(inviteCode),
-              RedisKeys.lobbyCodeLockKey(inviteCode)
-      ));
+    List<String> keysToDelete = List.of(
+            RedisKeys.lobbyKey(inviteCode),
+            RedisKeys.lobbyParticipantsKey(inviteCode),
+            RedisKeys.lobbyOrderKey(inviteCode),
+            RedisKeys.lobbyKickedKey(inviteCode),
+            RedisKeys.lobbyReadyKey(inviteCode),
+            RedisKeys.lobbyCodeLockKey(inviteCode)
+    );
 
+    try {
+      redisTemplate.delete(keysToDelete);
       redisTemplate.opsForSet().remove(RedisKeys.LOBBY_PUBLIC, inviteCode);
 
-      log.info("Redis 보상 삭제 완료 - 코드: {}", inviteCode);
+      log.info("Redis 보상 삭제 완료 - code: {}, keys: {}", inviteCode, keysToDelete);
       return true;
 
     } catch (Exception e) {
-      log.error("Redis 보상 삭제 실패 - 코드: {}. 수동 정리 필요.", inviteCode, e);
+      log.error(
+              "{} Redis 보상 삭제 실패 - code: {}, keys: {}, publicLobbyKey: {}. "
+                      + "로비 잔여 데이터가 조회/ready/canStart 계산에 영향을 줄 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
+              LOG_MONITORING_REQUIRED,
+              inviteCode,
+              keysToDelete,
+              RedisKeys.LOBBY_PUBLIC,
+              e
+      );
       return false;
     }
   }
@@ -633,18 +650,29 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           String userId,
           LeaveLobbyResult leaveResult
   ) {
+    String readyKey = RedisKeys.lobbyReadyKey(code);
+
     try {
       if (leaveResult instanceof LeaveLobbyResult.Destroyed) {
-        redisTemplate.delete(RedisKeys.lobbyReadyKey(code));
+        redisTemplate.delete(readyKey);
         return;
       }
 
       if (leaveResult instanceof LeaveLobbyResult.Left
               || leaveResult instanceof LeaveLobbyResult.Delegated) {
-        redisTemplate.opsForSet().remove(RedisKeys.lobbyReadyKey(code), userId);
+        redisTemplate.opsForSet().remove(readyKey, userId);
       }
     } catch (Exception e) {
-      log.warn("퇴장 후 ready 상태 정리 실패 - lobbyCode: {}, userId: {}", code, userId, e);
+      log.error(
+              "{} 퇴장 후 ready 상태 정리 실패 - lobbyCode: {}, userId: {}, readyKey: {}, leaveResult: {}. "
+                      + "ready Set 잔여 데이터가 canStart 계산을 왜곡할 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
+              LOG_MONITORING_REQUIRED,
+              code,
+              userId,
+              readyKey,
+              leaveResult.getClass().getSimpleName(),
+              e
+      );
     }
   }
 
@@ -763,6 +791,13 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       String notReadyUserIdentifier = result.substring(RESULT_NOT_READY_PREFIX.length());
       return new StartLobbyResult.NotReady(code, notReadyUserIdentifier);
     }
+
+    log.error(
+            "start_lobby.lua 알 수 없는 반환값 - lobbyCode: {}, requesterIdentifier: {}, result: {}",
+            code,
+            requesterIdentifier,
+            result
+    );
 
     return new StartLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
   }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -21,7 +21,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -99,6 +98,10 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   /** Lua 스크립트 null 반환 시 에러 메시지 */
   private static final String ERROR_REDIS_SCRIPT_NULL =
           "Redis 스크립트 실행 결과가 null입니다. Redis 연결 상태를 확인해주세요.";
+
+  /** Lua 스크립트가 예상하지 못한 값을 반환했을 때의 에러 메시지 */
+  private static final String ERROR_REDIS_SCRIPT_UNKNOWN_RESULT =
+          "Redis 로비 생성 처리 결과가 유효하지 않습니다.";
 
   // =========================================================
   // findByInviteCode 관련 상수
@@ -204,7 +207,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             .members(RedisKeys.lobbyReadyKey(code));
 
     if (readyParticipants == null || readyParticipants.isEmpty()) {
-      return new HashSet<>();
+      return Set.of();
     }
 
     return readyParticipants;
@@ -250,8 +253,26 @@ public class LobbyRepositoryImpl implements LobbyRepository {
         return candidate;
       }
 
-      log.warn("초대 코드 충돌 - 재시도 {}/{}: {}",
-              attempt + 1, LobbyDefaults.INVITE_CODE_MAX_RETRY, candidate);
+      if (RESULT_LOCK_FAILED.equals(result)) {
+        log.warn(
+                "초대 코드 충돌 - 재시도 {}/{}: {}",
+                attempt + 1,
+                LobbyDefaults.INVITE_CODE_MAX_RETRY,
+                candidate
+        );
+        continue;
+      }
+
+      log.error(
+              "create_lobby.lua 알 수 없는 반환값 - code: {}, result: {}",
+              candidate,
+              result
+      );
+
+      throw new ResponseStatusException(
+              HttpStatus.SERVICE_UNAVAILABLE,
+              ERROR_REDIS_SCRIPT_UNKNOWN_RESULT
+      );
     }
 
     throw new ResponseStatusException(
@@ -422,7 +443,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               .status((String) data.get(RedisKeys.FIELD_STATUS))
               .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
               .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-              .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))              .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
+              .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
+              .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
               .currentPlayers(getCurrentPlayerCount(code))
               .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
               .build());
@@ -475,7 +497,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             .status((String) data.get(RedisKeys.FIELD_STATUS))
             .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
             .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-            .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))            .build());
+            .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
+            .build());
   }
 
   /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -481,19 +481,49 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               LobbyStatus.WAITING.name()
       );
 
-      boolean isPrivate = Boolean.parseBoolean(
-              (String) lobbyData.get(RedisKeys.FIELD_IS_PRIVATE)
-      );
+      String rawIsPrivate = (String) lobbyData.get(RedisKeys.FIELD_IS_PRIVATE);
 
-      if (!isPrivate) {
+      if (rawIsPrivate == null || rawIsPrivate.isBlank()) {
+        log.error(
+                "{} 게임 시작 Redis 보상 롤백 중 is_private 필드 누락 - public 복구 생략. "
+                        + "code: {}, lobbyKey: {}",
+                LOG_MONITORING_REQUIRED,
+                code,
+                lobbyKey
+        );
+
+        log.warn(
+                "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}",
+                code,
+                LobbyStatus.WAITING.name(),
+                false
+        );
+
+        return true;
+      }
+
+      boolean restoredPublic = false;
+
+      if (IS_PRIVATE_FALSE.equals(rawIsPrivate)) {
         redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, code);
+        restoredPublic = true;
+      } else if (!IS_PRIVATE_TRUE.equals(rawIsPrivate)) {
+        log.error(
+                "{} 게임 시작 Redis 보상 롤백 중 알 수 없는 is_private 값 - public 복구 생략. "
+                        + "code: {}, lobbyKey: {}, rawIsPrivate: {}",
+                LOG_MONITORING_REQUIRED,
+                code,
+                lobbyKey,
+                rawIsPrivate
+        );
       }
 
       log.warn(
-              "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}",
+              "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}, rawIsPrivate: {}",
               code,
               LobbyStatus.WAITING.name(),
-              !isPrivate
+              restoredPublic,
+              rawIsPrivate
       );
 
       return true;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.StartLobbyLuaResultCode;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
@@ -68,11 +69,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String RESULT_FORBIDDEN = "FORBIDDEN";
   private static final String RESULT_CANNOT_KICK_SELF = "CANNOT_KICK_SELF";
   private static final String RESULT_TARGET_NOT_PARTICIPANT = "TARGET_NOT_PARTICIPANT";
-  private static final String RESULT_STARTED = "STARTED";
-  private static final String RESULT_MAP_NOT_SELECTED = "MAP_NOT_SELECTED";
-  private static final String RESULT_LOBBY_NOT_WAITING = "LOBBY_NOT_WAITING";
-  private static final String RESULT_NO_PLAYER = "NO_PLAYER";
-  private static final String RESULT_NOT_READY_PREFIX = "NOT_READY:";
 
   // =========================================================
   // 게임 시작 상태 재처리 상수
@@ -521,7 +517,13 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    */
   @Override
   public void enqueueStartReconciliation(String code, String reason) {
-    String payload = code + RECONCILIATION_PAYLOAD_DELIMITER + reason;
+    String payload = String.join(
+            RECONCILIATION_PAYLOAD_DELIMITER,
+            code,
+            reason,
+            "0",
+            String.valueOf(System.currentTimeMillis())
+    );
 
     try {
       redisTemplate.opsForList().rightPush(
@@ -894,50 +896,63 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           String requesterIdentifier
   ) {
     if (result == null) {
+      incrementStartReconciliationMetric(RedisKeys.METRIC_START_LOBBY_UNKNOWN_RESULT);
+
+      log.error(
+              "{} start_lobby.lua null 반환값 - lobbyCode: {}, requesterIdentifier: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              requesterIdentifier
+      );
+
       return new StartLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
     }
 
-    if (RESULT_STARTED.equals(result)) {
-      return new StartLobbyResult.Started(code);
-    }
+    if (StartLobbyLuaResultCode.isNotReadyResult(result)) {
+      String notReadyUserIdentifier =
+              StartLobbyLuaResultCode.extractNotReadyUserIdentifier(result);
 
-    if (RESULT_LOBBY_NOT_FOUND.equals(result)) {
-      return new StartLobbyResult.LobbyNotFound(code);
-    }
-
-    if (RESULT_HOST_NOT_FOUND.equals(result)) {
-      return new StartLobbyResult.HostNotFound(code);
-    }
-
-    if (RESULT_FORBIDDEN.equals(result)) {
-      return new StartLobbyResult.Forbidden(code, requesterIdentifier);
-    }
-
-    if (RESULT_LOBBY_NOT_WAITING.equals(result)) {
-      return new StartLobbyResult.LobbyNotWaiting(code);
-    }
-
-    if (RESULT_MAP_NOT_SELECTED.equals(result)) {
-      return new StartLobbyResult.MapNotSelected(code);
-    }
-
-    if (RESULT_NO_PLAYER.equals(result)) {
-      return new StartLobbyResult.NoPlayer(code);
-    }
-
-    if (result.startsWith(RESULT_NOT_READY_PREFIX)) {
-      String notReadyUserIdentifier = result.substring(RESULT_NOT_READY_PREFIX.length());
       return new StartLobbyResult.NotReady(code, notReadyUserIdentifier);
     }
 
-    log.error(
-            "start_lobby.lua 알 수 없는 반환값 - lobbyCode: {}, requesterIdentifier: {}, result: {}",
-            code,
-            requesterIdentifier,
-            result
-    );
+    return StartLobbyLuaResultCode.fromExactValue(result)
+            .map(resultCode -> toStartLobbyResult(resultCode, code, requesterIdentifier))
+            .orElseGet(() -> {
+              incrementStartReconciliationMetric(RedisKeys.METRIC_START_LOBBY_UNKNOWN_RESULT);
 
-    return new StartLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+              log.error(
+                      "{} start_lobby.lua 알 수 없는 반환값 - lobbyCode: {}, requesterIdentifier: {}, result: {}",
+                      LOG_MONITORING_REQUIRED,
+                      code,
+                      requesterIdentifier,
+                      result
+              );
+
+              return new StartLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+            });
+  }
+
+  /**
+   * start_lobby.lua 반환 코드를 도메인 결과 타입으로 변환한다.
+   * StartLobbyLuaResultCode는 Lua 스크립트 반환 문자열과 1:1로 매핑됩니다.
+   */
+  private StartLobbyResult toStartLobbyResult(
+          StartLobbyLuaResultCode resultCode,
+          String code,
+          String requesterIdentifier
+  ) {
+    return switch (resultCode) {
+      case STARTED -> new StartLobbyResult.Started(code);
+      case LOBBY_NOT_FOUND -> new StartLobbyResult.LobbyNotFound(code);
+      case HOST_NOT_FOUND -> new StartLobbyResult.HostNotFound(code);
+      case FORBIDDEN -> new StartLobbyResult.Forbidden(code, requesterIdentifier);
+      case LOBBY_NOT_WAITING -> new StartLobbyResult.LobbyNotWaiting(code);
+      case MAP_NOT_SELECTED -> new StartLobbyResult.MapNotSelected(code);
+      case NO_PLAYER -> new StartLobbyResult.NoPlayer(code);
+      case NOT_READY_PREFIX -> new StartLobbyResult.Error(
+              "NOT_READY_PREFIX는 동적 prefix 결과이므로 exact 매핑 대상이 아닙니다."
+      );
+    };
   }
 
   private Long parseNullableLong(Object value) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -75,6 +75,12 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String RESULT_NOT_READY_PREFIX = "NOT_READY:";
 
   // =========================================================
+  // 게임 시작 상태 재처리 상수
+  // =========================================================
+
+  private static final String RECONCILIATION_PAYLOAD_DELIMITER = "|";
+
+  // =========================================================
   // isPrivate 정규화 상수
   // =========================================================
 
@@ -454,20 +460,20 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    * Redis 보상 롤백도 실패할 수 있으므로, 실패 시 운영 확인 로그를 남긴다.
    */
   @Override
-  public void rollbackStartedLobbyStatus(String code) {
+  public boolean rollbackStartedLobbyStatus(String code) {
     String lobbyKey = RedisKeys.lobbyKey(code);
 
     try {
       Map<Object, Object> lobbyData = redisTemplate.opsForHash().entries(lobbyKey);
 
       if (lobbyData.isEmpty()) {
-        log.warn(
-                "{} 게임 시작 Redis 보상 롤백 생략 - 로비 데이터 없음. code: {}, lobbyKey: {}",
+        log.error(
+                "{} 게임 시작 Redis 보상 롤백 실패 - 로비 데이터 없음. code: {}, lobbyKey: {}",
                 LOG_MONITORING_REQUIRED,
                 code,
                 lobbyKey
         );
-        return;
+        return false;
       }
 
       redisTemplate.opsForHash().put(
@@ -491,15 +497,80 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               !isPrivate
       );
 
+      return true;
+
     } catch (Exception e) {
       log.error(
               "{} 게임 시작 Redis 보상 롤백 실패 - code: {}, lobbyKey: {}. "
-                      + "Redis는 PLAYING인데 DB는 WAITING일 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
+                      + "Redis는 PLAYING인데 DB는 WAITING일 수 있으므로 재처리 큐 확인이 필요합니다.",
               LOG_MONITORING_REQUIRED,
               code,
               lobbyKey,
               e
       );
+      return false;
+    }
+  }
+
+  /**
+   * Redis-DB 상태 불일치 재처리 요청을 Redis 큐에 적재한다.
+   *
+   * [사용 목적]
+   * Redis 게임 시작 상태는 PLAYING으로 전환되었지만 DB 상태 변경 또는 Redis 롤백이 실패한 경우,
+   * 후속 백그라운드 리컨실리에이션 작업이 처리할 수 있도록 최소 정보를 남긴다.
+   */
+  @Override
+  public void enqueueStartReconciliation(String code, String reason) {
+    String payload = code + RECONCILIATION_PAYLOAD_DELIMITER + reason;
+
+    try {
+      redisTemplate.opsForList().rightPush(
+              RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
+              payload
+      );
+      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_START_RECONCILIATION_ENQUEUED);
+
+      log.error(
+              "{} 게임 시작 상태 재처리 큐 적재 완료 - code: {}, reason: {}, queueKey: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              reason,
+              RedisKeys.LOBBY_START_RECONCILIATION_QUEUE
+      );
+    } catch (Exception e) {
+      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED);
+
+      log.error(
+              "{} 게임 시작 상태 재처리 큐 적재 실패 - code: {}, reason: {}, queueKey: {}. "
+                      + "Redis-DB 불일치 수동 확인이 필요합니다.",
+              LOG_MONITORING_REQUIRED,
+              code,
+              reason,
+              RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
+              e
+      );
+    }
+  }
+
+  @Override
+  public String pollStartReconciliation() {
+    return redisTemplate.opsForList().leftPop(RedisKeys.LOBBY_START_RECONCILIATION_QUEUE);
+  }
+
+  @Override
+  public void requeueStartReconciliation(String payload) {
+    redisTemplate.opsForList().rightPush(
+            RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
+            payload
+    );
+  }
+
+  @Override
+  public void incrementStartReconciliationMetric(String metricKey) {
+    try {
+      redisTemplate.opsForValue().increment(metricKey);
+    } catch (Exception e) {
+      log.warn("게임 시작 상태 재처리 metric 증가 실패 - metricKey: {}", metricKey, e);
     }
   }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -22,6 +22,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -412,6 +413,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     );
 
     try {
+      cleanupStaleReadyParticipantsBeforeStart(code, requesterIdentifier);
+
       String result = redisTemplate.execute(
               startLobbyScript,
               keys,
@@ -912,6 +915,12 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       String notReadyUserIdentifier =
               StartLobbyLuaResultCode.extractNotReadyUserIdentifier(result);
 
+      logReadyConsistencyFailure(
+              code,
+              requesterIdentifier,
+              notReadyUserIdentifier
+      );
+
       return new StartLobbyResult.NotReady(code, notReadyUserIdentifier);
     }
 
@@ -930,6 +939,147 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
               return new StartLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
             });
+  }
+
+  /**
+   * 게임 시작 직전에 stale ready 데이터를 정리한다.
+   *
+   * 정리 대상 : ready Set에는 존재하지만 participants Set에는 없는 userIdentifier
+   *
+   * [정책]
+   * participants Set을 현재 로비 참여자의 source of truth로 사용한다.
+   * ready Set 잔여 데이터는 게임 시작 조건에 영향을 주면 안 되므로 start_lobby.lua 실행 전에 제거한다.
+   *
+   * [주의]
+   * participants에 남아 있지만 ready가 아닌 유저는 실제 미준비 유저일 수 있으므로
+   * 여기서 자동 제거하지 않는다.
+   */
+  private void cleanupStaleReadyParticipantsBeforeStart(
+          String code,
+          String requesterIdentifier
+  ) {
+    String participantsKey = RedisKeys.lobbyParticipantsKey(code);
+    String readyKey = RedisKeys.lobbyReadyKey(code);
+
+    try {
+      Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
+      Set<String> readyParticipants = redisTemplate.opsForSet().members(readyKey);
+
+      if (readyParticipants == null || readyParticipants.isEmpty()) {
+        return;
+      }
+
+      Set<String> participantSet = participants != null ? participants : Set.of();
+
+      Set<String> staleReadyParticipants = new HashSet<>(readyParticipants);
+      staleReadyParticipants.removeAll(participantSet);
+
+      if (staleReadyParticipants.isEmpty()) {
+        return;
+      }
+
+      redisTemplate.opsForSet().remove(
+              readyKey,
+              staleReadyParticipants.toArray()
+      );
+
+      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_READY_STALE_CLEANUP);
+
+      log.warn(
+              "{} 게임 시작 전 stale ready 데이터 정리 - lobbyCode: {}, requester: {}, "
+                      + "participantsKey: {}, readyKey: {}, staleReadyParticipants: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              requesterIdentifier,
+              participantsKey,
+              readyKey,
+              staleReadyParticipants
+      );
+
+    } catch (Exception e) {
+      log.error(
+              "{} 게임 시작 전 ready 정합성 스캔 실패 - lobbyCode: {}, requester: {}, "
+                      + "participantsKey: {}, readyKey: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              requesterIdentifier,
+              participantsKey,
+              readyKey,
+              e
+      );
+    }
+  }
+
+  /**
+   * start_lobby.lua가 NOT_READY를 반환했을 때 ready/participants 정합성 진단 로그를 남긴다.
+   *
+   * [목적]
+   * 단순히 "준비 안 됨"으로만 남기면 실제 미준비 유저인지, 퇴장/강퇴 후 participants Set에 남은 stale 유저인지 추적하기 어렵다.
+   *
+   * 따라서 participants 포함 여부, ready 포함 여부, 로비 세션 키 존재 여부, stale ready 데이터 수를 함께 기록한다.
+   */
+  private void logReadyConsistencyFailure(
+          String code,
+          String requesterIdentifier,
+          String notReadyUserIdentifier
+  ) {
+    String participantsKey = RedisKeys.lobbyParticipantsKey(code);
+    String readyKey = RedisKeys.lobbyReadyKey(code);
+    String lobbyUserSessionKey = RedisKeys.lobbyUserSessionKey(code, notReadyUserIdentifier);
+
+    try {
+      Long participantCount = redisTemplate.opsForSet().size(participantsKey);
+      Long readyCount = redisTemplate.opsForSet().size(readyKey);
+
+      Boolean isParticipant = redisTemplate.opsForSet()
+              .isMember(participantsKey, notReadyUserIdentifier);
+
+      Boolean isReady = redisTemplate.opsForSet()
+              .isMember(readyKey, notReadyUserIdentifier);
+
+      boolean hasActiveLobbySession = Boolean.TRUE.equals(
+              redisTemplate.hasKey(lobbyUserSessionKey)
+      );
+
+      Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
+      Set<String> readyParticipants = redisTemplate.opsForSet().members(readyKey);
+
+      Set<String> staleReadyParticipants = new HashSet<>(
+              readyParticipants != null ? readyParticipants : Set.of()
+      );
+      staleReadyParticipants.removeAll(participants != null ? participants : Set.of());
+
+      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_READY_CONSISTENCY_FAILURE);
+
+      log.warn(
+              "{} 게임 시작 실패 READY 정합성 진단 - lobbyCode: {}, requester: {}, "
+                      + "notReadyUserIdentifier: {}, participantCount: {}, readyCount: {}, "
+                      + "isParticipant: {}, isReady: {}, hasActiveLobbySession: {}, "
+                      + "staleReadyCount: {}, staleReadyParticipants: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              requesterIdentifier,
+              notReadyUserIdentifier,
+              participantCount,
+              readyCount,
+              isParticipant,
+              isReady,
+              hasActiveLobbySession,
+              staleReadyParticipants.size(),
+              staleReadyParticipants
+      );
+
+    } catch (Exception e) {
+      log.error(
+              "{} 게임 시작 실패 READY 정합성 진단 로그 생성 실패 - lobbyCode: {}, requester: {}, "
+                      + "notReadyUserIdentifier: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              requesterIdentifier,
+              notReadyUserIdentifier,
+              e
+      );
+    }
   }
 
   /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -924,6 +924,29 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       return new StartLobbyResult.NotReady(code, notReadyUserIdentifier);
     }
 
+    if (StartLobbyLuaResultCode.isStaleParticipantResult(result)) {
+      String staleParticipantUserIdentifier =
+              StartLobbyLuaResultCode.extractStaleParticipantUserIdentifier(result);
+
+      logReadyConsistencyFailure(
+              code,
+              requesterIdentifier,
+              staleParticipantUserIdentifier
+      );
+
+      log.error(
+              "{} 게임 시작 실패 - stale participant 감지. lobbyCode: {}, requester: {}, staleParticipant: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              requesterIdentifier,
+              staleParticipantUserIdentifier
+      );
+
+      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_READY_CONSISTENCY_FAILURE);
+
+      return new StartLobbyResult.StaleParticipant(code, staleParticipantUserIdentifier);
+    }
+
     return StartLobbyLuaResultCode.fromExactValue(result)
             .map(resultCode -> toStartLobbyResult(resultCode, code, requesterIdentifier))
             .orElseGet(() -> {
@@ -1101,6 +1124,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       case NO_PLAYER -> new StartLobbyResult.NoPlayer(code);
       case NOT_READY_PREFIX -> new StartLobbyResult.Error(
               "NOT_READY_PREFIX는 동적 prefix 결과이므로 exact 매핑 대상이 아닙니다."
+      );
+      case STALE_PARTICIPANT_PREFIX -> new StartLobbyResult.Error(
+              "STALE_PARTICIPANT_PREFIX는 동적 prefix 결과이므로 exact 매핑 대상이 아닙니다."
       );
     };
   }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -121,6 +121,18 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     );
   }
 
+  @Override
+  public void updateReadyStatus(String code, String userIdentifier, boolean ready) {
+    String readyKey = RedisKeys.lobbyReadyKey(code);
+
+    if (ready) {
+      redisTemplate.opsForSet().add(readyKey, userIdentifier);
+      return;
+    }
+
+    redisTemplate.opsForSet().remove(readyKey, userIdentifier);
+  }
+
   /**
    * Lua 스크립트로 SETNX 선점과 로비 데이터 저장을 원자적으로 수행하고 초대 코드를 반환한다.
    *
@@ -185,6 +197,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               RedisKeys.lobbyKey(inviteCode),
               RedisKeys.lobbyParticipantsKey(inviteCode),
               RedisKeys.lobbyOrderKey(inviteCode),
+              RedisKeys.lobbyKickedKey(inviteCode),
+              RedisKeys.lobbyReadyKey(inviteCode),
               RedisKeys.lobbyCodeLockKey(inviteCode)
       ));
 
@@ -211,7 +225,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
     try {
       String result = redisTemplate.execute(leaveLobbyScript, keys, userId, code);
-      return parseLuaResult(result, code, userId);
+      LeaveLobbyResult leaveResult = parseLuaResult(result, code, userId);
+
+      cleanupReadyStatusAfterLeave(code, userId, leaveResult);
+
+      return leaveResult;
     } catch (Exception e) {
       return new LeaveLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
     }
@@ -240,12 +258,17 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               targetUserIdentifier
       );
 
-      return parseKickLuaResult(
+      KickLobbyResult kickResult = parseKickLuaResult(
               result,
               code,
               requesterIdentifier,
               targetUserIdentifier
       );
+
+      cleanupReadyStatusAfterKick(code, targetUserIdentifier, kickResult);
+
+      return kickResult;
+
     } catch (Exception e) {
       log.error(
               "강퇴 Lua 스크립트 실행 중 예외 발생 - lobbyCode: {}, requester: {}, target: {}",
@@ -453,6 +476,68 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       return new LeaveLobbyResult.Delegated(code, newHostId);
     }
     return new LeaveLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+  }
+
+  /**
+   * 퇴장 처리 결과에 따라 ready Set을 정리한다.
+   *
+   * [필요 이유]
+   * 참여자가 로비를 나가면 더 이상 준비 상태에 포함되면 안 된다.
+   * 로비가 폭파된 경우에는 ready Set 전체를 삭제한다.
+   *
+   * [주의]
+   * leave_lobby.lua의 원자 처리 이후 보조 정리로 수행한다.
+   * ready 정리 실패가 퇴장 자체를 실패로 되돌리면 안 되므로 예외는 로그만 남긴다.
+   */
+  private void cleanupReadyStatusAfterLeave(
+          String code,
+          String userId,
+          LeaveLobbyResult leaveResult
+  ) {
+    try {
+      if (leaveResult instanceof LeaveLobbyResult.Destroyed) {
+        redisTemplate.delete(RedisKeys.lobbyReadyKey(code));
+        return;
+      }
+
+      if (leaveResult instanceof LeaveLobbyResult.Left
+              || leaveResult instanceof LeaveLobbyResult.Delegated) {
+        redisTemplate.opsForSet().remove(RedisKeys.lobbyReadyKey(code), userId);
+      }
+    } catch (Exception e) {
+      log.warn("퇴장 후 ready 상태 정리 실패 - lobbyCode: {}, userId: {}", code, userId, e);
+    }
+  }
+
+  /**
+   * 강퇴 성공 후 강퇴 대상의 ready 상태를 제거한다.
+   *
+   * [필요 이유]
+   * 강퇴된 유저가 lobby:{code}:ready Set에 남아 있으면
+   * 이후 canStart 계산이나 준비 상태 표시가 왜곡될 수 있다.
+   */
+  private void cleanupReadyStatusAfterKick(
+          String code,
+          String targetUserIdentifier,
+          KickLobbyResult kickResult
+  ) {
+    if (!(kickResult instanceof KickLobbyResult.Kicked)) {
+      return;
+    }
+
+    try {
+      redisTemplate.opsForSet().remove(
+              RedisKeys.lobbyReadyKey(code),
+              targetUserIdentifier
+      );
+    } catch (Exception e) {
+      log.warn(
+              "강퇴 후 ready 상태 정리 실패 - lobbyCode: {}, targetUserIdentifier: {}",
+              code,
+              targetUserIdentifier,
+              e
+      );
+    }
   }
 
   private KickLobbyResult parseKickLuaResult(

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyEventService.java
@@ -111,6 +111,32 @@ public class LobbyEventService {
   }
 
   /**
+   * 로비 참여자에게 게임 시작 이벤트를 브로드캐스트한다.
+   *
+   * [사용 목적]
+   * 시작 조건을 모두 충족해 로비 상태가 PLAYING으로 바뀐 후,
+   * FE가 대기실 화면에서 인게임 화면으로 전환할 수 있도록 알린다.
+   *
+   * [검증]
+   * 게임 시작 이벤트는 서버 내부에서만 호출하므로,
+   * userIdentifier 참여자 검증 없이 로비 코드 형식과 로비 존재 여부만 확인한다.
+   */
+  public void notifyGameStarted(String code) {
+    if (!StringUtils.hasText(code) || !LOBBY_CODE_PATTERN.matcher(code).matches()) {
+      return;
+    }
+
+    if (!lobbyRepository.existsByCode(code)) {
+      return;
+    }
+
+    messagingTemplate.convertAndSend(
+            StompDestinations.subscribeLobbyGame(code),
+            StompDestinations.MSG_GAME_STARTED
+    );
+  }
+
+  /**
    * 방장의 로비 유저 강퇴 요청을 처리한다.
    *
    * [처리 흐름]

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -327,7 +327,7 @@ public class LobbyService {
         GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCode(code)
                 .orElse(null);
 
-        boolean canStart = calculateCanStart(lobbyInfo, players);
+        boolean canStart = calculateCanStart(lobbyInfo, players, gameLobby);
 
         return LobbyDetailResponse.builder()
                 .inviteCode(lobbyInfo.inviteCode())
@@ -645,22 +645,29 @@ public class LobbyService {
      * [canStart 조건]
      * - 로비 상태가 WAITING이어야 한다.
      * - 맵이 선택되어 있어야 한다.
+     * - 맵의 문제 수가 설정된 라운드 수 이상이어야 한다.
      * - 방장을 제외한 일반 참여자가 최소 1명 이상 있어야 한다.
      * - 방장을 제외한 모든 참여자가 ready 상태여야 한다.
      *
-     * [주의]
-     * 맵 문제 수가 roundCount 이상인지 검증하는 최종 조건은
-     * 다음 단계의 게임 시작 요청 처리에서 DB 조회 기반으로 다시 검증한다.
+     * [중요]
+     * canStart는 FE의 게임 시작 버튼 활성화 기준이다.
+     * 실제 /start API의 검증 조건과 불일치하면,
+     * FE에서는 버튼이 활성화되지만 서버에서는 409 Conflict가 발생하는 UX 문제가 생긴다.
      */
     private boolean calculateCanStart(
             JoinLobbyResponse lobbyInfo,
-            List<LobbyPlayerResponse> players
+            List<LobbyPlayerResponse> players,
+            GameLobby gameLobby
     ) {
         if (!LOBBY_STATUS_WAITING.equals(lobbyInfo.status())) {
             return false;
         }
 
         if (lobbyInfo.mapId() == null) {
+            return false;
+        }
+
+        if (!hasEnoughSongsForRound(gameLobby)) {
             return false;
         }
 
@@ -673,6 +680,31 @@ public class LobbyService {
         }
 
         return nonHostPlayers.stream().allMatch(LobbyPlayerResponse::ready);
+    }
+
+    /**
+     * 로비에 연결된 맵의 문제 수가 설정된 라운드 수 이상인지 확인한다.
+     *
+     * [필요 이유]
+     * Data API 없이 저장된 맵 문제 수(numOfSong)를 기준으로 출제 가능 여부를 판단한다.
+     * 이 조건은 실제 게임 시작 API에서도 검증하므로,
+     * canStart 계산에서도 동일하게 반영해야 한다.
+     *
+     * @param gameLobby DB에 저장된 로비 스냅샷
+     * @return 맵 문제 수가 라운드 수 이상이면 true
+     */
+    private boolean hasEnoughSongsForRound(GameLobby gameLobby) {
+        if (gameLobby == null || gameLobby.getMapId() == null || gameLobby.getRoundCount() == null) {
+            return false;
+        }
+
+        return quizMapJpaRepository.findById(gameLobby.getMapId())
+                .filter(quizMap -> !Boolean.TRUE.equals(quizMap.getIsDeleted()))
+                .map(quizMap -> {
+                    Integer numOfSong = quizMap.getNumOfSong();
+                    return numOfSong != null && numOfSong >= gameLobby.getRoundCount();
+                })
+                .orElse(false);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -564,7 +564,7 @@ public class LobbyService {
             }
         });
     }
-    
+
     /**
      * 로비 참여자의 준비 상태를 변경한다.
      *
@@ -808,26 +808,30 @@ public class LobbyService {
     }
 
     /**
-     * 현재 로비가 게임 시작 가능한 상태인지 계산한다.
+     * 로비 상세 응답의 canStart 값을 계산한다.
      *
-     * [canStart 조건]
-     * - Redis 로비 상태가 WAITING이어야 한다.
-     * - Redis 로비 메타데이터에 mapId가 존재해야 한다.
-     * - DB 기준 맵 문제 수가 설정된 라운드 수 이상이어야 한다.
-     * - Redis participants 기준 방장 제외 일반 참여자가 최소 1명 이상 있어야 한다.
-     * - Redis ready Set 기준 방장 제외 모든 참여자가 ready 상태여야 한다.
+     * [역할]
+     * canStart는 FE의 게임 시작 버튼 활성화를 위한 조회 시점 snapshot 값이다.
+     * 실제 게임 시작 가능 여부는 POST /api/lobbies/{code}/start에서
+     * start_lobby.lua가 Redis 기준으로 최종 검증한다.
      *
-     * [DB 기반 추가 조건]
-     * - DB 기준 맵 문제 수가 설정된 라운드 수 이상이어야 한다.
-     *   → start API 진입 전 validateMapSongCount()에서도 동일하게 검증한다.
+     * [start_lobby.lua와 동일하게 맞추는 조건]
+     * - 로비 상태가 WAITING이어야 한다.
+     * - mapId가 존재해야 한다.
+     * - 방장을 제외한 참여자가 1명 이상이어야 한다.
+     * - 방장을 제외한 모든 참여자가 ready 상태여야 한다.
      *
-     * [중요]
-     * canStart는 FE의 게임 시작 버튼 활성화 기준으로 사용하는 조회 시점의 snapshot 값이다.
-     * 실제 게임 시작 가능 여부의 최종 권한은 POST /api/lobbies/{code}/start에 있다.
+     * [start_lobby.lua보다 Java에서 추가로 확인하는 조건]
+     * - DB GAME_LOBBY 스냅샷이 존재해야 한다.
+     * - 맵 문제 수가 roundCount 이상이어야 한다.
      *
-     * 따라서 canStart=true여도 사용자가 동시에 퇴장하거나 ready를 해제하면,
-     * /start 요청은 Redis Lua 최종 검증에서 409 Conflict로 실패할 수 있다.
-     * FE는 /start 실패 응답을 버튼 재활성화 및 안내 메시지로 처리해야 한다.
+     * [의도적으로 완전히 동일하지 않은 부분]
+     * start_lobby.lua는 게임 시작 직전에 participants Set의 stale participant 여부를
+     * user_session 키로 한 번 더 검증한다.
+     * canStart는 상세 조회 시점 snapshot이므로 stale participant까지 완전히 확정하지 않는다.
+     *
+     * 따라서 canStart=true여도 사용자가 퇴장/ready 해제/세션 만료를 겪으면
+     * /start는 409 Conflict로 실패할 수 있다.
      */
     private boolean calculateCanStart(
             JoinLobbyResponse lobbyInfo,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -86,6 +86,10 @@ public class LobbyService {
             "START_DB_SYNC_FAILED";
     private static final String ERROR_START_EVENT_TRANSACTION_REQUIRED =
             "게임 시작 이벤트 발행을 위한 트랜잭션 동기화가 활성화되어 있지 않습니다.";
+    private static final String ERROR_LOBBY_SNAPSHOT_NOT_FOUND =
+            "로비 상태 정보가 일치하지 않습니다. 로비를 다시 생성해주세요.";
+    private static final String RECONCILIATION_REASON_DB_SNAPSHOT_NOT_FOUND =
+            "START_DB_SNAPSHOT_NOT_FOUND";
 
     // =========================================================
     // 로그 메시지 상수
@@ -387,10 +391,7 @@ public class LobbyService {
         }
 
         GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCode(code)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND,
-                        ERROR_LOBBY_NOT_FOUND
-                ));
+                .orElseGet(() -> handleMissingGameLobbySnapshot(code, requesterIdentifier));
 
         QuizMap quizMap = validateStartMap(gameLobby);
 
@@ -437,6 +438,53 @@ public class LobbyService {
                 requesterIdentifier,
                 quizMap.getId(),
                 gameLobby.getRoundCount()
+        );
+    }
+
+    /**
+     * Redis에는 로비가 존재하지만 DB GAME_LOBBY 스냅샷이 없는 비정상 상태를 처리한다.
+     *
+     * [발생 가능한 상황]
+     * - 로비 생성 중 Redis 저장은 성공했지만 DB 저장 실패 후 Redis 보상 삭제가 실패한 경우
+     * - 운영 중 Redis/DB 정합성이 깨진 경우
+     *
+     * [처리 정책]
+     * 이 상태에서는 roundCount, timeLimitSeconds, DB 상태 동기화 대상이 없으므로
+     * 게임 시작을 진행할 수 없다.
+     *
+     * 따라서 Redis 잔존 로비를 보상 삭제하고, 삭제 실패 시 재처리 큐에 적재한다.
+     */
+    private GameLobby handleMissingGameLobbySnapshot(
+            String code,
+            String requesterIdentifier
+    ) {
+        log.error(
+                "{} Redis 로비는 존재하지만 DB GAME_LOBBY 스냅샷이 없습니다. "
+                        + "Redis 잔존 로비 보상 삭제를 시도합니다. code: {}, requester: {}",
+                "[ALERT_REQUIRED]",
+                code,
+                requesterIdentifier
+        );
+
+        boolean deleted = lobbyRepository.deleteFromRedis(code);
+
+        if (!deleted) {
+            lobbyRepository.enqueueStartReconciliation(
+                    code,
+                    RECONCILIATION_REASON_DB_SNAPSHOT_NOT_FOUND
+            );
+
+            log.error(
+                    "{} DB 스냅샷 누락 로비 Redis 삭제 실패 - 재처리 큐 적재 완료. code: {}, requester: {}",
+                    "[ALERT_REQUIRED]",
+                    code,
+                    requesterIdentifier
+            );
+        }
+
+        throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                ERROR_LOBBY_SNAPSHOT_NOT_FOUND
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -692,6 +692,18 @@ public class LobbyService {
                         ERROR_START_FAILED
                 );
             }
+
+            case StartLobbyResult.StaleParticipant staleParticipant -> {
+                log.warn(
+                        "게임 시작 요청 거부 - stale 참여자 감지. code: {}, userIdentifier: {}",
+                        staleParticipant.lobbyCode(),
+                        staleParticipant.userIdentifier()
+                );
+                throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        ERROR_START_NOT_READY
+                );
+            }
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -326,7 +327,12 @@ public class LobbyService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_LOBBY_DETAIL_FORBIDDEN);
         }
 
-        List<String> participantIdentifiers = lobbyRepository.getParticipantIdentifiers(code);
+        List<String> participantIdentifiers = includeHostIfMissing(
+                lobbyRepository.getParticipantIdentifiers(code),
+                lobbyInfo.hostId(),
+                code
+        );
+
         Set<String> readyParticipantIdentifiers = lobbyRepository.getReadyParticipantIdentifiers(code);
 
         List<LobbyPlayerResponse> players = participantIdentifiers.stream()
@@ -347,8 +353,7 @@ public class LobbyService {
                 .title(lobbyInfo.title())
                 .hostId(lobbyInfo.hostId())
                 .maxPlayers(lobbyInfo.maxPlayers())
-                .currentPlayers(lobbyInfo.currentPlayers())
-                .status(lobbyInfo.status())
+                .currentPlayers(Math.max(lobbyInfo.currentPlayers(), players.size()))                .status(lobbyInfo.status())
                 .mapId(lobbyInfo.mapId())
                 .mapTitle(lobbyInfo.mapTitle())
                 .mapCategory(lobbyInfo.mapCategory())
@@ -945,5 +950,39 @@ public class LobbyService {
         return quizMap.getOwner() != null
                 && quizMap.getOwner().getId() != null
                 && quizMap.getOwner().getId().equals(requesterUserId);
+    }
+
+    /**
+     * 로비 상세 응답에서 방장 정보가 누락되지 않도록 보정한다.
+     *
+     * [필요 이유]
+     * 정상 흐름에서는 로비 생성 시 방장이 participants Set에 포함되어야 한다.
+     * 다만 Redis 데이터 손상, 과거 데이터, WebSocket 입장 상태 불일치가 있으면
+     * participants Set에서 방장이 누락될 수 있다.
+     *
+     * FE 대기실 UI는 players 목록의 host=true 값을 기준으로 방장 표시/시작 버튼/ready 버튼을 분기하므로,
+     * 상세 응답에서는 hostId가 존재하면 players 목록에 방장을 보장한다.
+     */
+    private List<String> includeHostIfMissing(
+            List<String> participantIdentifiers,
+            String hostId,
+            String code
+    ) {
+        if (hostId == null || hostId.isBlank() || participantIdentifiers.contains(hostId)) {
+            return participantIdentifiers;
+        }
+
+        List<String> result = new ArrayList<>(participantIdentifiers);
+        result.add(0, hostId);
+
+        log.warn(
+                "{} 로비 상세 응답 보정 - participants Set에 방장이 없어 응답 목록에 추가. "
+                        + "code: {}, hostId: {}",
+                LOG_ALERT_REQUIRED,
+                code,
+                hostId
+        );
+
+        return result;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -8,6 +8,8 @@ import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyReadyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -58,6 +61,8 @@ public class LobbyService {
             "로비 참여자만 준비 상태를 변경할 수 있습니다.";
     private static final String ERROR_HOST_READY_NOT_ALLOWED =
             "방장은 준비 상태를 변경하지 않고 시작 버튼을 사용합니다.";
+    private static final String ERROR_LOBBY_DETAIL_FORBIDDEN =
+            "로비 참여자만 로비 상세 정보를 조회할 수 있습니다.";
 
     // =========================================================
     // 로그 메시지 상수
@@ -252,6 +257,81 @@ public class LobbyService {
     }
 
     /**
+     * 로비 대기실 상세 정보를 조회한다.
+     *
+     * [조회 대상]
+     * - 로비 기본 정보
+     * - DB에 저장된 룰 정보(roundCount, timeLimitSeconds)
+     * - Redis 참여자 목록
+     * - Redis ready 상태
+     * - 현재 시작 가능 여부(canStart)
+     *
+     * [접근 정책]
+     * 로비 상세 정보에는 참여자 ready 상태가 포함되므로,
+     * 로비 참여자 또는 방장만 조회할 수 있도록 제한한다.
+     *
+     * @param code 로비 초대 코드
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 로비 상세 응답
+     */
+    public LobbyDetailResponse getLobbyDetail(String code, CustomPrincipal principal) {
+        if (principal == null || principal.userId() == null) {
+            log.warn("로비 상세 조회 거부 - principal 또는 userId가 null. code: {}", code);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+        }
+
+        JoinLobbyResponse lobbyInfo = lobbyRepository.findByInviteCode(code)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_LOBBY_NOT_FOUND
+                ));
+
+        String userIdentifier = principal.userIdentifier();
+
+        if (!canAccessLobbyDetail(code, lobbyInfo, userIdentifier)) {
+            log.warn(
+                    "로비 상세 조회 거부 - 참여자가 아님. code: {}, userIdentifier: {}, hostId: {}",
+                    code,
+                    userIdentifier,
+                    lobbyInfo.hostId()
+            );
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_LOBBY_DETAIL_FORBIDDEN);
+        }
+
+        List<String> participantIdentifiers = lobbyRepository.getParticipantIdentifiers(code);
+        Set<String> readyParticipantIdentifiers = lobbyRepository.getReadyParticipantIdentifiers(code);
+
+        List<LobbyPlayerResponse> players = participantIdentifiers.stream()
+                .map(participantIdentifier -> toLobbyPlayerResponse(
+                        participantIdentifier,
+                        lobbyInfo.hostId(),
+                        readyParticipantIdentifiers
+                ))
+                .toList();
+
+        GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCode(code)
+                .orElse(null);
+
+        boolean canStart = calculateCanStart(lobbyInfo, players);
+
+        return LobbyDetailResponse.builder()
+                .inviteCode(lobbyInfo.inviteCode())
+                .title(lobbyInfo.title())
+                .hostId(lobbyInfo.hostId())
+                .maxPlayers(lobbyInfo.maxPlayers())
+                .currentPlayers(lobbyInfo.currentPlayers())
+                .status(lobbyInfo.status())
+                .mapId(lobbyInfo.mapId())
+                .mapTitle(lobbyInfo.mapTitle())
+                .mapCategory(lobbyInfo.mapCategory())
+                .roundCount(gameLobby != null ? gameLobby.getRoundCount() : null)
+                .timeLimitSeconds(gameLobby != null ? gameLobby.getTimeLimitSeconds() : null)
+                .players(players)
+                .canStart(canStart)
+                .build();
+    }
+
+    /**
      * 로비 참여자의 준비 상태를 변경한다.
      *
      * [정책]
@@ -327,6 +407,83 @@ public class LobbyService {
      */
     private boolean isLobbyHost(JoinLobbyResponse lobbyInfo, String userIdentifier) {
         return lobbyInfo.hostId() != null && lobbyInfo.hostId().equals(userIdentifier);
+    }
+
+    /**
+     * 로비 상세 조회 권한을 확인한다.
+     *
+     * [정책]
+     * - 방장은 참여자 Set 누락 여부와 관계없이 조회할 수 있다.
+     * - 일반 유저는 WebSocket 구독으로 participants Set에 등록된 이후 조회할 수 있다.
+     */
+    private boolean canAccessLobbyDetail(
+            String code,
+            JoinLobbyResponse lobbyInfo,
+            String userIdentifier
+    ) {
+        if (isLobbyHost(lobbyInfo, userIdentifier)) {
+            return true;
+        }
+
+        return lobbyRepository.isParticipant(code, userIdentifier);
+    }
+
+    /**
+     * 참여자 식별자를 로비 상세 응답용 플레이어 DTO로 변환한다.
+     *
+     * [방장 ready 정책]
+     * 방장은 ready 대상에서 제외하므로 ready=false로 내려간다.
+     * FE는 host=true 여부를 기준으로 ready 버튼을 숨김 처리
+     */
+    private LobbyPlayerResponse toLobbyPlayerResponse(
+            String participantIdentifier,
+            String hostId,
+            Set<String> readyParticipantIdentifiers
+    ) {
+        boolean host = hostId != null && hostId.equals(participantIdentifier);
+        boolean ready = !host && readyParticipantIdentifiers.contains(participantIdentifier);
+
+        return new LobbyPlayerResponse(
+                participantIdentifier,
+                host,
+                ready
+        );
+    }
+
+    /**
+     * 현재 로비가 게임 시작 가능한 상태인지 계산한다.
+     *
+     * [canStart 조건]
+     * - 로비 상태가 WAITING이어야 한다.
+     * - 맵이 선택되어 있어야 한다.
+     * - 방장을 제외한 일반 참여자가 최소 1명 이상 있어야 한다.
+     * - 방장을 제외한 모든 참여자가 ready 상태여야 한다.
+     *
+     * [주의]
+     * 맵 문제 수가 roundCount 이상인지 검증하는 최종 조건은
+     * 다음 단계의 게임 시작 요청 처리에서 DB 조회 기반으로 다시 검증한다.
+     */
+    private boolean calculateCanStart(
+            JoinLobbyResponse lobbyInfo,
+            List<LobbyPlayerResponse> players
+    ) {
+        if (!LOBBY_STATUS_WAITING.equals(lobbyInfo.status())) {
+            return false;
+        }
+
+        if (lobbyInfo.mapId() == null) {
+            return false;
+        }
+
+        List<LobbyPlayerResponse> nonHostPlayers = players.stream()
+                .filter(player -> !player.host())
+                .toList();
+
+        if (nonHostPlayers.isEmpty()) {
+            return false;
+        }
+
+        return nonHostPlayers.stream().allMatch(LobbyPlayerResponse::ready);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -9,6 +9,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyReadyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
@@ -53,6 +54,10 @@ public class LobbyService {
             "삭제된 맵은 로비에 연결할 수 없습니다.";
     private static final String ERROR_PRIVATE_MAP_FORBIDDEN =
             "비공개 맵은 소유자만 로비에 연결할 수 있습니다.";
+    private static final String ERROR_READY_FORBIDDEN =
+            "로비 참여자만 준비 상태를 변경할 수 있습니다.";
+    private static final String ERROR_HOST_READY_NOT_ALLOWED =
+            "방장은 준비 상태를 변경하지 않고 시작 버튼을 사용합니다.";
 
     // =========================================================
     // 로그 메시지 상수
@@ -84,6 +89,7 @@ public class LobbyService {
     private static final String LOBBY_STATUS_WAITING = LobbyStatus.WAITING.name();
 
     private final LobbyRepository lobbyRepository;
+    private final LobbyEventService lobbyEventService;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final UserRepository userRepository;
     private final QuizMapJpaRepository quizMapJpaRepository;
@@ -243,6 +249,84 @@ public class LobbyService {
      */
     public List<LobbyRedisDto> getPublicLobbies() {
         return lobbyRepository.getPublicLobbies();
+    }
+
+    /**
+     * 로비 참여자의 준비 상태를 변경한다.
+     *
+     * [정책]
+     * - 인증된 사용자만 요청할 수 있다.
+     * - Redis에 존재하는 로비만 대상으로 한다.
+     * - WAITING 상태의 로비에서만 준비 상태를 변경할 수 있다.
+     * - 로비 참여자만 준비 상태를 변경할 수 있다.
+     * - 방장은 준비 대상에서 제외하고, 게임 시작 버튼으로 역할을 대체한다.
+     *
+     * @param code 로비 초대 코드
+     * @param request 준비 상태 변경 요청
+     * @param principal JWT에서 추출한 인증 주체
+     */
+    public void updateReadyStatus(
+            String code,
+            UpdateLobbyReadyRequest request,
+            CustomPrincipal principal
+    ) {
+        if (principal == null || principal.userId() == null) {
+            log.warn("로비 준비 상태 변경 거부 - principal 또는 userId가 null. code: {}", code);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+        }
+
+        JoinLobbyResponse lobbyInfo = lobbyRepository.findByInviteCode(code)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_LOBBY_NOT_FOUND
+                ));
+
+        if (!LOBBY_STATUS_WAITING.equals(lobbyInfo.status())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
+        }
+
+        String userIdentifier = principal.userIdentifier();
+
+        boolean participant = lobbyRepository.isParticipant(code, userIdentifier);
+
+        if (!participant) {
+            log.warn(
+                    "로비 준비 상태 변경 거부 - 참여자가 아님. code: {}, userIdentifier: {}, hostId: {}",
+                    code,
+                    userIdentifier,
+                    lobbyInfo.hostId()
+            );
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_READY_FORBIDDEN);
+        }
+
+        if (isLobbyHost(lobbyInfo, userIdentifier)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_HOST_READY_NOT_ALLOWED);
+        }
+
+        lobbyRepository.updateReadyStatus(
+                code,
+                userIdentifier,
+                Boolean.TRUE.equals(request.ready())
+        );
+
+        lobbyEventService.notifyLobbyInfoRefresh(code, userIdentifier);
+
+        log.info(
+                "로비 준비 상태 변경 완료 - code: {}, userIdentifier: {}, ready: {}",
+                code,
+                userIdentifier,
+                request.ready()
+        );
+    }
+
+    /**
+     * 요청자가 로비 방장인지 확인한다.
+     *
+     * Redis 로비 정보의 hostId는 userIdentifier 기준으로 저장되므로,
+     * JWT principal의 userIdentifier와 직접 비교한다.
+     */
+    private boolean isLobbyHost(JoinLobbyResponse lobbyInfo, String userIdentifier) {
+        return lobbyInfo.hostId() != null && lobbyInfo.hostId().equals(userIdentifier);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -26,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
@@ -76,6 +78,8 @@ public class LobbyService {
             "맵의 문제 수가 설정된 라운드 수보다 적습니다.";
     private static final String ERROR_START_FAILED =
             "게임 시작 처리에 실패했습니다.";
+    private static final String ERROR_START_DB_SYNC_FAILED =
+            "게임 시작 상태 동기화에 실패했습니다. 잠시 후 다시 시도해주세요.";
     private static final String ERROR_LOBBY_DETAIL_FORBIDDEN =
             "로비 참여자만 로비 상세 정보를 조회할 수 있습니다.";
 
@@ -395,10 +399,26 @@ public class LobbyService {
 
         handleStartLobbyResult(result);
 
-        gameLobby.changeStatus(LobbyStatus.PLAYING);
+        try {
+            gameLobby.changeStatus(LobbyStatus.PLAYING);
+            gameLobbyJpaRepository.saveAndFlush(gameLobby);
+        } catch (Exception e) {
+            log.error(
+                    "게임 시작 DB 상태 변경 실패 - Redis 상태 보상 롤백 시도. code: {}, requester: {}",
+                    code,
+                    requesterIdentifier,
+                    e
+            );
 
-        lobbyEventService.notifyGameStarted(code);
-        lobbyEventService.notifyLobbyInfoRefresh(code, requesterIdentifier);
+            lobbyRepository.rollbackStartedLobbyStatus(code);
+
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    ERROR_START_DB_SYNC_FAILED
+            );
+        }
+
+        registerGameStartedEventAfterCommit(code, requesterIdentifier);
 
         log.info(
                 "게임 시작 처리 완료 - code: {}, requester: {}, mapId: {}, roundCount: {}",
@@ -407,6 +427,28 @@ public class LobbyService {
                 quizMap.getId(),
                 gameLobby.getRoundCount()
         );
+    }
+
+    /**
+     * 게임 시작 이벤트를 DB 트랜잭션 커밋 이후에 발행한다.
+     */
+    private void registerGameStartedEventAfterCommit(
+            String code,
+            String requesterIdentifier
+    ) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            lobbyEventService.notifyGameStarted(code);
+            lobbyEventService.notifyLobbyInfoRefresh(code, requesterIdentifier);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                lobbyEventService.notifyGameStarted(code);
+                lobbyEventService.notifyLobbyInfoRefresh(code, requesterIdentifier);
+            }
+        });
     }
 
     /**
@@ -643,16 +685,19 @@ public class LobbyService {
      * 현재 로비가 게임 시작 가능한 상태인지 계산한다.
      *
      * [canStart 조건]
-     * - 로비 상태가 WAITING이어야 한다.
-     * - 맵이 선택되어 있어야 한다.
-     * - 맵의 문제 수가 설정된 라운드 수 이상이어야 한다.
-     * - 방장을 제외한 일반 참여자가 최소 1명 이상 있어야 한다.
-     * - 방장을 제외한 모든 참여자가 ready 상태여야 한다.
+     * - Redis 로비 상태가 WAITING이어야 한다.
+     * - Redis 로비 메타데이터에 mapId가 존재해야 한다.
+     * - DB 기준 맵 문제 수가 설정된 라운드 수 이상이어야 한다.
+     * - Redis participants 기준 방장 제외 일반 참여자가 최소 1명 이상 있어야 한다.
+     * - Redis ready Set 기준 방장 제외 모든 참여자가 ready 상태여야 한다.
      *
      * [중요]
-     * canStart는 FE의 게임 시작 버튼 활성화 기준이다.
-     * 실제 /start API의 검증 조건과 불일치하면,
-     * FE에서는 버튼이 활성화되지만 서버에서는 409 Conflict가 발생하는 UX 문제가 생긴다.
+     * canStart는 FE의 게임 시작 버튼 활성화 기준으로 사용하는 조회 시점의 snapshot 값이다.
+     * 실제 게임 시작 가능 여부의 최종 권한은 POST /api/lobbies/{code}/start에 있다.
+     *
+     * 따라서 canStart=true여도 사용자가 동시에 퇴장하거나 ready를 해제하면,
+     * /start 요청은 Redis Lua 최종 검증에서 409 Conflict로 실패할 수 있다.
+     * FE는 /start 실패 응답을 버튼 재활성화 및 안내 메시지로 처리해야 한다.
      */
     private boolean calculateCanStart(
             JoinLobbyResponse lobbyInfo,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -11,6 +11,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyReadyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
@@ -61,6 +62,20 @@ public class LobbyService {
             "로비 참여자만 준비 상태를 변경할 수 있습니다.";
     private static final String ERROR_HOST_READY_NOT_ALLOWED =
             "방장은 준비 상태를 변경하지 않고 시작 버튼을 사용합니다.";
+    private static final String ERROR_START_FORBIDDEN =
+            "방장만 게임을 시작할 수 있습니다.";
+    private static final String ERROR_START_HOST_NOT_FOUND =
+            "로비 방장 정보가 유효하지 않습니다.";
+    private static final String ERROR_START_MAP_NOT_SELECTED =
+            "게임을 시작하려면 맵을 선택해야 합니다.";
+    private static final String ERROR_START_NO_PLAYER =
+            "게임을 시작하려면 방장을 제외한 참여자가 1명 이상 필요합니다.";
+    private static final String ERROR_START_NOT_READY =
+            "모든 참여자가 준비 완료 상태여야 합니다.";
+    private static final String ERROR_START_MAP_SONG_COUNT_NOT_ENOUGH =
+            "맵의 문제 수가 설정된 라운드 수보다 적습니다.";
+    private static final String ERROR_START_FAILED =
+            "게임 시작 처리에 실패했습니다.";
     private static final String ERROR_LOBBY_DETAIL_FORBIDDEN =
             "로비 참여자만 로비 상세 정보를 조회할 수 있습니다.";
 
@@ -332,6 +347,69 @@ public class LobbyService {
     }
 
     /**
+     * 로비 게임 시작 요청을 처리한다.
+     *
+     * [검증 순서]
+     * 1. 인증 정보 확인
+     * 2. Redis 로비 존재 여부 확인
+     * 3. DB 로비 스냅샷 조회
+     * 4. 선택된 맵 존재 및 삭제 여부 확인
+     * 5. 맵 문제 수가 roundCount 이상인지 확인
+     * 6. start_lobby.lua로 방장 권한, WAITING 상태, ready 상태를 원자 검증
+     * 7. DB 로비 상태를 PLAYING으로 변경
+     * 8. 로비 참여자에게 게임 시작 이벤트 브로드캐스트
+     *
+     * @param code 로비 초대 코드
+     * @param principal JWT에서 추출한 인증 주체
+     */
+    @Transactional
+    public void startLobbyGame(String code, CustomPrincipal principal) {
+        if (principal == null || principal.userId() == null) {
+            log.warn("게임 시작 요청 거부 - principal 또는 userId가 null. code: {}", code);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+        }
+
+        String requesterIdentifier = principal.userIdentifier();
+
+        if (lobbyRepository.findByInviteCode(code).isEmpty()) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    ERROR_LOBBY_NOT_FOUND
+            );
+        }
+
+        GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCode(code)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_LOBBY_NOT_FOUND
+                ));
+
+        QuizMap quizMap = validateStartMap(gameLobby);
+
+        validateMapSongCount(quizMap, gameLobby);
+
+        StartLobbyResult result = lobbyRepository.executeStartLobbyProcess(
+                code,
+                requesterIdentifier
+        );
+
+        handleStartLobbyResult(result);
+
+        gameLobby.changeStatus(LobbyStatus.PLAYING);
+
+        lobbyEventService.notifyGameStarted(code);
+        lobbyEventService.notifyLobbyInfoRefresh(code, requesterIdentifier);
+
+        log.info(
+                "게임 시작 처리 완료 - code: {}, requester: {}, mapId: {}, roundCount: {}",
+                code,
+                requesterIdentifier,
+                quizMap.getId(),
+                gameLobby.getRoundCount()
+        );
+    }
+
+    /**
      * 로비 참여자의 준비 상태를 변경한다.
      *
      * [정책]
@@ -397,6 +475,117 @@ public class LobbyService {
                 userIdentifier,
                 request.ready()
         );
+    }
+
+    /**
+     * 게임 시작에 사용할 맵을 검증한다.
+     *
+     * [검증]
+     * - 로비에 mapId가 있어야 한다.
+     * - 맵이 존재해야 한다.
+     * - 삭제된 맵이면 시작할 수 없다.
+     */
+    private QuizMap validateStartMap(GameLobby gameLobby) {
+        if (gameLobby.getMapId() == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_START_MAP_NOT_SELECTED
+            );
+        }
+
+        QuizMap quizMap = quizMapJpaRepository.findById(gameLobby.getMapId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_MAP_NOT_FOUND
+                ));
+
+        if (Boolean.TRUE.equals(quizMap.getIsDeleted())) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_MAP_DELETED
+            );
+        }
+
+        return quizMap;
+    }
+
+    /**
+     * 맵의 문제 수가 로비 라운드 수 이상인지 검증한다.
+     *
+     * Data API 없이 게임을 운영하므로, 실제 출제 가능 여부는
+     * 맵에 저장된 문제 수(numOfSong)를 기준으로 판단한다.
+     */
+    private void validateMapSongCount(QuizMap quizMap, GameLobby gameLobby) {
+        Integer numOfSong = quizMap.getNumOfSong();
+        Integer roundCount = gameLobby.getRoundCount();
+
+        if (numOfSong == null || roundCount == null || numOfSong < roundCount) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_START_MAP_SONG_COUNT_NOT_ENOUGH
+            );
+        }
+    }
+
+    /**
+     * 게임 시작 Lua 결과를 HTTP 예외 또는 성공 흐름으로 변환한다.
+     */
+    private void handleStartLobbyResult(StartLobbyResult result) {
+        switch (result) {
+            case StartLobbyResult.Started ignored -> {
+                return;
+            }
+
+            case StartLobbyResult.LobbyNotFound ignored -> throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    ERROR_LOBBY_NOT_FOUND
+            );
+
+            case StartLobbyResult.HostNotFound ignored -> throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_START_HOST_NOT_FOUND
+            );
+
+            case StartLobbyResult.Forbidden ignored -> throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_START_FORBIDDEN
+            );
+
+            case StartLobbyResult.LobbyNotWaiting ignored -> throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_LOBBY_NOT_WAITING
+            );
+
+            case StartLobbyResult.MapNotSelected ignored -> throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_START_MAP_NOT_SELECTED
+            );
+
+            case StartLobbyResult.NoPlayer ignored -> throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_START_NO_PLAYER
+            );
+
+            case StartLobbyResult.NotReady notReady -> {
+                log.warn(
+                        "게임 시작 요청 거부 - 준비하지 않은 참여자 존재. code: {}, userIdentifier: {}",
+                        notReady.lobbyCode(),
+                        notReady.userIdentifier()
+                );
+                throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        ERROR_START_NOT_READY
+                );
+            }
+
+            case StartLobbyResult.Error error -> {
+                log.error("게임 시작 처리 실패 - reason: {}", error.reason());
+                throw new ResponseStatusException(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        ERROR_START_FAILED
+                );
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -82,6 +82,10 @@ public class LobbyService {
             "게임 시작 상태 동기화에 실패했습니다. 잠시 후 다시 시도해주세요.";
     private static final String ERROR_LOBBY_DETAIL_FORBIDDEN =
             "로비 참여자만 로비 상세 정보를 조회할 수 있습니다.";
+    private static final String RECONCILIATION_REASON_DB_SYNC_FAILED =
+            "START_DB_SYNC_FAILED";
+    private static final String ERROR_START_EVENT_TRANSACTION_REQUIRED =
+            "게임 시작 이벤트 발행을 위한 트랜잭션 동기화가 활성화되어 있지 않습니다.";
 
     // =========================================================
     // 로그 메시지 상수
@@ -410,7 +414,14 @@ public class LobbyService {
                     e
             );
 
-            lobbyRepository.rollbackStartedLobbyStatus(code);
+            boolean rollbackSucceeded = lobbyRepository.rollbackStartedLobbyStatus(code);
+
+            if (!rollbackSucceeded) {
+                lobbyRepository.enqueueStartReconciliation(
+                        code,
+                        RECONCILIATION_REASON_DB_SYNC_FAILED
+                );
+            }
 
             throw new ResponseStatusException(
                     HttpStatus.INTERNAL_SERVER_ERROR,
@@ -437,9 +448,15 @@ public class LobbyService {
             String requesterIdentifier
     ) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            lobbyEventService.notifyGameStarted(code);
-            lobbyEventService.notifyLobbyInfoRefresh(code, requesterIdentifier);
-            return;
+            log.error(
+                    "게임 시작 이벤트 발행 실패 - 트랜잭션 동기화 비활성. code: {}, requester: {}",
+                    code,
+                    requesterIdentifier
+            );
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    ERROR_START_EVENT_TRANSACTION_REQUIRED
+            );
         }
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
@@ -690,6 +707,10 @@ public class LobbyService {
      * - DB 기준 맵 문제 수가 설정된 라운드 수 이상이어야 한다.
      * - Redis participants 기준 방장 제외 일반 참여자가 최소 1명 이상 있어야 한다.
      * - Redis ready Set 기준 방장 제외 모든 참여자가 ready 상태여야 한다.
+     *
+     * [DB 기반 추가 조건]
+     * - DB 기준 맵 문제 수가 설정된 라운드 수 이상이어야 한다.
+     *   → start API 진입 전 validateMapSongCount()에서도 동일하게 검증한다.
      *
      * [중요]
      * canStart는 FE의 게임 시작 버튼 활성화 기준으로 사용하는 조회 시점의 snapshot 값이다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -107,6 +107,7 @@ public class LobbyService {
             "로비 입장 요청 - 초대 코드: {}, 식별자: {}";
     private static final String LOG_JOIN_LOBBY_SUCCESS =
             "로비 입장 사전 검증 통과 - 초대 코드: {}, 식별자: {}, 현재 인원: {}/{}";
+    private static final String LOG_ALERT_REQUIRED = "[ALERT_REQUIRED]";
 
     // =========================================================
     // 비즈니스 규칙 상수
@@ -397,6 +398,15 @@ public class LobbyService {
 
         validateMapSongCount(quizMap, gameLobby);
 
+        /*
+         * Redis Lua가 status=PLAYING으로 변경하기 전에 트랜잭션 동기화 활성 여부를 확인한다.
+         *
+         * 이 검증이 없으면 Redis는 PLAYING으로 바뀐 뒤
+         * afterCommit 이벤트 등록 단계에서 500이 발생할 수 있다.
+         * 그 경우 클라이언트는 GAME_STARTED를 받지 못하고, Redis/DB 상태 불일치도 남을 수 있다.
+         */
+        validateTransactionSynchronizationForGameStart(code, requesterIdentifier);
+
         StartLobbyResult result = lobbyRepository.executeStartLobbyProcess(
                 code,
                 requesterIdentifier
@@ -489,6 +499,43 @@ public class LobbyService {
     }
 
     /**
+     * 게임 시작 처리 전 트랜잭션 동기화 활성 여부를 검증한다.
+     *
+     * [이유]
+     * GAME_STARTED 이벤트는 DB GAME_LOBBY 상태가 PLAYING으로 커밋된 이후에만 발행되어야 한다.
+     * 따라서 afterCommit 등록이 가능한 트랜잭션 동기화 상태가 아니면 게임 시작 처리를 진행하면 안 된다.
+     *
+     * [중요]
+     * 이 검증은 Redis start_lobby.lua 실행 전에 수행해야 한다.
+     * Redis가 먼저 PLAYING으로 바뀐 뒤 이벤트 등록이 실패하면 클라이언트가 GAME_STARTED를 받지 못하고,
+     * Redis-DB 상태 불일치가 남을 수 있다.
+     */
+    private void validateTransactionSynchronizationForGameStart(
+            String code,
+            String requesterIdentifier
+    ) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+
+        log.error(
+                "{} 게임 시작 요청 거부 - 트랜잭션 동기화 비활성. "
+                        + "Redis 상태 변경 전에 차단합니다. code: {}, requester: {}",
+                LOG_ALERT_REQUIRED,
+                code,
+                requesterIdentifier
+        );
+
+        throw new ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ERROR_START_EVENT_TRANSACTION_REQUIRED
+        );
+    }
+
+    /**
+     * 게임 시작 이벤트를 DB 트랜잭션 커밋 이후에 발행한다.
+     */
+    /**
      * 게임 시작 이벤트를 DB 트랜잭션 커밋 이후에 발행한다.
      */
     private void registerGameStartedEventAfterCommit(
@@ -497,7 +544,9 @@ public class LobbyService {
     ) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
             log.error(
-                    "게임 시작 이벤트 발행 실패 - 트랜잭션 동기화 비활성. code: {}, requester: {}",
+                    "{} 게임 시작 이벤트 afterCommit 등록 실패 - 트랜잭션 동기화 비활성. "
+                            + "code: {}, requester: {}",
+                    LOG_ALERT_REQUIRED,
                     code,
                     requesterIdentifier
             );
@@ -515,7 +564,7 @@ public class LobbyService {
             }
         });
     }
-
+    
     /**
      * 로비 참여자의 준비 상태를 변경한다.
      *

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
@@ -16,10 +16,14 @@ import org.springframework.util.StringUtils;
  * Redis start_lobby.lua는 성공했지만 DB GAME_LOBBY 상태 변경 또는
  * Redis 보상 롤백이 실패하여 Redis-DB 상태가 불일치할 가능성이 있는 로비를 보정한다.
  *
- * [현재 보정 정책]
- * START_DB_SYNC_FAILED 사유는 사용자가 /start 요청에서 500을 받은 상황
- * GAME_STARTED 이벤트도 afterCommit 이전에 발행되지 않았으므로,
- * Redis 상태를 DB 기준 WAITING 상태로 되돌리는 것을 우선한다.
+ * [재시도 정책]
+ * - payload에 attempt와 nextRetryAtEpochMillis를 포함한다.
+ * - 아직 재시도 시각이 아니면 다시 큐 뒤에 넣는다.
+ * - 실패 시 exponential backoff로 재시도 간격을 늘힌다.
+ * - 최대 재시도 횟수를 초과하면 재적재하지 않고 ALERT 로그를 남긴다.
+ *
+ * [payload 형식]
+ * lobbyCode|reason|attempt|nextRetryAtEpochMillis
  */
 @Slf4j
 @Service
@@ -28,16 +32,27 @@ import org.springframework.util.StringUtils;
 public class LobbyStartReconciliationService {
 
     private static final String LOG_ALERT_REQUIRED = "[ALERT_REQUIRED]";
-    private static final String PAYLOAD_DELIMITER = "\\|";
-    private static final int EXPECTED_PAYLOAD_PARTS = 2;
+
+    private static final String PAYLOAD_DELIMITER_REGEX = "\\|";
+    private static final String PAYLOAD_DELIMITER = "|";
+
+    private static final int EXPECTED_PAYLOAD_PARTS = 4;
+
+    private static final long BASE_BACKOFF_MS = 30_000L;
+    private static final long MAX_BACKOFF_MS = 5 * 60_000L;
+    private static final int MAX_RETRY_ATTEMPT = 5;
 
     private final LobbyRepository lobbyRepository;
 
     /**
      * Redis-DB 게임 시작 상태 불일치 재처리 큐를 주기적으로 처리한다.
      *
-     * fixedDelayString은 환경별 조정을 위해 설정값을 사용할 수 있게 둔다.
-     * 기본값은 30초
+     * [동작]
+     * 1. Redis 큐에서 payload를 하나 꺼낸다.
+     * 2. payload 형식이 잘못되었으면 실패 metric을 증가시키고 종료한다.
+     * 3. 아직 nextRetryAtEpochMillis에 도달하지 않았으면 다시 큐에 넣는다.
+     * 4. 재처리 대상 로비의 Redis 상태를 WAITING으로 롤백한다.
+     * 5. 실패 시 backoff 정보를 갱신해 다시 큐에 넣는다.
      */
     @Scheduled(fixedDelayString = "${monomat.lobby.start-reconciliation.fixed-delay-ms:30000}")
     public void reconcileStartState() {
@@ -61,6 +76,13 @@ public class LobbyStartReconciliationService {
             return;
         }
 
+        long now = System.currentTimeMillis();
+
+        if (parsedPayload.nextRetryAtEpochMillis() > now) {
+            lobbyRepository.requeueStartReconciliation(payload);
+            return;
+        }
+
         boolean reconciled = lobbyRepository.rollbackStartedLobbyStatus(parsedPayload.lobbyCode());
 
         if (reconciled) {
@@ -69,45 +91,115 @@ public class LobbyStartReconciliationService {
             );
 
             log.warn(
-                    "게임 시작 상태 재처리 완료 - lobbyCode: {}, reason: {}",
+                    "게임 시작 상태 재처리 완료 - lobbyCode: {}, reason: {}, attempt: {}",
                     parsedPayload.lobbyCode(),
-                    parsedPayload.reason()
+                    parsedPayload.reason(),
+                    parsedPayload.attempt()
             );
             return;
         }
 
-        lobbyRepository.requeueStartReconciliation(payload);
         lobbyRepository.incrementStartReconciliationMetric(
                 RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED
         );
 
+        if (parsedPayload.attempt() >= MAX_RETRY_ATTEMPT) {
+            log.error(
+                    "{} 게임 시작 상태 재처리 최대 횟수 초과 - lobbyCode: {}, reason: {}, attempt: {}. "
+                            + "수동 정합성 확인이 필요합니다.",
+                    LOG_ALERT_REQUIRED,
+                    parsedPayload.lobbyCode(),
+                    parsedPayload.reason(),
+                    parsedPayload.attempt()
+            );
+            return;
+        }
+
+        String retryPayload = parsedPayload.nextRetryPayload();
+
+        lobbyRepository.requeueStartReconciliation(retryPayload);
+
         log.error(
-                "{} 게임 시작 상태 재처리 실패 - payload 재적재 완료. lobbyCode: {}, reason: {}",
+                "{} 게임 시작 상태 재처리 실패 - backoff 후 재시도 예정. "
+                        + "lobbyCode: {}, reason: {}, nextPayload: {}",
                 LOG_ALERT_REQUIRED,
                 parsedPayload.lobbyCode(),
-                parsedPayload.reason()
+                parsedPayload.reason(),
+                retryPayload
         );
     }
 
     /**
      * Redis 큐 payload를 파싱
-     * payload 형식 : lobbyCode|reason
+     *
+     * payload 형식:
+     * lobbyCode|reason|attempt|nextRetryAtEpochMillis
+     *
+     * @param payload Redis 큐에서 꺼낸 원본 payload
+     * @return 파싱 성공 시 ReconciliationPayload, 실패 시 null
      */
     private ReconciliationPayload parsePayload(String payload) {
-        String[] parts = payload.split(PAYLOAD_DELIMITER, EXPECTED_PAYLOAD_PARTS);
+        String[] parts = payload.split(PAYLOAD_DELIMITER_REGEX, EXPECTED_PAYLOAD_PARTS);
 
         if (parts.length != EXPECTED_PAYLOAD_PARTS
                 || !StringUtils.hasText(parts[0])
-                || !StringUtils.hasText(parts[1])) {
+                || !StringUtils.hasText(parts[1])
+                || !StringUtils.hasText(parts[2])
+                || !StringUtils.hasText(parts[3])) {
             return null;
         }
 
-        return new ReconciliationPayload(parts[0], parts[1]);
+        try {
+            return new ReconciliationPayload(
+                    parts[0],
+                    parts[1],
+                    Integer.parseInt(parts[2]),
+                    Long.parseLong(parts[3])
+            );
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
+    /**
+     * 게임 시작 상태 재처리 payload.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param reason 재처리 사유
+     * @param attempt 현재 재시도 횟수
+     * @param nextRetryAtEpochMillis 다음 재시도 가능 시각
+     */
     private record ReconciliationPayload(
             String lobbyCode,
-            String reason
+            String reason,
+            int attempt,
+            long nextRetryAtEpochMillis
     ) {
+
+        /**
+         * 다음 재시도를 위한 payload를 생성한다.
+         *
+         * [backoff 계산]
+         * - attempt가 증가할수록 재시도 간격을 늘린다.
+         * - 최대 backoff는 MAX_BACKOFF_MS로 제한한다.
+         *
+         * @return 다음 재시도 payload
+         */
+        String nextRetryPayload() {
+            int nextAttempt = attempt + 1;
+            long backoffMs = Math.min(
+                    BASE_BACKOFF_MS * (1L << Math.min(nextAttempt, 4)),
+                    MAX_BACKOFF_MS
+            );
+            long nextRetryAt = System.currentTimeMillis() + backoffMs;
+
+            return String.join(
+                    PAYLOAD_DELIMITER,
+                    lobbyCode,
+                    reason,
+                    String.valueOf(nextAttempt),
+                    String.valueOf(nextRetryAt)
+            );
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
@@ -10,16 +10,24 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 /**
- * 게임 시작 상태 동기화 실패 재처리 서비스
+ * 게임 시작 상태 동기화 실패 재처리 서비스.
  *
  * [처리 대상]
  * Redis start_lobby.lua는 성공했지만 DB GAME_LOBBY 상태 변경 또는
  * Redis 보상 롤백이 실패하여 Redis-DB 상태가 불일치할 가능성이 있는 로비를 보정한다.
  *
+ * [재처리 사유별 보정 정책]
+ * - START_DB_SYNC_FAILED:
+ *   Redis는 PLAYING인데 DB는 WAITING일 수 있으므로 Redis 로비 상태를 WAITING으로 롤백한다.
+ *
+ * - START_DB_SNAPSHOT_NOT_FOUND:
+ *   Redis에는 로비가 있지만 DB GAME_LOBBY 스냅샷이 없는 orphan Redis lobby 상태이므로
+ *   Redis 잔존 로비를 삭제한다.
+ *
  * [재시도 정책]
  * - payload에 attempt와 nextRetryAtEpochMillis를 포함한다.
  * - 아직 재시도 시각이 아니면 다시 큐 뒤에 넣는다.
- * - 실패 시 exponential backoff로 재시도 간격을 늘힌다.
+ * - 실패 시 exponential backoff로 재시도 간격을 늘린다.
  * - 최대 재시도 횟수를 초과하면 재적재하지 않고 ALERT 로그를 남긴다.
  *
  * [payload 형식]
@@ -42,6 +50,9 @@ public class LobbyStartReconciliationService {
     private static final long MAX_BACKOFF_MS = 5 * 60_000L;
     private static final int MAX_RETRY_ATTEMPT = 5;
 
+    private static final String REASON_DB_SYNC_FAILED = "START_DB_SYNC_FAILED";
+    private static final String REASON_DB_SNAPSHOT_NOT_FOUND = "START_DB_SNAPSHOT_NOT_FOUND";
+
     private final LobbyRepository lobbyRepository;
 
     /**
@@ -51,7 +62,7 @@ public class LobbyStartReconciliationService {
      * 1. Redis 큐에서 payload를 하나 꺼낸다.
      * 2. payload 형식이 잘못되었으면 실패 metric을 증가시키고 종료한다.
      * 3. 아직 nextRetryAtEpochMillis에 도달하지 않았으면 다시 큐에 넣는다.
-     * 4. 재처리 대상 로비의 Redis 상태를 WAITING으로 롤백한다.
+     * 4. 재처리 사유에 따라 Redis 상태를 보정한다.
      * 5. 실패 시 backoff 정보를 갱신해 다시 큐에 넣는다.
      */
     @Scheduled(fixedDelayString = "${monomat.lobby.start-reconciliation.fixed-delay-ms:30000}")
@@ -83,7 +94,7 @@ public class LobbyStartReconciliationService {
             return;
         }
 
-        boolean reconciled = lobbyRepository.rollbackStartedLobbyStatus(parsedPayload.lobbyCode());
+        boolean reconciled = reconcileByReason(parsedPayload);
 
         if (reconciled) {
             lobbyRepository.incrementStartReconciliationMetric(
@@ -130,7 +141,39 @@ public class LobbyStartReconciliationService {
     }
 
     /**
-     * Redis 큐 payload를 파싱
+     * 재처리 사유에 따라 보정 정책을 선택한다.
+     *
+     * [START_DB_SYNC_FAILED]
+     * Redis start_lobby.lua 성공 이후 DB GAME_LOBBY 상태 변경에 실패한 경우다.
+     * 사용자는 /start 요청에서 실패 응답을 받았고, GAME_STARTED 이벤트도 afterCommit 이전에
+     * 발행되지 않았으므로 Redis 상태를 WAITING으로 되돌린다.
+     *
+     * [START_DB_SNAPSHOT_NOT_FOUND]
+     * Redis에는 로비가 있지만 DB GAME_LOBBY 스냅샷이 없는 orphan Redis lobby 상태다.
+     * 이 경우 roundCount, timeLimitSeconds, DB 상태 동기화 대상이 없으므로
+     * 유효한 로비로 볼 수 없다. Redis 잔존 로비를 삭제한다.
+     */
+    private boolean reconcileByReason(ReconciliationPayload payload) {
+        if (REASON_DB_SYNC_FAILED.equals(payload.reason())) {
+            return lobbyRepository.rollbackStartedLobbyStatus(payload.lobbyCode());
+        }
+
+        if (REASON_DB_SNAPSHOT_NOT_FOUND.equals(payload.reason())) {
+            return lobbyRepository.deleteFromRedis(payload.lobbyCode());
+        }
+
+        log.error(
+                "{} 알 수 없는 게임 시작 상태 재처리 사유 - lobbyCode: {}, reason: {}",
+                LOG_ALERT_REQUIRED,
+                payload.lobbyCode(),
+                payload.reason()
+        );
+
+        return false;
+    }
+
+    /**
+     * Redis 큐 payload를 파싱한다.
      *
      * payload 형식:
      * lobbyCode|reason|attempt|nextRetryAtEpochMillis

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
@@ -1,0 +1,113 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * 게임 시작 상태 동기화 실패 재처리 서비스
+ *
+ * [처리 대상]
+ * Redis start_lobby.lua는 성공했지만 DB GAME_LOBBY 상태 변경 또는
+ * Redis 보상 롤백이 실패하여 Redis-DB 상태가 불일치할 가능성이 있는 로비를 보정한다.
+ *
+ * [현재 보정 정책]
+ * START_DB_SYNC_FAILED 사유는 사용자가 /start 요청에서 500을 받은 상황
+ * GAME_STARTED 이벤트도 afterCommit 이전에 발행되지 않았으므로,
+ * Redis 상태를 DB 기준 WAITING 상태로 되돌리는 것을 우선한다.
+ */
+@Slf4j
+@Service
+@Profile("!test")
+@RequiredArgsConstructor
+public class LobbyStartReconciliationService {
+
+    private static final String LOG_ALERT_REQUIRED = "[ALERT_REQUIRED]";
+    private static final String PAYLOAD_DELIMITER = "\\|";
+    private static final int EXPECTED_PAYLOAD_PARTS = 2;
+
+    private final LobbyRepository lobbyRepository;
+
+    /**
+     * Redis-DB 게임 시작 상태 불일치 재처리 큐를 주기적으로 처리한다.
+     *
+     * fixedDelayString은 환경별 조정을 위해 설정값을 사용할 수 있게 둔다.
+     * 기본값은 30초
+     */
+    @Scheduled(fixedDelayString = "${monomat.lobby.start-reconciliation.fixed-delay-ms:30000}")
+    public void reconcileStartState() {
+        String payload = lobbyRepository.pollStartReconciliation();
+
+        if (!StringUtils.hasText(payload)) {
+            return;
+        }
+
+        ReconciliationPayload parsedPayload = parsePayload(payload);
+
+        if (parsedPayload == null) {
+            log.error(
+                    "{} 게임 시작 상태 재처리 payload 파싱 실패 - payload: {}",
+                    LOG_ALERT_REQUIRED,
+                    payload
+            );
+            lobbyRepository.incrementStartReconciliationMetric(
+                    RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED
+            );
+            return;
+        }
+
+        boolean reconciled = lobbyRepository.rollbackStartedLobbyStatus(parsedPayload.lobbyCode());
+
+        if (reconciled) {
+            lobbyRepository.incrementStartReconciliationMetric(
+                    RedisKeys.METRIC_LOBBY_START_RECONCILIATION_SUCCESS
+            );
+
+            log.warn(
+                    "게임 시작 상태 재처리 완료 - lobbyCode: {}, reason: {}",
+                    parsedPayload.lobbyCode(),
+                    parsedPayload.reason()
+            );
+            return;
+        }
+
+        lobbyRepository.requeueStartReconciliation(payload);
+        lobbyRepository.incrementStartReconciliationMetric(
+                RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED
+        );
+
+        log.error(
+                "{} 게임 시작 상태 재처리 실패 - payload 재적재 완료. lobbyCode: {}, reason: {}",
+                LOG_ALERT_REQUIRED,
+                parsedPayload.lobbyCode(),
+                parsedPayload.reason()
+        );
+    }
+
+    /**
+     * Redis 큐 payload를 파싱
+     * payload 형식 : lobbyCode|reason
+     */
+    private ReconciliationPayload parsePayload(String payload) {
+        String[] parts = payload.split(PAYLOAD_DELIMITER, EXPECTED_PAYLOAD_PARTS);
+
+        if (parts.length != EXPECTED_PAYLOAD_PARTS
+                || !StringUtils.hasText(parts[0])
+                || !StringUtils.hasText(parts[1])) {
+            return null;
+        }
+
+        return new ReconciliationPayload(parts[0], parts[1]);
+    }
+
+    private record ReconciliationPayload(
+            String lobbyCode,
+            String reason
+    ) {
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategory.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategory.java
@@ -5,34 +5,52 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Locale;
 
+/**
+ * 퀴즈 맵 카테고리.
+ *
+ * [역할]
+ * - DB에는 EnumType.STRING 정책에 따라 KPOP, JPOP, POP 형태로 저장된다.
+ * - HTTP JSON 응답에는 FE 필터 값과 맞춘 표시 값(K-POP, J-POP, POP)을 내려준다.
+ *
+ * [입력 정책]
+ * 요청 값은 하이픈, 언더스코어, 공백, 대소문자 차이를 허용한다.
+ * 예: "jpop", "JPOP", "J-POP", "J_POP", "J POP" 모두 JPOP으로 정규화한다.
+ */
 public enum MapCategory {
-    KPOP("kpop"),
-    JPOP("jpop"),
-    POP("pop");
 
-    private final String value;
+    KPOP("K-POP"),
+    JPOP("J-POP"),
+    POP("POP");
 
-    MapCategory(String value) {
-        this.value = value;
+    private final String displayValue;
+
+    MapCategory(String displayValue) {
+        this.displayValue = displayValue;
     }
 
+    /**
+     * JSON 응답에 사용할 카테고리 표시 값을 반환한다.
+     *
+     * FE 필터 값과 응답 값을 일치시키기 위해 내부 enum 이름이 아니라 displayValue를 직렬화한다.
+     */
     @JsonValue
     public String value() {
-        return value;
+        return displayValue;
     }
 
+    /**
+     * 요청 또는 저장소에서 들어온 카테고리 문자열을 enum으로 변환한다.
+     *
+     * @param rawValue 원본 카테고리 값
+     * @return 정규화된 MapCategory
+     */
     @JsonCreator
     public static MapCategory from(String rawValue) {
         if (rawValue == null) {
             throw new IllegalArgumentException("category는 null일 수 없습니다.");
         }
 
-        String normalized = rawValue
-                .trim()
-                .toLowerCase(Locale.ROOT)
-                .replace("-", "")
-                .replace("_", "")
-                .replace(" ", "");
+        String normalized = normalize(rawValue);
 
         return switch (normalized) {
             case "kpop" -> KPOP;
@@ -40,5 +58,38 @@ public enum MapCategory {
             case "pop" -> POP;
             default -> throw new IllegalArgumentException("지원하지 않는 category입니다: " + rawValue);
         };
+    }
+
+    /**
+     * 외부 저장소 또는 요청 값으로 들어온 카테고리를 응답 표시 값으로 변환한다.
+     *
+     * Redis에 과거 값("jpop")이 남아 있어도 FE 응답 계약("J-POP")을 유지하기 위해 사용한다.
+     *
+     * @param rawValue 원본 카테고리 값
+     * @return FE 응답에 사용할 표시 값
+     */
+    public static String toDisplayValue(String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return null;
+        }
+
+        return from(rawValue).value();
+    }
+
+    /**
+     * 카테고리 입력값을 비교 가능한 내부 문자열로 정규화한다.
+     *
+     * 예:
+     * - "J-POP" -> "jpop"
+     * - "J_POP" -> "jpop"
+     * - "J POP" -> "jpop"
+     */
+    private static String normalize(String rawValue) {
+        return rawValue
+                .trim()
+                .toLowerCase(Locale.ROOT)
+                .replace("-", "")
+                .replace("_", "")
+                .replace(" ", "");
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -12,16 +12,17 @@ import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -30,7 +31,6 @@ import java.util.List;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class MapService {
 
     private static final Duration MAP_CACHE_TTL = Duration.ofMinutes(5);
@@ -43,12 +43,25 @@ public class MapService {
     private static final String ERROR_MAP_NOT_FOUND = "맵을 찾을 수 없습니다.";
     private static final String ERROR_MAP_FORBIDDEN = "본인 소유의 맵만 수정/삭제할 수 있습니다.";
     private static final String ERROR_USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
+
     private final QuizMapJpaRepository quizMapJpaRepository;
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
     private final JsonMapper jsonMapper;
 
-    // 공개된 맵 목록을 페이징하여 조회 (Redis 캐싱 적용)
+    public MapService(
+            QuizMapJpaRepository quizMapJpaRepository,
+            UserRepository userRepository,
+            StringRedisTemplate redisTemplate,
+            @Qualifier("cacheJsonMapper") JsonMapper jsonMapper
+    ) {
+        this.quizMapJpaRepository = quizMapJpaRepository;
+        this.userRepository = userRepository;
+        this.redisTemplate = redisTemplate;
+        this.jsonMapper = jsonMapper;
+    }
+
+    // 공개된 맵 목록을 페이징하여 조회합니다. Redis 캐싱을 적용합니다.
     @Transactional(readOnly = true)
     public PublicMapPageResponse getPublicMaps(Integer page, Integer size) {
         // 파라미터 정규화 및 유효성 검사
@@ -58,12 +71,17 @@ public class MapService {
         // 캐시 키 생성 및 조회
         String version = getPublicListCacheVersion();
         String cacheKey = RedisKeys.mapPublicListKey(version, normalizedPage, normalizedSize);
-        // 캐시 조회/역직렬화 실패는 DB fallback으로 처리한다.
+
+        // 캐시 조회/역직렬화 실패는 DB fallback으로 처리합니다.
         try {
             String cachedValue = redisTemplate.opsForValue().get(cacheKey);
             if (cachedValue != null) {
                 try {
-                    return jsonMapper.readValue(cachedValue, new TypeReference<PublicMapPageResponse>() {});
+                    return jsonMapper.readValue(
+                            cachedValue,
+                            new TypeReference<PublicMapPageResponse>() {
+                            }
+                    );
                 } catch (Exception e) {
                     log.warn("공개 맵 목록 캐시 역직렬화 실패 - key: {}. 캐시 삭제 후 DB fallback", cacheKey, e);
                     safeDeleteCache(cacheKey);
@@ -73,13 +91,15 @@ public class MapService {
             log.warn("공개 맵 목록 캐시 조회 실패 - key: {}. DB fallback", cacheKey, e);
         }
 
-        // 캐시 미스시 DB에서 데이터 조회
+        // 캐시 미스 시 DB에서 데이터 조회
         Pageable pageable = PageRequest.of(
                 normalizedPage,
                 normalizedSize,
                 Sort.by(Sort.Direction.DESC, "updatedAt")
         );
+
         Page<QuizMap> pageResult = quizMapJpaRepository.findAllByIsDeletedFalseAndIsPublicTrue(pageable);
+
         List<MapSummaryResponse> content = pageResult.getContent()
                 .stream()
                 .map(this::toSummaryResponse)
@@ -95,13 +115,15 @@ public class MapService {
                 .build();
 
         safeWriteCache(cacheKey, response);
+
         return response;
     }
 
     @Transactional(readOnly = true)
     public MapDetailResponse getPublicMap(Long mapId) {
         String cacheKey = RedisKeys.mapPublicDetailKey(mapId);
-        // 캐시 조회/역직렬화 실패는 DB fallback으로 처리한다.
+
+        // 캐시 조회/역직렬화 실패는 DB fallback으로 처리합니다.
         try {
             String cachedValue = redisTemplate.opsForValue().get(cacheKey);
             if (cachedValue != null) {
@@ -117,11 +139,14 @@ public class MapService {
         }
 
         QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalseAndIsPublicTrue(mapId)
-                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
-                        HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_MAP_NOT_FOUND
+                ));
 
         MapDetailResponse response = toDetailResponse(quizMap);
         safeWriteCache(cacheKey, response);
+
         return response;
     }
 
@@ -130,11 +155,16 @@ public class MapService {
         validateRegisteredPrincipal(principal);
 
         User owner = userRepository.findById(principal.userId())
-                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
-                        HttpStatus.NOT_FOUND, ERROR_USER_NOT_FOUND));
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_USER_NOT_FOUND
+                ));
+
         if (owner.getUserType() != UserType.REGISTERED) {
-            throw new org.springframework.web.server.ResponseStatusException(
-                    HttpStatus.FORBIDDEN, ERROR_REGISTERED_ONLY);
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_REGISTERED_ONLY
+            );
         }
 
         QuizMap created = quizMapJpaRepository.save(QuizMap.builder()
@@ -146,6 +176,7 @@ public class MapService {
                 .build());
 
         safeEvictMapCache(created.getId());
+
         return toDetailResponse(created);
     }
 
@@ -154,13 +185,22 @@ public class MapService {
         validatePrincipal(principal);
 
         QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalse(mapId)
-                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
-                        HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_MAP_NOT_FOUND
+                ));
 
         validateOwnership(quizMap, principal);
-        quizMap.update(request.title(), request.description(), request.category(), request.isPublic());
+
+        quizMap.update(
+                request.title(),
+                request.description(),
+                request.category(),
+                request.isPublic()
+        );
 
         safeEvictMapCache(quizMap.getId());
+
         return toDetailResponse(quizMap);
     }
 
@@ -169,33 +209,43 @@ public class MapService {
         validatePrincipal(principal);
 
         QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalse(mapId)
-                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
-                        HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_MAP_NOT_FOUND
+                ));
 
         validateOwnership(quizMap, principal);
+
         quizMap.softDelete();
         safeEvictMapCache(quizMap.getId());
     }
 
     private void validatePrincipal(CustomPrincipal principal) {
         if (principal == null || principal.userId() == null) {
-            throw new org.springframework.web.server.ResponseStatusException(
-                    HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    ERROR_INVALID_PRINCIPAL
+            );
         }
     }
 
     private void validateRegisteredPrincipal(CustomPrincipal principal) {
         validatePrincipal(principal);
+
         if (principal.userType() != UserType.REGISTERED) {
-            throw new org.springframework.web.server.ResponseStatusException(
-                    HttpStatus.FORBIDDEN, ERROR_REGISTERED_ONLY);
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_REGISTERED_ONLY
+            );
         }
     }
 
     private void validateOwnership(QuizMap quizMap, CustomPrincipal principal) {
         if (!quizMap.getOwner().getId().equals(principal.userId())) {
-            throw new org.springframework.web.server.ResponseStatusException(
-                    HttpStatus.FORBIDDEN, ERROR_MAP_FORBIDDEN);
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_MAP_FORBIDDEN
+            );
         }
     }
 
@@ -203,11 +253,15 @@ public class MapService {
         try {
             redisTemplate.opsForValue().increment(RedisKeys.mapPublicListVersionKey());
         } catch (Exception e) {
-            log.warn("공개 맵 목록 캐시 버전 무효화 실패 - key: {}",
-                    RedisKeys.mapPublicListVersionKey(), e);
+            log.warn(
+                    "공개 맵 목록 캐시 버전 무효화 실패 - key: {}",
+                    RedisKeys.mapPublicListVersionKey(),
+                    e
+            );
         }
 
         String detailKey = RedisKeys.mapPublicDetailKey(mapId);
+
         try {
             redisTemplate.delete(detailKey);
         } catch (Exception e) {
@@ -217,6 +271,7 @@ public class MapService {
 
     private String getPublicListCacheVersion() {
         String key = RedisKeys.mapPublicListVersionKey();
+
         try {
             String version = redisTemplate.opsForValue().get(key);
             if (version != null) {

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -16,7 +16,8 @@
  *   따라서 Redis 역직렬화에 필요한 타입 정보는 유지하면서,
  *   HTTP 응답 JSON 계약은 순수 DTO 형태로 분리합니다.
  *
- * - Pub/Sub 메시지는 프론트 계약을 위해 타입 정보 없는 순수 JSON JsonMapper를 사용합니다.
+ * - Pub/Sub 메시지와 Redis 문자열 캐시는 각각 타입 정보 없는 순수 JSON JsonMapper를 사용합니다.
+ *   두 Mapper 모두 activateDefaultTyping을 적용하지 않으며, 역할별 Bean 이름으로 분리합니다.
  */
 package io.github.ascrew.monomatbe.global.config;
 
@@ -25,6 +26,7 @@ import io.github.ascrew.monomatbe.global.redis.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
@@ -88,20 +90,37 @@ public class RedisConfig {
      * Redis Pub/Sub 전용 JsonMapper.
      *
      * [역할]
-     * WebSocket 클라이언트로 전달되는 Pub/Sub 메시지는 Java 클래스 타입 정보가 포함되면 안 된다.
+     * WebSocket 클라이언트로 전달되는 Pub/Sub 메시지는 Java 클래스 타입 정보가 포함되면 안 됩니다.
      *
      * [Bean 이름 정책]
-     * 기존 Redis 직렬화용 jsonMapper Bean은 HTTP 응답 직렬화 오염을 방지하기 위해 제거함
-     * 현재 Bean으로 노출되는 JsonMapper는 Pub/Sub 메시지 직렬화 전용인 pubSubJsonMapper뿐임
+     * Redis 직렬화용 JsonMapper는 HTTP 응답 직렬화 오염을 방지하기 위해 Bean으로 노출하지 않습니다.
+     * Pub/Sub 메시지 직렬화가 필요한 코드는 @Qualifier("pubSubJsonMapper")를 명시해서 주입받습니다.
      *
-     * JsonMapper가 필요한 다른 코드에서는 목적에 맞는 Bean을 명시적으로 주입해야 함
-     * - Pub/Sub / WebSocket 메시지: @Qualifier("pubSubJsonMapper")
-     * - RedisTemplate 값 직렬화: RedisTemplate 내부 private createRedisJsonMapper() 사용
-     *
-     * 따라서 이 Mapper는 activateDefaultTyping를 적용하지 않고 순수 JSON 직렬화에만 사용한다.
+     * [주의]
+     * 이 Mapper는 activateDefaultTyping을 적용하지 않고 순수 JSON 직렬화에만 사용합니다.
      */
-    @Bean
+    @Bean("pubSubJsonMapper")
     public JsonMapper pubSubJsonMapper() {
+        return JsonMapper.builder().build();
+    }
+
+    /**
+     * Redis 문자열 캐시 및 애플리케이션 기본 JSON 직렬화용 JsonMapper.
+     *
+     * [역할]
+     * MapService 등에서 Redis 문자열 캐시에 DTO를 저장/조회할 때 사용합니다.
+     *
+     * [Primary 지정 이유]
+     * JsonMapper Bean이 pubSubJsonMapper, cacheJsonMapper로 2개 이상 존재하면
+     * Spring 내부 자동 설정 또는 명시 Qualifier가 없는 주입 지점에서
+     * NoUniqueBeanDefinitionException이 발생할 수 있습니다.
+     *
+     * cacheJsonMapper는 activateDefaultTyping을 사용하지 않는 순수 JSON Mapper이므로
+     * 기본 JsonMapper로 선택되어도 HTTP 응답에 타입 정보가 노출되지 않습니다.
+     */
+    @Primary
+    @Bean("cacheJsonMapper")
+    public JsonMapper cacheJsonMapper() {
         return JsonMapper.builder().build();
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -88,11 +88,17 @@ public class RedisConfig {
      * Redis Pub/Sub 전용 JsonMapper.
      *
      * [역할]
-     * WebSocket 클라이언트로 전달되는 Pub/Sub 메시지는
-     * Java 클래스 타입 정보가 포함되면 안 됩니다.
+     * WebSocket 클라이언트로 전달되는 Pub/Sub 메시지는 Java 클래스 타입 정보가 포함되면 안 된다.
      *
-     * 따라서 이 Mapper는 activateDefaultTyping을 적용하지 않고,
-     * 순수 JSON 직렬화에만 사용합니다.
+     * [Bean 이름 정책]
+     * 기존 Redis 직렬화용 jsonMapper Bean은 HTTP 응답 직렬화 오염을 방지하기 위해 제거함
+     * 현재 Bean으로 노출되는 JsonMapper는 Pub/Sub 메시지 직렬화 전용인 pubSubJsonMapper뿐임
+     *
+     * JsonMapper가 필요한 다른 코드에서는 목적에 맞는 Bean을 명시적으로 주입해야 함
+     * - Pub/Sub / WebSocket 메시지: @Qualifier("pubSubJsonMapper")
+     * - RedisTemplate 값 직렬화: RedisTemplate 내부 private createRedisJsonMapper() 사용
+     *
+     * 따라서 이 Mapper는 activateDefaultTyping를 적용하지 않고 순수 JSON 직렬화에만 사용한다.
      */
     @Bean
     public JsonMapper pubSubJsonMapper() {

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -2,35 +2,33 @@
  * 애플리케이션의 Redis 연결 및 실시간 통신 환경을 구성하는 설정 클래스.
  *
  * [주요 설정]
- * - Connection  : 비동기 처리에 특화된 Lettuce 클라이언트로 Redis 연결
- *                 (Virtual Thread 핀닝 방지를 위해 Jedis 대신 Lettuce 사용)
- * - Serializer  : JsonMapper (Jackson 3.x)를 단일 @Bean으로 관리하여
- *                 RedisTemplate의 직렬화 설정을 중앙화
- *                 activateDefaultTyping(NON_FINAL) 설정으로 역직렬화 시 타입 정보 보존
- * - Pub/Sub     : 실시간 채팅 및 상태 동기화를 위한 MessageListenerContainer 활성화
+ * - Connection : 비동기 처리에 특화된 Lettuce 클라이언트로 Redis 연결
+ *                (Virtual Thread 핀닝 방지를 위해 Jedis 대신 Lettuce 사용)
+ * - Serializer : RedisTemplate 내부에서만 타입 정보 포함 JsonMapper를 사용
+ * - Pub/Sub    : 실시간 채팅 및 상태 동기화를 위한 MessageListenerContainer 활성화
  *
- * [리팩토링 변경 사항]
- * - redisTemplate() 메서드에 JsonMapper 파라미터 추가
- *   기존에 @Bean jsonMapper()를 등록해 두고도 redisTemplate()에서 주입받지 않아
- *   Dead Code 상태였던 문제를 수정합니다.
- *   파라미터로 주입받도록 변경하여 화이트리스트 보안 정책이 실제로 적용되도록 합니다.
+ * [중요 변경 사항]
+ * - Redis 직렬화용 JsonMapper를 Spring Bean으로 노출하지 않습니다.
+ *   activateDefaultTyping이 적용된 JsonMapper가 HTTP 응답 직렬화에 사용되면
+ *   GET /api/lobbies 같은 REST 응답에 Java 클래스 타입 정보가 포함될 수 있습니다.
  *
- * - Pub/Sub 전용 JsonMapper 추가
- *   일반 RedisTemplate은 타입 정보를 포함하는 JsonMapper를 사용하고,
- *   Pub/Sub 메시지는 프론트 계약을 위해 타입 정보 없는 순수 JSON JsonMapper를 사용합니다.
+ * - RedisTemplate은 내부 private 메서드로 생성한 Redis 전용 JsonMapper를 사용합니다.
+ *   따라서 Redis 역직렬화에 필요한 타입 정보는 유지하면서,
+ *   HTTP 응답 JSON 계약은 순수 DTO 형태로 분리합니다.
+ *
+ * - Pub/Sub 메시지는 프론트 계약을 위해 타입 정보 없는 순수 JSON JsonMapper를 사용합니다.
  */
 package io.github.ascrew.monomatbe.global.config;
 
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import io.github.ascrew.monomatbe.global.redis.RedisSubscriber;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
@@ -48,6 +46,16 @@ import java.util.concurrent.Executors;
 @Configuration
 public class RedisConfig {
 
+    /*
+     * Redis 역직렬화 허용 패키지 목록입니다.
+     *
+     * 문자열 리터럴을 직접 흩뿌리지 않고 상수로 관리하여
+     * 허용 범위 변경 시 수정 위치를 한 곳으로 제한합니다.
+     */
+    private static final String ALLOWED_APPLICATION_PACKAGE = "io.github.ascrew.monomatbe.";
+    private static final String ALLOWED_JAVA_UTIL_PACKAGE = "java.util.";
+    private static final String ALLOWED_JAVA_LANG_PACKAGE = "java.lang.";
+
     @Value("${spring.data.redis.host}")
     private String redisHost;
 
@@ -60,10 +68,10 @@ public class RedisConfig {
     /**
      * Redis 연결 팩토리 Bean.
      *
-     * [Lettuce를 사용하는 이유]
-     * Jedis는 동기 블로킹 방식으로 Virtual Thread를 핀닝(Pinning)할 수 있습니다.
-     * Lettuce는 Netty 기반 비동기 드라이버로, Virtual Thread와 함께 사용해도
-     * 캐리어 스레드를 점유하지 않아 성능 저하 없이 동작합니다.
+     * [Lettuce 사용 이유]
+     * Jedis는 동기 블로킹 방식으로 Virtual Thread를 핀닝할 수 있습니다.
+     * Lettuce는 Netty 기반 비동기 드라이버이므로 Virtual Thread 환경에서
+     * 캐리어 스레드 점유 위험을 줄일 수 있습니다.
      */
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -77,43 +85,14 @@ public class RedisConfig {
     }
 
     /**
-     * Jackson 3.x JsonMapper Bean.
-     *
-     * [단일 Bean으로 관리하는 이유]
-     * 역직렬화 허용 타입 화이트리스트 정책을 이 Bean 하나에서 중앙 관리합니다.
-     * 정책 변경 시 이 메서드만 수정하면 JsonMapper를 사용하는 모든 곳에 반영됩니다.
-     *
-     * [activateDefaultTyping 설정]
-     * JSON에 @class 필드를 포함시켜 역직렬화 시 타입 정보를 보존합니다.
-     * NON_FINAL 클래스에만 적용하여 불필요한 오버헤드를 줄입니다.
-     *
-     * [보안 — 화이트리스트]
-     * 허용 패키지를 명시적으로 제한하여 역직렬화 공격(Deserialization Attack)을 방지합니다.
-     */
-    @Bean
-    public JsonMapper jsonMapper() {
-        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-                .allowIfSubType("io.github.ascrew.monomatbe.")
-                .allowIfSubType("java.util.")
-                .allowIfSubType("java.lang.")
-                .build();
-
-        return JsonMapper.builder()
-                .activateDefaultTyping(typeValidator, DefaultTyping.NON_FINAL)
-                .build();
-    }
-
-    /**
      * Redis Pub/Sub 전용 JsonMapper.
      *
-     * RedisTemplate<String, Object>에서 사용하는 jsonMapper()는
-     * activateDefaultTyping 설정으로 타입 정보를 JSON에 포함합니다.
+     * [역할]
+     * WebSocket 클라이언트로 전달되는 Pub/Sub 메시지는
+     * Java 클래스 타입 정보가 포함되면 안 됩니다.
      *
-     * 이 설정은 Redis Hash/Value에 객체 타입을 보존해야 할 때는 유용하지만,
-     * WebSocket 클라이언트로 전달되는 Pub/Sub 메시지에는 부적합합니다.
-     *
-     * 따라서 Pub/Sub 메시지는 클래스 타입 정보 없이 순수 JSON 형태로 직렬화하기 위해
-     * 별도의 JsonMapper를 사용합니다.
+     * 따라서 이 Mapper는 activateDefaultTyping을 적용하지 않고,
+     * 순수 JSON 직렬화에만 사용합니다.
      */
     @Bean
     public JsonMapper pubSubJsonMapper() {
@@ -124,27 +103,21 @@ public class RedisConfig {
      * RedisTemplate Bean.
      *
      * [직렬화 전략]
-     * - Key      : StringRedisSerializer             → 사람이 읽을 수 있는 문자열
-     * - Hash Key : StringRedisSerializer             → Hash 필드명도 문자열 유지
-     * - Value    : GenericJacksonJsonRedisSerializer → JSON 직렬화, 타입 정보 포함
-     * - Hash Val : GenericJacksonJsonRedisSerializer → Hash 값 직렬화, 타입 정보 포함
+     * - Key       : StringRedisSerializer
+     * - Hash Key  : StringRedisSerializer
+     * - Value     : GenericJacksonJsonRedisSerializer
+     * - Hash Value: GenericJacksonJsonRedisSerializer
      *
      * [중요]
-     * RedisConfig에는 JsonMapper 타입 Bean이 2개 있습니다.
-     * - jsonMapper       : 일반 RedisTemplate용, 타입 정보 포함
-     * - pubSubJsonMapper : Pub/Sub용, 타입 정보 미포함
-     *
-     * 따라서 redisTemplate()에는 @Qualifier("jsonMapper")를 명시하여
-     * 일반 RedisTemplate용 Mapper가 주입되도록 고정합니다.
+     * 타입 정보가 포함된 JsonMapper는 RedisTemplate 내부에서만 생성하여 사용합니다.
+     * 이를 Spring Bean으로 등록하지 않아 HTTP 응답 직렬화에 영향을 주지 않도록 합니다.
      *
      * @param connectionFactory Redis 연결 팩토리
-     * @param jsonMapper 일반 RedisTemplate 직렬화용 JsonMapper
      * @return RedisTemplate<String, Object>
      */
     @Bean
     public RedisTemplate<String, Object> redisTemplate(
-            RedisConnectionFactory connectionFactory,
-            @Qualifier("jsonMapper") JsonMapper jsonMapper
+            RedisConnectionFactory connectionFactory
     ) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
@@ -152,8 +125,10 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setHashKeySerializer(new StringRedisSerializer());
 
+        JsonMapper redisJsonMapper = createRedisJsonMapper();
+
         GenericJacksonJsonRedisSerializer valueSerializer =
-                new GenericJacksonJsonRedisSerializer(jsonMapper);
+                new GenericJacksonJsonRedisSerializer(redisJsonMapper);
 
         template.setValueSerializer(valueSerializer);
         template.setHashValueSerializer(valueSerializer);
@@ -162,11 +137,35 @@ public class RedisConfig {
     }
 
     /**
+     * Redis 직렬화 전용 JsonMapper를 생성합니다.
+     *
+     * [Bean으로 등록하지 않는 이유]
+     * activateDefaultTyping이 적용된 JsonMapper가 Spring MVC의 HTTP 응답 직렬화에 사용되면,
+     * 응답 JSON에 java.util.ArrayList 또는 DTO 클래스명이 포함될 수 있습니다.
+     *
+     * [보안]
+     * 역직렬화 허용 타입은 프로젝트 패키지와 필요한 JDK 기본 패키지로 제한합니다.
+     *
+     * @return RedisTemplate 내부에서만 사용하는 타입 정보 포함 JsonMapper
+     */
+    private JsonMapper createRedisJsonMapper() {
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType(ALLOWED_APPLICATION_PACKAGE)
+                .allowIfSubType(ALLOWED_JAVA_UTIL_PACKAGE)
+                .allowIfSubType(ALLOWED_JAVA_LANG_PACKAGE)
+                .build();
+
+        return JsonMapper.builder()
+                .activateDefaultTyping(typeValidator, DefaultTyping.NON_FINAL)
+                .build();
+    }
+
+    /**
      * Redis Pub/Sub 메시지 리스너 컨테이너 Bean.
      *
-     * [구독 채널 목록]
-     * - ChannelTopic("/topic/chat/global") : 전체 채팅 채널
-     * - PatternTopic("/topic/lobby/*")     : 로비별 채팅 채널
+     * [구독 채널]
+     * - /topic/chat/global : 전체 채팅 채널
+     * - /topic/lobby/*     : 로비별 채팅 채널
      *
      * [Virtual Thread Executor]
      * 메시지 처리 스레드를 Virtual Thread로 설정하여

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -74,4 +74,24 @@ public class RedisScriptConfig {
         redisScript.setResultType(String.class);
         return redisScript;
     }
+
+    /**
+     * 로비 게임 시작 처리 Lua 스크립트
+     *
+     * [처리 내용]
+     * - 로비 존재 여부 확인
+     * - 방장 권한 검증
+     * - WAITING 상태 검증
+     * - 맵 선택 여부 검증
+     * - 방장 제외 참여자 ready 상태 검증
+     * - 로비 상태 PLAYING 전환
+     * - 공개 로비 목록에서 제거
+     */
+    @Bean
+    public RedisScript<String> startLobbyScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/start_lobby.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SchedulingConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SchedulingConfig.java
@@ -1,0 +1,15 @@
+package io.github.ascrew.monomatbe.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Spring Scheduling 활성화 설정.
+ *
+ * [사용 목적]
+ * Redis-DB 상태 불일치 재처리 작업처럼 주기적으로 실행되어야 하는 백그라운드 보정 루틴을 실행한다.
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -235,6 +235,14 @@ public final class RedisKeys {
     public static final String METRIC_START_LOBBY_UNKNOWN_RESULT =
             "metric:lobby:start:unknown-result";
 
+    /** 게임 시작 전 stale ready 데이터 정리 횟수 */
+    public static final String METRIC_LOBBY_READY_STALE_CLEANUP =
+            "metric:lobby:ready:stale-cleanup";
+
+    /** 게임 시작 실패 시 ready/participants 정합성 진단 발생 횟수 */
+    public static final String METRIC_LOBBY_READY_CONSISTENCY_FAILURE =
+            "metric:lobby:ready:consistency-failure";
+
     /**
      * 사용자 온라인 상태 키를 반환합니다.
      * 저장 구조: String "ONLINE"

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -37,6 +37,9 @@ public final class RedisKeys {
     /** 로비별 강퇴 유저 Set 키 접미사 */
     private static final String KICKED_SUFFIX = ":kicked";
 
+    /** 로비별 준비 완료 유저 Set 키 접미사 */
+    private static final String READY_SUFFIX = ":ready";
+
     /** 로비 내 사용자별 현재 유효 WebSocket 세션 키 접미사 */
     private static final String USER_SESSION_SUFFIX = ":user_session:";
 
@@ -190,6 +193,20 @@ public final class RedisKeys {
     }
 
     public static String lobbyKickedKey(String code) { return LOBBY_PREFIX + code + KICKED_SUFFIX; }
+
+    /**
+     * 로비별 준비 완료 유저 Set 키를 반환한다.
+     * 정책 : 방장은 준비 대상에서 제외하고, 일반 참여자만 ready 상태에 포함한다.
+     * 저장 구조:
+     * - Key   : lobby:{code}:ready
+     * - Type  : Set
+     * - Value : 준비 완료 상태인 userIdentifier 목록
+     * @param code 로비 초대 코드
+     * @return "lobby:{code}:ready"
+     */
+    public static String lobbyReadyKey(String code) {
+        return LOBBY_PREFIX + code + READY_SUFFIX;
+    }
 
     /**
      * 사용자 온라인 상태 키를 반환합니다.

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -209,6 +209,29 @@ public final class RedisKeys {
     }
 
     /**
+     * 게임 시작 상태 동기화 실패 재처리 큐.
+     *
+     * 저장 구조:
+     * - Key  : lobby:start:reconciliation
+     * - Type : List
+     * - Value: "lobbyCode|reason"
+     */
+    public static final String LOBBY_START_RECONCILIATION_QUEUE =
+            "lobby:start:reconciliation";
+
+    /** 게임 시작 상태 재처리 큐 적재 횟수 metric counter */
+    public static final String METRIC_LOBBY_START_RECONCILIATION_ENQUEUED =
+            "metric:lobby:start:reconciliation:enqueued";
+
+    /** 게임 시작 상태 재처리 성공 횟수 metric counter */
+    public static final String METRIC_LOBBY_START_RECONCILIATION_SUCCESS =
+            "metric:lobby:start:reconciliation:success";
+
+    /** 게임 시작 상태 재처리 실패 횟수 metric counter */
+    public static final String METRIC_LOBBY_START_RECONCILIATION_FAILED =
+            "metric:lobby:start:reconciliation:failed";
+
+    /**
      * 사용자 온라인 상태 키를 반환합니다.
      * 저장 구조: String "ONLINE"
      *

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -231,6 +231,10 @@ public final class RedisKeys {
     public static final String METRIC_LOBBY_START_RECONCILIATION_FAILED =
             "metric:lobby:start:reconciliation:failed";
 
+    /** start_lobby.lua 알 수 없는 반환값 발생 횟수 */
+    public static final String METRIC_START_LOBBY_UNKNOWN_RESULT =
+            "metric:lobby:start:unknown-result";
+
     /**
      * 사용자 온라인 상태 키를 반환합니다.
      * 저장 구조: String "ONLINE"

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
@@ -62,6 +62,7 @@ public final class StompDestinations {
 
     public static final String MSG_REFRESH_LOBBY_LIST = "REFRESH_LOBBY_LIST";
     public static final String MSG_REFRESH_LOBBY_INFO = "REFRESH_LOBBY_INFO";
+    public static final String MSG_GAME_STARTED = "GAME_STARTED";
 
     // =========================================================
     // 동적 경로 생성 팩토리 메서드
@@ -75,6 +76,11 @@ public final class StompDestinations {
     /** @return "/topic/lobby/{code}/refresh" */
     public static String subscribeLobbyRefresh(String code) {
         return LOBBY_CHANNEL_PREFIX + code + "/refresh";
+    }
+
+    /** @return "/topic/lobby/{code}/game" */
+    public static String subscribeLobbyGame(String code) {
+        return LOBBY_CHANNEL_PREFIX + code + "/game";
     }
 
     /** @return "/app/chat/lobby/{code}" */

--- a/src/main/resources/scripts/start_lobby.lua
+++ b/src/main/resources/scripts/start_lobby.lua
@@ -72,15 +72,20 @@ local nonHostPlayerCount = 0
 
 -- participants Set을 현재 로비 참여자의 source of truth로 사용한다.
 --
--- ready Set에만 남아 있는 잔여 데이터는 여기서 순회하지 않으므로 게임 시작 조건에 영향을 주지 않는다.
--- 반대로 participants에 남아 있는데 ready Set에 없는 유저는 "아직 준비하지 않은 현재 참여자"로 판단한다.
+-- ready Set에만 남아 있는 stale 데이터는 Java Repository 레이어에서
+-- start_lobby.lua 실행 직전에 정리한다.
 --
--- Lua 단계에서 participants/ready 불일치를 자동 보정하지 않는 이유:
--- participants에 존재하고 ready에 없는 유저는 실제 미준비 참여자일 수 있으므로,
+-- 이 Lua 스크립트는 participants에 존재하지만 ready Set에 없는 유저를
+-- "아직 준비하지 않은 현재 참여자"로 판단한다.
+--
+-- 단, 퇴장/강퇴 처리 실패 등으로 participants Set 자체가 stale 상태가 되면
+-- 정상 유저도 게임 시작 실패를 겪을 수 있다.
+-- 이 경우 Java Repository 레이어에서 NOT_READY 반환 시
+-- participants/ready/session 정합성 진단 로그를 남긴다.
+--
+-- Lua 내부에서 participants를 자동 제거하지 않는 이유:
+-- participants에 있고 ready에 없는 유저는 실제 미준비 참여자일 수 있으므로,
 -- start_lobby.lua가 임의로 제거하면 정상 참여자를 잘못 삭제할 수 있다.
---
--- 퇴장/강퇴 이후 participants가 남는 비정상 상황은 leave_lobby.lua / kick_lobby.lua 처리 실패에 가깝다.
--- 해당 정합성 문제는 Repository 레벨의 MONITORING_REQUIRED 로그와 후속 재처리/운영 정리 이슈에서 다룬다.
 
 for _, userIdentifier in ipairs(participants) do
     if userIdentifier ~= hostUserId then

--- a/src/main/resources/scripts/start_lobby.lua
+++ b/src/main/resources/scripts/start_lobby.lua
@@ -70,6 +70,18 @@ end
 local participants = redis.call('SMEMBERS', participantsKey)
 local nonHostPlayerCount = 0
 
+-- participants Set을 현재 로비 참여자의 source of truth로 사용한다.
+--
+-- ready Set에만 남아 있는 잔여 데이터는 여기서 순회하지 않으므로 게임 시작 조건에 영향을 주지 않는다.
+-- 반대로 participants에 남아 있는데 ready Set에 없는 유저는 "아직 준비하지 않은 현재 참여자"로 판단한다.
+--
+-- Lua 단계에서 participants/ready 불일치를 자동 보정하지 않는 이유:
+-- participants에 존재하고 ready에 없는 유저는 실제 미준비 참여자일 수 있으므로,
+-- start_lobby.lua가 임의로 제거하면 정상 참여자를 잘못 삭제할 수 있다.
+--
+-- 퇴장/강퇴 이후 participants가 남는 비정상 상황은 leave_lobby.lua / kick_lobby.lua 처리 실패에 가깝다.
+-- 해당 정합성 문제는 Repository 레벨의 MONITORING_REQUIRED 로그와 후속 재처리/운영 정리 이슈에서 다룬다.
+
 for _, userIdentifier in ipairs(participants) do
     if userIdentifier ~= hostUserId then
         nonHostPlayerCount = nonHostPlayerCount + 1

--- a/src/main/resources/scripts/start_lobby.lua
+++ b/src/main/resources/scripts/start_lobby.lua
@@ -1,0 +1,90 @@
+---@diagnostic disable: undefined-global
+--
+-- [역할]
+-- 로비 게임 시작 조건 중 Redis 기준으로 원자 검증 가능한 조건을 확인하고,
+-- 조건 충족 시 로비 상태를 PLAYING으로 변경한다.
+--
+-- [검증 조건]
+-- 1. 로비 존재
+-- 2. 방장 정보 존재
+-- 3. 요청자가 방장
+-- 4. 로비 상태가 WAITING
+-- 5. 맵이 선택되어 있음
+-- 6. 방장 제외 참여자가 1명 이상 존재
+-- 7. 방장 제외 모든 참여자가 ready 상태
+--
+-- [KEYS]
+-- KEYS[1] = lobby:{code}
+-- KEYS[2] = lobby:{code}:participants
+-- KEYS[3] = lobby:{code}:ready
+-- KEYS[4] = lobby:public
+--
+-- [ARGV]
+-- ARGV[1] = requesterIdentifier
+-- ARGV[2] = lobbyCode
+-- ARGV[3] = fieldHostUserId
+-- ARGV[4] = fieldStatus
+-- ARGV[5] = fieldMapId
+-- ARGV[6] = waitingStatus
+-- ARGV[7] = playingStatus
+
+local lobbyKey = KEYS[1]
+local participantsKey = KEYS[2]
+local readyKey = KEYS[3]
+local publicLobbyKey = KEYS[4]
+
+local requesterIdentifier = ARGV[1]
+local lobbyCode = ARGV[2]
+local fieldHostUserId = ARGV[3]
+local fieldStatus = ARGV[4]
+local fieldMapId = ARGV[5]
+local waitingStatus = ARGV[6]
+local playingStatus = ARGV[7]
+
+if redis.call('EXISTS', lobbyKey) == 0 then
+    return 'LOBBY_NOT_FOUND'
+end
+
+local hostUserId = redis.call('HGET', lobbyKey, fieldHostUserId)
+
+if hostUserId == false or hostUserId == nil or hostUserId == '' then
+    return 'HOST_NOT_FOUND'
+end
+
+if hostUserId ~= requesterIdentifier then
+    return 'FORBIDDEN'
+end
+
+local status = redis.call('HGET', lobbyKey, fieldStatus)
+
+if status ~= waitingStatus then
+    return 'LOBBY_NOT_WAITING'
+end
+
+local mapId = redis.call('HGET', lobbyKey, fieldMapId)
+
+if mapId == false or mapId == nil or mapId == '' then
+    return 'MAP_NOT_SELECTED'
+end
+
+local participants = redis.call('SMEMBERS', participantsKey)
+local nonHostPlayerCount = 0
+
+for _, userIdentifier in ipairs(participants) do
+    if userIdentifier ~= hostUserId then
+        nonHostPlayerCount = nonHostPlayerCount + 1
+
+        if redis.call('SISMEMBER', readyKey, userIdentifier) == 0 then
+            return 'NOT_READY:' .. userIdentifier
+        end
+    end
+end
+
+if nonHostPlayerCount == 0 then
+    return 'NO_PLAYER'
+end
+
+redis.call('HSET', lobbyKey, fieldStatus, playingStatus)
+redis.call('SREM', publicLobbyKey, lobbyCode)
+
+return 'STARTED'

--- a/src/main/resources/scripts/start_lobby.lua
+++ b/src/main/resources/scripts/start_lobby.lua
@@ -12,6 +12,7 @@
 -- 5. 맵이 선택되어 있음
 -- 6. 방장 제외 참여자가 1명 이상 존재
 -- 7. 방장 제외 모든 참여자가 ready 상태
+-- 8. 방장 제외 참여자의 활설 로비 세션 키 존재 여부
 --
 -- [KEYS]
 -- KEYS[1] = lobby:{code}
@@ -89,6 +90,12 @@ local nonHostPlayerCount = 0
 
 for _, userIdentifier in ipairs(participants) do
     if userIdentifier ~= hostUserId then
+        local sessionKey = 'lobby:' .. lobbyCode .. ':user_session:' .. userIdentifier
+
+        if redis.call('EXISTS', sessionKey) == 0 then
+            return 'STALE_PARTICIPANT:' .. userIdentifier
+        end
+
         nonHostPlayerCount = nonHostPlayerCount + 1
 
         if redis.call('SISMEMBER', readyKey, userIdentifier) == 0 then

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCodeContractTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCodeContractTest.java
@@ -25,6 +25,7 @@ class StartLobbyLuaResultCodeContractTest {
         assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.NO_PLAYER));
 
         assertThat(script).contains("'NOT_READY:'");
+        assertThat(script).contains("'STALE_PARTICIPANT:'");
     }
 
     private String returnLiteral(StartLobbyLuaResultCode resultCode) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCodeContractTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/StartLobbyLuaResultCodeContractTest.java
@@ -1,0 +1,33 @@
+package io.github.ascrew.monomatbe.domain.lobby;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StartLobbyLuaResultCodeContractTest {
+
+    private static final String START_LOBBY_SCRIPT_PATH = "scripts/start_lobby.lua";
+
+    @Test
+    void start_lobby_lua_반환값은_Java_enum_계약과_일치해야_한다() throws Exception {
+        String script = new ClassPathResource(START_LOBBY_SCRIPT_PATH)
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.STARTED));
+        assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.LOBBY_NOT_FOUND));
+        assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.HOST_NOT_FOUND));
+        assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.FORBIDDEN));
+        assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.LOBBY_NOT_WAITING));
+        assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.MAP_NOT_SELECTED));
+        assertThat(script).contains(returnLiteral(StartLobbyLuaResultCode.NO_PLAYER));
+
+        assertThat(script).contains("'NOT_READY:'");
+    }
+
+    private String returnLiteral(StartLobbyLuaResultCode resultCode) {
+        return "return '" + resultCode.wireValue() + "'";
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyServiceCanStartTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyServiceCanStartTest.java
@@ -1,0 +1,149 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LobbyServiceCanStartTest {
+
+    private LobbyRepository lobbyRepository;
+    private GameLobbyJpaRepository gameLobbyJpaRepository;
+    private QuizMapJpaRepository quizMapJpaRepository;
+    private LobbyService lobbyService;
+
+    @BeforeEach
+    void setUp() {
+        lobbyRepository = mock(LobbyRepository.class);
+        LobbyEventService lobbyEventService = mock(LobbyEventService.class);
+        gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        quizMapJpaRepository = mock(QuizMapJpaRepository.class);
+
+        lobbyService = new LobbyService(
+                lobbyRepository,
+                lobbyEventService,
+                gameLobbyJpaRepository,
+                userRepository,
+                quizMapJpaRepository
+        );
+    }
+
+    @Test
+    void canStart는_Lua와_동일하게_방장_제외_참여자가_모두_ready이면_true다() {
+        String code = "ABC123";
+        String hostId = "11111111-1111-1111-1111-111111111111";
+        String guestId = "22222222-2222-2222-2222-222222222222";
+
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
+        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
+        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
+        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
+        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
+
+        LobbyDetailResponse response = lobbyService.getLobbyDetail(
+                code,
+                new CustomPrincipal(1L, hostId, UserType.GUEST)
+        );
+
+        assertThat(response.canStart()).isTrue();
+    }
+
+    @Test
+    void canStart는_참여자가_ready가_아니면_false다() {
+        String code = "ABC123";
+        String hostId = "11111111-1111-1111-1111-111111111111";
+        String guestId = "22222222-2222-2222-2222-222222222222";
+
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
+        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
+        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
+        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of());
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
+        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
+
+        LobbyDetailResponse response = lobbyService.getLobbyDetail(
+                code,
+                new CustomPrincipal(1L, hostId, UserType.GUEST)
+        );
+
+        assertThat(response.canStart()).isFalse();
+    }
+
+    @Test
+    void canStart는_맵_문제수가_라운드수보다_적으면_false다() {
+        String code = "ABC123";
+        String hostId = "11111111-1111-1111-1111-111111111111";
+        String guestId = "22222222-2222-2222-2222-222222222222";
+
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
+        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
+        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
+        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
+        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(4)));
+
+        LobbyDetailResponse response = lobbyService.getLobbyDetail(
+                code,
+                new CustomPrincipal(1L, hostId, UserType.GUEST)
+        );
+
+        assertThat(response.canStart()).isFalse();
+    }
+
+    private JoinLobbyResponse lobbyInfo(String code, String hostId) {
+        return JoinLobbyResponse.builder()
+                .inviteCode(code)
+                .title("테스트 로비")
+                .hostId(hostId)
+                .maxPlayers(4)
+                .currentPlayers(2)
+                .status("WAITING")
+                .mapId(2L)
+                .mapTitle("테스트 맵")
+                .mapCategory("J-POP")
+                .build();
+    }
+
+    private GameLobby gameLobby() {
+        return GameLobby.builder()
+                .inviteCode("ABC123")
+                .mapId(2L)
+                .title("테스트 로비")
+                .maxPlayers(4)
+                .roundCount(5)
+                .timeLimitSeconds(30)
+                .isPrivate(false)
+                .build();
+    }
+
+    private QuizMap quizMap(int numOfSong) {
+        return QuizMap.builder()
+                .id(2L)
+                .title("테스트 맵")
+                .category(MapCategory.JPOP)
+                .numOfSong(numOfSong)
+                .totalPlayTime(300)
+                .isPublic(true)
+                .isDeleted(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #63

## 📝 Summary

- `GET /api/lobbies` 응답에서 Jackson 타입 정보가 노출되던 문제를 수정했습니다.
- Redis 직렬화용 `JsonMapper`와 HTTP 응답용 JSON 직렬화 설정을 분리했습니다.
- 로비 목록 및 상세 응답의 `mapCategory` 값을 FE 필터 값과 맞는 `K-POP`, `J-POP`, `POP` 형식으로 정규화했습니다.
- 로비 참여자의 ready 상태 변경 API를 추가했습니다.
  - `PATCH /api/lobbies/{code}/ready`
  - 방장은 ready 대상에서 제외하고, 일반 참여자만 준비 상태를 변경할 수 있도록 처리했습니다.
- 유저 퇴장/강퇴/로비 삭제 시 ready 상태가 함께 정리되도록 처리했습니다.
- 로비 상세 조회 API를 추가했습니다.
  - `GET /api/lobbies/{code}`
  - 참여자 목록, 방장 여부, ready 상태, `canStart`, 라운드 수, 제한 시간을 포함합니다.
- 게임 시작 API를 추가했습니다.
  - `POST /api/lobbies/{code}/start`
  - 방장 권한, `WAITING` 상태, 맵 선택 여부, 맵 문제 수, 참여자 ready 상태를 검증합니다.
- 시작 조건 충족 시 Redis 및 DB의 로비 상태를 `PLAYING`으로 변경하도록 구현했습니다.
- 게임 시작 성공 시 로비 참여자에게 WebSocket으로 `GAME_STARTED` 이벤트를 브로드캐스트하도록 구현했습니다.

## 🙏PR point

- 방장은 ready 대상에서 제외했습니다.
  - 방장은 ready 버튼이 아니라 게임 시작 버튼만 사용하는 정책입니다.
  - 방장 ready 요청 시 `400 Bad Request`가 반환됩니다.
- 실제 로비 참여자 등록은 기존 구조와 동일하게 WebSocket `/topic/lobby/{code}` 구독 시점에 처리됩니다.
  - 따라서 ready 변경 및 로비 상세 조회 테스트 시 Swagger 인증 사용자와 `ws-test.html`의 `userIdentifier`가 일치해야 합니다.
- `canStart`는 FE 시작 버튼 활성화 기준입니다.
  - `WAITING` 상태
  - 맵 선택됨
  - 맵 문제 수가 라운드 수 이상
  - 방장 제외 참여자 1명 이상
  - 방장 제외 모든 참여자 ready 완료
- `/start` 요청에서는 Redis Lua 스크립트로 방장 권한, 로비 상태, ready 상태를 원자적으로 검증합니다.
- 테스트를 위해서는 `map_item` 데이터가 필요합니다.
  - `map.num_of_song < roundCount`이면 `/start` 요청은 `409 Conflict`가 정상입니다.
- `ws-test.html`은 `/topic/lobby/{code}/game` 구독을 추가해 `GAME_STARTED` 이벤트를 확인할 수 있도록 수정했습니다.
  - 단, 임시 테스트 파일이면 PR 포함 여부를 확인해야 합니다.

## 📬 Reference

- Redis Lua Script 기반 기존 로비 입장/퇴장/강퇴 처리 구조 참고
- 기존 `LobbyEventService`의 로비 refresh WebSocket 브로드캐스트 흐름 참고