### PR TITLE
[Refactor/#80] 로비 Redis Repository 책임 분리

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -13,10 +13,9 @@ import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaResultMa
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaScriptExecutor;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyRedisCommandRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyRedisQueryRepository;
-import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyStartReconciliationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
@@ -30,7 +29,7 @@ import java.util.Set;
  *
  * [현재 책임]
  * 이 클래스는 기존 LobbyRepository 인터페이스 계약을 유지하는 facade 역할을 합니다.
- * 세부 Redis 책임은 역할별 컴포넌트로 점진적으로 분리합니다.
+ * 세부 Redis 책임은 역할별 컴포넌트로 분리합니다.
  *
  * [분리 완료]
  * - 초대 코드 생성: LobbyInviteCodeGenerator
@@ -38,9 +37,7 @@ import java.util.Set;
  * - Lua 실행: LobbyLuaScriptExecutor
  * - Redis 조회: LobbyRedisQueryRepository
  * - Redis command: LobbyRedisCommandRepository
- *
- * [아직 남은 책임]
- * - start reconciliation queue 처리
+ * - start reconciliation queue: LobbyStartReconciliationRepository
  *
  * [중요]
  * 이번 리팩토링은 외부 서비스 계층의 의존성을 바꾸지 않기 위한 내부 구조 개선입니다.
@@ -51,12 +48,12 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class LobbyRepositoryImpl implements LobbyRepository {
 
-  private final StringRedisTemplate redisTemplate;
   private final LobbyInviteCodeGenerator lobbyInviteCodeGenerator;
   private final LobbyLuaResultMapper lobbyLuaResultMapper;
   private final LobbyLuaScriptExecutor lobbyLuaScriptExecutor;
   private final LobbyRedisQueryRepository lobbyRedisQueryRepository;
   private final LobbyRedisCommandRepository lobbyRedisCommandRepository;
+  private final LobbyStartReconciliationRepository lobbyStartReconciliationRepository;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -64,17 +61,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   private static final String RESULT_OK = "OK";
   private static final String RESULT_LOCK_FAILED = "LOCK_FAILED";
-
-  // =========================================================
-  // 게임 시작 상태 재처리 상수
-  // =========================================================
-
-  private static final String RECONCILIATION_PAYLOAD_DELIMITER = "|";
-
-  /**
-   * 운영 확인이 필요한 Redis 정리 실패 로그 식별자.
-   */
-  private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
 
   /** 초대 코드 생성 실패 시 반환할 에러 메시지 */
   private static final String ERROR_INVITE_CODE_EXHAUSTED =
@@ -298,67 +284,26 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   // =========================================================
-  // Start reconciliation queue
+  // Start reconciliation queue 위임
   // =========================================================
 
   @Override
   public void enqueueStartReconciliation(String code, String reason) {
-    String payload = String.join(
-            RECONCILIATION_PAYLOAD_DELIMITER,
-            code,
-            reason,
-            "0",
-            String.valueOf(System.currentTimeMillis())
-    );
-
-    try {
-      redisTemplate.opsForList().rightPush(
-              RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
-              payload
-      );
-      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_START_RECONCILIATION_ENQUEUED);
-
-      log.error(
-              "{} 게임 시작 상태 재처리 큐 적재 완료 - code: {}, reason: {}, queueKey: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              reason,
-              RedisKeys.LOBBY_START_RECONCILIATION_QUEUE
-      );
-    } catch (Exception e) {
-      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED);
-
-      log.error(
-              "{} 게임 시작 상태 재처리 큐 적재 실패 - code: {}, reason: {}, queueKey: {}. "
-                      + "Redis-DB 불일치 수동 확인이 필요합니다.",
-              LOG_MONITORING_REQUIRED,
-              code,
-              reason,
-              RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
-              e
-      );
-    }
+    lobbyStartReconciliationRepository.enqueueStartReconciliation(code, reason);
   }
 
   @Override
   public String pollStartReconciliation() {
-    return redisTemplate.opsForList().leftPop(RedisKeys.LOBBY_START_RECONCILIATION_QUEUE);
+    return lobbyStartReconciliationRepository.pollStartReconciliation();
   }
 
   @Override
   public void requeueStartReconciliation(String payload) {
-    redisTemplate.opsForList().rightPush(
-            RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
-            payload
-    );
+    lobbyStartReconciliationRepository.requeueStartReconciliation(payload);
   }
 
   @Override
   public void incrementStartReconciliationMetric(String metricKey) {
-    try {
-      redisTemplate.opsForValue().increment(metricKey);
-    } catch (Exception e) {
-      log.warn("게임 시작 상태 재처리 metric 증가 실패 - metricKey: {}", metricKey, e);
-    }
+    lobbyStartReconciliationRepository.incrementStartReconciliationMetric(metricKey);
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -12,7 +12,7 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyInviteCodeGenerator;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaResultMapper;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaScriptExecutor;
-import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyRedisQueryRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,13 +21,33 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * 로비 Redis Repository 구현체.
+ *
+ * [현재 책임]
+ * 이 클래스는 기존 LobbyRepository 인터페이스 계약을 유지하는 facade 역할을 합니다.
+ * 세부 Redis 책임은 역할별 컴포넌트로 점진적으로 분리합니다.
+ *
+ * [분리 완료]
+ * - 초대 코드 생성: LobbyInviteCodeGenerator
+ * - Lua 결과 매핑: LobbyLuaResultMapper
+ * - Lua 실행: LobbyLuaScriptExecutor
+ * - Redis 조회: LobbyRedisQueryRepository
+ *
+ * [아직 남은 책임]
+ * - Redis command 처리
+ * - start reconciliation queue 처리
+ *
+ * [중요]
+ * 이번 리팩토링은 외부 서비스 계층의 의존성을 바꾸지 않기 위한 내부 구조 개선입니다.
+ * 따라서 LobbyRepository 인터페이스, Redis key 구조, Lua script 계약은 변경하지 않습니다.
+ */
 @Slf4j
 @Repository
 @RequiredArgsConstructor
@@ -37,6 +57,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private final LobbyInviteCodeGenerator lobbyInviteCodeGenerator;
   private final LobbyLuaResultMapper lobbyLuaResultMapper;
   private final LobbyLuaScriptExecutor lobbyLuaScriptExecutor;
+  private final LobbyRedisQueryRepository lobbyRedisQueryRepository;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -52,10 +73,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String RECONCILIATION_PAYLOAD_DELIMITER = "|";
 
   /**
-   * 운영 확인이 필요한 Redis 정리 실패 로그 식별자
-   *
-   * 현재 프로젝트에 별도 알림/재처리 큐 인프라가 없으므로,
-   * 운영 로그 수집 시스템에서 이 키워드를 기준으로 알림을 연계할 수 있도록 한다.
+   * 운영 확인이 필요한 Redis 정리 실패 로그 식별자.
    */
   private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
 
@@ -71,30 +89,48 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String ERROR_REDIS_SCRIPT_UNKNOWN_RESULT =
           "Redis 로비 생성 처리 결과가 유효하지 않습니다.";
 
-  /**
-   * 로비가 존재하지 않거나 TTL이 만료된 경우 반환할 빈 Optional.
-   * 매번 새 객체를 생성하지 않기 위해 상수로 관리한다.
-   */
-  private static final Optional<JoinLobbyResponse> EMPTY_LOBBY = Optional.empty();
-
-  private static final String ERROR_INVALID_LOBBY_DATA =
-          "로비 정보가 유효하지 않습니다.";
-
   // =========================================================
-  // 공개 메서드
+  // Redis 조회 위임
   // =========================================================
 
   @Override
   public boolean existsByCode(String code) {
-    return Boolean.TRUE.equals(redisTemplate.hasKey(RedisKeys.lobbyKey(code)));
+    return lobbyRedisQueryRepository.existsByCode(code);
   }
 
   @Override
   public boolean isParticipant(String code, String userId) {
-    return Boolean.TRUE.equals(
-            redisTemplate.opsForSet().isMember(RedisKeys.lobbyParticipantsKey(code), userId)
-    );
+    return lobbyRedisQueryRepository.isParticipant(code, userId);
   }
+
+  @Override
+  public List<String> getParticipantIdentifiers(String code) {
+    return lobbyRedisQueryRepository.getParticipantIdentifiers(code);
+  }
+
+  @Override
+  public Set<String> getReadyParticipantIdentifiers(String code) {
+    return lobbyRedisQueryRepository.getReadyParticipantIdentifiers(code);
+  }
+
+  @Override
+  public List<LobbyRedisDto> getPublicLobbies() {
+    return lobbyRedisQueryRepository.getPublicLobbies();
+  }
+
+  @Override
+  public Optional<JoinLobbyResponse> findByInviteCode(String inviteCode) {
+    return lobbyRedisQueryRepository.findByInviteCode(inviteCode);
+  }
+
+  @Override
+  public int getCurrentPlayerCount(String inviteCode) {
+    return lobbyRedisQueryRepository.getCurrentPlayerCount(inviteCode);
+  }
+
+  // =========================================================
+  // Redis 명령 / Lua 실행
+  // =========================================================
 
   @Override
   public void updateReadyStatus(String code, String userIdentifier, boolean ready) {
@@ -109,58 +145,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   /**
-   * 로비 참여자 목록을 입장 순서 기준으로 조회한다.
-   */
-  @Override
-  public List<String> getParticipantIdentifiers(String code) {
-    Set<String> participantSet = redisTemplate.opsForSet()
-            .members(RedisKeys.lobbyParticipantsKey(code));
-
-    if (participantSet == null || participantSet.isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    List<String> orderedParticipants = redisTemplate.opsForList()
-            .range(RedisKeys.lobbyOrderKey(code), 0, -1);
-
-    if (orderedParticipants == null || orderedParticipants.isEmpty()) {
-      return new ArrayList<>(participantSet);
-    }
-
-    List<String> result = new ArrayList<>();
-
-    for (String userIdentifier : orderedParticipants) {
-      if (participantSet.contains(userIdentifier)) {
-        result.add(userIdentifier);
-      }
-    }
-
-    for (String userIdentifier : participantSet) {
-      if (!result.contains(userIdentifier)) {
-        result.add(userIdentifier);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * ready 상태인 참여자 식별자 목록을 조회한다.
-   */
-  @Override
-  public Set<String> getReadyParticipantIdentifiers(String code) {
-    Set<String> readyParticipants = redisTemplate.opsForSet()
-            .members(RedisKeys.lobbyReadyKey(code));
-
-    if (readyParticipants == null || readyParticipants.isEmpty()) {
-      return Set.of();
-    }
-
-    return readyParticipants;
-  }
-
-  /**
-   * Lua 스크립트로 SETNX 선점과 로비 데이터 저장을 원자적으로 수행하고 초대 코드를 반환한다.
+   * Lua 스크립트로 SETNX 선점과 로비 데이터 저장을 원자적으로 수행하고 초대 코드를 반환합니다.
    */
   @Override
   public String saveToRedis(
@@ -181,7 +166,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       if (result == null) {
         log.error("Lua 스크립트 null 반환 - Redis 연결 오류 가능성. 코드: {}", candidate);
         throw new ResponseStatusException(
-                HttpStatus.SERVICE_UNAVAILABLE, ERROR_REDIS_SCRIPT_NULL);
+                HttpStatus.SERVICE_UNAVAILABLE,
+                ERROR_REDIS_SCRIPT_NULL
+        );
       }
 
       if (RESULT_OK.equals(result)) {
@@ -217,11 +204,13 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
 
     throw new ResponseStatusException(
-            HttpStatus.SERVICE_UNAVAILABLE, ERROR_INVITE_CODE_EXHAUSTED);
+            HttpStatus.SERVICE_UNAVAILABLE,
+            ERROR_INVITE_CODE_EXHAUSTED
+    );
   }
 
   /**
-   * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
+   * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제합니다.
    */
   @Override
   public boolean deleteFromRedis(String inviteCode) {
@@ -331,7 +320,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   /**
-   * Redis 로비 상태를 WAITING으로 보상 롤백한다.
+   * Redis 로비 상태를 WAITING으로 보상 롤백합니다.
    */
   @Override
   public boolean rollbackStartedLobbyStatus(String code) {
@@ -421,9 +410,10 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     return false;
   }
 
-  /**
-   * Redis-DB 상태 불일치 재처리 요청을 Redis 큐에 적재한다.
-   */
+  // =========================================================
+  // Start reconciliation queue
+  // =========================================================
+
   @Override
   public void enqueueStartReconciliation(String code, String reason) {
     String payload = String.join(
@@ -485,77 +475,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  @Override
-  public List<LobbyRedisDto> getPublicLobbies() {
-    Set<String> publicLobbyCodes =
-            redisTemplate.opsForSet().members(RedisKeys.LOBBY_PUBLIC);
-
-    if (publicLobbyCodes == null || publicLobbyCodes.isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    List<LobbyRedisDto> result = new ArrayList<>();
-
-    for (String code : publicLobbyCodes) {
-      Map<Object, Object> data =
-              redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(code));
-
-      if (data.isEmpty()) continue;
-
-      result.add(LobbyRedisDto.builder()
-              .code((String) data.get(RedisKeys.FIELD_CODE))
-              .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
-              .title((String) data.get(RedisKeys.FIELD_TITLE))
-              .status((String) data.get(RedisKeys.FIELD_STATUS))
-              .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
-              .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-              .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
-              .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
-              .currentPlayers(getCurrentPlayerCount(code))
-              .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
-              .build());
-    }
-
-    return result;
-  }
-
-  @Override
-  public Optional<JoinLobbyResponse> findByInviteCode(String inviteCode) {
-    Map<Object, Object> data =
-            redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(inviteCode));
-
-    if (data.isEmpty()) {
-      return EMPTY_LOBBY;
-    }
-
-    int currentPlayers = getCurrentPlayerCount(inviteCode);
-
-    int maxPlayers = parseRequiredPositiveInt(
-            data.get(RedisKeys.FIELD_MAX_PLAYERS),
-            RedisKeys.FIELD_MAX_PLAYERS,
-            inviteCode
-    );
-
-    return Optional.of(JoinLobbyResponse.builder()
-            .inviteCode(inviteCode)
-            .title((String) data.get(RedisKeys.FIELD_TITLE))
-            .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
-            .maxPlayers(maxPlayers)
-            .currentPlayers(currentPlayers)
-            .status((String) data.get(RedisKeys.FIELD_STATUS))
-            .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
-            .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-            .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
-            .build());
-  }
-
-  @Override
-  public int getCurrentPlayerCount(String inviteCode) {
-    Long count = redisTemplate.opsForSet()
-            .size(RedisKeys.lobbyParticipantsKey(inviteCode));
-
-    return count != null ? count.intValue() : 0;
-  }
+  // =========================================================
+  // private command helper
+  // =========================================================
 
   private void cleanupReadyStatusAfterLeave(
           String code,
@@ -664,69 +586,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               participantsKey,
               readyKey,
               e
-      );
-    }
-  }
-
-  private Long parseNullableLong(Object value) {
-    if (value == null) return null;
-    try {
-      return Long.parseLong((String) value);
-    } catch (NumberFormatException e) {
-      log.warn("Redis Hash 필드 Long 파싱 실패 - 값: {}", value);
-      return null;
-    }
-  }
-
-  private Integer parseNullableInt(Object value) {
-    if (value == null) return null;
-    try {
-      return Integer.parseInt((String) value);
-    } catch (NumberFormatException e) {
-      log.warn("Redis Hash 필드 Integer 파싱 실패 - 값: {}", value);
-      return null;
-    }
-  }
-
-  private String toDisplayMapCategory(String rawCategory) {
-    try {
-      return MapCategory.toDisplayValue(rawCategory);
-    } catch (IllegalArgumentException e) {
-      log.warn("알 수 없는 맵 카테고리 값 - rawCategory: {}", rawCategory);
-      return rawCategory;
-    }
-  }
-
-  private int parseRequiredPositiveInt(Object value, String fieldName, String inviteCode) {
-    if (value == null) {
-      log.error("Redis 로비 필수 필드 누락 - inviteCode: {}, field: {}",
-              inviteCode, fieldName);
-      throw new ResponseStatusException(
-              HttpStatus.INTERNAL_SERVER_ERROR,
-              ERROR_INVALID_LOBBY_DATA
-      );
-    }
-
-    try {
-      int parsed = Integer.parseInt((String) value);
-
-      if (parsed <= 0) {
-        log.error("Redis 로비 필수 필드 값이 유효하지 않음 - inviteCode: {}, field: {}, value: {}",
-                inviteCode, fieldName, value);
-        throw new ResponseStatusException(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                ERROR_INVALID_LOBBY_DATA
-        );
-      }
-
-      return parsed;
-
-    } catch (NumberFormatException e) {
-      log.error("Redis 로비 필수 필드 숫자 파싱 실패 - inviteCode: {}, field: {}, value: {}",
-              inviteCode, fieldName, value, e);
-      throw new ResponseStatusException(
-              HttpStatus.INTERNAL_SERVER_ERROR,
-              ERROR_INVALID_LOBBY_DATA
       );
     }
   }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -2,7 +2,6 @@ package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
-import io.github.ascrew.monomatbe.domain.lobby.StartLobbyLuaResultCode;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
@@ -11,6 +10,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyInviteCodeGenerator;
+import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaResultMapper;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +45,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private final RedisScript<String> kickLobbyScript;
   private final RedisScript<String> startLobbyScript;
   private final LobbyInviteCodeGenerator lobbyInviteCodeGenerator;
+  private final LobbyLuaResultMapper lobbyLuaResultMapper;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -52,25 +53,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   private static final String RESULT_OK = "OK";
   private static final String RESULT_LOCK_FAILED = "LOCK_FAILED";
-
-  // =========================================================
-  // leave_lobby.lua 반환값 상수
-  // =========================================================
-
-  private static final String RESULT_DESTROYED = "DESTROYED";
-  private static final String RESULT_LEFT = "LEFT";
-  private static final String RESULT_DELEGATED_PREFIX = "DELEGATED:";
-
-  // =========================================================
-  // kick_lobby.lua 반환값 상수
-  // =========================================================
-
-  private static final String RESULT_KICKED_PREFIX = "KICKED:";
-  private static final String RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
-  private static final String RESULT_HOST_NOT_FOUND = "HOST_NOT_FOUND";
-  private static final String RESULT_FORBIDDEN = "FORBIDDEN";
-  private static final String RESULT_CANNOT_KICK_SELF = "CANNOT_KICK_SELF";
-  private static final String RESULT_TARGET_NOT_PARTICIPANT = "TARGET_NOT_PARTICIPANT";
 
   // =========================================================
   // 게임 시작 상태 재처리 상수
@@ -341,7 +323,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
     try {
       String result = redisTemplate.execute(leaveLobbyScript, keys, userId, code);
-      LeaveLobbyResult leaveResult = parseLuaResult(result, code, userId);
+      LeaveLobbyResult leaveResult = lobbyLuaResultMapper.toLeaveLobbyResult(result, code, userId);
 
       cleanupReadyStatusAfterLeave(code, userId, leaveResult);
 
@@ -374,7 +356,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               targetUserIdentifier
       );
 
-      KickLobbyResult kickResult = parseKickLuaResult(
+      KickLobbyResult kickResult = lobbyLuaResultMapper.toKickLobbyResult(
               result,
               code,
               requesterIdentifier,
@@ -425,7 +407,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               LobbyStatus.PLAYING.name()
       );
 
-      return parseStartLuaResult(result, code, requesterIdentifier);
+      return lobbyLuaResultMapper.toStartLobbyResult(result, code, requesterIdentifier);
 
     } catch (Exception e) {
       log.error(
@@ -776,23 +758,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     return isPrivate ? IS_PRIVATE_TRUE : IS_PRIVATE_FALSE;
   }
 
-  private LeaveLobbyResult parseLuaResult(String result, String code, String userId) {
-    if (result == null) {
-      return new LeaveLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
-    }
-    if (RESULT_DESTROYED.equals(result)) {
-      return new LeaveLobbyResult.Destroyed(code);
-    }
-    if (RESULT_LEFT.equals(result)) {
-      return new LeaveLobbyResult.Left(code, userId);
-    }
-    if (result.startsWith(RESULT_DELEGATED_PREFIX)) {
-      String newHostId = result.substring(RESULT_DELEGATED_PREFIX.length());
-      return new LeaveLobbyResult.Delegated(code, newHostId);
-    }
-    return new LeaveLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
-  }
-
   /**
    * 퇴장 처리 결과에 따라 ready Set을 정리한다.
    *
@@ -866,120 +831,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  private KickLobbyResult parseKickLuaResult(
-          String result,
-          String code,
-          String requesterIdentifier,
-          String targetUserIdentifier
-  ) {
-    if (result == null) {
-      return new KickLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
-    }
-
-    if (result.startsWith(RESULT_KICKED_PREFIX)) {
-      String targetWsSessionId = result.substring(RESULT_KICKED_PREFIX.length());
-
-      return new KickLobbyResult.Kicked(
-              code,
-              targetUserIdentifier,
-              targetWsSessionId
-      );
-    }
-
-    if (RESULT_LOBBY_NOT_FOUND.equals(result)) {
-      return new KickLobbyResult.LobbyNotFound(code);
-    }
-
-    if (RESULT_HOST_NOT_FOUND.equals(result)) {
-      return new KickLobbyResult.HostNotFound(code);
-    }
-
-    if (RESULT_FORBIDDEN.equals(result)) {
-      return new KickLobbyResult.Forbidden(code, requesterIdentifier);
-    }
-
-    if (RESULT_CANNOT_KICK_SELF.equals(result)) {
-      return new KickLobbyResult.CannotKickSelf(code, requesterIdentifier);
-    }
-
-    if (RESULT_TARGET_NOT_PARTICIPANT.equals(result)) {
-      return new KickLobbyResult.TargetNotParticipant(code, targetUserIdentifier);
-    }
-
-    return new KickLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
-  }
-
-  private StartLobbyResult parseStartLuaResult(
-          String result,
-          String code,
-          String requesterIdentifier
-  ) {
-    if (result == null) {
-      incrementStartReconciliationMetric(RedisKeys.METRIC_START_LOBBY_UNKNOWN_RESULT);
-
-      log.error(
-              "{} start_lobby.lua null 반환값 - lobbyCode: {}, requesterIdentifier: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              requesterIdentifier
-      );
-
-      return new StartLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
-    }
-
-    if (StartLobbyLuaResultCode.isNotReadyResult(result)) {
-      String notReadyUserIdentifier =
-              StartLobbyLuaResultCode.extractNotReadyUserIdentifier(result);
-
-      logReadyConsistencyFailure(
-              code,
-              requesterIdentifier,
-              notReadyUserIdentifier
-      );
-
-      return new StartLobbyResult.NotReady(code, notReadyUserIdentifier);
-    }
-
-    if (StartLobbyLuaResultCode.isStaleParticipantResult(result)) {
-      String staleParticipantUserIdentifier =
-              StartLobbyLuaResultCode.extractStaleParticipantUserIdentifier(result);
-
-      logReadyConsistencyFailure(
-              code,
-              requesterIdentifier,
-              staleParticipantUserIdentifier
-      );
-
-      log.error(
-              "{} 게임 시작 실패 - stale participant 감지. lobbyCode: {}, requester: {}, staleParticipant: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              requesterIdentifier,
-              staleParticipantUserIdentifier
-      );
-
-      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_READY_CONSISTENCY_FAILURE);
-
-      return new StartLobbyResult.StaleParticipant(code, staleParticipantUserIdentifier);
-    }
-
-    return StartLobbyLuaResultCode.fromExactValue(result)
-            .map(resultCode -> toStartLobbyResult(resultCode, code, requesterIdentifier))
-            .orElseGet(() -> {
-              incrementStartReconciliationMetric(RedisKeys.METRIC_START_LOBBY_UNKNOWN_RESULT);
-
-              log.error(
-                      "{} start_lobby.lua 알 수 없는 반환값 - lobbyCode: {}, requesterIdentifier: {}, result: {}",
-                      LOG_MONITORING_REQUIRED,
-                      code,
-                      requesterIdentifier,
-                      result
-              );
-
-              return new StartLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
-            });
-  }
-
   /**
    * 게임 시작 직전에 stale ready 데이터를 정리한다.
    *
@@ -1047,106 +898,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               e
       );
     }
-  }
-
-  /**
-   * start_lobby.lua가 NOT_READY를 반환했을 때 ready/participants 정합성 진단 로그를 남긴다.
-   *
-   * [목적]
-   * 단순히 "준비 안 됨"으로만 남기면 실제 미준비 유저인지,
-   * 퇴장/강퇴 후 participants Set에 남은 stale 유저인지 추적하기 어렵다.
-   *
-   * 따라서 participants 포함 여부, ready 포함 여부, 로비 세션 키 존재 여부,
-   * stale ready 데이터 수를 함께 기록한다.
-   */
-  private void logReadyConsistencyFailure(
-          String code,
-          String requesterIdentifier,
-          String notReadyUserIdentifier
-  ) {
-    String participantsKey = RedisKeys.lobbyParticipantsKey(code);
-    String readyKey = RedisKeys.lobbyReadyKey(code);
-    String lobbyUserSessionKey = RedisKeys.lobbyUserSessionKey(code, notReadyUserIdentifier);
-
-    try {
-      Long participantCount = redisTemplate.opsForSet().size(participantsKey);
-      Long readyCount = redisTemplate.opsForSet().size(readyKey);
-
-      Boolean isParticipant = redisTemplate.opsForSet()
-              .isMember(participantsKey, notReadyUserIdentifier);
-
-      Boolean isReady = redisTemplate.opsForSet()
-              .isMember(readyKey, notReadyUserIdentifier);
-
-      boolean hasActiveLobbySession = Boolean.TRUE.equals(
-              redisTemplate.hasKey(lobbyUserSessionKey)
-      );
-
-      Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
-      Set<String> readyParticipants = redisTemplate.opsForSet().members(readyKey);
-
-      Set<String> staleReadyParticipants = new HashSet<>(
-              readyParticipants != null ? readyParticipants : Set.of()
-      );
-      staleReadyParticipants.removeAll(participants != null ? participants : Set.of());
-
-      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_READY_CONSISTENCY_FAILURE);
-
-      log.warn(
-              "{} 게임 시작 실패 READY 정합성 진단 - lobbyCode: {}, requester: {}, "
-                      + "notReadyUserIdentifier: {}, participantCount: {}, readyCount: {}, "
-                      + "isParticipant: {}, isReady: {}, hasActiveLobbySession: {}, "
-                      + "staleReadyCount: {}, staleReadyParticipants: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              requesterIdentifier,
-              notReadyUserIdentifier,
-              participantCount,
-              readyCount,
-              isParticipant,
-              isReady,
-              hasActiveLobbySession,
-              staleReadyParticipants.size(),
-              staleReadyParticipants
-      );
-
-    } catch (Exception e) {
-      log.error(
-              "{} 게임 시작 실패 READY 정합성 진단 로그 생성 실패 - lobbyCode: {}, requester: {}, "
-                      + "notReadyUserIdentifier: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              requesterIdentifier,
-              notReadyUserIdentifier,
-              e
-      );
-    }
-  }
-
-  /**
-   * start_lobby.lua 반환 코드를 도메인 결과 타입으로 변환한다.
-   * StartLobbyLuaResultCode는 Lua 스크립트 반환 문자열과 1:1로 매핑됩니다.
-   */
-  private StartLobbyResult toStartLobbyResult(
-          StartLobbyLuaResultCode resultCode,
-          String code,
-          String requesterIdentifier
-  ) {
-    return switch (resultCode) {
-      case STARTED -> new StartLobbyResult.Started(code);
-      case LOBBY_NOT_FOUND -> new StartLobbyResult.LobbyNotFound(code);
-      case HOST_NOT_FOUND -> new StartLobbyResult.HostNotFound(code);
-      case FORBIDDEN -> new StartLobbyResult.Forbidden(code, requesterIdentifier);
-      case LOBBY_NOT_WAITING -> new StartLobbyResult.LobbyNotWaiting(code);
-      case MAP_NOT_SELECTED -> new StartLobbyResult.MapNotSelected(code);
-      case NO_PLAYER -> new StartLobbyResult.NoPlayer(code);
-      case NOT_READY_PREFIX -> new StartLobbyResult.Error(
-              "NOT_READY_PREFIX는 동적 prefix 결과이므로 exact 매핑 대상이 아닙니다."
-      );
-      case STALE_PARTICIPANT_PREFIX -> new StartLobbyResult.Error(
-              "STALE_PARTICIPANT_PREFIX는 동적 prefix 결과이므로 exact 매핑 대상이 아닙니다."
-      );
-    };
   }
 
   private Long parseNullableLong(Object value) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -1,17 +1,18 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
+import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyLuaResultCode;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
-import io.github.ascrew.monomatbe.global.constant.RedisKeys;
-import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
-import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
+import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyInviteCodeGenerator;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -20,7 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +44,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private final RedisScript<String> createLobbyScript;
   private final RedisScript<String> kickLobbyScript;
   private final RedisScript<String> startLobbyScript;
+  private final LobbyInviteCodeGenerator lobbyInviteCodeGenerator;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -88,11 +89,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private static final String IS_PRIVATE_FALSE = "false";
 
   // =========================================================
-  // 초대 코드 생성 상수
+  // 초대 코드 생성 관련 에러 상수
   // =========================================================
-
-  /** 초대 코드 생성용 보안 난수 생성기 */
-  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   /** 초대 코드 생성 실패 시 반환할 에러 메시지 */
   private static final String ERROR_INVITE_CODE_EXHAUSTED =
@@ -245,7 +243,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           LobbyMapMetadata mapMetadata
   ) {
     for (int attempt = 0; attempt < LobbyDefaults.INVITE_CODE_MAX_RETRY; attempt++) {
-      String candidate = generateInviteCode();
+      String candidate = lobbyInviteCodeGenerator.generate();
       String result = executeCreateLobbyScript(candidate, request, userIdentifier, mapMetadata);
 
       if (result == null) {
@@ -778,23 +776,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     return isPrivate ? IS_PRIVATE_TRUE : IS_PRIVATE_FALSE;
   }
 
-  /**
-   * LobbyDefaults 상수 기반으로 6자리 초대 코드를 생성한다.
-   *
-   * [SecureRandom 사용 이유]
-   * Random 대신 SecureRandom을 사용하여 코드 예측 가능성을 낮춘다.
-   * 게임 특성상 코드 추측으로 비공개 로비에 무단 입장하는 것을 방지한다.
-   */
-  private String generateInviteCode() {
-    StringBuilder sb = new StringBuilder(LobbyDefaults.INVITE_CODE_LENGTH);
-    for (int i = 0; i < LobbyDefaults.INVITE_CODE_LENGTH; i++) {
-      sb.append(LobbyDefaults.INVITE_CODE_CHARACTERS.charAt(
-              SECURE_RANDOM.nextInt(LobbyDefaults.INVITE_CODE_CHARACTERS.length())
-      ));
-    }
-    return sb.toString();
-  }
-
   private LeaveLobbyResult parseLuaResult(String result, String code, String userId) {
     if (result == null) {
       return new LeaveLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
@@ -1072,9 +1053,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
    * start_lobby.lua가 NOT_READY를 반환했을 때 ready/participants 정합성 진단 로그를 남긴다.
    *
    * [목적]
-   * 단순히 "준비 안 됨"으로만 남기면 실제 미준비 유저인지, 퇴장/강퇴 후 participants Set에 남은 stale 유저인지 추적하기 어렵다.
+   * 단순히 "준비 안 됨"으로만 남기면 실제 미준비 유저인지,
+   * 퇴장/강퇴 후 participants Set에 남은 stale 유저인지 추적하기 어렵다.
    *
-   * 따라서 participants 포함 여부, ready 포함 여부, 로비 세션 키 존재 여부, stale ready 데이터 수를 함께 기록한다.
+   * 따라서 participants 포함 여부, ready 포함 여부, 로비 세션 키 존재 여부,
+   * stale ready 데이터 수를 함께 기록한다.
    */
   private void logReadyConsistencyFailure(
           String code,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -25,57 +25,46 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * 로비 Redis Repository 구현체.
+ * 로비 Redis Repository 구현체
  *
- * [현재 책임]
- * 이 클래스는 기존 LobbyRepository 인터페이스 계약을 유지하는 facade 역할을 합니다.
- * 세부 Redis 책임은 역할별 컴포넌트로 분리합니다.
+ * [역할]
+ * 이 클래스는 기존 LobbyRepository 인터페이스 계약을 유지하는 Facade
+ * Redis 접근 세부 책임은 역할별 하위 컴포넌트로 위임한다.
  *
- * [분리 완료]
+ * [분리된 책임]
  * - 초대 코드 생성: LobbyInviteCodeGenerator
- * - Lua 결과 매핑: LobbyLuaResultMapper
  * - Lua 실행: LobbyLuaScriptExecutor
+ * - Lua 결과 매핑: LobbyLuaResultMapper
  * - Redis 조회: LobbyRedisQueryRepository
  * - Redis command: LobbyRedisCommandRepository
  * - start reconciliation queue: LobbyStartReconciliationRepository
- *
- * [중요]
- * 이번 리팩토링은 외부 서비스 계층의 의존성을 바꾸지 않기 위한 내부 구조 개선입니다.
- * 따라서 LobbyRepository 인터페이스, Redis key 구조, Lua script 계약은 변경하지 않습니다.
  */
 @Slf4j
 @Repository
 @RequiredArgsConstructor
 public class LobbyRepositoryImpl implements LobbyRepository {
 
+  private static final String CREATE_LOBBY_RESULT_OK = "OK";
+  private static final String CREATE_LOBBY_RESULT_LOCK_FAILED = "LOCK_FAILED";
+
+  private static final String ERROR_INVITE_CODE_EXHAUSTED =
+          "초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
+  private static final String ERROR_REDIS_SCRIPT_NULL =
+          "Redis 스크립트 실행 결과가 null입니다. Redis 연결 상태를 확인해주세요.";
+
+  private static final String ERROR_REDIS_SCRIPT_UNKNOWN_RESULT =
+          "Redis 로비 생성 처리 결과가 유효하지 않습니다.";
+
   private final LobbyInviteCodeGenerator lobbyInviteCodeGenerator;
-  private final LobbyLuaResultMapper lobbyLuaResultMapper;
   private final LobbyLuaScriptExecutor lobbyLuaScriptExecutor;
+  private final LobbyLuaResultMapper lobbyLuaResultMapper;
   private final LobbyRedisQueryRepository lobbyRedisQueryRepository;
   private final LobbyRedisCommandRepository lobbyRedisCommandRepository;
   private final LobbyStartReconciliationRepository lobbyStartReconciliationRepository;
 
   // =========================================================
-  // create_lobby.lua 반환값 상수
-  // =========================================================
-
-  private static final String RESULT_OK = "OK";
-  private static final String RESULT_LOCK_FAILED = "LOCK_FAILED";
-
-  /** 초대 코드 생성 실패 시 반환할 에러 메시지 */
-  private static final String ERROR_INVITE_CODE_EXHAUSTED =
-          "초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
-
-  /** Lua 스크립트 null 반환 시 에러 메시지 */
-  private static final String ERROR_REDIS_SCRIPT_NULL =
-          "Redis 스크립트 실행 결과가 null입니다. Redis 연결 상태를 확인해주세요.";
-
-  /** Lua 스크립트가 예상하지 못한 값을 반환했을 때의 에러 메시지 */
-  private static final String ERROR_REDIS_SCRIPT_UNKNOWN_RESULT =
-          "Redis 로비 생성 처리 결과가 유효하지 않습니다.";
-
-  // =========================================================
-  // Redis 조회 위임
+  // Redis Query
   // =========================================================
 
   @Override
@@ -114,7 +103,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   // =========================================================
-  // Redis command 위임
+  // Redis Command
   // =========================================================
 
   @Override
@@ -133,12 +122,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   // =========================================================
-  // Lua 기반 로비 상태 변경
+  // Lua-backed State Transition
   // =========================================================
 
-  /**
-   * Lua 스크립트로 SETNX 선점과 로비 데이터 저장을 원자적으로 수행하고 초대 코드를 반환합니다.
-   */
   @Override
   public String saveToRedis(
           CreateLobbyRequest request,
@@ -156,30 +142,33 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       );
 
       if (result == null) {
-        log.error("Lua 스크립트 null 반환 - Redis 연결 오류 가능성. 코드: {}", candidate);
+        log.error("Lua 스크립트 null 반환 - Redis 연결 오류 가능성. code: {}", candidate);
+
         throw new ResponseStatusException(
                 HttpStatus.SERVICE_UNAVAILABLE,
                 ERROR_REDIS_SCRIPT_NULL
         );
       }
 
-      if (RESULT_OK.equals(result)) {
+      if (CREATE_LOBBY_RESULT_OK.equals(result)) {
         log.info(
-                "로비 Redis 저장 완료 - 코드: {}, 방장: {}, mapId: {}",
+                "로비 Redis 저장 완료 - code: {}, host: {}, mapId: {}",
                 candidate,
                 userIdentifier,
                 mapMetadata != null ? mapMetadata.mapId() : null
         );
+
         return candidate;
       }
 
-      if (RESULT_LOCK_FAILED.equals(result)) {
+      if (CREATE_LOBBY_RESULT_LOCK_FAILED.equals(result)) {
         log.warn(
-                "초대 코드 충돌 - 재시도 {}/{}: {}",
+                "초대 코드 충돌 - retry: {}/{}, code: {}",
                 attempt + 1,
                 LobbyDefaults.INVITE_CODE_MAX_RETRY,
                 candidate
         );
+
         continue;
       }
 
@@ -205,11 +194,18 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   public LeaveLobbyResult executeLeaveLobbyProcess(String code, String userId) {
     try {
       String result = lobbyLuaScriptExecutor.executeLeaveLobby(code, userId);
-      LeaveLobbyResult leaveResult = lobbyLuaResultMapper.toLeaveLobbyResult(result, code, userId);
 
-      lobbyRedisCommandRepository.cleanupReadyStatusAfterLeave(code, userId, leaveResult);
+      LeaveLobbyResult leaveResult =
+              lobbyLuaResultMapper.toLeaveLobbyResult(result, code, userId);
+
+      lobbyRedisCommandRepository.cleanupReadyStatusAfterLeave(
+              code,
+              userId,
+              leaveResult
+      );
 
       return leaveResult;
+
     } catch (Exception e) {
       return new LeaveLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
     }
@@ -267,9 +263,16 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               requesterIdentifier
       );
 
-      String result = lobbyLuaScriptExecutor.executeStartLobby(code, requesterIdentifier);
+      String result = lobbyLuaScriptExecutor.executeStartLobby(
+              code,
+              requesterIdentifier
+      );
 
-      return lobbyLuaResultMapper.toStartLobbyResult(result, code, requesterIdentifier);
+      return lobbyLuaResultMapper.toStartLobbyResult(
+              result,
+              code,
+              requesterIdentifier
+      );
 
     } catch (Exception e) {
       log.error(
@@ -284,7 +287,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   // =========================================================
-  // Start reconciliation queue 위임
+  // Start Reconciliation
   // =========================================================
 
   @Override

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -8,10 +8,10 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
-import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyInviteCodeGenerator;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaResultMapper;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaScriptExecutor;
+import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyRedisCommandRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyRedisQueryRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -39,9 +37,9 @@ import java.util.Set;
  * - Lua 결과 매핑: LobbyLuaResultMapper
  * - Lua 실행: LobbyLuaScriptExecutor
  * - Redis 조회: LobbyRedisQueryRepository
+ * - Redis command: LobbyRedisCommandRepository
  *
  * [아직 남은 책임]
- * - Redis command 처리
  * - start reconciliation queue 처리
  *
  * [중요]
@@ -58,6 +56,7 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   private final LobbyLuaResultMapper lobbyLuaResultMapper;
   private final LobbyLuaScriptExecutor lobbyLuaScriptExecutor;
   private final LobbyRedisQueryRepository lobbyRedisQueryRepository;
+  private final LobbyRedisCommandRepository lobbyRedisCommandRepository;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -129,20 +128,27 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   // =========================================================
-  // Redis 명령 / Lua 실행
+  // Redis command 위임
   // =========================================================
 
   @Override
   public void updateReadyStatus(String code, String userIdentifier, boolean ready) {
-    String readyKey = RedisKeys.lobbyReadyKey(code);
-
-    if (ready) {
-      redisTemplate.opsForSet().add(readyKey, userIdentifier);
-      return;
-    }
-
-    redisTemplate.opsForSet().remove(readyKey, userIdentifier);
+    lobbyRedisCommandRepository.updateReadyStatus(code, userIdentifier, ready);
   }
+
+  @Override
+  public boolean deleteFromRedis(String inviteCode) {
+    return lobbyRedisCommandRepository.deleteFromRedis(inviteCode);
+  }
+
+  @Override
+  public boolean rollbackStartedLobbyStatus(String code) {
+    return lobbyRedisCommandRepository.rollbackStartedLobbyStatus(code);
+  }
+
+  // =========================================================
+  // Lua 기반 로비 상태 변경
+  // =========================================================
 
   /**
    * Lua 스크립트로 SETNX 선점과 로비 데이터 저장을 원자적으로 수행하고 초대 코드를 반환합니다.
@@ -209,48 +215,13 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     );
   }
 
-  /**
-   * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제합니다.
-   */
-  @Override
-  public boolean deleteFromRedis(String inviteCode) {
-    List<String> keysToDelete = List.of(
-            RedisKeys.lobbyKey(inviteCode),
-            RedisKeys.lobbyParticipantsKey(inviteCode),
-            RedisKeys.lobbyOrderKey(inviteCode),
-            RedisKeys.lobbyKickedKey(inviteCode),
-            RedisKeys.lobbyReadyKey(inviteCode),
-            RedisKeys.lobbyCodeLockKey(inviteCode)
-    );
-
-    try {
-      redisTemplate.delete(keysToDelete);
-      redisTemplate.opsForSet().remove(RedisKeys.LOBBY_PUBLIC, inviteCode);
-
-      log.info("Redis 보상 삭제 완료 - code: {}, keys: {}", inviteCode, keysToDelete);
-      return true;
-
-    } catch (Exception e) {
-      log.error(
-              "{} Redis 보상 삭제 실패 - code: {}, keys: {}, publicLobbyKey: {}. "
-                      + "로비 잔여 데이터가 조회/ready/canStart 계산에 영향을 줄 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
-              LOG_MONITORING_REQUIRED,
-              inviteCode,
-              keysToDelete,
-              RedisKeys.LOBBY_PUBLIC,
-              e
-      );
-      return false;
-    }
-  }
-
   @Override
   public LeaveLobbyResult executeLeaveLobbyProcess(String code, String userId) {
     try {
       String result = lobbyLuaScriptExecutor.executeLeaveLobby(code, userId);
       LeaveLobbyResult leaveResult = lobbyLuaResultMapper.toLeaveLobbyResult(result, code, userId);
 
-      cleanupReadyStatusAfterLeave(code, userId, leaveResult);
+      lobbyRedisCommandRepository.cleanupReadyStatusAfterLeave(code, userId, leaveResult);
 
       return leaveResult;
     } catch (Exception e) {
@@ -278,7 +249,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               targetUserIdentifier
       );
 
-      cleanupReadyStatusAfterKick(code, targetUserIdentifier, kickResult);
+      lobbyRedisCommandRepository.cleanupReadyStatusAfterKick(
+              code,
+              targetUserIdentifier,
+              kickResult
+      );
 
       return kickResult;
 
@@ -301,7 +276,10 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           String requesterIdentifier
   ) {
     try {
-      cleanupStaleReadyParticipantsBeforeStart(code, requesterIdentifier);
+      lobbyRedisCommandRepository.cleanupStaleReadyParticipantsBeforeStart(
+              code,
+              requesterIdentifier
+      );
 
       String result = lobbyLuaScriptExecutor.executeStartLobby(code, requesterIdentifier);
 
@@ -317,97 +295,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
       return new StartLobbyResult.Error("Lua 스크립트 실행 중 예외 발생: " + e.getMessage());
     }
-  }
-
-  /**
-   * Redis 로비 상태를 WAITING으로 보상 롤백합니다.
-   */
-  @Override
-  public boolean rollbackStartedLobbyStatus(String code) {
-    String lobbyKey = RedisKeys.lobbyKey(code);
-
-    try {
-      Map<Object, Object> lobbyData = redisTemplate.opsForHash().entries(lobbyKey);
-
-      if (lobbyData.isEmpty()) {
-        log.error(
-                "{} 게임 시작 Redis 보상 롤백 실패 - 로비 데이터 없음. code: {}, lobbyKey: {}",
-                LOG_MONITORING_REQUIRED,
-                code,
-                lobbyKey
-        );
-        return false;
-      }
-
-      redisTemplate.opsForHash().put(
-              lobbyKey,
-              RedisKeys.FIELD_STATUS,
-              LobbyStatus.WAITING.name()
-      );
-
-      String rawIsPrivate = (String) lobbyData.get(RedisKeys.FIELD_IS_PRIVATE);
-      boolean restoredPublic = restorePublicLobbyIfClearlyPublic(
-              code,
-              lobbyKey,
-              rawIsPrivate
-      );
-
-      log.warn(
-              "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}, rawIsPrivate: {}",
-              code,
-              LobbyStatus.WAITING.name(),
-              restoredPublic,
-              rawIsPrivate
-      );
-
-      return true;
-
-    } catch (Exception e) {
-      log.error(
-              "{} 게임 시작 Redis 보상 롤백 실패 - code: {}, lobbyKey: {}. "
-                      + "Redis는 PLAYING인데 DB는 WAITING일 수 있으므로 재처리 큐 확인이 필요합니다.",
-              LOG_MONITORING_REQUIRED,
-              code,
-              lobbyKey,
-              e
-      );
-      return false;
-    }
-  }
-
-  private boolean restorePublicLobbyIfClearlyPublic(
-          String code,
-          String lobbyKey,
-          String rawIsPrivate
-  ) {
-    if (rawIsPrivate == null || rawIsPrivate.isBlank()) {
-      log.error(
-              "{} 게임 시작 Redis 보상 롤백 중 is_private 필드 누락 - public 복구 생략. "
-                      + "code: {}, lobbyKey: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              lobbyKey
-      );
-      return false;
-    }
-
-    if ("false".equals(rawIsPrivate)) {
-      redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, code);
-      return true;
-    }
-
-    if (!"true".equals(rawIsPrivate)) {
-      log.error(
-              "{} 게임 시작 Redis 보상 롤백 중 알 수 없는 is_private 값 - public 복구 생략. "
-                      + "code: {}, lobbyKey: {}, rawIsPrivate: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              lobbyKey,
-              rawIsPrivate
-      );
-    }
-
-    return false;
   }
 
   // =========================================================
@@ -472,121 +359,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       redisTemplate.opsForValue().increment(metricKey);
     } catch (Exception e) {
       log.warn("게임 시작 상태 재처리 metric 증가 실패 - metricKey: {}", metricKey, e);
-    }
-  }
-
-  // =========================================================
-  // private command helper
-  // =========================================================
-
-  private void cleanupReadyStatusAfterLeave(
-          String code,
-          String userId,
-          LeaveLobbyResult leaveResult
-  ) {
-    String readyKey = RedisKeys.lobbyReadyKey(code);
-
-    try {
-      if (leaveResult instanceof LeaveLobbyResult.Destroyed) {
-        redisTemplate.delete(readyKey);
-        return;
-      }
-
-      if (leaveResult instanceof LeaveLobbyResult.Left
-              || leaveResult instanceof LeaveLobbyResult.Delegated) {
-        redisTemplate.opsForSet().remove(readyKey, userId);
-      }
-    } catch (Exception e) {
-      log.error(
-              "{} 퇴장 후 ready 상태 정리 실패 - lobbyCode: {}, userId: {}, readyKey: {}, leaveResult: {}. "
-                      + "ready Set 잔여 데이터가 canStart 계산을 왜곡할 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
-              LOG_MONITORING_REQUIRED,
-              code,
-              userId,
-              readyKey,
-              leaveResult.getClass().getSimpleName(),
-              e
-      );
-    }
-  }
-
-  private void cleanupReadyStatusAfterKick(
-          String code,
-          String targetUserIdentifier,
-          KickLobbyResult kickResult
-  ) {
-    if (!(kickResult instanceof KickLobbyResult.Kicked)) {
-      return;
-    }
-
-    try {
-      redisTemplate.opsForSet().remove(
-              RedisKeys.lobbyReadyKey(code),
-              targetUserIdentifier
-      );
-    } catch (Exception e) {
-      log.warn(
-              "강퇴 후 ready 상태 정리 실패 - lobbyCode: {}, targetUserIdentifier: {}",
-              code,
-              targetUserIdentifier,
-              e
-      );
-    }
-  }
-
-  private void cleanupStaleReadyParticipantsBeforeStart(
-          String code,
-          String requesterIdentifier
-  ) {
-    String participantsKey = RedisKeys.lobbyParticipantsKey(code);
-    String readyKey = RedisKeys.lobbyReadyKey(code);
-
-    try {
-      Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
-      Set<String> readyParticipants = redisTemplate.opsForSet().members(readyKey);
-
-      if (readyParticipants == null || readyParticipants.isEmpty()) {
-        return;
-      }
-
-      Set<String> participantSet = participants != null ? participants : Set.of();
-
-      Set<String> staleReadyParticipants = new HashSet<>(readyParticipants);
-      staleReadyParticipants.removeAll(participantSet);
-
-      if (staleReadyParticipants.isEmpty()) {
-        return;
-      }
-
-      redisTemplate.opsForSet().remove(
-              readyKey,
-              staleReadyParticipants.toArray()
-      );
-
-      incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_READY_STALE_CLEANUP);
-
-      log.warn(
-              "{} 게임 시작 전 stale ready 데이터 정리 - lobbyCode: {}, requester: {}, "
-                      + "participantsKey: {}, readyKey: {}, staleReadyParticipants: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              requesterIdentifier,
-              participantsKey,
-              readyKey,
-              staleReadyParticipants
-      );
-
-    } catch (Exception e) {
-      log.error(
-              "{} 게임 시작 전 ready 정합성 스캔 실패 - lobbyCode: {}, requester: {}, "
-                      + "participantsKey: {}, readyKey: {}",
-              LOG_MONITORING_REQUIRED,
-              code,
-              requesterIdentifier,
-              participantsKey,
-              readyKey,
-              e
-      );
     }
   }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -11,12 +11,12 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyInviteCodeGenerator;
 import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaResultMapper;
+import io.github.ascrew.monomatbe.domain.lobby.repository.redis.LobbyLuaScriptExecutor;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
@@ -33,19 +33,10 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class LobbyRepositoryImpl implements LobbyRepository {
 
-  /**
-   * Lua 스크립트에 선택 값이 없음을 표현하기 위한 값.
-   * Redis Hash에 "null" 문자열이 저장되는 것을 방지하기 위해 빈 문자열을 사용합니다.
-   */
-  private static final String EMPTY_REDIS_VALUE = "";
-
   private final StringRedisTemplate redisTemplate;
-  private final RedisScript<String> leaveLobbyScript;
-  private final RedisScript<String> createLobbyScript;
-  private final RedisScript<String> kickLobbyScript;
-  private final RedisScript<String> startLobbyScript;
   private final LobbyInviteCodeGenerator lobbyInviteCodeGenerator;
   private final LobbyLuaResultMapper lobbyLuaResultMapper;
+  private final LobbyLuaScriptExecutor lobbyLuaScriptExecutor;
 
   // =========================================================
   // create_lobby.lua 반환값 상수
@@ -60,19 +51,13 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   private static final String RECONCILIATION_PAYLOAD_DELIMITER = "|";
 
-  // =========================================================
-  // isPrivate 정규화 상수
-  // =========================================================
-
-  /** Lua 스크립트에 전달할 공개 로비 isPrivate 값 */
-  private static final String IS_PRIVATE_TRUE = "true";
-
-  /** Lua 스크립트에 전달할 비공개 로비 isPrivate 값 */
-  private static final String IS_PRIVATE_FALSE = "false";
-
-  // =========================================================
-  // 초대 코드 생성 관련 에러 상수
-  // =========================================================
+  /**
+   * 운영 확인이 필요한 Redis 정리 실패 로그 식별자
+   *
+   * 현재 프로젝트에 별도 알림/재처리 큐 인프라가 없으므로,
+   * 운영 로그 수집 시스템에서 이 키워드를 기준으로 알림을 연계할 수 있도록 한다.
+   */
+  private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
 
   /** 초대 코드 생성 실패 시 반환할 에러 메시지 */
   private static final String ERROR_INVITE_CODE_EXHAUSTED =
@@ -85,18 +70,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   /** Lua 스크립트가 예상하지 못한 값을 반환했을 때의 에러 메시지 */
   private static final String ERROR_REDIS_SCRIPT_UNKNOWN_RESULT =
           "Redis 로비 생성 처리 결과가 유효하지 않습니다.";
-
-  /**
-   * 운영 확인이 필요한 Redis 정리 실패 로그 식별자
-   *
-   * 현재 프로젝트에 별도 알림/재처리 큐 인프라가 없으므로,
-   * 운영 로그 수집 시스템에서 이 키워드를 기준으로 알림을 연계할 수 있도록 한다.
-   */
-  private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
-
-  // =========================================================
-  // findByInviteCode 관련 상수
-  // =========================================================
 
   /**
    * 로비가 존재하지 않거나 TTL이 만료된 경우 반환할 빈 Optional.
@@ -137,13 +110,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   /**
    * 로비 참여자 목록을 입장 순서 기준으로 조회한다.
-   *
-   * [조회 전략]
-   * - lobby:{code}:order List를 우선 사용하여 FE 표시 순서를 안정적으로 유지한다.
-   * - participants Set을 함께 조회하여 이미 퇴장했지만 order에 남은 값은 제거한다.
-   *
-   * @param code 로비 초대 코드
-   * @return 현재 로비에 참여 중인 userIdentifier 목록
    */
   @Override
   public List<String> getParticipantIdentifiers(String code) {
@@ -169,10 +135,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       }
     }
 
-    /*
-     * order List에는 없지만 participants Set에는 존재하는 비정상 데이터를 보정한다.
-     * Redis 장애, 과거 데이터, Lua 계약 변경 상황에서도 상세 응답이 누락되지 않도록 한다.
-     */
     for (String userIdentifier : participantSet) {
       if (!result.contains(userIdentifier)) {
         result.add(userIdentifier);
@@ -184,13 +146,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   /**
    * ready 상태인 참여자 식별자 목록을 조회한다.
-   *
-   * [반환 정책]
-   * Redis Set 조회 결과가 null이면 빈 Set으로 반환하여
-   * 서비스 레이어에서 null 방어 로직을 반복하지 않도록 한다.
-   *
-   * @param code 로비 초대 코드
-   * @return ready 상태인 userIdentifier Set
    */
   @Override
   public Set<String> getReadyParticipantIdentifiers(String code) {
@@ -206,17 +161,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   /**
    * Lua 스크립트로 SETNX 선점과 로비 데이터 저장을 원자적으로 수행하고 초대 코드를 반환한다.
-   *
-   * [저장 구조]
-   * - lobby:{code}              Hash — 로비 메타 정보
-   * - lobby:{code}:participants Set  — 참여자 목록 (방장 선 추가)
-   * - lobby:{code}:order        List — 입장 순서 (방장 선 추가)
-   * - lobby:public              Set  — 공개 로비 목록 (isPrivate=false 시만)
-   *
-   * [재시도 전략]
-   * - LOCK_FAILED : 코드 충돌 → 새 코드 생성 후 재시도
-   * - null        : Redis 오류 → 재시도하지 않고 즉시 503 반환
-   * - 최대 재시도 횟수 초과 시 503 반환
    */
   @Override
   public String saveToRedis(
@@ -226,7 +170,13 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   ) {
     for (int attempt = 0; attempt < LobbyDefaults.INVITE_CODE_MAX_RETRY; attempt++) {
       String candidate = lobbyInviteCodeGenerator.generate();
-      String result = executeCreateLobbyScript(candidate, request, userIdentifier, mapMetadata);
+
+      String result = lobbyLuaScriptExecutor.executeCreateLobby(
+              candidate,
+              request,
+              userIdentifier,
+              mapMetadata
+      );
 
       if (result == null) {
         log.error("Lua 스크립트 null 반환 - Redis 연결 오류 가능성. 코드: {}", candidate);
@@ -272,12 +222,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   /**
    * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
-   *
-   * [삭제 실패 처리]
-   * 보상 삭제 실패 시 ERROR 로그를 남기고 false를 반환한다.
-   * 서비스 레이어에서 반환값을 확인하여 추가 알림 처리가 가능하다.
-   *
-   * @return 보상 삭제 성공 여부 (true: 성공, false: 실패)
    */
   @Override
   public boolean deleteFromRedis(String inviteCode) {
@@ -313,16 +257,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   @Override
   public LeaveLobbyResult executeLeaveLobbyProcess(String code, String userId) {
-    List<String> keys = List.of(
-            RedisKeys.lobbyKey(code),
-            RedisKeys.lobbyParticipantsKey(code),
-            RedisKeys.lobbyOrderKey(code),
-            RedisKeys.lobbyKickedKey(code),
-            RedisKeys.LOBBY_PUBLIC
-    );
-
     try {
-      String result = redisTemplate.execute(leaveLobbyScript, keys, userId, code);
+      String result = lobbyLuaScriptExecutor.executeLeaveLobby(code, userId);
       LeaveLobbyResult leaveResult = lobbyLuaResultMapper.toLeaveLobbyResult(result, code, userId);
 
       cleanupReadyStatusAfterLeave(code, userId, leaveResult);
@@ -339,19 +275,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           String requesterIdentifier,
           String targetUserIdentifier
   ) {
-    List<String> keys = List.of(
-            RedisKeys.lobbyKey(code),
-            RedisKeys.lobbyParticipantsKey(code),
-            RedisKeys.lobbyOrderKey(code),
-            RedisKeys.lobbyKickedKey(code),
-            RedisKeys.lobbyUserSessionKey(code, targetUserIdentifier),
-            RedisKeys.lobbyUserSessionSequenceKey(code, targetUserIdentifier)
-    );
-
     try {
-      String result = redisTemplate.execute(
-              kickLobbyScript,
-              keys,
+      String result = lobbyLuaScriptExecutor.executeKickLobby(
+              code,
               requesterIdentifier,
               targetUserIdentifier
       );
@@ -385,27 +311,10 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           String code,
           String requesterIdentifier
   ) {
-    List<String> keys = List.of(
-            RedisKeys.lobbyKey(code),
-            RedisKeys.lobbyParticipantsKey(code),
-            RedisKeys.lobbyReadyKey(code),
-            RedisKeys.LOBBY_PUBLIC
-    );
-
     try {
       cleanupStaleReadyParticipantsBeforeStart(code, requesterIdentifier);
 
-      String result = redisTemplate.execute(
-              startLobbyScript,
-              keys,
-              requesterIdentifier,
-              code,
-              RedisKeys.FIELD_HOST_USER_ID,
-              RedisKeys.FIELD_STATUS,
-              RedisKeys.FIELD_MAP_ID,
-              LobbyStatus.WAITING.name(),
-              LobbyStatus.PLAYING.name()
-      );
+      String result = lobbyLuaScriptExecutor.executeStartLobby(code, requesterIdentifier);
 
       return lobbyLuaResultMapper.toStartLobbyResult(result, code, requesterIdentifier);
 
@@ -423,20 +332,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   /**
    * Redis 로비 상태를 WAITING으로 보상 롤백한다.
-   *
-   * [필요 이유]
-   * 게임 시작 Lua가 성공하면 Redis 로비 상태는 PLAYING으로 바뀌고,
-   * 공개 로비 목록(lobby:public)에서도 제거된다.
-   *
-   * 이후 DB GAME_LOBBY 상태 변경이 실패하면 Redis는 PLAYING, DB는 WAITING인
-   * 불일치 상태가 될 수 있으므로 가능한 범위에서 Redis 상태를 되돌린다.
-   *
-   * [보상 범위]
-   * - lobby:{code}.status = WAITING
-   * - 공개 로비라면 lobby:public에 code 재등록
-   *
-   * [한계]
-   * Redis 보상 롤백도 실패할 수 있으므로, 실패 시 운영 확인 로그를 남긴다.
    */
   @Override
   public boolean rollbackStartedLobbyStatus(String code) {
@@ -507,12 +402,12 @@ public class LobbyRepositoryImpl implements LobbyRepository {
       return false;
     }
 
-    if (IS_PRIVATE_FALSE.equals(rawIsPrivate)) {
+    if ("false".equals(rawIsPrivate)) {
       redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, code);
       return true;
     }
 
-    if (!IS_PRIVATE_TRUE.equals(rawIsPrivate)) {
+    if (!"true".equals(rawIsPrivate)) {
       log.error(
               "{} 게임 시작 Redis 보상 롤백 중 알 수 없는 is_private 값 - public 복구 생략. "
                       + "code: {}, lobbyKey: {}, rawIsPrivate: {}",
@@ -528,10 +423,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
 
   /**
    * Redis-DB 상태 불일치 재처리 요청을 Redis 큐에 적재한다.
-   *
-   * [사용 목적]
-   * Redis 게임 시작 상태는 PLAYING으로 전환되었지만 DB 상태 변경 또는 Redis 롤백이 실패한 경우,
-   * 후속 백그라운드 리컨실리에이션 작업이 처리할 수 있도록 최소 정보를 남긴다.
    */
   @Override
   public void enqueueStartReconciliation(String code, String reason) {
@@ -628,33 +519,15 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     return result;
   }
 
-  /**
-   * 초대 코드로 로비 입장에 필요한 정보를 조회한다.
-   *
-   * [조회 전략]
-   * HGETALL로 lobby:{code} Hash를 한 번에 읽어 응답 객체를 구성한다.
-   * currentPlayers는 participants Set의 SCARD로 별도 조회한다.
-   *
-   * [mapCategory]
-   * 맵 선택 기능 구현 전까지 null로 반환한다.
-   * 맵 선택 이슈에서 Redis Hash에 map_category 필드가 추가되면
-   * FIELD_MAP_CATEGORY 상수로 조회한다.
-   *
-   * @param inviteCode 로비 초대 코드
-   * @return 로비 정보 Optional (로비 미존재 시 empty)
-   */
   @Override
   public Optional<JoinLobbyResponse> findByInviteCode(String inviteCode) {
-    // HGETALL로 Hash 전체를 한 번에 읽어 네트워크 왕복 횟수를 최소화한다.
     Map<Object, Object> data =
             redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(inviteCode));
 
-    // 로비가 존재하지 않거나 TTL이 만료된 경우
     if (data.isEmpty()) {
       return EMPTY_LOBBY;
     }
 
-    // 현재 참여 인원은 participants Set의 SCARD로 조회한다.
     int currentPlayers = getCurrentPlayerCount(inviteCode);
 
     int maxPlayers = parseRequiredPositiveInt(
@@ -676,99 +549,14 @@ public class LobbyRepositoryImpl implements LobbyRepository {
             .build());
   }
 
-  /**
-   * 해당 로비의 현재 참여 인원 수를 반환한다.
-   *
-   * [구현 방식]
-   * lobby:{code}:participants Set의 SCARD 명령으로 조회한다.
-   * null 반환 시 Redis 연결 이상이므로 0으로 폴백하여 NPE를 방지한다.
-   *
-   * @param inviteCode 로비 초대 코드
-   * @return 현재 참여 인원 수 (Redis 오류 시 0)
-   */
   @Override
   public int getCurrentPlayerCount(String inviteCode) {
     Long count = redisTemplate.opsForSet()
             .size(RedisKeys.lobbyParticipantsKey(inviteCode));
 
-    // null은 Redis 연결 이상을 의미한다.
-    // 0으로 폴백하여 NPE를 방지하고, 서비스 레이어에서 정상 흐름을 유지한다.
     return count != null ? count.intValue() : 0;
   }
 
-  // =========================================================
-  // private 메서드
-  // =========================================================
-
-  /**
-   * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행합니다.
-   *
-   * [맵 정보 저장 정책]
-   * mapMetadata가 null이면 빈 문자열을 Lua에 전달합니다.
-   * Lua는 mapId가 빈 문자열인 경우 map_id, map_title, map_category 필드를 저장하지 않습니다.
-   *
-   * @return "OK" | "LOCK_FAILED" | null
-   */
-  private String executeCreateLobbyScript(
-          String inviteCode,
-          CreateLobbyRequest request,
-          String userIdentifier,
-          LobbyMapMetadata mapMetadata
-  ) {
-    List<String> keys = List.of(
-            RedisKeys.lobbyCodeLockKey(inviteCode),
-            RedisKeys.lobbyKey(inviteCode),
-            RedisKeys.LOBBY_PUBLIC
-    );
-
-    String lockTtlMs = String.valueOf(LobbyDefaults.INVITE_CODE_LOCK_TTL.toMillis());
-    String isPrivateValue = normalizeIsPrivate(request.isPrivate());
-
-    return redisTemplate.execute(
-            createLobbyScript,
-            keys,
-            userIdentifier,
-            lockTtlMs,
-            inviteCode,
-            request.title(),
-            String.valueOf(request.maxPlayers()),
-            isPrivateValue,
-            LobbyStatus.WAITING.name(),
-
-            // 맵 미선택 시 빈 문자열을 전달하여 Redis에 "null" 문자열이 저장되지 않게 합니다.
-            mapMetadata != null ? String.valueOf(mapMetadata.mapId()) : EMPTY_REDIS_VALUE,
-            mapMetadata != null ? mapMetadata.mapTitle() : EMPTY_REDIS_VALUE,
-            mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE
-    );
-  }
-
-  /**
-   * isPrivate 값을 Lua 스크립트와 일치하는 소문자 문자열로 정규화한다.
-   *
-   * [정규화 이유]
-   * Lua 스크립트(create_lobby.lua)에서 isPrivate 값을
-   * if isPrivate == "false" then 으로 비교한다.
-   * IS_PRIVATE_TRUE / IS_PRIVATE_FALSE 상수를 사용하여
-   * 대소문자 불일치나 예상치 못한 값이 전달되는 것을 방지한다.
-   *
-   * @param isPrivate 로비 비공개 여부
-   * @return "true" (비공개) 또는 "false" (공개)
-   */
-  private String normalizeIsPrivate(boolean isPrivate) {
-    return isPrivate ? IS_PRIVATE_TRUE : IS_PRIVATE_FALSE;
-  }
-
-  /**
-   * 퇴장 처리 결과에 따라 ready Set을 정리한다.
-   *
-   * [필요 이유]
-   * 참여자가 로비를 나가면 더 이상 준비 상태에 포함되면 안 된다.
-   * 로비가 폭파된 경우에는 ready Set 전체를 삭제한다.
-   *
-   * [주의]
-   * leave_lobby.lua의 원자 처리 이후 보조 정리로 수행한다.
-   * ready 정리 실패가 퇴장 자체를 실패로 되돌리면 안 되므로 예외는 로그만 남긴다.
-   */
   private void cleanupReadyStatusAfterLeave(
           String code,
           String userId,
@@ -800,13 +588,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  /**
-   * 강퇴 성공 후 강퇴 대상의 ready 상태를 제거한다.
-   *
-   * [필요 이유]
-   * 강퇴된 유저가 lobby:{code}:ready Set에 남아 있으면
-   * 이후 canStart 계산이나 준비 상태 표시가 왜곡될 수 있다.
-   */
   private void cleanupReadyStatusAfterKick(
           String code,
           String targetUserIdentifier,
@@ -831,19 +612,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  /**
-   * 게임 시작 직전에 stale ready 데이터를 정리한다.
-   *
-   * 정리 대상 : ready Set에는 존재하지만 participants Set에는 없는 userIdentifier
-   *
-   * [정책]
-   * participants Set을 현재 로비 참여자의 source of truth로 사용한다.
-   * ready Set 잔여 데이터는 게임 시작 조건에 영향을 주면 안 되므로 start_lobby.lua 실행 전에 제거한다.
-   *
-   * [주의]
-   * participants에 남아 있지만 ready가 아닌 유저는 실제 미준비 유저일 수 있으므로
-   * 여기서 자동 제거하지 않는다.
-   */
   private void cleanupStaleReadyParticipantsBeforeStart(
           String code,
           String requesterIdentifier
@@ -920,18 +688,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  /**
-   * Redis에서 문자열을 직접 읽어 DTO에 넣으면 MapCategory의 @JsonValue가 적용되지 않으므로,
-   * 응답 생성 시점에 명시적으로 표시 값을 변환한다.
-   *
-   * [정책]
-   * - null 또는 blank는 맵 미선택 상태로 보고 null로 반환한다.
-   * - 정상 값은 MapCategory의 단일 정규화 규칙을 사용한다.
-   * - 알 수 없는 값은 데이터 손상을 숨기지 않기 위해 원본 값을 반환하고 경고 로그를 남긴다.
-   *
-   * @param rawCategory Redis Hash에서 읽은 원본 카테고리 값
-   * @return FE 응답에 사용할 카테고리 표시 값
-   */
   private String toDisplayMapCategory(String rawCategory) {
     try {
       return MapCategory.toDisplayValue(rawCategory);
@@ -941,25 +697,6 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     }
   }
 
-  /**
-   * Redis Hash의 필수 양수 정수 필드를 파싱한다.
-   *
-   * [사용 목적]
-   * max_players처럼 로비 입장 검증에 반드시 필요한 필드는
-   * 누락되거나 잘못된 값일 때 기본값으로 폴백하면 안 된다.
-   *
-   * [실패 처리]
-   * - null
-   * - 숫자 파싱 실패
-   * - 0 이하
-   *
-   * 위 경우는 Redis 로비 데이터 손상으로 보고 500을 반환한다.
-   *
-   * @param value      Redis Hash에서 조회한 원시값
-   * @param fieldName  Redis Hash 필드명
-   * @param inviteCode 로비 초대 코드
-   * @return 파싱된 양수 정수
-   */
   private int parseRequiredPositiveInt(Object value, String fieldName, String inviteCode) {
     if (value == null) {
       log.error("Redis 로비 필수 필드 누락 - inviteCode: {}, field: {}",

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyInviteCodeGenerator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyInviteCodeGenerator.java
@@ -1,0 +1,47 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
+
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+/**
+ * 로비 초대 코드 생성을 담당하는 컴포넌트
+ *
+ * [정책]
+ * - 초대 코드 길이와 문자셋은 기존 LobbyDefaults 계약을 그대로 사용한다.
+ * - 코드 생성 알고리즘만 이동하며, Redis key 구조나 Lua script 계약은 변경하지 않는다.
+ * - Random 대신 SecureRandom을 사용하여 코드 예측 가능성을 낮춘다.
+ */
+@Component
+public class LobbyInviteCodeGenerator {
+
+    /**
+     * 초대 코드 생성용 보안 난수 생성기
+     *
+     * [SecureRandom 사용 이유]
+     * 일반 Random은 예측 가능성이 상대적으로 높다.
+     * 초대 코드는 공개/비공개 로비 입장 경로로 사용되므로,
+     * 비공개 로비 코드 추측 가능성을 낮추기 위해 SecureRandom을 유지한다.
+     */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    /**
+     * LobbyDefaults 상수 기반으로 초대 코드를 생성한다.
+     *
+     * @return LobbyDefaults.INVITE_CODE_LENGTH 길이의 초대 코드
+     */
+    public String generate() {
+        StringBuilder code = new StringBuilder(LobbyDefaults.INVITE_CODE_LENGTH);
+
+        for (int i = 0; i < LobbyDefaults.INVITE_CODE_LENGTH; i++) {
+            int randomIndex = SECURE_RANDOM.nextInt(
+                    LobbyDefaults.INVITE_CODE_CHARACTERS.length()
+            );
+
+            code.append(LobbyDefaults.INVITE_CODE_CHARACTERS.charAt(randomIndex));
+        }
+
+        return code.toString();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaResultMapper.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaResultMapper.java
@@ -1,0 +1,328 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
+
+import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.StartLobbyLuaResultCode;
+import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 로비 Lua script 반환 문자열을 도메인 결과 타입으로 변환하는 Mapper
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LobbyLuaResultMapper {
+
+    // =========================================================
+    // leave_lobby.lua 반환값 상수
+    // =========================================================
+
+    private static final String RESULT_DESTROYED = "DESTROYED";
+    private static final String RESULT_LEFT = "LEFT";
+    private static final String RESULT_DELEGATED_PREFIX = "DELEGATED:";
+
+    // =========================================================
+    // kick_lobby.lua 반환값 상수
+    // =========================================================
+
+    private static final String RESULT_KICKED_PREFIX = "KICKED:";
+    private static final String RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
+    private static final String RESULT_HOST_NOT_FOUND = "HOST_NOT_FOUND";
+    private static final String RESULT_FORBIDDEN = "FORBIDDEN";
+    private static final String RESULT_CANNOT_KICK_SELF = "CANNOT_KICK_SELF";
+    private static final String RESULT_TARGET_NOT_PARTICIPANT = "TARGET_NOT_PARTICIPANT";
+
+    /**
+     * 운영 확인이 필요한 Redis 정합성 문제 로그 식별자
+     */
+    private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * leave_lobby.lua 반환 문자열을 LeaveLobbyResult로 변환한다.
+     *
+     * @param result Lua 반환 문자열
+     * @param code 로비 초대 코드
+     * @param userId 퇴장 요청 사용자 식별자
+     * @return 도메인 퇴장 결과
+     */
+    public LeaveLobbyResult toLeaveLobbyResult(String result, String code, String userId) {
+        if (result == null) {
+            return new LeaveLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
+        }
+
+        if (RESULT_DESTROYED.equals(result)) {
+            return new LeaveLobbyResult.Destroyed(code);
+        }
+
+        if (RESULT_LEFT.equals(result)) {
+            return new LeaveLobbyResult.Left(code, userId);
+        }
+
+        if (result.startsWith(RESULT_DELEGATED_PREFIX)) {
+            String newHostId = result.substring(RESULT_DELEGATED_PREFIX.length());
+            return new LeaveLobbyResult.Delegated(code, newHostId);
+        }
+
+        return new LeaveLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+    }
+
+    /**
+     * kick_lobby.lua 반환 문자열을 KickLobbyResult로 변환한다.
+     *
+     * @param result Lua 반환 문자열
+     * @param code 로비 초대 코드
+     * @param requesterIdentifier 강퇴 요청자 식별자
+     * @param targetUserIdentifier 강퇴 대상 식별자
+     * @return 도메인 강퇴 결과
+     */
+    public KickLobbyResult toKickLobbyResult(
+            String result,
+            String code,
+            String requesterIdentifier,
+            String targetUserIdentifier
+    ) {
+        if (result == null) {
+            return new KickLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
+        }
+
+        if (result.startsWith(RESULT_KICKED_PREFIX)) {
+            String targetWsSessionId = result.substring(RESULT_KICKED_PREFIX.length());
+
+            return new KickLobbyResult.Kicked(
+                    code,
+                    targetUserIdentifier,
+                    targetWsSessionId
+            );
+        }
+
+        if (RESULT_LOBBY_NOT_FOUND.equals(result)) {
+            return new KickLobbyResult.LobbyNotFound(code);
+        }
+
+        if (RESULT_HOST_NOT_FOUND.equals(result)) {
+            return new KickLobbyResult.HostNotFound(code);
+        }
+
+        if (RESULT_FORBIDDEN.equals(result)) {
+            return new KickLobbyResult.Forbidden(code, requesterIdentifier);
+        }
+
+        if (RESULT_CANNOT_KICK_SELF.equals(result)) {
+            return new KickLobbyResult.CannotKickSelf(code, requesterIdentifier);
+        }
+
+        if (RESULT_TARGET_NOT_PARTICIPANT.equals(result)) {
+            return new KickLobbyResult.TargetNotParticipant(code, targetUserIdentifier);
+        }
+
+        return new KickLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+    }
+
+    /**
+     * start_lobby.lua 반환 문자열을 StartLobbyResult로 변환한다.
+     *
+     * [주의]
+     * start 결과는 단순 매핑 외에 ready/participants 정합성 진단 로그와 metric 증가가 필요하다.
+     * 기존 LobbyRepositoryImpl에 있던 관측성 동작을 유지하기 위해 이 Mapper에서 동일하게 처리한다.
+     *
+     * @param result Lua 반환 문자열
+     * @param code 로비 초대 코드
+     * @param requesterIdentifier 게임 시작 요청자 식별자
+     * @return 도메인 게임 시작 결과
+     */
+    public StartLobbyResult toStartLobbyResult(
+            String result,
+            String code,
+            String requesterIdentifier
+    ) {
+        if (result == null) {
+            incrementMetric(RedisKeys.METRIC_START_LOBBY_UNKNOWN_RESULT);
+
+            log.error(
+                    "{} start_lobby.lua null 반환값 - lobbyCode: {}, requesterIdentifier: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    requesterIdentifier
+            );
+
+            return new StartLobbyResult.Error("Lua 스크립트 반환값이 null입니다.");
+        }
+
+        if (StartLobbyLuaResultCode.isNotReadyResult(result)) {
+            String notReadyUserIdentifier =
+                    StartLobbyLuaResultCode.extractNotReadyUserIdentifier(result);
+
+            logReadyConsistencyFailure(
+                    code,
+                    requesterIdentifier,
+                    notReadyUserIdentifier
+            );
+
+            return new StartLobbyResult.NotReady(code, notReadyUserIdentifier);
+        }
+
+        if (StartLobbyLuaResultCode.isStaleParticipantResult(result)) {
+            String staleParticipantUserIdentifier =
+                    StartLobbyLuaResultCode.extractStaleParticipantUserIdentifier(result);
+
+            logReadyConsistencyFailure(
+                    code,
+                    requesterIdentifier,
+                    staleParticipantUserIdentifier
+            );
+
+            log.error(
+                    "{} 게임 시작 실패 - stale participant 감지. lobbyCode: {}, requester: {}, staleParticipant: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    requesterIdentifier,
+                    staleParticipantUserIdentifier
+            );
+
+            incrementMetric(RedisKeys.METRIC_LOBBY_READY_CONSISTENCY_FAILURE);
+
+            return new StartLobbyResult.StaleParticipant(code, staleParticipantUserIdentifier);
+        }
+
+        return StartLobbyLuaResultCode.fromExactValue(result)
+                .map(resultCode -> toExactStartLobbyResult(resultCode, code, requesterIdentifier))
+                .orElseGet(() -> {
+                    incrementMetric(RedisKeys.METRIC_START_LOBBY_UNKNOWN_RESULT);
+
+                    log.error(
+                            "{} start_lobby.lua 알 수 없는 반환값 - lobbyCode: {}, requesterIdentifier: {}, result: {}",
+                            LOG_MONITORING_REQUIRED,
+                            code,
+                            requesterIdentifier,
+                            result
+                    );
+
+                    return new StartLobbyResult.Error("알 수 없는 Lua 반환값: " + result);
+                });
+    }
+
+    /**
+     * start_lobby.lua exact 반환 코드를 StartLobbyResult로 변환한다.
+     *
+     * NOT_READY_PREFIX, STALE_PARTICIPANT_PREFIX는 동적 prefix 결과이므로
+     * 이 메서드의 exact 매핑 대상이 아니다.
+     */
+    private StartLobbyResult toExactStartLobbyResult(
+            StartLobbyLuaResultCode resultCode,
+            String code,
+            String requesterIdentifier
+    ) {
+        return switch (resultCode) {
+            case STARTED -> new StartLobbyResult.Started(code);
+            case LOBBY_NOT_FOUND -> new StartLobbyResult.LobbyNotFound(code);
+            case HOST_NOT_FOUND -> new StartLobbyResult.HostNotFound(code);
+            case FORBIDDEN -> new StartLobbyResult.Forbidden(code, requesterIdentifier);
+            case LOBBY_NOT_WAITING -> new StartLobbyResult.LobbyNotWaiting(code);
+            case MAP_NOT_SELECTED -> new StartLobbyResult.MapNotSelected(code);
+            case NO_PLAYER -> new StartLobbyResult.NoPlayer(code);
+            case NOT_READY_PREFIX -> new StartLobbyResult.Error(
+                    "NOT_READY_PREFIX는 동적 prefix 결과이므로 exact 매핑 대상이 아닙니다."
+            );
+            case STALE_PARTICIPANT_PREFIX -> new StartLobbyResult.Error(
+                    "STALE_PARTICIPANT_PREFIX는 동적 prefix 결과이므로 exact 매핑 대상이 아닙니다."
+            );
+        };
+    }
+
+    /**
+     * start_lobby.lua가 NOT_READY 또는 STALE_PARTICIPANT를 반환했을 때
+     * ready/participants 정합성 진단 로그를 남긴다.
+     *
+     * [목적]
+     * 단순히 "준비 안 됨"으로만 남기면 실제 미준비 유저인지,
+     * 퇴장/강퇴 후 participants Set에 남은 stale 유저인지 추적하기 어렵다.
+     */
+    private void logReadyConsistencyFailure(
+            String code,
+            String requesterIdentifier,
+            String notReadyUserIdentifier
+    ) {
+        String participantsKey = RedisKeys.lobbyParticipantsKey(code);
+        String readyKey = RedisKeys.lobbyReadyKey(code);
+        String lobbyUserSessionKey = RedisKeys.lobbyUserSessionKey(code, notReadyUserIdentifier);
+
+        try {
+            Long participantCount = redisTemplate.opsForSet().size(participantsKey);
+            Long readyCount = redisTemplate.opsForSet().size(readyKey);
+
+            Boolean isParticipant = redisTemplate.opsForSet()
+                    .isMember(participantsKey, notReadyUserIdentifier);
+
+            Boolean isReady = redisTemplate.opsForSet()
+                    .isMember(readyKey, notReadyUserIdentifier);
+
+            boolean hasActiveLobbySession = Boolean.TRUE.equals(
+                    redisTemplate.hasKey(lobbyUserSessionKey)
+            );
+
+            Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
+            Set<String> readyParticipants = redisTemplate.opsForSet().members(readyKey);
+
+            Set<String> staleReadyParticipants = new HashSet<>(
+                    readyParticipants != null ? readyParticipants : Set.of()
+            );
+            staleReadyParticipants.removeAll(participants != null ? participants : Set.of());
+
+            incrementMetric(RedisKeys.METRIC_LOBBY_READY_CONSISTENCY_FAILURE);
+
+            log.warn(
+                    "{} 게임 시작 실패 READY 정합성 진단 - lobbyCode: {}, requester: {}, "
+                            + "notReadyUserIdentifier: {}, participantCount: {}, readyCount: {}, "
+                            + "isParticipant: {}, isReady: {}, hasActiveLobbySession: {}, "
+                            + "staleReadyCount: {}, staleReadyParticipants: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    requesterIdentifier,
+                    notReadyUserIdentifier,
+                    participantCount,
+                    readyCount,
+                    isParticipant,
+                    isReady,
+                    hasActiveLobbySession,
+                    staleReadyParticipants.size(),
+                    staleReadyParticipants
+            );
+
+        } catch (Exception e) {
+            log.error(
+                    "{} 게임 시작 실패 READY 정합성 진단 로그 생성 실패 - lobbyCode: {}, requester: {}, "
+                            + "notReadyUserIdentifier: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    requesterIdentifier,
+                    notReadyUserIdentifier,
+                    e
+            );
+        }
+    }
+
+    /**
+     * Redis metric counter를 증가시킨다.
+     *
+     * [정책]
+     * metric 증가 실패가 실제 로비 흐름을 실패시키면 안 된다.
+     * 따라서 실패 시 warn 로그만 남기고 흐름은 유지한다.
+     */
+    private void incrementMetric(String metricKey) {
+        try {
+            redisTemplate.opsForValue().increment(metricKey);
+        } catch (Exception e) {
+            log.warn("로비 Lua 결과 metric 증가 실패 - metricKey: {}", metricKey, e);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -1,0 +1,236 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
+
+import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 로비 관련 Redis Lua script 실행을 담당하는 컴포넌트
+ */
+@Slf4j
+@Component
+public class LobbyLuaScriptExecutor {
+
+    /**
+     * Lua 스크립트에 선택 값이 없음을 표현하기 위한 값
+     * Redis Hash에 "null" 문자열이 저장되는 것을 방지하기 위해 빈 문자열을 사용한다.
+     */
+    private static final String EMPTY_REDIS_VALUE = "";
+
+    /** Lua 스크립트에 전달할 비공개 로비 isPrivate 값 */
+    private static final String IS_PRIVATE_TRUE = "true";
+
+    /** Lua 스크립트에 전달할 공개 로비 isPrivate 값 */
+    private static final String IS_PRIVATE_FALSE = "false";
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisScript<String> leaveLobbyScript;
+    private final RedisScript<String> createLobbyScript;
+    private final RedisScript<String> kickLobbyScript;
+    private final RedisScript<String> startLobbyScript;
+
+    public LobbyLuaScriptExecutor(
+            StringRedisTemplate redisTemplate,
+            @Qualifier("leaveLobbyScript") RedisScript<String> leaveLobbyScript,
+            @Qualifier("createLobbyScript") RedisScript<String> createLobbyScript,
+            @Qualifier("kickLobbyScript") RedisScript<String> kickLobbyScript,
+            @Qualifier("startLobbyScript") RedisScript<String> startLobbyScript
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.leaveLobbyScript = leaveLobbyScript;
+        this.createLobbyScript = createLobbyScript;
+        this.kickLobbyScript = kickLobbyScript;
+        this.startLobbyScript = startLobbyScript;
+    }
+
+    /**
+     * create_lobby.lua를 실행하여 SETNX + 로비 데이터 저장을 원자적으로 수행한다.
+     *
+     * [KEYS 계약]
+     * KEYS[1] = lobby:{code}:lock
+     * KEYS[2] = lobby:{code}
+     * KEYS[3] = lobby:public
+     *
+     * [ARGV 계약]
+     * ARGV[1]  = host userIdentifier
+     * ARGV[2]  = lock ttl milliseconds
+     * ARGV[3]  = inviteCode
+     * ARGV[4]  = title
+     * ARGV[5]  = maxPlayers
+     * ARGV[6]  = isPrivate ("true" | "false")
+     * ARGV[7]  = status
+     * ARGV[8]  = mapId or ""
+     * ARGV[9]  = mapTitle or ""
+     * ARGV[10] = mapCategory or ""
+     *
+     * @return "OK" | "LOCK_FAILED" | null
+     */
+    public String executeCreateLobby(
+            String inviteCode,
+            CreateLobbyRequest request,
+            String userIdentifier,
+            LobbyMapMetadata mapMetadata
+    ) {
+        List<String> keys = List.of(
+                RedisKeys.lobbyCodeLockKey(inviteCode),
+                RedisKeys.lobbyKey(inviteCode),
+                RedisKeys.LOBBY_PUBLIC
+        );
+
+        String lockTtlMs = String.valueOf(LobbyDefaults.INVITE_CODE_LOCK_TTL.toMillis());
+        String isPrivateValue = normalizeIsPrivate(request.isPrivate());
+
+        return redisTemplate.execute(
+                createLobbyScript,
+                keys,
+                userIdentifier,
+                lockTtlMs,
+                inviteCode,
+                request.title(),
+                String.valueOf(request.maxPlayers()),
+                isPrivateValue,
+                LobbyStatus.WAITING.name(),
+
+                // 맵 미선택 시 빈 문자열을 전달하여 Redis에 "null" 문자열이 저장되지 않게 합니다.
+                mapMetadata != null ? String.valueOf(mapMetadata.mapId()) : EMPTY_REDIS_VALUE,
+                mapMetadata != null ? mapMetadata.mapTitle() : EMPTY_REDIS_VALUE,
+                mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE
+        );
+    }
+
+    /**
+     * leave_lobby.lua를 실행한다.
+     *
+     * [KEYS 계약]
+     * KEYS[1] = lobby:{code}
+     * KEYS[2] = lobby:{code}:participants
+     * KEYS[3] = lobby:{code}:order
+     * KEYS[4] = lobby:{code}:kicked
+     * KEYS[5] = lobby:public
+     *
+     * [ARGV 계약]
+     * ARGV[1] = userIdentifier
+     * ARGV[2] = lobbyCode
+     *
+     * @return leave_lobby.lua 반환 문자열
+     */
+    public String executeLeaveLobby(String code, String userIdentifier) {
+        List<String> keys = List.of(
+                RedisKeys.lobbyKey(code),
+                RedisKeys.lobbyParticipantsKey(code),
+                RedisKeys.lobbyOrderKey(code),
+                RedisKeys.lobbyKickedKey(code),
+                RedisKeys.LOBBY_PUBLIC
+        );
+
+        return redisTemplate.execute(
+                leaveLobbyScript,
+                keys,
+                userIdentifier,
+                code
+        );
+    }
+
+    /**
+     * kick_lobby.lua를 실행한다.
+     *
+     * [KEYS 계약]
+     * KEYS[1] = lobby:{code}
+     * KEYS[2] = lobby:{code}:participants
+     * KEYS[3] = lobby:{code}:order
+     * KEYS[4] = lobby:{code}:kicked
+     * KEYS[5] = lobby:{code}:user_session:{targetUserIdentifier}
+     * KEYS[6] = lobby:{code}:user_session_seq:{targetUserIdentifier}
+     *
+     * [ARGV 계약]
+     * ARGV[1] = requesterIdentifier
+     * ARGV[2] = targetUserIdentifier
+     *
+     * @return kick_lobby.lua 반환 문자열
+     */
+    public String executeKickLobby(
+            String code,
+            String requesterIdentifier,
+            String targetUserIdentifier
+    ) {
+        List<String> keys = List.of(
+                RedisKeys.lobbyKey(code),
+                RedisKeys.lobbyParticipantsKey(code),
+                RedisKeys.lobbyOrderKey(code),
+                RedisKeys.lobbyKickedKey(code),
+                RedisKeys.lobbyUserSessionKey(code, targetUserIdentifier),
+                RedisKeys.lobbyUserSessionSequenceKey(code, targetUserIdentifier)
+        );
+
+        return redisTemplate.execute(
+                kickLobbyScript,
+                keys,
+                requesterIdentifier,
+                targetUserIdentifier
+        );
+    }
+
+    /**
+     * start_lobby.lua를 실행한다.
+     *
+     * [KEYS 계약]
+     * KEYS[1] = lobby:{code}
+     * KEYS[2] = lobby:{code}:participants
+     * KEYS[3] = lobby:{code}:ready
+     * KEYS[4] = lobby:public
+     *
+     * [ARGV 계약]
+     * ARGV[1] = requesterIdentifier
+     * ARGV[2] = lobbyCode
+     * ARGV[3] = host field name
+     * ARGV[4] = status field name
+     * ARGV[5] = mapId field name
+     * ARGV[6] = WAITING status
+     * ARGV[7] = PLAYING status
+     *
+     * @return start_lobby.lua 반환 문자열
+     */
+    public String executeStartLobby(
+            String code,
+            String requesterIdentifier
+    ) {
+        List<String> keys = List.of(
+                RedisKeys.lobbyKey(code),
+                RedisKeys.lobbyParticipantsKey(code),
+                RedisKeys.lobbyReadyKey(code),
+                RedisKeys.LOBBY_PUBLIC
+        );
+
+        return redisTemplate.execute(
+                startLobbyScript,
+                keys,
+                requesterIdentifier,
+                code,
+                RedisKeys.FIELD_HOST_USER_ID,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_MAP_ID,
+                LobbyStatus.WAITING.name(),
+                LobbyStatus.PLAYING.name()
+        );
+    }
+
+    /**
+     * isPrivate 값을 Lua 스크립트와 일치하는 소문자 문자열로 정규화한다.
+     *
+     * [정규화 이유]
+     * create_lobby.lua는 isPrivate 값을 문자열 "false"와 비교하여 공개 로비 여부를 판단한다.
+     * Boolean.toString()에 직접 의존하지 않고 상수로 고정하여 Lua 계약을 명확히 유지한다.
+     */
+    private String normalizeIsPrivate(boolean isPrivate) {
+        return isPrivate ? IS_PRIVATE_TRUE : IS_PRIVATE_FALSE;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
@@ -1,0 +1,394 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
+
+import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 로비 Redis command 전용 Repository
+ *
+ * [담당 범위]
+ * - ready 상태 변경
+ * - Redis 로비 데이터 보상 삭제
+ * - 게임 시작 실패 시 Redis 상태 보상 롤백
+ * - 퇴장/강퇴 후 ready Set 정리
+ * - 게임 시작 전 stale ready 데이터 정리
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class LobbyRedisCommandRepository {
+
+    /**
+     * 운영 확인이 필요한 Redis 정리 실패 로그 식별자
+     */
+    private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
+
+    /** Redis Hash에 저장되는 공개 로비 is_private 값 */
+    private static final String IS_PRIVATE_FALSE = "false";
+
+    /** Redis Hash에 저장되는 비공개 로비 is_private 값 */
+    private static final String IS_PRIVATE_TRUE = "true";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 로비 참여자의 ready 상태를 변경한다.
+     *
+     * [정책]
+     * - ready=true  → lobby:{code}:ready Set에 사용자 추가
+     * - ready=false → lobby:{code}:ready Set에서 사용자 제거
+     *
+     * @param code 로비 초대 코드
+     * @param userIdentifier 사용자 식별자
+     * @param ready 변경할 ready 상태
+     */
+    public void updateReadyStatus(String code, String userIdentifier, boolean ready) {
+        String readyKey = RedisKeys.lobbyReadyKey(code);
+
+        if (ready) {
+            redisTemplate.opsForSet().add(readyKey, userIdentifier);
+            return;
+        }
+
+        redisTemplate.opsForSet().remove(readyKey, userIdentifier);
+    }
+
+    /**
+     * DB Insert 실패 시 Redis에 저장된 로비 데이터를 보상 삭제한다.
+     *
+     * [삭제 대상]
+     * - lobby:{code}
+     * - lobby:{code}:participants
+     * - lobby:{code}:order
+     * - lobby:{code}:kicked
+     * - lobby:{code}:ready
+     * - lobby:{code}:lock
+     * - lobby:public Set의 code
+     *
+     * [삭제 실패 처리]
+     * 보상 삭제 실패 시 ERROR 로그를 남기고 false를 반환한다.
+     * 서비스 레이어에서 반환값을 확인하여 추가 알림 처리가 가능하다.
+     *
+     * @param inviteCode 삭제할 로비 초대 코드
+     * @return 보상 삭제 성공 여부
+     */
+    public boolean deleteFromRedis(String inviteCode) {
+        List<String> keysToDelete = List.of(
+                RedisKeys.lobbyKey(inviteCode),
+                RedisKeys.lobbyParticipantsKey(inviteCode),
+                RedisKeys.lobbyOrderKey(inviteCode),
+                RedisKeys.lobbyKickedKey(inviteCode),
+                RedisKeys.lobbyReadyKey(inviteCode),
+                RedisKeys.lobbyCodeLockKey(inviteCode)
+        );
+
+        try {
+            redisTemplate.delete(keysToDelete);
+            redisTemplate.opsForSet().remove(RedisKeys.LOBBY_PUBLIC, inviteCode);
+
+            log.info("Redis 보상 삭제 완료 - code: {}, keys: {}", inviteCode, keysToDelete);
+            return true;
+
+        } catch (Exception e) {
+            log.error(
+                    "{} Redis 보상 삭제 실패 - code: {}, keys: {}, publicLobbyKey: {}. "
+                            + "로비 잔여 데이터가 조회/ready/canStart 계산에 영향을 줄 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
+                    LOG_MONITORING_REQUIRED,
+                    inviteCode,
+                    keysToDelete,
+                    RedisKeys.LOBBY_PUBLIC,
+                    e
+            );
+            return false;
+        }
+    }
+
+    /**
+     * Redis 로비 상태를 WAITING으로 보상 롤백한다.
+     *
+     * [필요 이유]
+     * 게임 시작 Lua가 성공하면 Redis 로비 상태는 PLAYING으로 바뀌고, 공개 로비 목록(lobby:public)에서도 제거된다.
+     * 이후 DB GAME_LOBBY 상태 변경이 실패하면 Redis는 PLAYING, DB는 WAITING인
+     * 불일치 상태가 될 수 있으므로 가능한 범위에서 Redis 상태를 되돌린다.
+     *
+     * [보상 범위]
+     * - lobby:{code}.status = WAITING
+     * - 확실히 공개 로비인 경우 lobby:public에 code 재등록
+     *
+     * [보안 정책]
+     * is_private 값이 null/blank/unknown이면 public 복구를 하지 않는다.
+     * 확실히 public일 때만 공개 로비 Set에 복구해야 private 로비 노출 위험을 줄일 수 있다.
+     *
+     * @param code 로비 초대 코드
+     * @return Redis 보상 롤백 성공 여부
+     */
+    public boolean rollbackStartedLobbyStatus(String code) {
+        String lobbyKey = RedisKeys.lobbyKey(code);
+
+        try {
+            Map<Object, Object> lobbyData = redisTemplate.opsForHash().entries(lobbyKey);
+
+            if (lobbyData.isEmpty()) {
+                log.error(
+                        "{} 게임 시작 Redis 보상 롤백 실패 - 로비 데이터 없음. code: {}, lobbyKey: {}",
+                        LOG_MONITORING_REQUIRED,
+                        code,
+                        lobbyKey
+                );
+                return false;
+            }
+
+            redisTemplate.opsForHash().put(
+                    lobbyKey,
+                    RedisKeys.FIELD_STATUS,
+                    LobbyStatus.WAITING.name()
+            );
+
+            String rawIsPrivate = (String) lobbyData.get(RedisKeys.FIELD_IS_PRIVATE);
+            boolean restoredPublic = restorePublicLobbyIfClearlyPublic(
+                    code,
+                    lobbyKey,
+                    rawIsPrivate
+            );
+
+            log.warn(
+                    "게임 시작 Redis 보상 롤백 완료 - code: {}, status: {}, restoredPublic: {}, rawIsPrivate: {}",
+                    code,
+                    LobbyStatus.WAITING.name(),
+                    restoredPublic,
+                    rawIsPrivate
+            );
+
+            return true;
+
+        } catch (Exception e) {
+            log.error(
+                    "{} 게임 시작 Redis 보상 롤백 실패 - code: {}, lobbyKey: {}. "
+                            + "Redis는 PLAYING인데 DB는 WAITING일 수 있으므로 재처리 큐 확인이 필요합니다.",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    lobbyKey,
+                    e
+            );
+            return false;
+        }
+    }
+
+    /**
+     * 확실히 공개 로비인 경우에만 lobby:public Set에 복구한다.
+     */
+    private boolean restorePublicLobbyIfClearlyPublic(
+            String code,
+            String lobbyKey,
+            String rawIsPrivate
+    ) {
+        if (rawIsPrivate == null || rawIsPrivate.isBlank()) {
+            log.error(
+                    "{} 게임 시작 Redis 보상 롤백 중 is_private 필드 누락 - public 복구 생략. "
+                            + "code: {}, lobbyKey: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    lobbyKey
+            );
+            return false;
+        }
+
+        if (IS_PRIVATE_FALSE.equals(rawIsPrivate)) {
+            redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, code);
+            return true;
+        }
+
+        if (!IS_PRIVATE_TRUE.equals(rawIsPrivate)) {
+            log.error(
+                    "{} 게임 시작 Redis 보상 롤백 중 알 수 없는 is_private 값 - public 복구 생략. "
+                            + "code: {}, lobbyKey: {}, rawIsPrivate: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    lobbyKey,
+                    rawIsPrivate
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * 퇴장 처리 결과에 따라 ready Set을 정리한다.
+     *
+     * [필요 이유]
+     * 참여자가 로비를 나가면 더 이상 준비 상태에 포함되면 안 된다.
+     * 로비가 폭파된 경우에는 ready Set 전체를 삭제한다.
+     *
+     * [주의]
+     * leave_lobby.lua의 원자 처리 이후 보조 정리로 수행한다.
+     * ready 정리 실패가 퇴장 자체를 실패로 되돌리면 안 되므로 예외는 로그만 남긴다.
+     *
+     * @param code 로비 초대 코드
+     * @param userId 퇴장 사용자 식별자
+     * @param leaveResult 퇴장 Lua 처리 결과
+     */
+    public void cleanupReadyStatusAfterLeave(
+            String code,
+            String userId,
+            LeaveLobbyResult leaveResult
+    ) {
+        String readyKey = RedisKeys.lobbyReadyKey(code);
+
+        try {
+            if (leaveResult instanceof LeaveLobbyResult.Destroyed) {
+                redisTemplate.delete(readyKey);
+                return;
+            }
+
+            if (leaveResult instanceof LeaveLobbyResult.Left
+                    || leaveResult instanceof LeaveLobbyResult.Delegated) {
+                redisTemplate.opsForSet().remove(readyKey, userId);
+            }
+        } catch (Exception e) {
+            log.error(
+                    "{} 퇴장 후 ready 상태 정리 실패 - lobbyCode: {}, userId: {}, readyKey: {}, leaveResult: {}. "
+                            + "ready Set 잔여 데이터가 canStart 계산을 왜곡할 수 있으므로 수동 정리 또는 재처리가 필요합니다.",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    userId,
+                    readyKey,
+                    leaveResult.getClass().getSimpleName(),
+                    e
+            );
+        }
+    }
+
+    /**
+     * 강퇴 성공 후 강퇴 대상의 ready 상태를 제거한다.
+     *
+     * [필요 이유]
+     * 강퇴된 유저가 lobby:{code}:ready Set에 남아 있으면
+     * 이후 canStart 계산이나 준비 상태 표시가 왜곡될 수 있다.
+     *
+     * @param code 로비 초대 코드
+     * @param targetUserIdentifier 강퇴 대상 사용자 식별자
+     * @param kickResult 강퇴 Lua 처리 결과
+     */
+    public void cleanupReadyStatusAfterKick(
+            String code,
+            String targetUserIdentifier,
+            KickLobbyResult kickResult
+    ) {
+        if (!(kickResult instanceof KickLobbyResult.Kicked)) {
+            return;
+        }
+
+        try {
+            redisTemplate.opsForSet().remove(
+                    RedisKeys.lobbyReadyKey(code),
+                    targetUserIdentifier
+            );
+        } catch (Exception e) {
+            log.warn(
+                    "강퇴 후 ready 상태 정리 실패 - lobbyCode: {}, targetUserIdentifier: {}",
+                    code,
+                    targetUserIdentifier,
+                    e
+            );
+        }
+    }
+
+    /**
+     * 게임 시작 직전에 stale ready 데이터를 정리한다.
+     *
+     * [정리 대상]
+     * ready Set에는 존재하지만 participants Set에는 없는 userIdentifier
+     *
+     * [정책]
+     * participants Set을 현재 로비 참여자의 source of truth로 사용한다.
+     * ready Set 잔여 데이터는 게임 시작 조건에 영향을 주면 안 되므로
+     * start_lobby.lua 실행 전에 제거한다.
+     *
+     * [주의]
+     * participants에 남아 있지만 ready가 아닌 유저는 실제 미준비 유저일 수 있으므로 여기서 자동 제거하지 않는다.
+     *
+     * @param code 로비 초대 코드
+     * @param requesterIdentifier 게임 시작 요청자 식별자
+     */
+    public void cleanupStaleReadyParticipantsBeforeStart(
+            String code,
+            String requesterIdentifier
+    ) {
+        String participantsKey = RedisKeys.lobbyParticipantsKey(code);
+        String readyKey = RedisKeys.lobbyReadyKey(code);
+
+        try {
+            Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
+            Set<String> readyParticipants = redisTemplate.opsForSet().members(readyKey);
+
+            if (readyParticipants == null || readyParticipants.isEmpty()) {
+                return;
+            }
+
+            Set<String> participantSet = participants != null ? participants : Set.of();
+
+            Set<String> staleReadyParticipants = new HashSet<>(readyParticipants);
+            staleReadyParticipants.removeAll(participantSet);
+
+            if (staleReadyParticipants.isEmpty()) {
+                return;
+            }
+
+            redisTemplate.opsForSet().remove(
+                    readyKey,
+                    staleReadyParticipants.toArray()
+            );
+
+            incrementMetric(RedisKeys.METRIC_LOBBY_READY_STALE_CLEANUP);
+
+            log.warn(
+                    "{} 게임 시작 전 stale ready 데이터 정리 - lobbyCode: {}, requester: {}, "
+                            + "participantsKey: {}, readyKey: {}, staleReadyParticipants: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    requesterIdentifier,
+                    participantsKey,
+                    readyKey,
+                    staleReadyParticipants
+            );
+
+        } catch (Exception e) {
+            log.error(
+                    "{} 게임 시작 전 ready 정합성 스캔 실패 - lobbyCode: {}, requester: {}, "
+                            + "participantsKey: {}, readyKey: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    requesterIdentifier,
+                    participantsKey,
+                    readyKey,
+                    e
+            );
+        }
+    }
+
+    /**
+     * Redis metric counter를 증가시킨다.
+     *
+     * [정책]
+     * metric 증가 실패가 실제 로비 흐름을 실패시키면 안 된다.
+     * 따라서 실패 시 warn 로그만 남기고 흐름은 유지한다.
+     */
+    private void incrementMetric(String metricKey) {
+        try {
+            redisTemplate.opsForValue().increment(metricKey);
+        } catch (Exception e) {
+            log.warn("로비 Redis command metric 증가 실패 - metricKey: {}", metricKey, e);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -1,0 +1,359 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
+
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 로비 Redis 조회 전용 Repository
+ *
+ * [담당 범위]
+ * - 로비 존재 여부 조회
+ * - 로비 참여자 여부 조회
+ * - 입장 순서 기반 참여자 목록 조회
+ * - ready 참여자 목록 조회
+ * - 공개 로비 목록 조회
+ * - 초대 코드 기반 로비 기본 정보 조회
+ * - 현재 참여 인원 수 조회
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class LobbyRedisQueryRepository {
+
+    /**
+     * 로비가 존재하지 않거나 TTL이 만료된 경우 반환할 빈 Optional
+     * 매번 새 객체를 생성하지 않기 위해 상수로 관리한다.
+     */
+    private static final Optional<JoinLobbyResponse> EMPTY_LOBBY = Optional.empty();
+
+    private static final String ERROR_INVALID_LOBBY_DATA =
+            "로비 정보가 유효하지 않습니다.";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 해당 코드의 로비가 Redis에 존재하는지 확인한다.
+     *
+     * @param code 로비 초대 코드
+     * @return 로비 Redis Hash 존재 여부
+     */
+    public boolean existsByCode(String code) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(RedisKeys.lobbyKey(code)));
+    }
+
+    /**
+     * 해당 유저가 로비 참여자인지 확인한다.
+     *
+     * @param code 로비 초대 코드
+     * @param userId 사용자 식별자
+     * @return participants Set 포함 여부
+     */
+    public boolean isParticipant(String code, String userId) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForSet().isMember(RedisKeys.lobbyParticipantsKey(code), userId)
+        );
+    }
+
+    /**
+     * 로비 참여자 목록을 입장 순서 기준으로 조회한다.
+     *
+     * [조회 전략]
+     * - lobby:{code}:order List를 우선 사용하여 FE 표시 순서를 안정적으로 유지한자.
+     * - participants Set을 함께 조회하여 이미 퇴장했지만 order에 남은 값은 제거한다.
+     * - order List에는 없지만 participants Set에는 존재하는 비정상 데이터는 응답 누락 방지를 위해 뒤에 보정한다.
+     *
+     * @param code 로비 초대 코드
+     * @return 현재 로비에 참여 중인 userIdentifier 목록
+     */
+    public List<String> getParticipantIdentifiers(String code) {
+        Set<String> participantSet = redisTemplate.opsForSet()
+                .members(RedisKeys.lobbyParticipantsKey(code));
+
+        if (participantSet == null || participantSet.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<String> orderedParticipants = redisTemplate.opsForList()
+                .range(RedisKeys.lobbyOrderKey(code), 0, -1);
+
+        if (orderedParticipants == null || orderedParticipants.isEmpty()) {
+            return new ArrayList<>(participantSet);
+        }
+
+        List<String> result = new ArrayList<>();
+
+        for (String userIdentifier : orderedParticipants) {
+            if (participantSet.contains(userIdentifier)) {
+                result.add(userIdentifier);
+            }
+        }
+
+        /*
+         * Redis 장애, 과거 데이터, Lua 계약 변경 상황에서도 상세 응답이 누락되지 않도록
+         * participants Set에만 존재하는 사용자를 뒤에 추가한다.
+         */
+        for (String userIdentifier : participantSet) {
+            if (!result.contains(userIdentifier)) {
+                result.add(userIdentifier);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * ready 상태인 참여자 식별자 목록을 조회한다.
+     *
+     * [반환 정책]
+     * Redis Set 조회 결과가 null이면 빈 Set으로 반환하여
+     * 서비스 레이어에서 null 방어 로직을 반복하지 않도록 한다.
+     *
+     * @param code 로비 초대 코드
+     * @return ready 상태인 userIdentifier Set
+     */
+    public Set<String> getReadyParticipantIdentifiers(String code) {
+        Set<String> readyParticipants = redisTemplate.opsForSet()
+                .members(RedisKeys.lobbyReadyKey(code));
+
+        if (readyParticipants == null || readyParticipants.isEmpty()) {
+            return Set.of();
+        }
+
+        return readyParticipants;
+    }
+
+    /**
+     * Redis에서 공개 로비 목록을 조회한다.
+     *
+     * [조회 기준]
+     * lobby:public Set에 들어 있는 초대 코드를 기준으로 lobby:{code} Hash를 조회한다.
+     *
+     * [주의]
+     * lobby:public에는 남아 있지만 lobby:{code} Hash가 TTL 만료 등으로 사라진 경우는 응답에서 제외한다.
+     *
+     * @return 공개 로비 목록
+     */
+    public List<LobbyRedisDto> getPublicLobbies() {
+        Set<String> publicLobbyCodes =
+                redisTemplate.opsForSet().members(RedisKeys.LOBBY_PUBLIC);
+
+        if (publicLobbyCodes == null || publicLobbyCodes.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<LobbyRedisDto> result = new ArrayList<>();
+
+        for (String code : publicLobbyCodes) {
+            Map<Object, Object> data =
+                    redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(code));
+
+            if (data.isEmpty()) {
+                continue;
+            }
+
+            result.add(LobbyRedisDto.builder()
+                    .code((String) data.get(RedisKeys.FIELD_CODE))
+                    .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
+                    .title((String) data.get(RedisKeys.FIELD_TITLE))
+                    .status((String) data.get(RedisKeys.FIELD_STATUS))
+                    .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
+                    .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
+                    .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
+                    .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
+                    .currentPlayers(getCurrentPlayerCount(code))
+                    .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
+                    .build());
+        }
+
+        return result;
+    }
+
+    /**
+     * 초대 코드로 로비 입장에 필요한 정보를 조회한다.
+     *
+     * [조회 전략]
+     * HGETALL로 lobby:{code} Hash를 한 번에 읽어 응답 객체를 구성한다.
+     * currentPlayers는 participants Set의 SCARD로 별도 조회한다.
+     *
+     * [반환 정책]
+     * 로비가 존재하지 않으면 Optional.empty()를 반환한다.
+     * 서비스 레이어에서 empty 여부로 404를 처리하므로, Repository는 존재 여부 판단만 수행한다.
+     *
+     * @param inviteCode 로비 초대 코드
+     * @return 로비 정보 Optional
+     */
+    public Optional<JoinLobbyResponse> findByInviteCode(String inviteCode) {
+        Map<Object, Object> data =
+                redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(inviteCode));
+
+        if (data.isEmpty()) {
+            return EMPTY_LOBBY;
+        }
+
+        int currentPlayers = getCurrentPlayerCount(inviteCode);
+
+        int maxPlayers = parseRequiredPositiveInt(
+                data.get(RedisKeys.FIELD_MAX_PLAYERS),
+                RedisKeys.FIELD_MAX_PLAYERS,
+                inviteCode
+        );
+
+        return Optional.of(JoinLobbyResponse.builder()
+                .inviteCode(inviteCode)
+                .title((String) data.get(RedisKeys.FIELD_TITLE))
+                .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
+                .maxPlayers(maxPlayers)
+                .currentPlayers(currentPlayers)
+                .status((String) data.get(RedisKeys.FIELD_STATUS))
+                .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
+                .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
+                .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
+                .build());
+    }
+
+    /**
+     * 해당 로비의 현재 참여 인원 수를 반환한다.
+     *
+     * [구현 방식]
+     * lobby:{code}:participants Set의 SCARD 명령으로 조회한다.
+     * null 반환 시 Redis 연결 이상일 수 있으므로 0으로 폴백하여 NPE를 방지한다.
+     *
+     * @param inviteCode 로비 초대 코드
+     * @return 현재 참여 인원 수
+     */
+    public int getCurrentPlayerCount(String inviteCode) {
+        Long count = redisTemplate.opsForSet()
+                .size(RedisKeys.lobbyParticipantsKey(inviteCode));
+
+        return count != null ? count.intValue() : 0;
+    }
+
+    private Long parseNullableLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return Long.parseLong((String) value);
+        } catch (NumberFormatException e) {
+            log.warn("Redis Hash 필드 Long 파싱 실패 - 값: {}", value);
+            return null;
+        }
+    }
+
+    private Integer parseNullableInt(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return Integer.parseInt((String) value);
+        } catch (NumberFormatException e) {
+            log.warn("Redis Hash 필드 Integer 파싱 실패 - 값: {}", value);
+            return null;
+        }
+    }
+
+    /**
+     * Redis에서 문자열을 직접 읽어 DTO에 넣으면 MapCategory의 @JsonValue가 적용되지 않으므로,
+     * 응답 생성 시점에 명시적으로 표시 값을 변환한다.
+     *
+     * [정책]
+     * - null 또는 blank는 맵 미선택 상태로 보고 null로 반환한다.
+     * - 정상 값은 MapCategory의 단일 정규화 규칙을 사용한다.
+     * - 알 수 없는 값은 데이터 손상을 숨기지 않기 위해 원본 값을 반환하고 경고 로그를 남긴다.
+     *
+     * @param rawCategory Redis Hash에서 읽은 원본 카테고리 값
+     * @return FE 응답에 사용할 카테고리 표시 값
+     */
+    private String toDisplayMapCategory(String rawCategory) {
+        try {
+            return MapCategory.toDisplayValue(rawCategory);
+        } catch (IllegalArgumentException e) {
+            log.warn("알 수 없는 맵 카테고리 값 - rawCategory: {}", rawCategory);
+            return rawCategory;
+        }
+    }
+
+    /**
+     * Redis Hash의 필수 양수 정수 필드를 파싱한다.
+     *
+     * [사용 목적]
+     * max_players처럼 로비 입장 검증에 반드시 필요한 필드는
+     * 누락되거나 잘못된 값일 때 기본값으로 폴백하면 안 된다.
+     *
+     * [실패 처리]
+     * - null
+     * - 숫자 파싱 실패
+     * - 0 이하
+     *
+     * 위 경우는 Redis 로비 데이터 손상으로 보고 500을 반환한다.
+     *
+     * @param value Redis Hash에서 조회한 원시값
+     * @param fieldName Redis Hash 필드명
+     * @param inviteCode 로비 초대 코드
+     * @return 파싱된 양수 정수
+     */
+    private int parseRequiredPositiveInt(Object value, String fieldName, String inviteCode) {
+        if (value == null) {
+            log.error(
+                    "Redis 로비 필수 필드 누락 - inviteCode: {}, field: {}",
+                    inviteCode,
+                    fieldName
+            );
+
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    ERROR_INVALID_LOBBY_DATA
+            );
+        }
+
+        try {
+            int parsed = Integer.parseInt((String) value);
+
+            if (parsed <= 0) {
+                log.error(
+                        "Redis 로비 필수 필드 값이 유효하지 않음 - inviteCode: {}, field: {}, value: {}",
+                        inviteCode,
+                        fieldName,
+                        value
+                );
+
+                throw new ResponseStatusException(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        ERROR_INVALID_LOBBY_DATA
+                );
+            }
+
+            return parsed;
+
+        } catch (NumberFormatException e) {
+            log.error(
+                    "Redis 로비 필수 필드 숫자 파싱 실패 - inviteCode: {}, field: {}, value: {}",
+                    inviteCode,
+                    fieldName,
+                    value,
+                    e
+            );
+
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    ERROR_INVALID_LOBBY_DATA
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyStartReconciliationRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyStartReconciliationRepository.java
@@ -1,0 +1,146 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 로비 게임 시작 Redis-DB 불일치 재처리 queue 전용 Repository
+ *
+ * [사용 목적]
+ * start_lobby.lua 실행 이후 Redis는 PLAYING으로 변경되었지만,
+ * DB GAME_LOBBY 상태 변경 또는 Redis 보상 롤백이 실패할 수 있다.
+ *
+ * 이 경우 운영자가 수동 확인할 수 있도록 로그를 남기고,
+ * 후속 reconciliation worker가 처리할 수 있도록 Redis queue에 payload를 적재한다.
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class LobbyStartReconciliationRepository {
+
+    /**
+     * Redis queue payload 구분자
+     * payload = code|reason|retryCount|timestamp
+     */
+    private static final String RECONCILIATION_PAYLOAD_DELIMITER = "|";
+
+    /**
+     * 운영 확인이 필요한 Redis 정합성 문제 로그 식별자
+     */
+    private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
+
+    /**
+     * 신규 reconciliation payload의 초기 재시도 횟수
+     */
+    private static final String INITIAL_RETRY_COUNT = "0";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * Redis-DB 상태 불일치 재처리 요청을 Redis queue에 적재한다.
+     *
+     * [payload 형식]
+     * code|reason|retryCount|timestamp
+     *
+     * [실패 처리]
+     * queue 적재 실패는 상태 불일치가 남을 수 있는 운영 이슈이므로 ERROR 로그를 남긴다.
+     * 단, 이 메서드 자체는 예외를 다시 던지지 않는다.
+     * 기존 LobbyRepositoryImpl 동작과 동일하게 호출 흐름을 유지한다.
+     *
+     * @param code 로비 초대 코드
+     * @param reason 재처리 사유
+     */
+    public void enqueueStartReconciliation(String code, String reason) {
+        String payload = String.join(
+                RECONCILIATION_PAYLOAD_DELIMITER,
+                code,
+                reason,
+                INITIAL_RETRY_COUNT,
+                String.valueOf(System.currentTimeMillis())
+        );
+
+        try {
+            redisTemplate.opsForList().rightPush(
+                    RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
+                    payload
+            );
+
+            incrementStartReconciliationMetric(
+                    RedisKeys.METRIC_LOBBY_START_RECONCILIATION_ENQUEUED
+            );
+
+            log.error(
+                    "{} 게임 시작 상태 재처리 큐 적재 완료 - code: {}, reason: {}, queueKey: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    reason,
+                    RedisKeys.LOBBY_START_RECONCILIATION_QUEUE
+            );
+        } catch (Exception e) {
+            incrementStartReconciliationMetric(
+                    RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED
+            );
+
+            log.error(
+                    "{} 게임 시작 상태 재처리 큐 적재 실패 - code: {}, reason: {}, queueKey: {}. "
+                            + "Redis-DB 불일치 수동 확인이 필요합니다.",
+                    LOG_MONITORING_REQUIRED,
+                    code,
+                    reason,
+                    RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
+                    e
+            );
+        }
+    }
+
+    /**
+     * Redis-DB 상태 불일치 재처리 queue에서 payload를 하나 꺼낸다.
+     *
+     * [주의]
+     * leftPop은 queue가 비어 있으면 null을 반환한다.
+     * 호출자는 null 여부를 확인해야 한다.
+     *
+     * @return "code|reason|retryCount|timestamp" 형태의 payload. 없으면 null.
+     */
+    public String pollStartReconciliation() {
+        return redisTemplate.opsForList().leftPop(
+                RedisKeys.LOBBY_START_RECONCILIATION_QUEUE
+        );
+    }
+
+    /**
+     * 재처리에 실패한 payload를 queue 뒤쪽에 다시 적재한다.
+     *
+     * [정책]
+     * retryCount 증가나 dead-letter 분리는 향후 reconciliation worker 단계에서 처리한다.
+     * 이번 리팩토링 단계에서는 기존 payload를 그대로 다시 넣는 동작을 유지한다.
+     *
+     * @param payload 재처리 payload
+     */
+    public void requeueStartReconciliation(String payload) {
+        redisTemplate.opsForList().rightPush(
+                RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
+                payload
+        );
+    }
+
+    /**
+     * 게임 시작 상태 재처리 관련 Redis metric counter를 증가시킨다.
+     *
+     * [정책]
+     * metric 증가 실패가 실제 로비 흐름을 실패시키면 안 된다.
+     * 따라서 실패 시 warn 로그만 남기고 흐름은 유지한다.
+     *
+     * @param metricKey Redis metric key
+     */
+    public void incrementStartReconciliationMetric(String metricKey) {
+        try {
+            redisTemplate.opsForValue().increment(metricKey);
+        } catch (Exception e) {
+            log.warn("게임 시작 상태 재처리 metric 증가 실패 - metricKey: {}", metricKey, e);
+        }
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #80

## 📝 Summary

- `LobbyRepositoryImpl`에 집중되어 있던 Redis 접근 책임을 역할별 컴포넌트로 분리했습니다.
- 초대 코드 생성 로직을 `LobbyInviteCodeGenerator`로 분리했습니다.
- Redis Lua script 실행 로직을 `LobbyLuaScriptExecutor`로 분리했습니다.
- Lua 반환값 문자열 파싱 로직을 `LobbyLuaResultMapper`로 분리했습니다.
- 공개 로비 목록/상세 조회 등 Redis 조회 로직을 `LobbyRedisQueryRepository`로 분리했습니다.
- ready 상태 변경, Redis 보상 삭제, ready 정리 등 Redis command 로직을 `LobbyRedisCommandRepository`로 분리했습니다.
- 게임 시작 Redis-DB 불일치 재처리 queue 로직을 `LobbyStartReconciliationRepository`로 분리했습니다.
- 기존 `LobbyRepository` 인터페이스 계약은 유지하고, `LobbyRepositoryImpl`은 하위 컴포넌트에 위임하는 Facade 역할로 정리했습니다.

## 🙏PR point

- 기능 추가가 아닌 구조 개선 리팩토링입니다.
- 기존 Redis key 구조와 Lua script의 `KEYS` / `ARGV` 순서는 변경하지 않았습니다.
- 기존 `LobbyRepository` 인터페이스 계약을 유지했기 때문에 서비스 계층 변경은 없습니다.
- 로비 생성, 입장, ready, start, kick 플로우가 기존과 동일하게 동작하는지 확인이 필요합니다.
- 특히 `LobbyLuaScriptExecutor`는 Lua script 실행 순서 계약을 그대로 보존하는 것이 핵심입니다.

## 📬 Reference

- 기존 `LobbyRepositoryImpl` 내부 책임을 역할별 Redis 컴포넌트로 분리
- Redis key 구조 및 Lua script 계약 변경 없음