### PR TITLE
[Refactor/#72] Redis 정합성 보상 로직 및 JsonMapper 설정 개선

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -482,41 +482,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       );
 
       String rawIsPrivate = (String) lobbyData.get(RedisKeys.FIELD_IS_PRIVATE);
-
-      if (rawIsPrivate == null || rawIsPrivate.isBlank()) {
-        log.error(
-                "{} 게임 시작 Redis 보상 롤백 중 is_private 필드 누락 - public 복구 생략. "
-                        + "code: {}, lobbyKey: {}",
-                LOG_MONITORING_REQUIRED,
-                code,
-                lobbyKey
-        );
-
-        log.warn(
-                "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}",
-                code,
-                LobbyStatus.WAITING.name(),
-                false
-        );
-
-        return true;
-      }
-
-      boolean restoredPublic = false;
-
-      if (IS_PRIVATE_FALSE.equals(rawIsPrivate)) {
-        redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, code);
-        restoredPublic = true;
-      } else if (!IS_PRIVATE_TRUE.equals(rawIsPrivate)) {
-        log.error(
-                "{} 게임 시작 Redis 보상 롤백 중 알 수 없는 is_private 값 - public 복구 생략. "
-                        + "code: {}, lobbyKey: {}, rawIsPrivate: {}",
-                LOG_MONITORING_REQUIRED,
-                code,
-                lobbyKey,
-                rawIsPrivate
-        );
-      }
+      boolean restoredPublic = restorePublicLobbyIfClearlyPublic(
+              code,
+              lobbyKey,
+              rawIsPrivate
+      );
 
       log.warn(
               "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}, rawIsPrivate: {}",
@@ -539,6 +509,41 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       );
       return false;
     }
+  }
+
+  private boolean restorePublicLobbyIfClearlyPublic(
+          String code,
+          String lobbyKey,
+          String rawIsPrivate
+  ) {
+    if (rawIsPrivate == null || rawIsPrivate.isBlank()) {
+      log.error(
+              "{} 게임 시작 Redis 보상 롤백 중 is_private 필드 누락 - public 복구 생략. "
+                      + "code: {}, lobbyKey: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              lobbyKey
+      );
+      return false;
+    }
+
+    if (IS_PRIVATE_FALSE.equals(rawIsPrivate)) {
+      redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, code);
+      return true;
+    }
+
+    if (!IS_PRIVATE_TRUE.equals(rawIsPrivate)) {
+      log.error(
+              "{} 게임 시작 Redis 보상 롤백 중 알 수 없는 is_private 값 - public 복구 생략. "
+                      + "code: {}, lobbyKey: {}, rawIsPrivate: {}",
+              LOG_MONITORING_REQUIRED,
+              code,
+              lobbyKey,
+              rawIsPrivate
+      );
+    }
+
+    return false;
   }
 
   /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyService.java
@@ -109,6 +109,7 @@ public class LobbyService {
     private static final String LOG_JOIN_LOBBY_SUCCESS =
             "로비 입장 사전 검증 통과 - 초대 코드: {}, 식별자: {}, 현재 인원: {}/{}";
     private static final String LOG_ALERT_REQUIRED = "[ALERT_REQUIRED]";
+    private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
 
     // =========================================================
     // 비즈니스 규칙 상수
@@ -214,7 +215,12 @@ public class LobbyService {
             if (compensationSuccess) {
                 log.info(LOG_COMPENSATION_SUCCESS, inviteCode);
             } else {
-                log.error(LOG_COMPENSATION_FAILED, inviteCode);
+                log.error(
+                        "{} {} code: {}",
+                        LOG_MONITORING_REQUIRED,
+                        LOG_COMPENSATION_FAILED,
+                        inviteCode
+                );
             }
 
             throw new ResponseStatusException(

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisConfig.java
@@ -95,13 +95,10 @@ public class RedisConfig {
      * [Bean 이름 정책]
      * Redis 직렬화용 JsonMapper는 HTTP 응답 직렬화 오염을 방지하기 위해 Bean으로 노출하지 않습니다.
      * Pub/Sub 메시지 직렬화가 필요한 코드는 @Qualifier("pubSubJsonMapper")를 명시해서 주입받습니다.
-     *
-     * [주의]
-     * 이 Mapper는 activateDefaultTyping을 적용하지 않고 순수 JSON 직렬화에만 사용합니다.
      */
     @Bean("pubSubJsonMapper")
     public JsonMapper pubSubJsonMapper() {
-        return JsonMapper.builder().build();
+        return createPlainJsonMapper();
     }
 
     /**
@@ -121,6 +118,24 @@ public class RedisConfig {
     @Primary
     @Bean("cacheJsonMapper")
     public JsonMapper cacheJsonMapper() {
+        return createPlainJsonMapper();
+    }
+
+    /**
+     * 타입 정보 없는 순수 JSON JsonMapper를 생성한다.
+     *
+     * [사용 대상]
+     * - Pub/Sub 메시지 직렬화
+     * - Redis 문자열 캐시 직렬화
+     *
+     * [주의]
+     * 이 Mapper에는 activateDefaultTyping을 적용하지 않는다.
+     * WebSocket 메시지와 REST 응답 JSON 계약에 Java 클래스 타입 정보가 섞이지 않도록
+     * RedisTemplate 내부 전용 Mapper와 명확히 분리한다.
+     *
+     * @return 타입 정보 없는 순수 JSON JsonMapper
+     */
+    private JsonMapper createPlainJsonMapper() {
         return JsonMapper.builder().build();
     }
 


### PR DESCRIPTION
## 📣 Related Issue

- #72

## 📝 Summary

- RedisConfig의 JsonMapper 생성 로직을 공통 메서드로 분리했습니다.
- `pubSubJsonMapper`, `cacheJsonMapper`, RedisTemplate 내부 전용 Mapper의 역할 분리는 유지했습니다.
- 게임 시작 DB 상태 변경 실패 시 Redis 롤백 과정에서 public Set 복구 판단 로직을 별도 메서드로 분리했습니다.
- `is_private` 값이 명확히 `false`인 경우에만 공개 로비 목록에 복구되도록 보수적 복구 정책을 유지했습니다.
- 로비 생성 DB 저장 실패 후 Redis 보상 삭제까지 실패하는 경우 운영 추적이 가능하도록 모니터링 로그 식별자를 추가했습니다.

## 🙏PR point

- RedisTemplate 내부 전용 JsonMapper는 `activateDefaultTyping`을 사용하므로 Spring Bean으로 노출하지 않았습니다.
- `pubSubJsonMapper`와 `cacheJsonMapper`는 타입 정보 없는 순수 JSON Mapper를 사용하도록 유지했습니다.
- Redis 롤백 시 `is_private` 값이 누락되었거나 알 수 없는 값이면 public Set 복구를 생략합니다.
- 기능 동작 변경보다는 Redis 정합성 보상 로직의 가독성 및 운영 추적성을 개선한 리팩토링입니다.
- `./gradlew compileJava`, `./gradlew test` 통과 확인했습니다.

## 📬 Reference

- RedisConfig JsonMapper 설정
- LobbyRepositoryImpl Redis 게임 시작 롤백 처리
- LobbyService 로비 생성 실패 보상 처리