### PR TITLE
[Feat/#64] 로비 목록 조회 필터링 및 정렬 기능 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -498,14 +498,14 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available
   {
     "code": "DEF456",
     "hostId": "b17f7ee0-614f-4f5f-b770-83f6d4b85f4a",
-    "title": "맵 미선택 퀴즈방",
-    "mapId": null,
-    "mapTitle": null,
-    "mapCategory": null,
+    "title": "진행 중인 POP 퀴즈방",
+    "mapId": 3,
+    "mapTitle": "POP 히트곡",
+    "mapCategory": "POP",
     "maxPlayers": 6,
-    "currentPlayers": 1,
+    "currentPlayers": 4,
     "isPrivate": false,
-    "status": "WAITING",
+    "status": "PLAYING",
     "createdAtEpochMillis": 1778990000000
   }
 ]
@@ -522,7 +522,7 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available
 | `maxPlayers` | Integer | 최대 참여 인원 |
 | `currentPlayers` | Integer | 현재 참여 인원 |
 | `isPrivate` | Boolean | 비공개 여부. 공개 로비 목록에서는 `false` |
-| `status` | String | 로비 상태. 공개 로비 목록에서는 `WAITING`만 반환 |
+| `status` | String | 로비 상태. 공개 로비 목록에서는 `WAITING`, `PLAYING`만 반환. `WAITING`은 입장 가능, `PLAYING`은 진행 중으로 목록에는 노출되지만 입장은 허용하지 않음 |
 | `createdAtEpochMillis` | Long | 로비 생성 시각. Redis `TIME` 기준 epoch milliseconds |
 
 **Error**

--- a/docs/API.md
+++ b/docs/API.md
@@ -436,10 +436,47 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 GET /api/lobbies
 ```
 
-현재 활성화된 공개(`isPrivate = false`) 로비 목록을 반환합니다.
-Redis에서 직접 필터링하여 고속 반환합니다.
+현재 입장 가능한 공개(`isPrivate = false`) 로비 목록을 반환합니다.  
+Redis의 `lobby:public` Set을 기준으로 공개 로비 원본을 조회한 뒤, 서비스 계층에서 검색/필터/정렬 정책을 적용합니다.
 
 Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때문에, 응답은 Jackson 타입 정보가 포함되지 않은 순수 DTO 배열로 반환됩니다.
+
+**목록 노출 정책**
+
+* 비공개 로비는 목록에 노출되지 않습니다.
+* `WAITING` 상태 로비만 기본 목록에 노출됩니다.
+* `PLAYING`, `FINISHED` 상태 로비는 기본 목록에서 제외됩니다.
+* 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외됩니다.
+* Redis에 잘못된 `mapCategory` 값이 남아 있는 로비는 전체 API 실패 없이 해당 로비만 제외됩니다.
+
+> `PLAYING` 로비는 현재 WebSocket 입장 단계에서 차단되므로, 기본 로비 목록에서는 제외합니다.  
+> 추후 관전 기능이 추가될 경우 별도 상태 필터 정책으로 확장할 수 있습니다.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+| --- | --- | --- | --- | --- |
+| `keyword` | String | ❌ | 없음 | 로비 제목 검색어. 앞뒤 공백은 제거되며, 대소문자를 구분하지 않습니다. |
+| `mapCategory` | String | ❌ | 없음 | 맵 카테고리 필터. `K-POP`, `J-POP`, `POP`을 지원합니다. |
+| `sort` | String | ❌ | `latest` | 정렬 기준. `latest`, `most_players`, `most_available`을 지원합니다. |
+
+**정렬 기준**
+
+| 값 | 설명 |
+| --- | --- |
+| `latest` | 최신 생성 로비 순 |
+| `most_players` | 현재 인원이 많은 순. 동률이면 최신순 |
+| `most_available` | 빈자리가 많은 순. 동률이면 최신순 |
+
+**Request 예시**
+
+```http
+GET /api/lobbies
+GET /api/lobbies?keyword=퀴즈
+GET /api/lobbies?mapCategory=K-POP
+GET /api/lobbies?sort=most_players
+GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available
+```
 
 **Response `200 OK`**
 
@@ -455,7 +492,8 @@ Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때�
     "maxPlayers": 8,
     "currentPlayers": 3,
     "isPrivate": false,
-    "status": "WAITING"
+    "status": "WAITING",
+    "createdAtEpochMillis": 1778990123456
   },
   {
     "code": "DEF456",
@@ -467,24 +505,31 @@ Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때�
     "maxPlayers": 6,
     "currentPlayers": 1,
     "isPrivate": false,
-    "status": "WAITING"
+    "status": "WAITING",
+    "createdAtEpochMillis": 1778990000000
   }
 ]
 ```
 
-| 필드               | 타입      | 설명                                                 |
-| ---------------- | ------- | -------------------------------------------------- |
-| `code`           | String  | 로비 초대 코드                                           |
-| `hostId`         | String  | 방장 사용자 식별자                                         |
-| `title`          | String  | 로비 제목                                              |
-| `mapId`          | Long    | 선택된 맵 ID (미선택 시 `null`)                            |
-| `mapTitle`       | String  | 선택된 맵 제목 (미선택 시 `null`)                            |
-| `mapCategory`    | String  | 선택된 맵 카테고리 (`K-POP`, `J-POP`, `POP`, 미선택 시 `null`) |
-| `maxPlayers`     | Integer | 최대 참여 인원                                           |
-| `currentPlayers` | Integer | 현재 참여 인원                                           |
-| `isPrivate`      | Boolean | 비공개 여부                                             |
-| `status`         | String  | 로비 상태 (`WAITING`, `PLAYING`, `FINISHED`)           |
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `code` | String | 로비 초대 코드 |
+| `hostId` | String | 방장 사용자 식별자 |
+| `title` | String | 로비 제목 |
+| `mapId` | Long | 선택된 맵 ID. 미선택 시 `null` |
+| `mapTitle` | String | 선택된 맵 제목. 미선택 시 `null` |
+| `mapCategory` | String | 선택된 맵 카테고리. `K-POP`, `J-POP`, `POP`, 미선택 시 `null` |
+| `maxPlayers` | Integer | 최대 참여 인원 |
+| `currentPlayers` | Integer | 현재 참여 인원 |
+| `isPrivate` | Boolean | 비공개 여부. 공개 로비 목록에서는 `false` |
+| `status` | String | 로비 상태. 공개 로비 목록에서는 `WAITING`만 반환 |
+| `createdAtEpochMillis` | Long | 로비 생성 시각. Redis `TIME` 기준 epoch milliseconds |
 
+**Error**
+
+| 상태 코드 | 설명 |
+| --- | --- |
+| `400 Bad Request` | 지원하지 않는 `sort` 값 또는 `mapCategory` 값 |
 ---
 
 #### 로비 상세 조회

--- a/docs/API.md
+++ b/docs/API.md
@@ -443,13 +443,11 @@ Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때�
 
 **목록 노출 정책**
 
-* 비공개 로비는 목록에 노출되지 않습니다.
-* `WAITING` 상태 로비만 기본 목록에 노출됩니다.
-* `PLAYING`, `FINISHED` 상태 로비는 기본 목록에서 제외됩니다.
-* 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외됩니다.
-* Redis에 잘못된 `mapCategory` 값이 남아 있는 로비는 전체 API 실패 없이 해당 로비만 제외됩니다.
-* `maxPlayers` 또는 `currentPlayers` 값이 유효하지 않은 로비는 목록에서 제외됩니다.
-* `currentPlayers > maxPlayers`인 로비는 Redis 손상 데이터로 보고 목록에서 제외됩니다.
+* 공개 로비 목록에는 `WAITING`, `PLAYING` 상태 로비가 노출됩니다.
+* `FINISHED` 상태 로비는 목록에서 제외됩니다.
+* `WAITING` 로비는 입장 가능한 로비입니다.
+* `PLAYING` 로비는 진행 중 상태로 목록에는 노출되지만, 현재 입장은 허용하지 않습니다.
+* 클라이언트는 `status=PLAYING` 로비를 “진행 중” 상태로 표시하고 입장 버튼을 비활성화해야 합니다.
 
 > `PLAYING` 로비는 현재 WebSocket 입장 단계에서 차단되므로, 기본 로비 목록에서는 제외합니다.  
 > 추후 관전 기능이 추가될 경우 별도 상태 필터 정책으로 확장할 수 있습니다.

--- a/docs/API.md
+++ b/docs/API.md
@@ -448,6 +448,8 @@ Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때�
 * `PLAYING`, `FINISHED` 상태 로비는 기본 목록에서 제외됩니다.
 * 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외됩니다.
 * Redis에 잘못된 `mapCategory` 값이 남아 있는 로비는 전체 API 실패 없이 해당 로비만 제외됩니다.
+* `maxPlayers` 또는 `currentPlayers` 값이 유효하지 않은 로비는 목록에서 제외됩니다.
+* `currentPlayers > maxPlayers`인 로비는 Redis 손상 데이터로 보고 목록에서 제외됩니다.
 
 > `PLAYING` 로비는 현재 WebSocket 입장 단계에서 차단되므로, 기본 로비 목록에서는 제외합니다.  
 > 추후 관전 기능이 추가될 경우 별도 상태 필터 정책으로 확장할 수 있습니다.

--- a/docs/API.md
+++ b/docs/API.md
@@ -436,7 +436,7 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 GET /api/lobbies
 ```
 
-현재 입장 가능한 공개(`isPrivate = false`) 로비 목록을 반환합니다.  
+공개(`isPrivate = false`) 로비 중 목록에 노출 가능한 로비를 반환합니다.
 Redis의 `lobby:public` Set을 기준으로 공개 로비 원본을 조회한 뒤, 서비스 계층에서 검색/필터/정렬 정책을 적용합니다.
 
 Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때문에, 응답은 Jackson 타입 정보가 포함되지 않은 순수 DTO 배열로 반환됩니다.
@@ -449,8 +449,8 @@ Redis 직렬화용 JsonMapper와 HTTP 응답용 JsonMapper를 분리했기 때�
 * `PLAYING` 로비는 진행 중 상태로 목록에는 노출되지만, 현재 입장은 허용하지 않습니다.
 * 클라이언트는 `status=PLAYING` 로비를 “진행 중” 상태로 표시하고 입장 버튼을 비활성화해야 합니다.
 
-> `PLAYING` 로비는 현재 WebSocket 입장 단계에서 차단되므로, 기본 로비 목록에서는 제외합니다.  
-> 추후 관전 기능이 추가될 경우 별도 상태 필터 정책으로 확장할 수 있습니다.
+> `PLAYING` 로비는 현재 WebSocket 입장 단계에서 차단됩니다.  
+> 따라서 목록에는 노출되지만, 클라이언트는 `status=PLAYING` 로비를 “진행 중” 상태로 표시하고 입장 버튼을 비활성화해야 합니다.
 
 **Query Parameters**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,8 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   ├── StartLobbyResult.java                   # 게임 시작 처리 결과 (sealed interface)
 │   │   ├── StartLobbyLuaResultCode.java            # start_lobby.lua 반환 문자열 계약 enum
 │   │   ├── controller/
-│   │   │   ├── LobbyController.java                # HTTP REST API (생성, 입장, 목록, 상세, ready, start)
+│   │   │   ├── LobbyCommandController.java         # 로비 생성, 입장 사전 검증, ready, start REST API
+│   │   │   ├── LobbyQueryController.java           # 공개 로비 목록 및 로비 상세 조회 REST API
 │   │   │   └── LobbyEventController.java           # STOMP 로비 이벤트 수신
 │   │   ├── dto/
 │   │   │   ├── CreateLobbyRequest.java             # 로비 생성 요청 DTO
@@ -54,6 +55,8 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   ├── LobbyPlayerResponse.java            # 로비 상세 참여자 응답 DTO
 │   │   │   ├── LobbyMapMetadata.java               # Redis 저장용 로비 맵 메타데이터 DTO
 │   │   │   ├── LobbyRedisDto.java                  # 공개 로비 목록 조회 응답 DTO
+│   │   │   ├── LobbySearchCondition.java           # 공개 로비 목록 검색/필터/정렬 조건 DTO
+│   │   │   ├── LobbySortType.java                  # 공개 로비 목록 정렬 기준 enum
 │   │   │   └── UpdateLobbyReadyRequest.java        # ready 상태 변경 요청 DTO
 │   │   ├── entity/
 │   │   │   ├── GameLobby.java                      # GAME_LOBBY 테이블 엔티티
@@ -62,10 +65,21 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   ├── repository/
 │   │   │   ├── GameLobbyJpaRepository.java         # GAME_LOBBY JPA 리포지토리
 │   │   │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
-│   │   │   └── LobbyRepositoryImpl.java            # Redis 기반 구현체 (Lua 스크립트 활용)
+│   │   │   ├── LobbyRepositoryImpl.java            # 로비 Repository Facade
+│   │   │   └── redis/
+│   │   │       ├── LobbyLuaScriptExecutor.java     # 로비 Lua 스크립트 실행 컴포넌트
+│   │   │       ├── LobbyLuaResultMapper.java       # Lua 반환 문자열 → 도메인 결과 매핑
+│   │   │       ├── LobbyRedisCommandRepository.java # Redis 로비 명령 처리
+│   │   │       ├── LobbyRedisQueryRepository.java  # Redis 로비 조회 처리
+│   │   │       └── LobbyStartReconciliationRepository.java # start 상태 불일치 재처리 큐 접근
 │   │   └── service/
-│   │       ├── LobbyEventService.java              # 로비 이벤트 처리 및 STOMP 브로드캐스트
-│   │       ├── LobbyService.java                   # 로비 생성/입장/상세/ready/start 비즈니스 로직
+│   │       ├── LobbyCanStartPolicy.java            # 조회 시점 canStart 계산 정책
+│   │       ├── LobbyCreateService.java             # 로비 생성 유스케이스
+│   │       ├── LobbyJoinService.java               # 초대 코드 기반 입장 사전 검증 유스케이스
+│   │       ├── LobbyQueryService.java              # 로비 목록/상세 조회 유스케이스
+│   │       ├── LobbyReadyService.java              # ready 상태 변경 유스케이스
+│   │       ├── LobbyStartService.java              # 게임 시작 유스케이스
+│   │       ├── LobbyRealtimeNotifier.java          # 로비 refresh/STOMP 브로드캐스트
 │   │       └── LobbyStartReconciliationService.java # 게임 시작 Redis-DB 상태 불일치 재처리 스케줄러
 │   │
 │   ├── map/                                        # 퀴즈 맵 도메인
@@ -170,6 +184,98 @@ LobbyRepositoryImpl
 ```
 
 이 구조를 통해 맵 도메인의 영속성 모델 변경이 Redis 저장 계층으로 직접 전파되는 것을 방지합니다.
+
+---
+
+## 📋 공개 로비 목록 조회 정책
+
+공개 로비 목록 조회는 `GET /api/lobbies`에서 처리합니다.  
+이 API는 FE 로비 목록 화면에서 사용자가 입장 가능한 공개 로비를 빠르게 찾기 위한 조회 API입니다.
+
+```text
+Client
+    │ GET /api/lobbies?keyword=&mapCategory=&sort=
+    ▼
+LobbyQueryController
+    │ 요청 파라미터 수집
+    │ - keyword
+    │ - mapCategory
+    │ - sort
+    ▼
+LobbySearchCondition
+    │ 요청 조건 정규화
+    │ - keyword trim + lower-case
+    │ - mapCategory MapCategory.from()으로 검증
+    │ - sort LobbySortType으로 검증
+    ▼
+LobbyQueryService
+    │ 로비 목록 노출 정책 적용
+    │ - WAITING 상태만 노출
+    │ - keyword 제목 검색
+    │ - mapCategory 필터링
+    │ - latest / most_players / most_available 정렬
+    │ - Redis 손상 mapCategory 로비 제외
+    ▼
+LobbyRepository
+    ▼
+LobbyRedisQueryRepository
+    │ Redis lobby:public Set 기준 원본 공개 로비 조회
+    ▼
+Redis
+```
+
+### 책임 분리
+
+| 계층 | 책임 |
+| --- | --- |
+| `LobbyQueryController` | HTTP 요청 파라미터 수집 |
+| `LobbySearchCondition` | 요청값 정규화 및 검증 |
+| `LobbyQueryService` | 로비 목록 노출 정책, 검색, 필터링, 정렬 |
+| `LobbyRedisQueryRepository` | Redis 원본 공개 로비 데이터 조회 |
+
+### 노출 정책
+
+* Redis `lobby:public` Set을 기준으로 공개 로비 원본 목록을 조회합니다.
+* 서비스 계층에서 `WAITING` 상태 로비만 노출합니다.
+* `PLAYING`, `FINISHED` 로비는 기본 목록에서 제외합니다.
+* 비공개 로비는 `lobby:public` Set에 들어가지 않으므로 목록에 노출되지 않습니다.
+* 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외합니다.
+* Redis에 잘못된 `mapCategory` 값이 들어 있어도 전체 API를 실패시키지 않고 해당 로비만 제외합니다.
+
+### 정렬 정책
+
+| 정렬 기준 | 설명 |
+| --- | --- |
+| `latest` | `createdAtEpochMillis` 내림차순 |
+| `most_players` | `currentPlayers` 내림차순, 동률이면 최신순 |
+| `most_available` | `maxPlayers - currentPlayers` 내림차순, 동률이면 최신순 |
+
+`latest` 정렬은 Redis `Set`의 순서에 의존하지 않습니다.  
+`lobby:public`은 Redis Set이므로 삽입 순서가 보장되지 않습니다. 따라서 로비 생성 시 Redis Hash에 `created_at_epoch_millis`를 저장하고, 이 값을 기준으로 최신순 정렬을 수행합니다.
+
+### 생성 시각 기준
+
+로비 생성 시각은 Java 애플리케이션 서버 시간이 아니라 Redis `TIME` 명령을 기준으로 생성합니다.
+
+```lua
+local redisTime = redis.call('TIME')
+local createdAtEpochMillis = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
+```
+
+멀티 인스턴스 운영 환경에서는 애플리케이션 서버 간 시간 편차가 발생할 수 있습니다.  
+따라서 Redis 서버 기준 단일 시간원을 사용해 최신순 정렬 기준을 일관되게 유지합니다.
+
+### Redis Hash 필드
+
+`lobby:{code}` Hash에는 공개 로비 목록 조회 및 정렬을 위해 다음 필드가 포함됩니다.
+
+| 필드 | 설명 |
+| --- | --- |
+| `created_at_epoch_millis` | Redis `TIME` 기준 로비 생성 시각. epoch milliseconds |
+| `map_category` | 선택된 맵 카테고리. `K-POP`, `J-POP`, `POP` |
+| `status` | 로비 상태. 목록에서는 `WAITING`만 노출 |
+| `is_private` | 비공개 여부. 공개 로비 목록은 `false`만 노출 |
+| `max_players` | 최대 참여 인원 |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -241,6 +241,8 @@ Redis
 * 비공개 로비는 `lobby:public` Set에 들어가지 않으므로 목록에 노출되지 않습니다.
 * 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외합니다.
 * Redis에 잘못된 `mapCategory` 값이 들어 있어도 전체 API를 실패시키지 않고 해당 로비만 제외합니다.
+* `maxPlayers` 또는 `currentPlayers` 값이 유효하지 않은 로비는 목록에서 제외됩니다.
+* `currentPlayers > maxPlayers`인 로비는 Redis 손상 데이터로 보고 목록에서 제외됩니다.
 
 ### 정렬 정책
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -235,14 +235,11 @@ Redis
 
 ### 노출 정책
 
-* Redis `lobby:public` Set을 기준으로 공개 로비 원본 목록을 조회합니다.
-* 서비스 계층에서 `WAITING` 상태 로비만 노출합니다.
-* `PLAYING`, `FINISHED` 로비는 기본 목록에서 제외합니다.
-* 비공개 로비는 `lobby:public` Set에 들어가지 않으므로 목록에 노출되지 않습니다.
-* 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외합니다.
-* Redis에 잘못된 `mapCategory` 값이 들어 있어도 전체 API를 실패시키지 않고 해당 로비만 제외합니다.
-* `maxPlayers` 또는 `currentPlayers` 값이 유효하지 않은 로비는 목록에서 제외됩니다.
-* `currentPlayers > maxPlayers`인 로비는 Redis 손상 데이터로 보고 목록에서 제외됩니다.
+* 공개 로비 목록에는 `WAITING`, `PLAYING` 상태 로비가 노출됩니다.
+* `FINISHED` 상태 로비는 목록에서 제외됩니다.
+* `WAITING` 로비는 입장 가능한 로비입니다.
+* `PLAYING` 로비는 진행 중 상태로 목록에는 노출되지만, 현재 입장은 허용하지 않습니다.
+* 클라이언트는 `status=PLAYING` 로비를 “진행 중” 상태로 표시하고 입장 버튼을 비활성화해야 합니다.
 
 ### 정렬 정책
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryController.java
@@ -4,14 +4,20 @@
  * [책임]
  * - 공개 로비 목록 조회
  * - 로비 대기실 상세 조회
+ *
+ * [주의]
+ * Controller는 HTTP 요청 파라미터를 수집하고, 요청 조건 객체로 변환한 뒤 Service에 위임하는 역할만 담당한다.
+ * 검색/필터/정렬 같은 비즈니스 정책은 Service 계층에서 처리한다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.controller;
 
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyQueryService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +27,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -37,7 +44,7 @@ public class LobbyQueryController {
     // =========================================================
 
     private static final String LOG_GET_PUBLIC_LOBBIES_REQUEST =
-            "요청 수신: 공개 로비 목록 조회 [GET /api/lobbies]";
+            "요청 수신: 공개 로비 목록 조회 [GET /api/lobbies] - keyword: {}, mapCategory: {}, sort: {}";
     private static final String LOG_GET_PUBLIC_LOBBIES_RESPONSE =
             "조회 완료: 공개 로비 {}개 반환";
     private static final String LOG_GET_LOBBY_DETAIL_REQUEST =
@@ -87,19 +94,54 @@ public class LobbyQueryController {
     /**
      * 공개 로비 목록 조회 API
      *
-     * Redis에서 직접 필터링하여 공개 로비만 반환한다.
+     * [현재 지원 조건]
+     * - keyword : 로비 제목 검색어
+     * - mapCategory : 선택된 맵 카테코리 필터
+     * - sort : 정렬 기준
      *
-     * @return 현재 활성화된 공개 로비 목록
+     * [기본 정책]
+     * - keyword가 없으면 제목 검색을 적용하지 않는다.
+     * - mapCategory가 없으면 카테고리 필터를 적용하지 않는다.
+     * - sort가 없으면 latest를 기본 정렬로 사용한다.
+     *
+     * [책임 경계]
+     * Controller는 요청 파라미터를 LobbySearchCondition으로 변환하는 역할만 한다.
+     * 실제 공개 로비 보장, WAITING 상태 필터, 검색, 정렬 정책은 LobbyQueryService에서 처리한다.
+     *
+     * @param keyword     로비 제목 검색어
+     * @param mapCategory 맵 카테고리 필터 값. 예: K-POP, J-POP, POP
+     * @param sort        정렬 기준. 예: latest, most_players, most_available
+     * @return 조건에 맞는 공개 로비 목록
      */
     @Operation(
             summary = "공개 로비 목록 조회",
-            description = "Redis에서 공개 상태인 로비만 필터링하여 반환합니다."
+            description = """
+                    공개 로비 목록을 조회합니다.
+                    keyword로 로비 제목을 검색할 수 있고,
+                    mapCategory로 선택된 맵 카테고리를 필터링할 수 있으며,
+                    sort로 정렬 기준을 지정할 수 있습니다.
+                    """
     )
     @GetMapping
-    public ResponseEntity<List<LobbyRedisDto>> getPublicLobbies() {
-        log.info(LOG_GET_PUBLIC_LOBBIES_REQUEST);
+    public ResponseEntity<List<LobbyRedisDto>> getPublicLobbies(
+            @Parameter(description = "로비 제목 검색어")
+            @RequestParam(required = false) String keyword,
 
-        List<LobbyRedisDto> publicLobbies = lobbyQueryService.getPublicLobbies();
+            @Parameter(description = "맵 카테고리 필터 값. 예: K-POP, J-POP, POP")
+            @RequestParam(required = false) String mapCategory,
+
+            @Parameter(description = "정렬 기준. latest, most_players, most_available")
+            @RequestParam(required = false) String sort
+    ) {
+        log.info(LOG_GET_PUBLIC_LOBBIES_REQUEST, keyword, mapCategory, sort);
+
+        LobbySearchCondition condition = LobbySearchCondition.of(
+                keyword,
+                mapCategory,
+                sort
+        );
+
+        List<LobbyRedisDto> publicLobbies = lobbyQueryService.getPublicLobbies(condition);
 
         log.info(LOG_GET_PUBLIC_LOBBIES_RESPONSE, publicLobbies.size());
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
@@ -1,5 +1,5 @@
 /*
- * Redis에 저장된 로비 정보를 클라이언트에 반환하기 위한 DTO.
+ * Redis에 저장된 로비 정보를 클라이언트에 반환하기 위한 DTO
  * Redis Hash 구조의 데이터를 Java 객체로 매핑한다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.dto;
@@ -27,4 +27,17 @@ public class LobbyRedisDto {
     private Integer currentPlayers; // 현재 참여 인원 수
     private Boolean isPrivate;    // 공개(false) / 비공개(true) 여부
     private String status;        // 로비 상태 (WAITING, PLAYING)
+
+    /*
+     * 로비 생성 시각
+     *
+     * [정렬 목적]
+     * Redis의 Set 자료구조는 삽입 순서를 보장하지 않는다.
+     * 따라서 최신순 정렬을 위해 로비 생성 시점의 epoch millis 값을 Hash에 저장하고,
+     * 목적 응답 DTO에도 함께 매핑한다.
+     *
+     * [기존 데이터 호환]
+     * 해당 필드 도입 전 생성된 로비에는 값이 없을 수 있으므로 null을 허용한다.
+     */
+    private Long createdAtEpochMillis;
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbySearchCondition.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbySearchCondition.java
@@ -4,6 +4,8 @@ import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Locale;
+
 /**
  * 공개 로비 목록 조회 조건
  *
@@ -38,7 +40,14 @@ public record LobbySearchCondition(
             return null;
         }
 
-        return keyword.trim();
+        /*
+         * 제목 검색은 대소문자를 구분하지 않는다.
+         *
+         * 검색어는 요청당 한 번만 생성되는 조건 값이므로,
+         * Service에서 로비마다 반복해서 lower-case 변환하지 않도록
+         * 조건 객체 생성 시점에 미리 정규화한다.
+         */
+        return keyword.trim().toLowerCase(Locale.ROOT);
     }
 
     private static MapCategory parseMapCategory(String rawCategory) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbySearchCondition.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbySearchCondition.java
@@ -1,0 +1,67 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 공개 로비 목록 조회 조건
+ *
+ * [책임]
+ * - 요청 파라미터 정규화
+ * - 잘못된 필터/정렬 값 차단
+ * - 서비스 계층에 검증된 검색 조건 전달
+ */
+public record LobbySearchCondition(
+        String keyword,
+        MapCategory mapCategory,
+        LobbySortType sortType
+) {
+
+    private static final String ERROR_INVALID_CATEGORY =
+            "지원하지 않는 맵 카테고리입니다.";
+
+    public static LobbySearchCondition of(
+            String keyword,
+            String mapCategory,
+            String sort
+    ) {
+        return new LobbySearchCondition(
+                normalizeKeyword(keyword),
+                parseMapCategory(mapCategory),
+                LobbySortType.from(sort)
+        );
+    }
+
+    private static String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+
+        return keyword.trim();
+    }
+
+    private static MapCategory parseMapCategory(String rawCategory) {
+        if (rawCategory == null || rawCategory.isBlank()) {
+            return null;
+        }
+
+        try {
+            return MapCategory.from(rawCategory);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    ERROR_INVALID_CATEGORY,
+                    e
+            );
+        }
+    }
+
+    public boolean hasKeyword() {
+        return keyword != null && !keyword.isBlank();
+    }
+
+    public boolean hasMapCategory() {
+        return mapCategory != null;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbySortType.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbySortType.java
@@ -1,0 +1,66 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/**
+ * 공개 로비 목록 정렬 기준
+ *
+ * [요청 값]
+ * - latest
+ * - most_players
+ * - most_available
+ *
+ * [정책]
+ * 문자열 파라미터를 서비스까지 그대로 전달하지 않고,
+ * enum으로 정규화하여 정렬 정책을 명확하게 제한한다.
+ */
+public enum LobbySortType {
+
+    LATEST("latest"),
+    MOST_PLAYERS("most_players"),
+    MOST_AVAILABLE("most_available");
+
+    private static final String ERROR_INVALID_SORT_FORMAT =
+            "지원하지 않는 로비 정렬 기준입니다. 사용 가능한 값: %s";
+
+    private final String requestValue;
+
+    LobbySortType(String requestValue) {
+        this.requestValue = requestValue;
+    }
+
+    public String requestValue() {
+        return requestValue;
+    }
+
+    public static LobbySortType from(String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return LATEST;
+        }
+
+        String normalized = normalize(rawValue);
+
+        return Arrays.stream(values())
+                .filter(sortType -> sortType.requestValue.equals(normalized))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        ERROR_INVALID_SORT_FORMAT.formatted(allowedValues())
+                ));
+    }
+
+    private static String normalize(String rawValue) {
+        return rawValue.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String allowedValues() {
+        return Arrays.stream(values())
+                .map(LobbySortType::requestValue)
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -12,7 +12,6 @@ import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.time.Instant;
 
 /**
  * 로비 관련 Redis Lua script 실행을 담당하는 컴포넌트
@@ -72,8 +71,7 @@ public class LobbyLuaScriptExecutor {
      * ARGV[8]  = mapId or ""
      * ARGV[9]  = mapTitle or ""
      * ARGV[10] = mapCategory or ""
-     * ARGV[11] = createdAtEpochMillis
-     * *
+     *
      * @return "OK" | "LOCK_FAILED" | null
      */
     public String executeCreateLobby(
@@ -105,14 +103,7 @@ public class LobbyLuaScriptExecutor {
                 // 맵 미선택 시 빈 문자열을 전달하여 Redis에 "null" 문자열이 저장되지 않게 한다.
                 mapMetadata != null ? String.valueOf(mapMetadata.mapId()) : EMPTY_REDIS_VALUE,
                 mapMetadata != null ? mapMetadata.mapTitle() : EMPTY_REDIS_VALUE,
-                mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE,
-
-                /*
-                 * Redis의 lobby:public Set은 순서를 보장하지 않는다.
-                 * 따라서 공개 로비 목록의 latest 정렬을 안정적으로 처리하기 위해
-                 * 로비 생성 시각을 epoch millis 문자열로 Hash에 함께 저장한다.
-                 */
-                String.valueOf(Instant.now().toEpochMilli())
+                mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -186,7 +186,16 @@ public class LobbyLuaScriptExecutor {
      * KEYS[1] = lobby:{code}
      * KEYS[2] = lobby:{code}:participants
      * KEYS[3] = lobby:{code}:ready
-     * KEYS[4] = lobby:public
+     *
+     * [정책]
+     * 게임 시작 후에도 공개 로비 목록에는 PLAYING 로비를 유지한다.
+     * 공개 로비 목록 API는 WAITING + PLAYING 상태를 내려주고,
+     * 클라이언트는 PLAYING 로비를 "진행 중" 상태로 표시한다.
+     *
+     * [주의]
+     * PLAYING 로비를 목록에 노출하더라도 실제 입장은 허용하지 않는다.
+     * enter_lobby.lua는 WAITING 상태 로비만 입장을 허용하므로,
+     * PLAYING 로비 클릭 시 FE는 입장 요청을 보내지 않거나 비활성화 처리해야 한다.
      *
      * [ARGV 계약]
      * ARGV[1] = requesterIdentifier
@@ -206,8 +215,7 @@ public class LobbyLuaScriptExecutor {
         List<String> keys = List.of(
                 RedisKeys.lobbyKey(code),
                 RedisKeys.lobbyParticipantsKey(code),
-                RedisKeys.lobbyReadyKey(code),
-                RedisKeys.LOBBY_PUBLIC
+                RedisKeys.lobbyReadyKey(code)
         );
 
         return redisTemplate.execute(

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.time.Instant;
 
 /**
  * 로비 관련 Redis Lua script 실행을 담당하는 컴포넌트
@@ -71,7 +72,8 @@ public class LobbyLuaScriptExecutor {
      * ARGV[8]  = mapId or ""
      * ARGV[9]  = mapTitle or ""
      * ARGV[10] = mapCategory or ""
-     *
+     * ARGV[11] = createdAtEpochMillis
+     * *
      * @return "OK" | "LOCK_FAILED" | null
      */
     public String executeCreateLobby(
@@ -100,10 +102,17 @@ public class LobbyLuaScriptExecutor {
                 isPrivateValue,
                 LobbyStatus.WAITING.name(),
 
-                // 맵 미선택 시 빈 문자열을 전달하여 Redis에 "null" 문자열이 저장되지 않게 합니다.
+                // 맵 미선택 시 빈 문자열을 전달하여 Redis에 "null" 문자열이 저장되지 않게 한다.
                 mapMetadata != null ? String.valueOf(mapMetadata.mapId()) : EMPTY_REDIS_VALUE,
                 mapMetadata != null ? mapMetadata.mapTitle() : EMPTY_REDIS_VALUE,
-                mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE
+                mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE,
+
+                /*
+                 * Redis의 lobby:public Set은 순서를 보장하지 않는다.
+                 * 따라서 공개 로비 목록의 latest 정렬을 안정적으로 처리하기 위해
+                 * 로비 생성 시각을 epoch millis 문자열로 Hash에 함께 저장한다.
+                 */
+                String.valueOf(Instant.now().toEpochMilli())
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -6,11 +6,13 @@ import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +142,15 @@ public class LobbyRedisQueryRepository {
      * Redis에서 공개 로비 목록을 조회한다.
      *
      * [조회 기준]
-     * lobby:public Set에 들어 있는 초대 코드를 기준으로 lobby:{code} Hash를 조회한다.
+     * lobby:public Set에 들어 있는 초대 코드를 기준으로 lobby:{code} Hash와
+     * lobby:{code}:participants Set 크기를 조회한다.
+     *
+     * [성능]
+     * 공개 로비 수가 N개일 때 개별 Redis 호출을 수행하면
+     * SMEMBERS 1회 + HGETALL N회 + SCARD N회로 총 1 + 2N번의 round-trip이 발생한다.
+     *
+     * 이 메서드는 HGETALL과 SCARD를 executePipelined()로 묶어
+     * Redis 명령 수는 유지하되 네트워크 round-trip을 줄인다.
      *
      * [주의]
      * lobby:public에는 남아 있지만 lobby:{code} Hash가 TTL 만료 등으로 사라진 경우는 응답에서 제외한다.
@@ -160,15 +170,45 @@ public class LobbyRedisQueryRepository {
             return new ArrayList<>();
         }
 
+        /*
+         * Set은 순서 보장을 전제로 쓰면 안 된다.
+         * pipeline 결과는 요청을 넣은 순서 그대로 반환되므로,
+         * 먼저 List로 고정한 뒤 같은 index 기준으로 code와 결과를 매칭한다.
+         */
+        List<String> lobbyCodes = new ArrayList<>(publicLobbyCodes);
+
+        List<Object> pipelineResults = redisTemplate.executePipelined((RedisConnection connection) -> {
+            for (String code : lobbyCodes) {
+                connection.hashCommands().hGetAll(rawKey(RedisKeys.lobbyKey(code)));
+                connection.setCommands().sCard(rawKey(RedisKeys.lobbyParticipantsKey(code)));
+            }
+
+            return null;
+        });
+
         List<LobbyRedisDto> result = new ArrayList<>();
 
-        for (String code : publicLobbyCodes) {
-            Map<Object, Object> data =
-                    redisTemplate.opsForHash().entries(RedisKeys.lobbyKey(code));
+        for (int i = 0; i < lobbyCodes.size(); i++) {
+            String code = lobbyCodes.get(i);
+
+            int hashResultIndex = i * 2;
+            int countResultIndex = hashResultIndex + 1;
+
+            Map<Object, Object> data = extractHashResult(
+                    pipelineResults,
+                    hashResultIndex,
+                    code
+            );
 
             if (data.isEmpty()) {
                 continue;
             }
+
+            Integer currentPlayers = extractCurrentPlayerCount(
+                    pipelineResults,
+                    countResultIndex,
+                    code
+            );
 
             String displayMapCategory = toDisplayMapCategoryOrNull(
                     code,
@@ -195,7 +235,7 @@ public class LobbyRedisQueryRepository {
                     .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
                     .mapCategory(displayMapCategory)
                     .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
-                    .currentPlayers(getCurrentPlayerCount(code))
+                    .currentPlayers(currentPlayers)
                     .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
                     .build());
         }
@@ -268,6 +308,97 @@ public class LobbyRedisQueryRepository {
                 .size(RedisKeys.lobbyParticipantsKey(inviteCode));
 
         return count != null ? count.intValue() : 0;
+    }
+
+    /**
+     * StringRedisTemplate의 pipeline low-level connection에서 사용할 raw key를 생성한다.
+     *
+     * StringRedisTemplate은 일반 ops API에서는 String 직렬화를 자동 적용하지만,
+     * RedisConnection을 직접 사용하는 pipeline 내부에서는 byte[] key를 명시해야 한다.
+     */
+    private byte[] rawKey(String key) {
+        return key.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * pipeline 결과에서 HGETALL 결과를 안전하게 꺼낸다.
+     *
+     * [pipeline 결과 순서]
+     * - index 0: 첫 번째 로비 HGETALL
+     * - index 1: 첫 번째 로비 SCARD
+     * - index 2: 두 번째 로비 HGETALL
+     * - index 3: 두 번째 로비 SCARD
+     *
+     * Spring Data Redis는 StringRedisTemplate의 value serializer를 적용해
+     * Hash 결과를 Map<Object, Object> 형태로 역직렬화한다.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<Object, Object> extractHashResult(
+            List<Object> pipelineResults,
+            int index,
+            String lobbyCode
+    ) {
+        if (index >= pipelineResults.size()) {
+            log.warn(
+                    "Redis pipeline HGETALL 결과 누락 - lobbyCode: {}, resultIndex: {}",
+                    lobbyCode,
+                    index
+            );
+            return Map.of();
+        }
+
+        Object result = pipelineResults.get(index);
+        if (result == null) {
+            return Map.of();
+        }
+
+        if (result instanceof Map<?, ?> map) {
+            return (Map<Object, Object>) map;
+        }
+
+        log.warn(
+                "Redis pipeline HGETALL 결과 타입 불일치 - lobbyCode: {}, resultType: {}",
+                lobbyCode,
+                result.getClass().getName()
+        );
+        return Map.of();
+    }
+
+    /**
+     * pipeline 결과에서 SCARD 결과를 안전하게 꺼낸다.
+     *
+     * Redis SCARD 결과는 일반적으로 Long으로 역직렬화된다.
+     * 예상하지 못한 타입이 들어오면 null을 반환하여 Service 계층의 capacity 방어 필터가 제외하도록 한다.
+     */
+    private Integer extractCurrentPlayerCount(
+            List<Object> pipelineResults,
+            int index,
+            String lobbyCode
+    ) {
+        if (index >= pipelineResults.size()) {
+            log.warn(
+                    "Redis pipeline SCARD 결과 누락 - lobbyCode: {}, resultIndex: {}",
+                    lobbyCode,
+                    index
+            );
+            return null;
+        }
+
+        Object result = pipelineResults.get(index);
+        if (result == null) {
+            return null;
+        }
+
+        if (result instanceof Number count) {
+            return count.intValue();
+        }
+
+        log.warn(
+                "Redis pipeline SCARD 결과 타입 불일치 - lobbyCode: {}, resultType: {}",
+                lobbyCode,
+                result.getClass().getName()
+        );
+        return null;
     }
 
     private Long parseNullableLong(Object value) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -170,6 +170,7 @@ public class LobbyRedisQueryRepository {
                     .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
                     .title((String) data.get(RedisKeys.FIELD_TITLE))
                     .status((String) data.get(RedisKeys.FIELD_STATUS))
+                    .createdAtEpochMillis(parseNullableLong(data.get(RedisKeys.FIELD_CREATED_AT_EPOCH_MILLIS)))
                     .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
                     .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
                     .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public class LobbyRedisQueryRepository {
 
     /**
-     * 로비가 존재하지 않거나 TTL이 만료된 경우 반환할 빈 Optional
+     * 로비가 존재하지 않거나 TTL이 만료된 경우 반환할 빈 Optional.
      * 매번 새 객체를 생성하지 않기 위해 상수로 관리한다.
      */
     private static final Optional<JoinLobbyResponse> EMPTY_LOBBY = Optional.empty();
@@ -72,7 +72,7 @@ public class LobbyRedisQueryRepository {
      * 로비 참여자 목록을 입장 순서 기준으로 조회한다.
      *
      * [조회 전략]
-     * - lobby:{code}:order List를 우선 사용하여 FE 표시 순서를 안정적으로 유지한자.
+     * - lobby:{code}:order List를 우선 사용하여 FE 표시 순서를 안정적으로 유지한다.
      * - participants Set을 함께 조회하여 이미 퇴장했지만 order에 남은 값은 제거한다.
      * - order List에는 없지만 participants Set에는 존재하는 비정상 데이터는 응답 누락 방지를 위해 뒤에 보정한다.
      *
@@ -145,6 +145,11 @@ public class LobbyRedisQueryRepository {
      * [주의]
      * lobby:public에는 남아 있지만 lobby:{code} Hash가 TTL 만료 등으로 사라진 경우는 응답에서 제외한다.
      *
+     * [mapCategory 방어 정책]
+     * - mapCategory가 없거나 blank이면 맵 미선택 로비로 보고 목록에 포함한다.
+     * - mapCategory가 정상 값이면 FE 표시값(K-POP, J-POP, POP)으로 변환한다.
+     * - mapCategory 필드는 존재하지만 정규화할 수 없는 값이면 Redis 손상 데이터로 보고 목록에서 제외한다.
+     *
      * @return 공개 로비 목록
      */
     public List<LobbyRedisDto> getPublicLobbies() {
@@ -165,6 +170,21 @@ public class LobbyRedisQueryRepository {
                 continue;
             }
 
+            String displayMapCategory = toDisplayMapCategoryOrNull(
+                    code,
+                    (String) data.get(RedisKeys.FIELD_MAP_CATEGORY)
+            );
+
+            /*
+             * mapCategory 필드가 존재하는데 표시값으로 정규화할 수 없다면 손상 데이터다.
+             * 이 경우 FE에 알 수 없는 카테고리 값을 노출하지 않고 해당 로비만 목록에서 제외한다.
+             *
+             * mapCategory 필드가 없거나 blank인 경우는 맵 미선택 로비이므로 제외하지 않는다.
+             */
+            if (hasMapCategory(data) && displayMapCategory == null) {
+                continue;
+            }
+
             result.add(LobbyRedisDto.builder()
                     .code((String) data.get(RedisKeys.FIELD_CODE))
                     .hostId((String) data.get(RedisKeys.FIELD_HOST_USER_ID))
@@ -173,7 +193,7 @@ public class LobbyRedisQueryRepository {
                     .createdAtEpochMillis(parseNullableLong(data.get(RedisKeys.FIELD_CREATED_AT_EPOCH_MILLIS)))
                     .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
                     .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-                    .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
+                    .mapCategory(displayMapCategory)
                     .maxPlayers(parseNullableInt(data.get(RedisKeys.FIELD_MAX_PLAYERS)))
                     .currentPlayers(getCurrentPlayerCount(code))
                     .isPrivate(Boolean.parseBoolean((String) data.get(RedisKeys.FIELD_IS_PRIVATE)))
@@ -193,6 +213,10 @@ public class LobbyRedisQueryRepository {
      * [반환 정책]
      * 로비가 존재하지 않으면 Optional.empty()를 반환한다.
      * 서비스 레이어에서 empty 여부로 404를 처리하므로, Repository는 존재 여부 판단만 수행한다.
+     *
+     * [mapCategory 방어 정책]
+     * 단건 조회에서는 로비 자체를 제외할 수 없으므로,
+     * 알 수 없는 mapCategory 값은 null로 변환하여 FE에 비정상 값이 노출되지 않도록 한다.
      *
      * @param inviteCode 로비 초대 코드
      * @return 로비 정보 Optional
@@ -222,7 +246,10 @@ public class LobbyRedisQueryRepository {
                 .status((String) data.get(RedisKeys.FIELD_STATUS))
                 .mapId(parseNullableLong(data.get(RedisKeys.FIELD_MAP_ID)))
                 .mapTitle((String) data.get(RedisKeys.FIELD_MAP_TITLE))
-                .mapCategory(toDisplayMapCategory((String) data.get(RedisKeys.FIELD_MAP_CATEGORY)))
+                .mapCategory(toDisplayMapCategoryOrNull(
+                        inviteCode,
+                        (String) data.get(RedisKeys.FIELD_MAP_CATEGORY)
+                ))
                 .build());
     }
 
@@ -270,24 +297,49 @@ public class LobbyRedisQueryRepository {
     }
 
     /**
-     * Redis에서 문자열을 직접 읽어 DTO에 넣으면 MapCategory의 @JsonValue가 적용되지 않으므로,
-     * 응답 생성 시점에 명시적으로 표시 값을 변환한다.
+     * Redis에서 읽은 mapCategory 값을 FE 응답 표시값으로 변환한다.
      *
      * [정책]
      * - null 또는 blank는 맵 미선택 상태로 보고 null로 반환한다.
-     * - 정상 값은 MapCategory의 단일 정규화 규칙을 사용한다.
-     * - 알 수 없는 값은 데이터 손상을 숨기지 않기 위해 원본 값을 반환하고 경고 로그를 남긴다.
+     * - 정상 값은 MapCategory의 단일 정규화 규칙을 사용해 표시값으로 변환한다.
+     * - 알 수 없는 값은 Redis 데이터 손상으로 보고 null을 반환한다.
      *
+     * [주의]
+     * 잘못된 값을 원본 그대로 반환하면 FE가 알 수 없는 카테고리를 받게 된다.
+     * 따라서 Repository 경계에서 허용된 표시값 또는 null만 반환하도록 제한한다.
+     *
+     * @param lobbyCode 로비 코드. 로그 추적용
      * @param rawCategory Redis Hash에서 읽은 원본 카테고리 값
-     * @return FE 응답에 사용할 카테고리 표시 값
+     * @return FE 응답에 사용할 카테고리 표시값. 변환 불가 시 null
      */
-    private String toDisplayMapCategory(String rawCategory) {
+    private String toDisplayMapCategoryOrNull(String lobbyCode, String rawCategory) {
+        if (rawCategory == null || rawCategory.isBlank()) {
+            return null;
+        }
+
         try {
             return MapCategory.toDisplayValue(rawCategory);
         } catch (IllegalArgumentException e) {
-            log.warn("알 수 없는 맵 카테고리 값 - rawCategory: {}", rawCategory);
-            return rawCategory;
+            log.warn(
+                    "알 수 없는 맵 카테고리 값 - lobbyCode: {}, rawCategory: {}",
+                    lobbyCode,
+                    rawCategory,
+                    e
+            );
+            return null;
         }
+    }
+
+    /**
+     * Redis 로비 Hash에 mapCategory 필드가 실제로 존재하는지 확인한다.
+     *
+     * [필요 이유]
+     * mapCategory가 없는 로비는 맵 미선택 로비로 허용할 수 있다.
+     * 반면 mapCategory 필드는 존재하지만 값이 알 수 없는 경우는 Redis 손상 데이터로 보고 제외해야 한다.
+     */
+    private boolean hasMapCategory(Map<Object, Object> data) {
+        Object rawCategory = data.get(RedisKeys.FIELD_MAP_CATEGORY);
+        return rawCategory instanceof String category && !category.isBlank();
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -94,7 +94,7 @@ public class LobbyQueryService {
         List<LobbyRedisDto> publicLobbies = lobbyRepository.getPublicLobbies();
 
         return publicLobbies.stream()
-                .filter(this::isWaitingLobby)
+                .filter(this::isVisibleLobby)
                 .filter(this::hasValidCapacity)
                 .filter(this::hasValidMapCategory)
                 .filter(lobby -> matchesKeyword(lobby, condition))
@@ -103,25 +103,15 @@ public class LobbyQueryService {
                 .toList();
     }
 
-    /**
-     * 로비가 목록 노출 가능한 WAITING 상태인지 확인한다.
-     *
-     * [정책]
-     * - 상태가 WAITING인 로비만 true
-     * - status가 null/blank/알 수 없는 값이면 목록에서 제외
-     *
-     * [이유]
-     * Redis Hash는 운영 중 수동 수정, 과거 데이터, TTL 만료 경계 상황으로 인해
-     * 일부 필드가 누락되거나 예상하지 못한 값으로 남을 수 있다.
-     * 로비 목록은 사용자가 입장 가능한 방을 보여주는 화면이므로,
-     * 상태가 확실하지 않은 로비는 보수적으로 숨기는 편이 안전하다.
-     */
-    private boolean isWaitingLobby(LobbyRedisDto lobby) {
+    private boolean isVisibleLobby(LobbyRedisDto lobby) {
         if (lobby == null || lobby.getStatus() == null || lobby.getStatus().isBlank()) {
             return false;
         }
 
-        return LobbyStatus.WAITING.name().equals(lobby.getStatus());
+        String status = lobby.getStatus();
+
+        return LobbyStatus.WAITING.name().equals(status)
+                || LobbyStatus.PLAYING.name().equals(status);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -21,6 +21,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySortType;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
@@ -39,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.Comparator;
 
 @Slf4j
 @Service
@@ -94,6 +96,7 @@ public class LobbyQueryService {
                 .filter(this::isWaitingLobby)
                 .filter(lobby -> matchesKeyword(lobby, condition))
                 .filter(lobby -> matchesMapCategory(lobby, condition))
+                .sorted(lobbyComparator(condition.sortType()))
                 .toList();
     }
 
@@ -185,6 +188,118 @@ public class LobbyQueryService {
      */
     private String toDisplayValue(MapCategory mapCategory) {
         return mapCategory.value();
+    }
+
+    /**
+     * 공개 로비 목록 정렬 기준을 Comparator로 변환한다.
+     *
+     * [정렬 정책]
+     * - LATEST
+     *   createdAtEpochMillis 내림차순.
+     *   생성 시각 필드가 없는 기존 Redis 데이터는 0으로 취급하여 뒤로 보낸다.
+     *
+     * - MOST_PLAYERS
+     *   currentPlayers 내림차순.
+     *   동률이면 최신순으로 정렬한다.
+     *
+     * - MOST_AVAILABLE
+     *   남은 자리 수(maxPlayers - currentPlayers) 내림차순.
+     *   동률이면 최신순으로 정렬한다.
+     *
+     * [null 처리]
+     * Redis 데이터는 운영 중 TTL 만료, 과거 버전 데이터, 수동 수정 등으로 일부 숫자 필드가 누락될 수 있다.
+     * 목록 정렬은 사용자 편의 기능이므로, 숫자 필드 누락으로 전체 요청을 실패시키지 않고 안전한 기본값으로 보정한다.
+     */
+    private Comparator<LobbyRedisDto> lobbyComparator(LobbySortType sortType) {
+        return switch (sortType) {
+            case LATEST -> latestComparator();
+            case MOST_PLAYERS -> mostPlayersComparator();
+            case MOST_AVAILABLE -> mostAvailableComparator();
+        };
+    }
+
+    /**
+     * 최신순 정렬 Comparator
+     *
+     * createdAtEpochMillis 값이 클수록 최근 생성된 로비다.
+     * null은 0으로 취급하여 최신순 정렬에서 뒤로 보낸다.
+     */
+    private Comparator<LobbyRedisDto> latestComparator() {
+        return Comparator.comparingLong(this::createdAtEpochMillisOrDefault)
+                .reversed();
+    }
+
+    /**
+     * 현재 인원 많은 순 정렬 Comparator
+     *
+     * currentPlayers가 큰 로비를 먼저 보여준다.
+     * 같은 인원 수라면 사용자가 더 최근에 생성된 로비를 먼저 볼 수 있도록 최신순을 2차 정렬로 사용한다.
+     */
+    private Comparator<LobbyRedisDto> mostPlayersComparator() {
+        return Comparator.comparingInt(this::currentPlayersOrDefault)
+                .reversed()
+                .thenComparing(latestComparator());
+    }
+
+    /**
+     * 빈자리 많은 순 정렬 Comparator
+     *
+     * maxPlayers - currentPlayers 값이 큰 로비를 먼저 보여준다.
+     * 같은 빈자리 수라면 최신순을 2차 정렬로 사용한다.
+     */
+    private Comparator<LobbyRedisDto> mostAvailableComparator() {
+        return Comparator.comparingInt(this::availableSeatsOrDefault)
+                .reversed()
+                .thenComparing(latestComparator());
+    }
+
+    /**
+     * 로비 생성 시각을 정렬 가능한 long 값으로 변환한다.
+     *
+     * 기존 Redis 데이터에는 created_at_epoch_millis가 없을 수 있으므로 null이면 0으로 보정한다.
+     */
+    private long createdAtEpochMillisOrDefault(LobbyRedisDto lobby) {
+        return lobby.getCreatedAtEpochMillis() != null
+                ? lobby.getCreatedAtEpochMillis()
+                : 0L;
+    }
+
+    /**
+     * 현재 인원 값을 정렬 가능한 int 값으로 변환한다.
+     *
+     * Redis 조회 중 participants Set 크기 조회가 null이거나,
+     * 과거 데이터에서 currentPlayers가 누락된 경우 0으로 보정한다.
+     */
+    private int currentPlayersOrDefault(LobbyRedisDto lobby) {
+        return lobby.getCurrentPlayers() != null
+                ? lobby.getCurrentPlayers()
+                : 0;
+    }
+
+    /**
+     * 최대 인원 값을 정렬 가능한 int 값으로 변환한다.
+     *
+     * maxPlayers는 정상 로비라면 항상 존재해야 하지만,
+     * Redis Hash 손상 가능성을 고려해 null이면 0으로 보정한다.
+     */
+    private int maxPlayersOrDefault(LobbyRedisDto lobby) {
+        return lobby.getMaxPlayers() != null
+                ? lobby.getMaxPlayers()
+                : 0;
+    }
+
+    /**
+     * 남은 자리 수를 계산한다.
+     *
+     * [보정 정책]
+     * Redis 데이터가 손상되어 currentPlayers가 maxPlayers보다 큰 경우에도
+     * 음수 빈자리가 정렬에 영향을 주지 않도록 0으로 보정한다.
+     */
+    private int availableSeatsOrDefault(LobbyRedisDto lobby) {
+        return Math.max(
+                0,
+                maxPlayersOrDefault(lobby) - currentPlayersOrDefault(lobby)
+        );
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -3,6 +3,7 @@
  *
  * [책임]
  * - 공개 로비 목록 조회
+ * - 공개 로비 목록 검색/필터 정책 적용
  * - 로비 대기실 상세 조회
  * - 로비 상세 조회 접근 권한 검증
  * - 참여자 목록 조회 및 방장 누락 보정
@@ -22,8 +23,10 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +37,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 @Slf4j
@@ -66,23 +70,121 @@ public class LobbyQueryService {
      * 공개 로비 목록을 조회한다.
      *
      * [조회 기준]
-     * Redis의 공개 로비 Set을 기준으로 현재 활성화된 공개 로비만 조회한다.
+     * Repository는 Redis의 lobby:public Set을 기준으로 공개 로비 원본 목록을 반환한다.
+     * Service는 그 원본 목록에 실제 화면 노출 정책을 적용한다.
      *
-     * [조건 처리 방향]
-     * 이 메서드는 검색/필터/정렬 조건을 받는 진입점이다.
-     * 현재 단계에서는 API 계약을 먼저 연결하고,
-     * 다음 단계에서 WAITING 상태 필터, 제목 검색, 카테고리 필터, 정렬 정책을 순차적으로 적용한다.
+     * [현재 적용 정책]
+     * - WAITING 상태 로비만 목록에 노출한다.
+     * - keyword가 있으면 로비 제목에 keyword가 포함된 로비만 남긴다.
+     * - mapCategory가 있으면 선택된 맵 카테고리가 일치하는 로비만 남긴다.
      *
-     * [책임 경계]
-     * - Repository: Redis에서 공개 로비 원본 목록 조회
-     * - Service: 로비 목록 비즈니스 정책 적용
+     * [PLAYING 로비 제외 이유]
+     * 현재 게임이 시작된 로비는 WebSocket 입장 단계에서 LOBBY_NOT_WAITING으로 차단된다.
+     * 따라서 기본 로비 목록에 PLAYING 로비를 노출하면 사용자는 클릭 가능한 것처럼 보이지만,
+     * 실제 입장은 실패하는 UX 불일치가 발생한다.
      *
      * @param condition 공개 로비 목록 검색/필터/정렬 조건
      * @return 조건에 맞는 공개 로비 목록
      */
     @Transactional(readOnly = true)
     public List<LobbyRedisDto> getPublicLobbies(LobbySearchCondition condition) {
-        return lobbyRepository.getPublicLobbies();
+        List<LobbyRedisDto> publicLobbies = lobbyRepository.getPublicLobbies();
+
+        return publicLobbies.stream()
+                .filter(this::isWaitingLobby)
+                .filter(lobby -> matchesKeyword(lobby, condition))
+                .filter(lobby -> matchesMapCategory(lobby, condition))
+                .toList();
+    }
+
+    /**
+     * 로비가 목록 노출 가능한 WAITING 상태인지 확인한다.
+     *
+     * [정책]
+     * - 상태가 WAITING인 로비만 true
+     * - status가 null/blank/알 수 없는 값이면 목록에서 제외
+     *
+     * [이유]
+     * Redis Hash는 운영 중 수동 수정, 과거 데이터, TTL 만료 경계 상황으로 인해
+     * 일부 필드가 누락되거나 예상하지 못한 값으로 남을 수 있다.
+     * 로비 목록은 사용자가 입장 가능한 방을 보여주는 화면이므로,
+     * 상태가 확실하지 않은 로비는 보수적으로 숨기는 편이 안전하다.
+     */
+    private boolean isWaitingLobby(LobbyRedisDto lobby) {
+        if (lobby == null || lobby.getStatus() == null || lobby.getStatus().isBlank()) {
+            return false;
+        }
+
+        return LobbyStatus.WAITING.name().equals(lobby.getStatus());
+    }
+
+    /**
+     * 제목 검색 조건에 맞는지 확인한다.
+     *
+     * [검색 정책]
+     * - keyword가 없으면 모든 로비를 통과시킨다.
+     * - keyword가 있으면 title에 keyword가 포함된 경우만 통과시킨다.
+     * - 대소문자 차이는 무시한다.
+     *
+     * [null 처리]
+     * Redis에 title 필드가 누락된 손상 데이터는 검색 조건이 있을 때 매칭하지 않는다.
+     * 검색 조건이 없을 때는 상태/카테고리 등 다른 조건만 만족하면 통과할 수 있다.
+     */
+
+    private boolean matchesKeyword(
+            LobbyRedisDto lobby,
+            LobbySearchCondition condition
+    ) {
+        if (!condition.hasKeyword()) {
+            return true;
+        }
+
+        String title = lobby.getTitle();
+        if (title == null || title.isBlank()) {
+            return false;
+        }
+
+        return title.toLowerCase(Locale.ROOT)
+                .contains(condition.keyword().toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * 맵 카테고리 필터 조건에 맞는지 확인한다.
+     *
+     * [필터 정책]
+     * - mapCategory 조건이 없으면 모든 로비를 통과시킨다.
+     * - mapCategory 조건이 있으면 선택된 맵 카테고리가 일치하는 로비만 통과시킨다.
+     *
+     * [맵 미선택 로비 처리]
+     * 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외된다.
+     * 사용자가 특정 카테고리를 선택했다는 것은 해당 카테고리 맵이 연결된 로비만 보겠다는 의미이기 때문이다.
+     *
+     * [정규화]
+     * Redis에는 과거 값 또는 enum 이름 (KPOP) 또는 표시값 (K-POP)이 남을 수 있다.
+     * 비교 시 MapCategory.toDisplayValue()를 사용해 FE 응답 표시값 기준으로 정규화한다.
+     */
+    private boolean matchesMapCategory(
+            LobbyRedisDto lobby,
+            LobbySearchCondition condition
+    ) {
+        if (!condition.hasMapCategory()) {
+            return true;
+        }
+
+        String lobbyMapCategory = lobby.getMapCategory();
+        if (lobbyMapCategory == null || lobbyMapCategory.isBlank()) {
+            return false;
+        }
+
+        return toDisplayValue(condition.mapCategory())
+                .equals(MapCategory.toDisplayValue(lobbyMapCategory));
+    }
+
+    /**
+     * MapCategory enum을 HTTP 응답 표시값으로 변환한다.
+     */
+    private String toDisplayValue(MapCategory mapCategory) {
+        return mapCategory.value();
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -130,6 +130,10 @@ public class LobbyQueryService {
      * - keyword가 있으면 title에 keyword가 포함된 경우만 통과시킨다.
      * - 대소문자 차이는 무시한다.
      *
+     * [정규화 책임]
+     * LobbySearchCondition은 keyword를 생성 시점에 trim + lower-case로 정규화한다.
+     * 따라서 여기서는 로비 title만 lower-case로 변환하여 비교한다.
+     *
      * [null 처리]
      * Redis에 title 필드가 누락된 손상 데이터는 검색 조건이 있을 때 매칭하지 않는다.
      * 검색 조건이 없을 때는 상태/카테고리 등 다른 조건만 만족하면 통과할 수 있다.
@@ -149,7 +153,7 @@ public class LobbyQueryService {
         }
 
         return title.toLowerCase(Locale.ROOT)
-                .contains(condition.keyword().toLowerCase(Locale.ROOT));
+                .contains(condition.keyword());
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -88,6 +88,19 @@ public class LobbyQueryService {
      * enter_lobby.lua는 WAITING 상태 로비만 실제 입장을 허용하므로,
      * FE는 PLAYING 로비를 “진행 중” 상태로 표시하고 입장 버튼을 비활성화해야 한다.
      *
+     * [성능 범위]
+     * 현재 구현은 Redis에서 공개 로비 원본 목록을 조회한 뒤,
+     * Java 메모리에서 상태/정원/카테고리/검색어 필터링과 정렬을 수행한다.
+     *
+     * 이 방식은 공개 로비 수가 수십~수백 개 수준인 현재 서비스 단계에서는 구현 단순성과 정책 변경 유연성이 높다.
+     * 다만 공개 로비 수가 수천 개 이상으로 증가하면 애플리케이션 CPU/메모리 비용이 커질 수 있다.
+     *
+     * 향후 트래픽 증가 시에는 다음 구조로 확장한다.
+     * - cursor/page 기반 Pagination
+     * - Redis Sorted Set 기반 latest 정렬 인덱스
+     * - currentPlayers/availableSeats 기준 정렬 인덱스
+     * - 목록 조회 상한선 예: latest TOP 100 우선 조회
+     *
      * @param condition 공개 로비 목록 검색/필터/정렬 조건
      * @return 조건에 맞는 공개 로비 목록
      */

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -107,12 +107,36 @@ public class LobbyQueryService {
         List<LobbyRedisDto> publicLobbies = lobbyRepository.getPublicLobbies();
 
         return publicLobbies.stream()
+                .filter(this::isPublicLobby)
                 .filter(this::isVisibleLobby)
                 .filter(this::hasValidCapacity)
                 .filter(lobby -> matchesKeyword(lobby, condition))
                 .filter(lobby -> matchesMapCategory(lobby, condition))
                 .sorted(lobbyComparator(condition.sortType()))
                 .toList();
+    }
+
+    /**
+     * 공개 로비 목록에 노출 가능한 공개 로비인지 확인한다.
+     *
+     * [정책]
+     * - isPrivate == false인 로비만 공개 목록에 노출한다.
+     * - isPrivate가 null이면 Redis 손상 데이터로 보고 제외한다.
+     *
+     * [필요 이유]
+     * 정상 생성 경로에서는 create_lobby.lua가 공개 로비만 lobby:public Set에 추가한다.
+     * 하지만 운영 중 Redis 수동 조작, 과거 데이터, 복구 작업 등으로
+     * lobby:public Set에 비공개 로비 코드가 섞일 수 있다.
+     *
+     * 공개 로비 목록은 사용자에게 직접 노출되는 API이므로,
+     * Service 계층에서도 최종 방어 필터를 둔다.
+     */
+    private boolean isPublicLobby(LobbyRedisDto lobby) {
+        if (lobby == null || lobby.getIsPrivate() == null) {
+            return false;
+        }
+
+        return !lobby.getIsPrivate();
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -95,6 +95,7 @@ public class LobbyQueryService {
 
         return publicLobbies.stream()
                 .filter(this::isWaitingLobby)
+                .filter(this::hasValidMapCategory)
                 .filter(lobby -> matchesKeyword(lobby, condition))
                 .filter(lobby -> matchesMapCategory(lobby, condition))
                 .sorted(lobbyComparator(condition.sortType()))
@@ -157,6 +158,35 @@ public class LobbyQueryService {
     }
 
     /**
+     * Redis에 저장된 로비 mapCategory 값이 현재 서버 정책에서 해석 가능한 값인지 확인한다.
+     *
+     * [정책]
+     * - mapCategory가 null 또는 blank면 맵 미선택 로비로 보고 기본 목록 조회에서는 허용한다.
+     * - mapCategory가 존재하면 MapCategory 정책으로 정규화 가능한 값만 허용한다.
+     * - 알 수 없는 값은 Redis 손상 데이터 또는 과거 버전 데이터로 보고 목록에서 제외한다.
+     *
+     * [필요 이유]
+     * matchesMapCategory()는 요청에 mapCategory 필터가 있을 때만 카테고리 일치 여부를 검사한다.
+     * 따라서 이 방어 필터가 없으면 기본 목록 조회에서는 잘못된 mapCategory 값이 그대로 응답될 수 있다.
+     *
+     * FE는 mapCategory가 null이거나 `K-POP`, `J-POP`, `POP` 중 하나라고 가정할 수 있어야 하므로,
+     * 서버에서 비정상 카테고리 값을 가진 로비를 공통으로 제외한다.
+     */
+    private boolean hasValidMapCategory(LobbyRedisDto lobby) {
+        if (lobby == null) {
+            return false;
+        }
+
+        String lobbyMapCategory = lobby.getMapCategory();
+        if (lobbyMapCategory == null || lobbyMapCategory.isBlank()) {
+            return true;
+        }
+
+        return normalizeRedisMapCategory(lobby, lobbyMapCategory)
+                .isPresent();
+    }
+
+    /**
      * 맵 카테고리 필터 조건에 맞는지 확인한다.
      *
      * [필터 정책]
@@ -167,12 +197,9 @@ public class LobbyQueryService {
      * 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외된다.
      * 사용자가 특정 카테고리를 선택했다는 것은 해당 카테고리 맵이 연결된 로비만 보겠다는 의미이기 때문이다.
      *
-     * [Redis 손상 데이터 방어]
-     * Redis에 저장된 mapCategory는 운영 중 수동 수정, 과거 버전 데이터, 배포 중간 상태 등으로
-     * 현재 MapCategory 정책과 맞지 않는 값이 남아 있을 수 있다.
-     *
-     * 이 경우 전체 로비 목록 API를 500으로 실패시키지 않고,
-     * 해당 로비만 필터링에서 제외한다.
+     * [전제]
+     * Redis mapCategory 값 자체의 유효성은 hasValidMapCategory()에서 먼저 검증한다.
+     * 따라서 이 메서드는 요청 필터와 로비 카테고리의 일치 여부만 판단한다.
      */
     private boolean matchesMapCategory(
             LobbyRedisDto lobby,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -77,14 +77,16 @@ public class LobbyQueryService {
      * Service는 그 원본 목록에 실제 화면 노출 정책을 적용한다.
      *
      * [현재 적용 정책]
-     * - WAITING 상태 로비만 목록에 노출한다.
+     * - WAITING 상태 로비는 입장 가능한 공개 로비로 목록에 노출한다.
+     * - PLAYING 상태 로비는 진행 중 공개 로비로 목록에 노출한다.
+     * - FINISHED 상태 로비는 목록에서 제외한다.
      * - keyword가 있으면 로비 제목에 keyword가 포함된 로비만 남긴다.
      * - mapCategory가 있으면 선택된 맵 카테고리가 일치하는 로비만 남긴다.
      *
-     * [PLAYING 로비 제외 이유]
-     * 현재 게임이 시작된 로비는 WebSocket 입장 단계에서 LOBBY_NOT_WAITING으로 차단된다.
-     * 따라서 기본 로비 목록에 PLAYING 로비를 노출하면 사용자는 클릭 가능한 것처럼 보이지만,
-     * 실제 입장은 실패하는 UX 불일치가 발생한다.
+     * [PLAYING 로비 노출 정책]
+     * PLAYING 로비는 목록에 노출되지만, 현재 입장은 허용하지 않는다.
+     * enter_lobby.lua는 WAITING 상태 로비만 실제 입장을 허용하므로,
+     * FE는 PLAYING 로비를 “진행 중” 상태로 표시하고 입장 버튼을 비활성화해야 한다.
      *
      * @param condition 공개 로비 목록 검색/필터/정렬 조건
      * @return 조건에 맞는 공개 로비 목록
@@ -103,6 +105,17 @@ public class LobbyQueryService {
                 .toList();
     }
 
+    /**
+     * 공개 로비 목록에 노출 가능한 상태인지 확인한다.
+     *
+     * [노출 상태]
+     * - WAITING: 입장 가능한 공개 로비
+     * - PLAYING: 진행 중 공개 로비. 목록에는 노출하지만 입장은 허용하지 않음
+     *
+     * [제외 상태]
+     * - FINISHED: 종료된 로비이므로 목록에서 제외
+     * - null/blank/unknown: Redis 손상 데이터로 보고 제외
+     */
     private boolean isVisibleLobby(LobbyRedisDto lobby) {
         if (lobby == null || lobby.getStatus() == null || lobby.getStatus().isBlank()) {
             return false;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.Comparator;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -162,9 +163,12 @@ public class LobbyQueryService {
      * 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외된다.
      * 사용자가 특정 카테고리를 선택했다는 것은 해당 카테고리 맵이 연결된 로비만 보겠다는 의미이기 때문이다.
      *
-     * [정규화]
-     * Redis에는 과거 값 또는 enum 이름 (KPOP) 또는 표시값 (K-POP)이 남을 수 있다.
-     * 비교 시 MapCategory.toDisplayValue()를 사용해 FE 응답 표시값 기준으로 정규화한다.
+     * [Redis 손상 데이터 방어]
+     * Redis에 저장된 mapCategory는 운영 중 수동 수정, 과거 버전 데이터, 배포 중간 상태 등으로
+     * 현재 MapCategory 정책과 맞지 않는 값이 남아 있을 수 있다.
+     *
+     * 이 경우 전체 로비 목록 API를 500으로 실패시키지 않고,
+     * 해당 로비만 필터링에서 제외한다.
      */
     private boolean matchesMapCategory(
             LobbyRedisDto lobby,
@@ -179,12 +183,55 @@ public class LobbyQueryService {
             return false;
         }
 
-        return toDisplayValue(condition.mapCategory())
-                .equals(MapCategory.toDisplayValue(lobbyMapCategory));
+        String requestedCategory = toDisplayValue(condition.mapCategory());
+
+        return normalizeRedisMapCategory(lobby, lobbyMapCategory)
+                .map(requestedCategory::equals)
+                .orElse(false);
+    }
+
+    /**
+     * Redis에서 읽은 로비 mapCategory 값을 FE 응답 표시값으로 정규화한다.
+     *
+     * [정상 값 예시]
+     * - KPOP
+     * - K-POP
+     * - K_POP
+     * - kpop
+     *
+     * [비정상 값 처리]
+     * MapCategory.toDisplayValue()는 알 수 없는 값이 들어오면 IllegalArgumentException을 던진다.
+     * Redis 데이터 하나가 손상되었다는 이유로 전체 목록 조회가 실패하면 안 되므로,
+     * 여기서 예외를 잡고 Optional.empty()를 반환한다.
+     *
+     * @param lobby Redis에서 매핑한 로비 DTO. 로그에 code를 남기기 위해 전달한다.
+     * @param rawCategory Redis Hash에 저장된 원본 mapCategory 값
+     * @return 정규화된 표시값. 정규화 실패 시 Optional.empty()
+     */
+    private Optional<String> normalizeRedisMapCategory(
+            LobbyRedisDto lobby,
+            String rawCategory
+    ) {
+        try {
+            return Optional.ofNullable(MapCategory.toDisplayValue(rawCategory));
+        } catch (IllegalArgumentException e) {
+            log.warn(
+                    "Redis 로비 mapCategory 정규화 실패 - lobbyCode: {}, rawCategory: {}",
+                    lobby.getCode(),
+                    rawCategory,
+                    e
+            );
+            return Optional.empty();
+        }
     }
 
     /**
      * MapCategory enum을 HTTP 응답 표시값으로 변환한다.
+     *
+     * [이유]
+     * LobbySearchCondition에서 요청 mapCategory는 이미 MapCategory.from()으로 검증된 값이다.
+     * 따라서 요청 조건 쪽은 예외 가능성이 없는 안전한 enum 값이며,
+     * FE 응답 표시값(K-POP, J-POP, POP) 기준으로 비교하기 위해 value()를 사용한다.
      */
     private String toDisplayValue(MapCategory mapCategory) {
         return mapCategory.value();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -95,6 +95,7 @@ public class LobbyQueryService {
 
         return publicLobbies.stream()
                 .filter(this::isWaitingLobby)
+                .filter(this::hasValidCapacity)
                 .filter(this::hasValidMapCategory)
                 .filter(lobby -> matchesKeyword(lobby, condition))
                 .filter(lobby -> matchesMapCategory(lobby, condition))
@@ -121,6 +122,61 @@ public class LobbyQueryService {
         }
 
         return LobbyStatus.WAITING.name().equals(lobby.getStatus());
+    }
+
+    /**
+     * 로비 목록에 노출 가능한 인원/정원 값인지 확인한다.
+     *
+     * [정책]
+     * - maxPlayers가 null 또는 0 이하이면 제외한다.
+     * - currentPlayers가 null 또는 음수이면 제외한다.
+     * - currentPlayers가 maxPlayers보다 크면 제외한다.
+     *
+     * [필요 이유]
+     * 공개 로비 목록은 사용자가 입장 가능한 로비를 탐색하는 화면이다.
+     * Redis 데이터 손상으로 maxPlayers가 누락되거나 currentPlayers가 maxPlayers를 초과한 로비가
+     * 목록에 노출되면 FE에서는 입장 가능한 방처럼 보이지만 실제 입장 단계에서 실패할 수 있다.
+     *
+     * 따라서 정렬 단계에서 숫자를 0으로 보정하는 것과 별개로,
+     * 목록 노출 전에 capacity 값 자체가 유효한 로비만 통과시킨다.
+     */
+    private boolean hasValidCapacity(LobbyRedisDto lobby) {
+        if (lobby == null) {
+            return false;
+        }
+
+        Integer maxPlayers = lobby.getMaxPlayers();
+        Integer currentPlayers = lobby.getCurrentPlayers();
+
+        if (maxPlayers == null || maxPlayers <= 0) {
+            log.warn(
+                    "공개 로비 목록 제외 - maxPlayers 값이 유효하지 않음. lobbyCode: {}, maxPlayers: {}",
+                    lobby.getCode(),
+                    maxPlayers
+            );
+            return false;
+        }
+
+        if (currentPlayers == null || currentPlayers < 0) {
+            log.warn(
+                    "공개 로비 목록 제외 - currentPlayers 값이 유효하지 않음. lobbyCode: {}, currentPlayers: {}",
+                    lobby.getCode(),
+                    currentPlayers
+            );
+            return false;
+        }
+
+        if (currentPlayers > maxPlayers) {
+            log.warn(
+                    "공개 로비 목록 제외 - currentPlayers가 maxPlayers를 초과. lobbyCode: {}, currentPlayers: {}, maxPlayers: {}",
+                    lobby.getCode(),
+                    currentPlayers,
+                    maxPlayers
+            );
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -20,6 +20,7 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
@@ -65,15 +66,22 @@ public class LobbyQueryService {
      * 공개 로비 목록을 조회한다.
      *
      * [조회 기준]
-     * Redis의 공개 로비 Set을 기준으로 현재 활성화된 공개 로비만 반환한다.
+     * Redis의 공개 로비 Set을 기준으로 현재 활성화된 공개 로비만 조회한다.
      *
-     * [추후 확장]
-     * 로비 목록 검색, 카테고리 필터, 정렬 기능은 이 조회 유스케이스를 기준으로 확장할 수 있다.
+     * [조건 처리 방향]
+     * 이 메서드는 검색/필터/정렬 조건을 받는 진입점이다.
+     * 현재 단계에서는 API 계약을 먼저 연결하고,
+     * 다음 단계에서 WAITING 상태 필터, 제목 검색, 카테고리 필터, 정렬 정책을 순차적으로 적용한다.
      *
-     * @return 현재 활성화된 공개 로비 목록
+     * [책임 경계]
+     * - Repository: Redis에서 공개 로비 원본 목록 조회
+     * - Service: 로비 목록 비즈니스 정책 적용
+     *
+     * @param condition 공개 로비 목록 검색/필터/정렬 조건
+     * @return 조건에 맞는 공개 로비 목록
      */
     @Transactional(readOnly = true)
-    public List<LobbyRedisDto> getPublicLobbies() {
+    public List<LobbyRedisDto> getPublicLobbies(LobbySearchCondition condition) {
         return lobbyRepository.getPublicLobbies();
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -27,7 +27,6 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +40,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.Comparator;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -111,7 +109,6 @@ public class LobbyQueryService {
         return publicLobbies.stream()
                 .filter(this::isVisibleLobby)
                 .filter(this::hasValidCapacity)
-                .filter(this::hasValidMapCategory)
                 .filter(lobby -> matchesKeyword(lobby, condition))
                 .filter(lobby -> matchesMapCategory(lobby, condition))
                 .sorted(lobbyComparator(condition.sortType()))
@@ -230,35 +227,6 @@ public class LobbyQueryService {
     }
 
     /**
-     * Redis에 저장된 로비 mapCategory 값이 현재 서버 정책에서 해석 가능한 값인지 확인한다.
-     *
-     * [정책]
-     * - mapCategory가 null 또는 blank면 맵 미선택 로비로 보고 기본 목록 조회에서는 허용한다.
-     * - mapCategory가 존재하면 MapCategory 정책으로 정규화 가능한 값만 허용한다.
-     * - 알 수 없는 값은 Redis 손상 데이터 또는 과거 버전 데이터로 보고 목록에서 제외한다.
-     *
-     * [필요 이유]
-     * matchesMapCategory()는 요청에 mapCategory 필터가 있을 때만 카테고리 일치 여부를 검사한다.
-     * 따라서 이 방어 필터가 없으면 기본 목록 조회에서는 잘못된 mapCategory 값이 그대로 응답될 수 있다.
-     *
-     * FE는 mapCategory가 null이거나 `K-POP`, `J-POP`, `POP` 중 하나라고 가정할 수 있어야 하므로,
-     * 서버에서 비정상 카테고리 값을 가진 로비를 공통으로 제외한다.
-     */
-    private boolean hasValidMapCategory(LobbyRedisDto lobby) {
-        if (lobby == null) {
-            return false;
-        }
-
-        String lobbyMapCategory = lobby.getMapCategory();
-        if (lobbyMapCategory == null || lobbyMapCategory.isBlank()) {
-            return true;
-        }
-
-        return normalizeRedisMapCategory(lobby, lobbyMapCategory)
-                .isPresent();
-    }
-
-    /**
      * 맵 카테고리 필터 조건에 맞는지 확인한다.
      *
      * [필터 정책]
@@ -267,11 +235,10 @@ public class LobbyQueryService {
      *
      * [맵 미선택 로비 처리]
      * 카테고리 필터가 적용된 경우, 맵이 선택되지 않은 로비는 제외된다.
-     * 사용자가 특정 카테고리를 선택했다는 것은 해당 카테고리 맵이 연결된 로비만 보겠다는 의미이기 때문이다.
      *
      * [전제]
-     * Redis mapCategory 값 자체의 유효성은 hasValidMapCategory()에서 먼저 검증한다.
-     * 따라서 이 메서드는 요청 필터와 로비 카테고리의 일치 여부만 판단한다.
+     * LobbyRedisQueryRepository는 Redis raw mapCategory를 FE 표시값으로 정규화하여 DTO에 담는다.
+     * 따라서 Service에서는 이미 정규화된 표시값끼리 직접 비교한다.
      */
     private boolean matchesMapCategory(
             LobbyRedisDto lobby,
@@ -286,58 +253,7 @@ public class LobbyQueryService {
             return false;
         }
 
-        String requestedCategory = toDisplayValue(condition.mapCategory());
-
-        return normalizeRedisMapCategory(lobby, lobbyMapCategory)
-                .map(requestedCategory::equals)
-                .orElse(false);
-    }
-
-    /**
-     * Redis에서 읽은 로비 mapCategory 값을 FE 응답 표시값으로 정규화한다.
-     *
-     * [정상 값 예시]
-     * - KPOP
-     * - K-POP
-     * - K_POP
-     * - kpop
-     *
-     * [비정상 값 처리]
-     * MapCategory.toDisplayValue()는 알 수 없는 값이 들어오면 IllegalArgumentException을 던진다.
-     * Redis 데이터 하나가 손상되었다는 이유로 전체 목록 조회가 실패하면 안 되므로,
-     * 여기서 예외를 잡고 Optional.empty()를 반환한다.
-     *
-     * @param lobby Redis에서 매핑한 로비 DTO. 로그에 code를 남기기 위해 전달한다.
-     * @param rawCategory Redis Hash에 저장된 원본 mapCategory 값
-     * @return 정규화된 표시값. 정규화 실패 시 Optional.empty()
-     */
-    private Optional<String> normalizeRedisMapCategory(
-            LobbyRedisDto lobby,
-            String rawCategory
-    ) {
-        try {
-            return Optional.ofNullable(MapCategory.toDisplayValue(rawCategory));
-        } catch (IllegalArgumentException e) {
-            log.warn(
-                    "Redis 로비 mapCategory 정규화 실패 - lobbyCode: {}, rawCategory: {}",
-                    lobby.getCode(),
-                    rawCategory,
-                    e
-            );
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * MapCategory enum을 HTTP 응답 표시값으로 변환한다.
-     *
-     * [이유]
-     * LobbySearchCondition에서 요청 mapCategory는 이미 MapCategory.from()으로 검증된 값이다.
-     * 따라서 요청 조건 쪽은 예외 가능성이 없는 안전한 enum 값이며,
-     * FE 응답 표시값(K-POP, J-POP, POP) 기준으로 비교하기 위해 value()를 사용한다.
-     */
-    private String toDisplayValue(MapCategory mapCategory) {
-        return mapCategory.value();
+        return condition.mapCategory().value().equals(lobbyMapCategory);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -160,6 +160,17 @@ public final class RedisKeys {
     /** 로비 Hash의 상태 필드. 저장 값: "WAITING" / "PLAYING" */
     public static final String FIELD_STATUS = "status";
 
+    /**
+     * 로비 Hash의 생성 시각 필드
+     * 저장 값 : System.currentTimeMillis() 기준 epoch milliseconds 문자열
+     *
+     * [사용 목적]
+     * 공개 로비 목록의 latest 정렬 기준으로 사용한다.
+     * Redis Set (lobby:public)은 순서를 보장하지 않으므로,
+     * 최신순 정렬을 안정적으로 제공하려면 로비 Hash에 생성 시각을 별도로 저장해야 한다.
+     */
+    public static final String FIELD_CREATED_AT_EPOCH_MILLIS = "created_at_epoch_millis";
+
     // =========================================================
     // 동적 키 생성 팩토리 메서드
     // =========================================================

--- a/src/main/resources/scripts/create_lobby.lua
+++ b/src/main/resources/scripts/create_lobby.lua
@@ -27,18 +27,20 @@ local status         = ARGV[7]  -- "WAITING"
 
 local mapId           = ARGV[8]   -- 선택된 맵 ID. 미선택 시 ""
 local mapTitle        = ARGV[9]   -- 선택된 맵 제목. 미선택 시 ""
-local mapCategory    = ARGV[10]  -- 선택된 맵 카테고리. 미선택 시 ""
+local mapCategory        = ARGV[10] -- 선택된 맵 카테고리. 미선택 시 ""
+local createdAtEpochMillis = ARGV[11] -- 로비 생성 시각. epoch milliseconds 문자열
 
 -- Redis Hash 필드명은 스크립트 상단에서 중앙 관리합니다.
-local FIELD_CODE         = 'code'
-local FIELD_HOST_USER_ID = 'host_user_id'
-local FIELD_TITLE        = 'title'
-local FIELD_MAX_PLAYERS  = 'max_players'
-local FIELD_IS_PRIVATE   = 'is_private'
-local FIELD_STATUS       = 'status'
-local FIELD_MAP_ID       = 'map_id'
-local FIELD_MAP_TITLE    = 'map_title'
-local FIELD_MAP_CATEGORY = 'map_category'
+local FIELD_CODE                    = 'code'
+local FIELD_HOST_USER_ID            = 'host_user_id'
+local FIELD_TITLE                   = 'title'
+local FIELD_MAX_PLAYERS             = 'max_players'
+local FIELD_IS_PRIVATE              = 'is_private'
+local FIELD_STATUS                  = 'status'
+local FIELD_MAP_ID                  = 'map_id'
+local FIELD_MAP_TITLE               = 'map_title'
+local FIELD_MAP_CATEGORY            = 'map_category'
+local FIELD_CREATED_AT_EPOCH_MILLIS = 'created_at_epoch_millis'
 
 -- 1. SETNX 선점 시도
 --    이미 동일한 코드가 선점되어 있으면 LOCK_FAILED 반환
@@ -49,13 +51,18 @@ if acquired == false then
 end
 
 -- 2. 로비 메타 정보 Hash 저장 (lobby:{code})
+--
+-- [created_at_epoch_millis 저장 이유]
+-- lobby:public은 Redis Set이므로 생성 순서를 보장하지 않는다.
+-- 공개 로비 목록에서 latest 정렬을 제공하려면 생성 시각을 별도 필드로 저장해야 한다.
 redis.call('HSET', lobbyKey,
-    'code',         inviteCode,
-    'host_user_id', userIdentifier,
-    'title',        title,
-    'max_players',  maxPlayers,
-    'is_private',   isPrivate,
-    'status',       status
+    FIELD_CODE,                    inviteCode,
+    FIELD_HOST_USER_ID,            userIdentifier,
+    FIELD_TITLE,                   title,
+    FIELD_MAX_PLAYERS,             maxPlayers,
+    FIELD_IS_PRIVATE,              isPrivate,
+    FIELD_STATUS,                  status,
+    FIELD_CREATED_AT_EPOCH_MILLIS, createdAtEpochMillis
 )
 
 -- 3. 맵이 선택된 경우에만 맵 메타 정보 저장

--- a/src/main/resources/scripts/create_lobby.lua
+++ b/src/main/resources/scripts/create_lobby.lua
@@ -23,12 +23,11 @@ local inviteCode      = ARGV[3]   -- 초대 코드
 local title           = ARGV[4]   -- 로비 제목
 local maxPlayers      = ARGV[5]   -- 최대 인원
 local isPrivate       = ARGV[6]   -- "true" | "false"
-local status         = ARGV[7]  -- "WAITING"
+local status          = ARGV[7]   -- "WAITING"
 
 local mapId           = ARGV[8]   -- 선택된 맵 ID. 미선택 시 ""
 local mapTitle        = ARGV[9]   -- 선택된 맵 제목. 미선택 시 ""
-local mapCategory        = ARGV[10] -- 선택된 맵 카테고리. 미선택 시 ""
-local createdAtEpochMillis = ARGV[11] -- 로비 생성 시각. epoch milliseconds 문자열
+local mapCategory     = ARGV[10]  -- 선택된 맵 카테고리. 미선택 시 ""
 
 -- Redis Hash 필드명은 스크립트 상단에서 중앙 관리합니다.
 local FIELD_CODE                    = 'code'
@@ -41,6 +40,18 @@ local FIELD_MAP_ID                  = 'map_id'
 local FIELD_MAP_TITLE               = 'map_title'
 local FIELD_MAP_CATEGORY            = 'map_category'
 local FIELD_CREATED_AT_EPOCH_MILLIS = 'created_at_epoch_millis'
+
+-- Redis 서버 기준 현재 시각을 epoch milliseconds로 계산한다.
+--
+-- [Java 서버 시간이 아니라 Redis TIME을 사용하는 이유]
+-- Monomat-BE가 멀티 인스턴스로 운영될 경우 각 애플리케이션 서버의 시간이
+-- 미세하게 다를 수 있다. latest 정렬 기준을 Java Instant.now()에 의존하면
+-- 서버 간 NTP drift로 인해 생성 순서가 흔들릴 수 있다.
+--
+-- Redis TIME은 Redis 서버 기준 단일 시간원이므로,
+-- Redis에 저장되는 로비 생성 시각 정렬 기준을 일관되게 유지할 수 있다.
+local redisTime = redis.call('TIME')
+local createdAtEpochMillis = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
 
 -- 1. SETNX 선점 시도
 --    이미 동일한 코드가 선점되어 있으면 LOCK_FAILED 반환
@@ -62,7 +73,7 @@ redis.call('HSET', lobbyKey,
     FIELD_MAX_PLAYERS,             maxPlayers,
     FIELD_IS_PRIVATE,              isPrivate,
     FIELD_STATUS,                  status,
-    FIELD_CREATED_AT_EPOCH_MILLIS, createdAtEpochMillis
+    FIELD_CREATED_AT_EPOCH_MILLIS, tostring(createdAtEpochMillis)
 )
 
 -- 3. 맵이 선택된 경우에만 맵 메타 정보 저장

--- a/src/main/resources/scripts/start_lobby.lua
+++ b/src/main/resources/scripts/start_lobby.lua
@@ -18,7 +18,6 @@
 -- KEYS[1] = lobby:{code}
 -- KEYS[2] = lobby:{code}:participants
 -- KEYS[3] = lobby:{code}:ready
--- KEYS[4] = lobby:public
 --
 -- [ARGV]
 -- ARGV[1] = requesterIdentifier
@@ -32,7 +31,6 @@
 local lobbyKey = KEYS[1]
 local participantsKey = KEYS[2]
 local readyKey = KEYS[3]
-local publicLobbyKey = KEYS[4]
 
 local requesterIdentifier = ARGV[1]
 local lobbyCode = ARGV[2]
@@ -109,6 +107,5 @@ if nonHostPlayerCount == 0 then
 end
 
 redis.call('HSET', lobbyKey, fieldStatus, playingStatus)
-redis.call('SREM', publicLobbyKey, lobbyCode)
 
 return 'STARTED'

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
@@ -1,159 +1,301 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
-import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
-import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
-import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
-import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
-import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
-import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
-import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * LobbyQueryService의 로비 상세 조회 응답 중 canStart 계산을 검증한다.
+ * LobbyQueryService의 공개 로비 목록 조회 정책을 검증한다.
  *
- * [변경 배경]
- * Issue #78에서 LobbyService facade를 제거하고,
- * 로비 상세 조회 책임을 LobbyQueryService로 분리했습니다.
+ * [테스트 범위]
+ * - Redis 조회 자체는 LobbyRepository의 책임이므로 mock 처리한다.
+ * - 이 테스트는 Service 계층의 목록 노출 정책만 검증한다.
  *
- * canStart 계산 자체는 LobbyCanStartPolicy가 담당하지만,
- * 이 테스트는 "로비 상세 조회 결과에 canStart가 올바르게 반영되는지"를 검증하므로
- * LobbyQueryService 기준으로 유지합니다.
+ * [검증 정책]
+ * - PLAYING / FINISHED 로비는 기본 목록에서 제외한다.
+ * - 제목 검색은 대소문자를 무시하고 contains 기준으로 동작한다.
+ * - 카테고리 필터는 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
+ * - Redis에 잘못된 mapCategory 값이 있어도 전체 API가 실패하지 않고 해당 로비만 제외한다.
+ * - 정렬은 최신순, 인원 많은 순, 빈자리 많은 순을 지원한다.
  */
-class LobbyQueryServiceCanStartTest {
+class LobbyQueryServiceTest {
 
-    private LobbyRepository lobbyRepository;
-    private GameLobbyJpaRepository gameLobbyJpaRepository;
-    private QuizMapJpaRepository quizMapJpaRepository;
-    private LobbyQueryService lobbyQueryService;
+    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
+    private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
+    private final LobbyCanStartPolicy lobbyCanStartPolicy = mock(LobbyCanStartPolicy.class);
 
-    @BeforeEach
-    void setUp() {
-        lobbyRepository = mock(LobbyRepository.class);
-        gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
-        quizMapJpaRepository = mock(QuizMapJpaRepository.class);
+    private final LobbyQueryService lobbyQueryService = new LobbyQueryService(
+            lobbyRepository,
+            gameLobbyJpaRepository,
+            lobbyCanStartPolicy
+    );
 
-        LobbyCanStartPolicy lobbyCanStartPolicy = new LobbyCanStartPolicy(
-                quizMapJpaRepository
-        );
+    @Test
+    @DisplayName("공개 로비 목록 조회 시 WAITING 상태 로비만 반환한다")
+    void getPublicLobbies_filtersWaitingLobbyOnly() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("WAITING-1", "대기 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("PLAYING-1", "진행 로비", "K-POP", 4, 6, LobbyStatus.PLAYING, 2000L),
+                lobby("FINISHED-1", "종료 로비", "K-POP", 6, 6, LobbyStatus.FINISHED, 1000L)
+        ));
 
-        lobbyQueryService = new LobbyQueryService(
-                lobbyRepository,
-                gameLobbyJpaRepository,
-                lobbyCanStartPolicy
-        );
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("WAITING-1");
     }
 
     @Test
-    void canStart는_Lua와_동일하게_방장_제외_참여자가_모두_ready이면_true다() {
-        String code = "ABC123";
-        String hostId = "11111111-1111-1111-1111-111111111111";
-        String guestId = "22222222-2222-2222-2222-222222222222";
+    @DisplayName("keyword가 있으면 로비 제목 기준으로 검색한다")
+    void getPublicLobbies_filtersByKeyword() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "KPOP 랜덤 퀴즈", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "JPOP 애니송 퀴즈", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L),
+                lobby("LOBBY-3", "POP 히트곡 퀴즈", "POP", 2, 6, LobbyStatus.WAITING, 1000L)
+        ));
 
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
-        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
-        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
-        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
-        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
+        LobbySearchCondition condition = LobbySearchCondition.of("애니송", null, "latest");
 
-        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(
-                code,
-                new CustomPrincipal(1L, hostId, UserType.GUEST)
-        );
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
 
-        assertThat(response.canStart()).isTrue();
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-2");
     }
 
     @Test
-    void canStart는_참여자가_ready가_아니면_false다() {
-        String code = "ABC123";
-        String hostId = "11111111-1111-1111-1111-111111111111";
-        String guestId = "22222222-2222-2222-2222-222222222222";
+    @DisplayName("keyword 검색은 대소문자를 구분하지 않는다")
+    void getPublicLobbies_filtersByKeywordIgnoringCase() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "KPOP Random Quiz", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "JPOP Anime Quiz", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
 
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
-        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
-        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
-        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of());
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
-        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
+        LobbySearchCondition condition = LobbySearchCondition.of("random", null, "latest");
 
-        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(
-                code,
-                new CustomPrincipal(1L, hostId, UserType.GUEST)
-        );
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
 
-        assertThat(response.canStart()).isFalse();
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-1");
     }
 
     @Test
-    void canStart는_맵_문제수가_라운드수보다_적으면_false다() {
-        String code = "ABC123";
-        String hostId = "11111111-1111-1111-1111-111111111111";
-        String guestId = "22222222-2222-2222-2222-222222222222";
+    @DisplayName("mapCategory가 있으면 선택된 맵 카테고리 기준으로 필터링한다")
+    void getPublicLobbies_filtersByMapCategory() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "케이팝", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "제이팝", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L),
+                lobby("LOBBY-3", "팝", "POP", 2, 6, LobbyStatus.WAITING, 1000L)
+        ));
 
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
-        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
-        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
-        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
-        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(4)));
+        LobbySearchCondition condition = LobbySearchCondition.of(null, "J-POP", "latest");
 
-        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(
-                code,
-                new CustomPrincipal(1L, hostId, UserType.GUEST)
-        );
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
 
-        assertThat(response.canStart()).isFalse();
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-2");
     }
 
-    private JoinLobbyResponse lobbyInfo(String code, String hostId) {
-        return JoinLobbyResponse.builder()
-                .inviteCode(code)
-                .title("테스트 로비")
-                .hostId(hostId)
-                .maxPlayers(4)
-                .currentPlayers(2)
-                .status("WAITING")
-                .mapId(2L)
+    @Test
+    @DisplayName("카테고리 필터 적용 시 맵이 선택되지 않은 로비는 제외한다")
+    void getPublicLobbies_excludesLobbyWithoutMapCategoryWhenCategoryFilterExists() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("MATCHED", "카테고리 일치 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("NO-MAP", "맵 미선택 로비", null, 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, "K-POP", "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("MATCHED");
+    }
+
+    @Test
+    @DisplayName("카테고리 필터 적용 시 Redis에 잘못된 mapCategory가 있으면 해당 로비만 제외한다")
+    void getPublicLobbies_excludesLobbyWithInvalidRedisMapCategory() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("VALID", "정상 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("INVALID", "손상 로비", "UNKNOWN", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, "K-POP", "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("VALID");
+    }
+
+    @Test
+    @DisplayName("latest 정렬은 생성 시각 내림차순으로 정렬한다")
+    void getPublicLobbies_sortsByLatest() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("OLD", "오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L),
+                lobby("NEW", "최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("MID", "중간 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("NEW", "MID", "OLD");
+    }
+
+    @Test
+    @DisplayName("latest 정렬에서 생성 시각이 없는 기존 Redis 데이터는 후순위로 정렬한다")
+    void getPublicLobbies_sortsLobbyWithoutCreatedAtLastByLatest() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("NO-CREATED-AT", "과거 데이터 로비", "K-POP", 2, 6, LobbyStatus.WAITING, null),
+                lobby("NEW", "최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("OLD", "오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("NEW", "OLD", "NO-CREATED-AT");
+    }
+
+    @Test
+    @DisplayName("most_players 정렬은 현재 인원 많은 순으로 정렬하고 동률이면 최신순으로 정렬한다")
+    void getPublicLobbies_sortsByMostPlayers() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("TWO", "2명 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("FOUR-OLD", "4명 오래된 로비", "K-POP", 4, 6, LobbyStatus.WAITING, 1000L),
+                lobby("FOUR-NEW", "4명 최신 로비", "K-POP", 4, 6, LobbyStatus.WAITING, 4000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_players");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("FOUR-NEW", "FOUR-OLD", "TWO");
+    }
+
+    @Test
+    @DisplayName("most_available 정렬은 빈자리 많은 순으로 정렬하고 동률이면 최신순으로 정렬한다")
+    void getPublicLobbies_sortsByMostAvailable() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("ONE-SEAT", "빈자리 1개", "K-POP", 5, 6, LobbyStatus.WAITING, 3000L),
+                lobby("FOUR-SEATS-OLD", "빈자리 4개 오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L),
+                lobby("FOUR-SEATS-NEW", "빈자리 4개 최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 4000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_available");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("FOUR-SEATS-NEW", "FOUR-SEATS-OLD", "ONE-SEAT");
+    }
+
+    @Test
+    @DisplayName("빈자리 계산 시 현재 인원이 최대 인원보다 크면 0으로 보정한다")
+    void getPublicLobbies_clampsNegativeAvailableSeatsToZero() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("BROKEN", "손상 데이터 로비", "K-POP", 8, 6, LobbyStatus.WAITING, 4000L),
+                lobby("NORMAL", "정상 로비", "K-POP", 5, 6, LobbyStatus.WAITING, 3000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_available");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("NORMAL", "BROKEN");
+    }
+
+    /**
+     * 테스트용 로비 DTO를 생성한다.
+     *
+     * [의도]
+     * 각 테스트에서 필요한 값만 명확히 드러내기 위해 fixture 생성 메서드를 둔다.
+     * 실제 Redis 조회 로직은 테스트 대상이 아니므로,
+     * LobbyRedisDto builder를 사용해 Service 정책 검증에 필요한 필드만 채운다.
+     */
+    private LobbyRedisDto lobby(
+            String code,
+            String title,
+            String mapCategory,
+            int currentPlayers,
+            int maxPlayers,
+            LobbyStatus status,
+            Long createdAtEpochMillis
+    ) {
+        return LobbyRedisDto.builder()
+                .code(code)
+                .hostId("host-user-id")
+                .title(title)
+                .mapId(1L)
                 .mapTitle("테스트 맵")
-                .mapCategory("J-POP")
-                .build();
-    }
-
-    private GameLobby gameLobby() {
-        return GameLobby.builder()
-                .inviteCode("ABC123")
-                .mapId(2L)
-                .title("테스트 로비")
-                .maxPlayers(4)
-                .roundCount(5)
-                .timeLimitSeconds(30)
+                .mapCategory(mapCategory)
+                .currentPlayers(currentPlayers)
+                .maxPlayers(maxPlayers)
                 .isPrivate(false)
-                .build();
-    }
-
-    private QuizMap quizMap(int numOfSong) {
-        return QuizMap.builder()
-                .id(2L)
-                .title("테스트 맵")
-                .category(MapCategory.JPOP)
-                .numOfSong(numOfSong)
-                .totalPlayTime(300)
-                .isPublic(true)
-                .isDeleted(false)
+                .status(status.name())
+                .createdAtEpochMillis(createdAtEpochMillis)
                 .build();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
@@ -1,327 +1,159 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
-import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
-import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
-import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import org.junit.jupiter.api.DisplayName;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * LobbyQueryService의 공개 로비 목록 조회 정책을 검증한다.
+ * LobbyQueryService의 로비 상세 조회 응답 중 canStart 계산을 검증한다.
  *
- * [테스트 범위]
- * - Redis 조회 자체는 LobbyRepository의 책임이므로 mock 처리한다.
- * - 이 테스트는 Service 계층의 목록 노출 정책만 검증한다.
+ * [변경 배경]
+ * Issue #78에서 LobbyService facade를 제거하고,
+ * 로비 상세 조회 책임을 LobbyQueryService로 분리했다.
  *
- * [검증 정책]
- * - PLAYING / FINISHED 로비는 기본 목록에서 제외한다.
- * - 제목 검색은 대소문자를 무시하고 contains 기준으로 동작한다.
- * - 검색어는 LobbySearchCondition 생성 시점에 lower-case로 정규화된다.
- * - 카테고리 필터는 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
- * - Redis에 잘못된 mapCategory 값이 있어도 전체 API가 실패하지 않고 해당 로비만 제외한다.
- * - 정렬은 최신순, 인원 많은 순, 빈자리 많은 순을 지원한다.
+ * canStart 계산 자체는 LobbyCanStartPolicy가 담당하지만,
+ * 이 테스트는 "로비 상세 조회 결과에 canStart가 올바르게 반영되는지"를 검증하므로
+ * LobbyQueryService 기준으로 유지한다.
  */
-class LobbyQueryServiceTest {
+class LobbyQueryServiceCanStartTest {
 
-    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
-    private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
-    private final LobbyCanStartPolicy lobbyCanStartPolicy = mock(LobbyCanStartPolicy.class);
+    private LobbyRepository lobbyRepository;
+    private GameLobbyJpaRepository gameLobbyJpaRepository;
+    private QuizMapJpaRepository quizMapJpaRepository;
+    private LobbyQueryService lobbyQueryService;
 
-    private final LobbyQueryService lobbyQueryService = new LobbyQueryService(
-            lobbyRepository,
-            gameLobbyJpaRepository,
-            lobbyCanStartPolicy
-    );
+    @BeforeEach
+    void setUp() {
+        lobbyRepository = mock(LobbyRepository.class);
+        gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
+        quizMapJpaRepository = mock(QuizMapJpaRepository.class);
 
-    @Test
-    @DisplayName("공개 로비 목록 조회 시 WAITING 상태 로비만 반환한다")
-    void getPublicLobbies_filtersWaitingLobbyOnly() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("WAITING-1", "대기 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("PLAYING-1", "진행 로비", "K-POP", 4, 6, LobbyStatus.PLAYING, 2000L),
-                lobby("FINISHED-1", "종료 로비", "K-POP", 6, 6, LobbyStatus.FINISHED, 1000L)
-        ));
+        LobbyCanStartPolicy lobbyCanStartPolicy = new LobbyCanStartPolicy(
+                quizMapJpaRepository
+        );
 
-        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("WAITING-1");
+        lobbyQueryService = new LobbyQueryService(
+                lobbyRepository,
+                gameLobbyJpaRepository,
+                lobbyCanStartPolicy
+        );
     }
 
     @Test
-    @DisplayName("keyword가 있으면 로비 제목 기준으로 검색한다")
-    void getPublicLobbies_filtersByKeyword() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("LOBBY-1", "KPOP 랜덤 퀴즈", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("LOBBY-2", "JPOP 애니송 퀴즈", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L),
-                lobby("LOBBY-3", "POP 히트곡 퀴즈", "POP", 2, 6, LobbyStatus.WAITING, 1000L)
-        ));
+    void canStart는_Lua와_동일하게_방장_제외_참여자가_모두_ready이면_true다() {
+        String code = "ABC123";
+        String hostId = "11111111-1111-1111-1111-111111111111";
+        String guestId = "22222222-2222-2222-2222-222222222222";
 
-        LobbySearchCondition condition = LobbySearchCondition.of("애니송", null, "latest");
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
+        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
+        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
+        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
+        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
 
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(
+                code,
+                new CustomPrincipal(1L, hostId, UserType.GUEST)
+        );
 
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("LOBBY-2");
+        assertThat(response.canStart()).isTrue();
     }
 
     @Test
-    @DisplayName("keyword 검색은 대소문자를 구분하지 않는다")
-    void getPublicLobbies_filtersByKeywordIgnoringCase() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("LOBBY-1", "KPOP Random Quiz", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("LOBBY-2", "JPOP Anime Quiz", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L)
-        ));
+    void canStart는_참여자가_ready가_아니면_false다() {
+        String code = "ABC123";
+        String hostId = "11111111-1111-1111-1111-111111111111";
+        String guestId = "22222222-2222-2222-2222-222222222222";
 
-        /*
-         * LobbySearchCondition 생성 시점에 keyword가 lower-case로 정규화된다.
-         * Service는 로비 title만 lower-case로 변환하여 비교하므로,
-         * 요청 keyword의 대소문자 차이는 결과에 영향을 주지 않아야 한다.
-         */
-        LobbySearchCondition condition = LobbySearchCondition.of("random", null, "latest");
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
+        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
+        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
+        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of());
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
+        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
 
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(
+                code,
+                new CustomPrincipal(1L, hostId, UserType.GUEST)
+        );
 
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("LOBBY-1");
+        assertThat(response.canStart()).isFalse();
     }
 
     @Test
-    @DisplayName("keyword 검색어의 앞뒤 공백은 제거된다")
-    void getPublicLobbies_trimsKeyword() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("LOBBY-1", "KPOP Random Quiz", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("LOBBY-2", "JPOP Anime Quiz", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L)
-        ));
+    void canStart는_맵_문제수가_라운드수보다_적으면_false다() {
+        String code = "ABC123";
+        String hostId = "11111111-1111-1111-1111-111111111111";
+        String guestId = "22222222-2222-2222-2222-222222222222";
 
-        LobbySearchCondition condition = LobbySearchCondition.of("  random  ", null, "latest");
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(lobbyInfo(code, hostId)));
+        when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
+        when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
+        when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
+        when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(4)));
 
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(
+                code,
+                new CustomPrincipal(1L, hostId, UserType.GUEST)
+        );
 
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("LOBBY-1");
+        assertThat(response.canStart()).isFalse();
     }
 
-    @Test
-    @DisplayName("mapCategory가 있으면 선택된 맵 카테고리 기준으로 필터링한다")
-    void getPublicLobbies_filtersByMapCategory() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("LOBBY-1", "케이팝", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("LOBBY-2", "제이팝", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L),
-                lobby("LOBBY-3", "팝", "POP", 2, 6, LobbyStatus.WAITING, 1000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, "J-POP", "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("LOBBY-2");
-    }
-
-    @Test
-    @DisplayName("카테고리 필터 적용 시 맵이 선택되지 않은 로비는 제외한다")
-    void getPublicLobbies_excludesLobbyWithoutMapCategoryWhenCategoryFilterExists() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("MATCHED", "카테고리 일치 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("NO-MAP", "맵 미선택 로비", null, 2, 6, LobbyStatus.WAITING, 2000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, "K-POP", "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("MATCHED");
-    }
-
-    @Test
-    @DisplayName("카테고리 필터 적용 시 Redis에 잘못된 mapCategory가 있으면 해당 로비만 제외한다")
-    void getPublicLobbies_excludesLobbyWithInvalidRedisMapCategory() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("VALID", "정상 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("INVALID", "손상 로비", "UNKNOWN", 2, 6, LobbyStatus.WAITING, 2000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, "K-POP", "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("VALID");
-    }
-
-    @Test
-    @DisplayName("latest 정렬은 생성 시각 내림차순으로 정렬한다")
-    void getPublicLobbies_sortsByLatest() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("OLD", "오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L),
-                lobby("NEW", "최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("MID", "중간 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 2000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("NEW", "MID", "OLD");
-    }
-
-    @Test
-    @DisplayName("latest 정렬에서 생성 시각이 없는 기존 Redis 데이터는 후순위로 정렬한다")
-    void getPublicLobbies_sortsLobbyWithoutCreatedAtLastByLatest() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("NO-CREATED-AT", "과거 데이터 로비", "K-POP", 2, 6, LobbyStatus.WAITING, null),
-                lobby("NEW", "최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("OLD", "오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("NEW", "OLD", "NO-CREATED-AT");
-    }
-
-    @Test
-    @DisplayName("most_players 정렬은 현재 인원 많은 순으로 정렬하고 동률이면 최신순으로 정렬한다")
-    void getPublicLobbies_sortsByMostPlayers() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("TWO", "2명 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("FOUR-OLD", "4명 오래된 로비", "K-POP", 4, 6, LobbyStatus.WAITING, 1000L),
-                lobby("FOUR-NEW", "4명 최신 로비", "K-POP", 4, 6, LobbyStatus.WAITING, 4000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_players");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("FOUR-NEW", "FOUR-OLD", "TWO");
-    }
-
-    @Test
-    @DisplayName("most_available 정렬은 빈자리 많은 순으로 정렬하고 동률이면 최신순으로 정렬한다")
-    void getPublicLobbies_sortsByMostAvailable() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("ONE-SEAT", "빈자리 1개", "K-POP", 5, 6, LobbyStatus.WAITING, 3000L),
-                lobby("FOUR-SEATS-OLD", "빈자리 4개 오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L),
-                lobby("FOUR-SEATS-NEW", "빈자리 4개 최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 4000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_available");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("FOUR-SEATS-NEW", "FOUR-SEATS-OLD", "ONE-SEAT");
-    }
-
-    @Test
-    @DisplayName("빈자리 계산 시 현재 인원이 최대 인원보다 크면 0으로 보정한다")
-    void getPublicLobbies_clampsNegativeAvailableSeatsToZero() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("BROKEN", "손상 데이터 로비", "K-POP", 8, 6, LobbyStatus.WAITING, 4000L),
-                lobby("NORMAL", "정상 로비", "K-POP", 5, 6, LobbyStatus.WAITING, 3000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_available");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("NORMAL", "BROKEN");
-    }
-
-    /**
-     * 테스트용 로비 DTO를 생성한다.
-     *
-     * [의도]
-     * 각 테스트에서 필요한 값만 명확히 드러내기 위해 fixture 생성 메서드를 둔다.
-     * 실제 Redis 조회 로직은 테스트 대상이 아니므로,
-     * LobbyRedisDto builder를 사용해 Service 정책 검증에 필요한 필드만 채운다.
-     */
-    private LobbyRedisDto lobby(
-            String code,
-            String title,
-            String mapCategory,
-            int currentPlayers,
-            int maxPlayers,
-            LobbyStatus status,
-            Long createdAtEpochMillis
-    ) {
-        return LobbyRedisDto.builder()
-                .code(code)
-                .hostId("host-user-id")
-                .title(title)
-                .mapId(1L)
+    private JoinLobbyResponse lobbyInfo(String code, String hostId) {
+        return JoinLobbyResponse.builder()
+                .inviteCode(code)
+                .title("테스트 로비")
+                .hostId(hostId)
+                .maxPlayers(4)
+                .currentPlayers(2)
+                .status("WAITING")
+                .mapId(2L)
                 .mapTitle("테스트 맵")
-                .mapCategory(mapCategory)
-                .currentPlayers(currentPlayers)
-                .maxPlayers(maxPlayers)
+                .mapCategory("J-POP")
+                .build();
+    }
+
+    private GameLobby gameLobby() {
+        return GameLobby.builder()
+                .inviteCode("ABC123")
+                .mapId(2L)
+                .title("테스트 로비")
+                .maxPlayers(4)
+                .roundCount(5)
+                .timeLimitSeconds(30)
                 .isPrivate(false)
-                .status(status.name())
-                .createdAtEpochMillis(createdAtEpochMillis)
+                .build();
+    }
+
+    private QuizMap quizMap(int numOfSong) {
+        return QuizMap.builder()
+                .id(2L)
+                .title("테스트 맵")
+                .category(MapCategory.JPOP)
+                .numOfSong(numOfSong)
+                .totalPlayTime(300)
+                .isPublic(true)
+                .isDeleted(false)
                 .build();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
  * [검증 정책]
  * - PLAYING / FINISHED 로비는 기본 목록에서 제외한다.
  * - 제목 검색은 대소문자를 무시하고 contains 기준으로 동작한다.
+ * - 검색어는 LobbySearchCondition 생성 시점에 lower-case로 정규화된다.
  * - 카테고리 필터는 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
  * - Redis에 잘못된 mapCategory 값이 있어도 전체 API가 실패하지 않고 해당 로비만 제외한다.
  * - 정렬은 최신순, 인원 많은 순, 빈자리 많은 순을 지원한다.
@@ -91,7 +92,32 @@ class LobbyQueryServiceTest {
                 lobby("LOBBY-2", "JPOP Anime Quiz", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L)
         ));
 
+        /*
+         * LobbySearchCondition 생성 시점에 keyword가 lower-case로 정규화된다.
+         * Service는 로비 title만 lower-case로 변환하여 비교하므로,
+         * 요청 keyword의 대소문자 차이는 결과에 영향을 주지 않아야 한다.
+         */
         LobbySearchCondition condition = LobbySearchCondition.of("random", null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-1");
+    }
+
+    @Test
+    @DisplayName("keyword 검색어의 앞뒤 공백은 제거된다")
+    void getPublicLobbies_trimsKeyword() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "KPOP Random Quiz", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "JPOP Anime Quiz", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of("  random  ", null, "latest");
 
         // when
         List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -274,8 +274,8 @@ class LobbyQueryServiceTest {
     }
 
     @Test
-    @DisplayName("빈자리 계산 시 현재 인원이 최대 인원보다 크면 0으로 보정한다")
-    void getPublicLobbies_clampsNegativeAvailableSeatsToZero() {
+    @DisplayName("currentPlayers가 maxPlayers보다 크면 공개 로비 목록에서 제외한다")
+    void getPublicLobbies_excludesLobbyWhenCurrentPlayersExceedsMaxPlayers() {
         // given
         when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
                 lobby("BROKEN", "손상 데이터 로비", "K-POP", 8, 6, LobbyStatus.WAITING, 4000L),
@@ -290,7 +290,7 @@ class LobbyQueryServiceTest {
         // then
         assertThat(result)
                 .extracting(LobbyRedisDto::getCode)
-                .containsExactly("NORMAL", "BROKEN");
+                .containsExactly("NORMAL");
     }
 
     @Test
@@ -343,6 +343,49 @@ class LobbyQueryServiceTest {
                 .isPrivate(false)
                 .status(status.name())
                 .createdAtEpochMillis(createdAtEpochMillis)
+                .build();
+    }
+
+    @Test
+    @DisplayName("maxPlayers 또는 currentPlayers가 유효하지 않으면 공개 로비 목록에서 제외한다")
+    void getPublicLobbies_excludesLobbyWithInvalidCapacityValues() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobbyWithCapacity("NULL-MAX", 1, null),
+                lobbyWithCapacity("ZERO-MAX", 1, 0),
+                lobbyWithCapacity("NULL-CURRENT", null, 6),
+                lobbyWithCapacity("NEGATIVE-CURRENT", -1, 6),
+                lobbyWithCapacity("VALID", 2, 6)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("VALID");
+    }
+
+    private LobbyRedisDto lobbyWithCapacity(
+            String code,
+            Integer currentPlayers,
+            Integer maxPlayers
+    ) {
+        return LobbyRedisDto.builder()
+                .code(code)
+                .hostId("host-user-id")
+                .title("테스트 로비")
+                .mapId(1L)
+                .mapTitle("테스트 맵")
+                .mapCategory("K-POP")
+                .currentPlayers(currentPlayers)
+                .maxPlayers(maxPlayers)
+                .isPrivate(false)
+                .status(LobbyStatus.WAITING.name())
+                .createdAtEpochMillis(1000L)
                 .build();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -293,6 +293,27 @@ class LobbyQueryServiceTest {
                 .containsExactly("NORMAL", "BROKEN");
     }
 
+    @Test
+    @DisplayName("기본 조회에서도 Redis에 잘못된 mapCategory가 있으면 해당 로비를 제외한다")
+    void getPublicLobbies_excludesLobbyWithInvalidRedisMapCategoryWithoutCategoryFilter() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("VALID", "정상 카테고리 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("NO-MAP", "맵 미선택 로비", null, 2, 6, LobbyStatus.WAITING, 2000L),
+                lobby("INVALID", "손상 카테고리 로비", "UNKNOWN", 2, 6, LobbyStatus.WAITING, 1000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("VALID", "NO-MAP");
+    }
+
     /**
      * 테스트용 로비 DTO를 생성한다.
      *

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -42,8 +42,8 @@ class LobbyQueryServiceTest {
     );
 
     @Test
-    @DisplayName("공개 로비 목록 조회 시 WAITING 상태 로비만 반환한다")
-    void getPublicLobbies_filtersWaitingLobbyOnly() {
+    @DisplayName("공개 로비 목록 조회 시 WAITING과 PLAYING 상태 로비를 반환하고 FINISHED는 제외한다")
+    void getPublicLobbies_filtersVisibleLobbyStatuses() {
         // given
         when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
                 lobby("WAITING-1", "대기 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
@@ -59,7 +59,7 @@ class LobbyQueryServiceTest {
         // then
         assertThat(result)
                 .extracting(LobbyRedisDto::getCode)
-                .containsExactly("WAITING-1");
+                .containsExactly("WAITING-1", "PLAYING-1");
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -1,0 +1,327 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * LobbyQueryService의 공개 로비 목록 조회 정책을 검증한다.
+ *
+ * [테스트 범위]
+ * - Redis 조회 자체는 LobbyRepository의 책임이므로 mock 처리한다.
+ * - 이 테스트는 Service 계층의 목록 노출 정책만 검증한다.
+ *
+ * [검증 정책]
+ * - PLAYING / FINISHED 로비는 기본 목록에서 제외한다.
+ * - 제목 검색은 대소문자를 무시하고 contains 기준으로 동작한다.
+ * - 검색어는 LobbySearchCondition 생성 시점에 lower-case로 정규화된다.
+ * - 카테고리 필터는 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
+ * - Redis에 잘못된 mapCategory 값이 있어도 전체 API가 실패하지 않고 해당 로비만 제외한다.
+ * - 정렬은 최신순, 인원 많은 순, 빈자리 많은 순을 지원한다.
+ */
+class LobbyQueryServiceTest {
+
+    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
+    private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
+    private final LobbyCanStartPolicy lobbyCanStartPolicy = mock(LobbyCanStartPolicy.class);
+
+    private final LobbyQueryService lobbyQueryService = new LobbyQueryService(
+            lobbyRepository,
+            gameLobbyJpaRepository,
+            lobbyCanStartPolicy
+    );
+
+    @Test
+    @DisplayName("공개 로비 목록 조회 시 WAITING 상태 로비만 반환한다")
+    void getPublicLobbies_filtersWaitingLobbyOnly() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("WAITING-1", "대기 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("PLAYING-1", "진행 로비", "K-POP", 4, 6, LobbyStatus.PLAYING, 2000L),
+                lobby("FINISHED-1", "종료 로비", "K-POP", 6, 6, LobbyStatus.FINISHED, 1000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("WAITING-1");
+    }
+
+    @Test
+    @DisplayName("keyword가 있으면 로비 제목 기준으로 검색한다")
+    void getPublicLobbies_filtersByKeyword() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "KPOP 랜덤 퀴즈", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "JPOP 애니송 퀴즈", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L),
+                lobby("LOBBY-3", "POP 히트곡 퀴즈", "POP", 2, 6, LobbyStatus.WAITING, 1000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of("애니송", null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-2");
+    }
+
+    @Test
+    @DisplayName("keyword 검색은 대소문자를 구분하지 않는다")
+    void getPublicLobbies_filtersByKeywordIgnoringCase() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "KPOP Random Quiz", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "JPOP Anime Quiz", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        /*
+         * LobbySearchCondition 생성 시점에 keyword가 lower-case로 정규화된다.
+         * Service는 로비 title만 lower-case로 변환하여 비교하므로,
+         * 요청 keyword의 대소문자 차이는 결과에 영향을 주지 않아야 한다.
+         */
+        LobbySearchCondition condition = LobbySearchCondition.of("random", null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-1");
+    }
+
+    @Test
+    @DisplayName("keyword 검색어의 앞뒤 공백은 제거된다")
+    void getPublicLobbies_trimsKeyword() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "KPOP Random Quiz", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "JPOP Anime Quiz", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of("  random  ", null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-1");
+    }
+
+    @Test
+    @DisplayName("mapCategory가 있으면 선택된 맵 카테고리 기준으로 필터링한다")
+    void getPublicLobbies_filtersByMapCategory() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("LOBBY-1", "케이팝", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("LOBBY-2", "제이팝", "J-POP", 2, 6, LobbyStatus.WAITING, 2000L),
+                lobby("LOBBY-3", "팝", "POP", 2, 6, LobbyStatus.WAITING, 1000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, "J-POP", "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("LOBBY-2");
+    }
+
+    @Test
+    @DisplayName("카테고리 필터 적용 시 맵이 선택되지 않은 로비는 제외한다")
+    void getPublicLobbies_excludesLobbyWithoutMapCategoryWhenCategoryFilterExists() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("MATCHED", "카테고리 일치 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("NO-MAP", "맵 미선택 로비", null, 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, "K-POP", "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("MATCHED");
+    }
+
+    @Test
+    @DisplayName("카테고리 필터 적용 시 Redis에 잘못된 mapCategory가 있으면 해당 로비만 제외한다")
+    void getPublicLobbies_excludesLobbyWithInvalidRedisMapCategory() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("VALID", "정상 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("INVALID", "손상 로비", "UNKNOWN", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, "K-POP", "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("VALID");
+    }
+
+    @Test
+    @DisplayName("latest 정렬은 생성 시각 내림차순으로 정렬한다")
+    void getPublicLobbies_sortsByLatest() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("OLD", "오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L),
+                lobby("NEW", "최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("MID", "중간 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 2000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("NEW", "MID", "OLD");
+    }
+
+    @Test
+    @DisplayName("latest 정렬에서 생성 시각이 없는 기존 Redis 데이터는 후순위로 정렬한다")
+    void getPublicLobbies_sortsLobbyWithoutCreatedAtLastByLatest() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("NO-CREATED-AT", "과거 데이터 로비", "K-POP", 2, 6, LobbyStatus.WAITING, null),
+                lobby("NEW", "최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("OLD", "오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("NEW", "OLD", "NO-CREATED-AT");
+    }
+
+    @Test
+    @DisplayName("most_players 정렬은 현재 인원 많은 순으로 정렬하고 동률이면 최신순으로 정렬한다")
+    void getPublicLobbies_sortsByMostPlayers() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("TWO", "2명 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
+                lobby("FOUR-OLD", "4명 오래된 로비", "K-POP", 4, 6, LobbyStatus.WAITING, 1000L),
+                lobby("FOUR-NEW", "4명 최신 로비", "K-POP", 4, 6, LobbyStatus.WAITING, 4000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_players");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("FOUR-NEW", "FOUR-OLD", "TWO");
+    }
+
+    @Test
+    @DisplayName("most_available 정렬은 빈자리 많은 순으로 정렬하고 동률이면 최신순으로 정렬한다")
+    void getPublicLobbies_sortsByMostAvailable() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("ONE-SEAT", "빈자리 1개", "K-POP", 5, 6, LobbyStatus.WAITING, 3000L),
+                lobby("FOUR-SEATS-OLD", "빈자리 4개 오래된 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 1000L),
+                lobby("FOUR-SEATS-NEW", "빈자리 4개 최신 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 4000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_available");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("FOUR-SEATS-NEW", "FOUR-SEATS-OLD", "ONE-SEAT");
+    }
+
+    @Test
+    @DisplayName("빈자리 계산 시 현재 인원이 최대 인원보다 크면 0으로 보정한다")
+    void getPublicLobbies_clampsNegativeAvailableSeatsToZero() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("BROKEN", "손상 데이터 로비", "K-POP", 8, 6, LobbyStatus.WAITING, 4000L),
+                lobby("NORMAL", "정상 로비", "K-POP", 5, 6, LobbyStatus.WAITING, 3000L)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "most_available");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("NORMAL", "BROKEN");
+    }
+
+    /**
+     * 테스트용 로비 DTO를 생성한다.
+     *
+     * [의도]
+     * 각 테스트에서 필요한 값만 명확히 드러내기 위해 fixture 생성 메서드를 둔다.
+     * 실제 Redis 조회 로직은 테스트 대상이 아니므로,
+     * LobbyRedisDto builder를 사용해 Service 정책 검증에 필요한 필드만 채운다.
+     */
+    private LobbyRedisDto lobby(
+            String code,
+            String title,
+            String mapCategory,
+            int currentPlayers,
+            int maxPlayers,
+            LobbyStatus status,
+            Long createdAtEpochMillis
+    ) {
+        return LobbyRedisDto.builder()
+                .code(code)
+                .hostId("host-user-id")
+                .title(title)
+                .mapId(1L)
+                .mapTitle("테스트 맵")
+                .mapCategory(mapCategory)
+                .currentPlayers(currentPlayers)
+                .maxPlayers(maxPlayers)
+                .isPrivate(false)
+                .status(status.name())
+                .createdAtEpochMillis(createdAtEpochMillis)
+                .build();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -22,11 +22,13 @@ import static org.mockito.Mockito.when;
  * - 이 테스트는 Service 계층의 목록 노출 정책만 검증한다.
  *
  * [검증 정책]
- * - PLAYING / FINISHED 로비는 기본 목록에서 제외한다.
+ * - 비공개 로비가 공개 목록 원본에 섞여 있으면 제외한다.
+ * - WAITING / PLAYING 로비는 공개 목록에 노출한다.
+ * - FINISHED 로비는 공개 목록에서 제외한다.
  * - 제목 검색은 대소문자를 무시하고 contains 기준으로 동작한다.
  * - 검색어는 LobbySearchCondition 생성 시점에 lower-case로 정규화된다.
- * - 카테고리 필터는 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
  * - 카테고리 필터는 Repository에서 정규화된 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
+ * - 정원/현재 인원 값이 유효하지 않은 로비는 제외한다.
  * - 정렬은 최신순, 인원 많은 순, 빈자리 많은 순을 지원한다.
  */
 class LobbyQueryServiceTest {
@@ -60,6 +62,26 @@ class LobbyQueryServiceTest {
         assertThat(result)
                 .extracting(LobbyRedisDto::getCode)
                 .containsExactly("WAITING-1", "PLAYING-1");
+    }
+
+    @Test
+    @DisplayName("비공개 로비가 공개 로비 목록 원본에 섞여 있으면 제외한다")
+    void getPublicLobbies_excludesPrivateLobby() {
+        // given
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobby("PUBLIC", "공개 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L, false),
+                lobby("PRIVATE", "비공개 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 2000L, true)
+        ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
+
+        // when
+        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
+
+        // then
+        assertThat(result)
+                .extracting(LobbyRedisDto::getCode)
+                .containsExactly("PUBLIC");
     }
 
     @Test
@@ -273,38 +295,6 @@ class LobbyQueryServiceTest {
                 .containsExactly("NORMAL");
     }
 
-    /**
-     * 테스트용 로비 DTO를 생성한다.
-     *
-     * [의도]
-     * 각 테스트에서 필요한 값만 명확히 드러내기 위해 fixture 생성 메서드를 둔다.
-     * 실제 Redis 조회 로직은 테스트 대상이 아니므로,
-     * LobbyRedisDto builder를 사용해 Service 정책 검증에 필요한 필드만 채운다.
-     */
-    private LobbyRedisDto lobby(
-            String code,
-            String title,
-            String mapCategory,
-            int currentPlayers,
-            int maxPlayers,
-            LobbyStatus status,
-            Long createdAtEpochMillis
-    ) {
-        return LobbyRedisDto.builder()
-                .code(code)
-                .hostId("host-user-id")
-                .title(title)
-                .mapId(1L)
-                .mapTitle("테스트 맵")
-                .mapCategory(mapCategory)
-                .currentPlayers(currentPlayers)
-                .maxPlayers(maxPlayers)
-                .isPrivate(false)
-                .status(status.name())
-                .createdAtEpochMillis(createdAtEpochMillis)
-                .build();
-    }
-
     @Test
     @DisplayName("maxPlayers 또는 currentPlayers가 유효하지 않으면 공개 로비 목록에서 제외한다")
     void getPublicLobbies_excludesLobbyWithInvalidCapacityValues() {
@@ -328,6 +318,77 @@ class LobbyQueryServiceTest {
                 .containsExactly("VALID");
     }
 
+    /**
+     * 테스트용 로비 DTO를 생성한다.
+     *
+     * [의도]
+     * 각 테스트에서 필요한 값만 명확히 드러내기 위해 fixture 생성 메서드를 둔다.
+     * 실제 Redis 조회 로직은 테스트 대상이 아니므로,
+     * LobbyRedisDto builder를 사용해 Service 정책 검증에 필요한 필드만 채운다.
+     */
+    private LobbyRedisDto lobby(
+            String code,
+            String title,
+            String mapCategory,
+            int currentPlayers,
+            int maxPlayers,
+            LobbyStatus status,
+            Long createdAtEpochMillis
+    ) {
+        return lobby(
+                code,
+                title,
+                mapCategory,
+                currentPlayers,
+                maxPlayers,
+                status,
+                createdAtEpochMillis,
+                false
+        );
+    }
+
+    /**
+     * 공개/비공개 여부를 직접 지정할 수 있는 테스트용 로비 DTO를 생성한다.
+     *
+     * [사용 목적]
+     * 정상 Redis 생성 경로에서는 비공개 로비가 lobby:public Set에 들어가지 않는다.
+     * 다만 운영 중 Redis 수동 조작이나 복구 과정에서 비공개 로비 코드가 섞일 수 있으므로,
+     * Service 계층의 최종 방어 필터를 검증하기 위해 isPrivate 값을 지정할 수 있게 한다.
+     */
+    private LobbyRedisDto lobby(
+            String code,
+            String title,
+            String mapCategory,
+            int currentPlayers,
+            int maxPlayers,
+            LobbyStatus status,
+            Long createdAtEpochMillis,
+            boolean isPrivate
+    ) {
+        return LobbyRedisDto.builder()
+                .code(code)
+                .hostId("host-user-id")
+                .title(title)
+                .mapId(1L)
+                .mapTitle("테스트 맵")
+                .mapCategory(mapCategory)
+                .currentPlayers(currentPlayers)
+                .maxPlayers(maxPlayers)
+                .isPrivate(isPrivate)
+                .status(status.name())
+                .createdAtEpochMillis(createdAtEpochMillis)
+                .build();
+    }
+
+    /**
+     * capacity 유효성 검증 테스트용 로비 DTO를 생성한다.
+     *
+     * [의도]
+     * 기존 lobby() fixture는 currentPlayers/maxPlayers를 primitive int로 받기 때문에
+     * null 값 검증에 사용할 수 없다.
+     * Redis 손상 데이터 방어 테스트에서는 null/0/음수 값을 명시적으로 만들 수 있어야 하므로
+     * Integer 기반 별도 fixture를 사용한다.
+     */
     private LobbyRedisDto lobbyWithCapacity(
             String code,
             Integer currentPlayers,

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
  * - 제목 검색은 대소문자를 무시하고 contains 기준으로 동작한다.
  * - 검색어는 LobbySearchCondition 생성 시점에 lower-case로 정규화된다.
  * - 카테고리 필터는 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
- * - Redis에 잘못된 mapCategory 값이 있어도 전체 API가 실패하지 않고 해당 로비만 제외한다.
+ * - 카테고리 필터는 Repository에서 정규화된 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
  * - 정렬은 최신순, 인원 많은 순, 빈자리 많은 순을 지원한다.
  */
 class LobbyQueryServiceTest {
@@ -170,26 +170,6 @@ class LobbyQueryServiceTest {
     }
 
     @Test
-    @DisplayName("카테고리 필터 적용 시 Redis에 잘못된 mapCategory가 있으면 해당 로비만 제외한다")
-    void getPublicLobbies_excludesLobbyWithInvalidRedisMapCategory() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("VALID", "정상 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("INVALID", "손상 로비", "UNKNOWN", 2, 6, LobbyStatus.WAITING, 2000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, "K-POP", "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("VALID");
-    }
-
-    @Test
     @DisplayName("latest 정렬은 생성 시각 내림차순으로 정렬한다")
     void getPublicLobbies_sortsByLatest() {
         // given
@@ -291,27 +271,6 @@ class LobbyQueryServiceTest {
         assertThat(result)
                 .extracting(LobbyRedisDto::getCode)
                 .containsExactly("NORMAL");
-    }
-
-    @Test
-    @DisplayName("기본 조회에서도 Redis에 잘못된 mapCategory가 있으면 해당 로비를 제외한다")
-    void getPublicLobbies_excludesLobbyWithInvalidRedisMapCategoryWithoutCategoryFilter() {
-        // given
-        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
-                lobby("VALID", "정상 카테고리 로비", "K-POP", 2, 6, LobbyStatus.WAITING, 3000L),
-                lobby("NO-MAP", "맵 미선택 로비", null, 2, 6, LobbyStatus.WAITING, 2000L),
-                lobby("INVALID", "손상 카테고리 로비", "UNKNOWN", 2, 6, LobbyStatus.WAITING, 1000L)
-        ));
-
-        LobbySearchCondition condition = LobbySearchCondition.of(null, null, "latest");
-
-        // when
-        List<LobbyRedisDto> result = lobbyQueryService.getPublicLobbies(condition);
-
-        // then
-        assertThat(result)
-                .extracting(LobbyRedisDto::getCode)
-                .containsExactly("VALID", "NO-MAP");
     }
 
     /**

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
@@ -10,6 +10,7 @@ import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,14 +43,18 @@ class MapServiceTest {
     private ValueOperations<String, String> valueOperations;
     @Mock
     private JsonMapper jsonMapper;
-    @Mock
-    private MapCacheEvictor mapCacheEvictor;
 
     private MapService mapService;
 
     @BeforeEach
     void setUp() {
-        mapService = new MapService(quizMapJpaRepository, userRepository, mapCacheEvictor, redisTemplate, jsonMapper);
+        mapService = new MapService(
+                quizMapJpaRepository,
+                userRepository,
+                redisTemplate,
+                jsonMapper
+        );
+
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
     }
 
@@ -98,8 +103,8 @@ class MapServiceTest {
         assertThat(response.ownerId()).isEqualTo(10L);
         assertThat(response.title()).isEqualTo("new map");
         assertThat(response.isPublic()).isTrue();
-        verify(mapCacheEvictor).evictPublicMapCaches(300L);
-    }
+        verify(valueOperations).increment(RedisKeys.mapPublicListVersionKey());
+        verify(redisTemplate).delete(RedisKeys.mapPublicDetailKey(300L));    }
 
     @Test
     void updateMap_notOwner_forbidden() {
@@ -156,6 +161,6 @@ class MapServiceTest {
 
         mapService.updateMap(200L, request, ownerPrincipal);
 
-        verify(mapCacheEvictor).evictPublicMapCaches(200L);
-    }
+        verify(valueOperations).increment(RedisKeys.mapPublicListVersionKey());
+        verify(redisTemplate).delete(RedisKeys.mapPublicDetailKey(200L));    }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationServiceTest.java
@@ -26,10 +26,18 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class YoutubeValidationServiceTest {
 
+    private static final String TEST_VIDEO_ID = "abcde123456";
+    private static final String TEST_YOUTUBE_URL = "https://www.youtube.com/watch?v=" + TEST_VIDEO_ID;
+    private static final String MIXED_CASE_ID = "dQw4w9WgXcQ";
+    private static final String OEMBED_RESPONSE =
+            "{\"title\":\"t\",\"author_name\":\"a\",\"thumbnail_url\":\"th\"}";
+
     @Mock
     private StringRedisTemplate redisTemplate;
+
     @Mock
     private ValueOperations<String, String> valueOperations;
+
     @Mock
     private YoutubeOEmbedClient youtubeOEmbedClient;
 
@@ -39,13 +47,18 @@ class YoutubeValidationServiceTest {
     @BeforeEach
     void setUp() {
         jsonMapper = JsonMapper.builder().build();
-        youtubeValidationService = new YoutubeValidationService(redisTemplate, jsonMapper, youtubeOEmbedClient);
+        youtubeValidationService = new YoutubeValidationService(
+                redisTemplate,
+                jsonMapper,
+                youtubeOEmbedClient
+        );
+
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
     }
 
     @Test
     void validateYoutubeUrl_invalidFormat_badRequest() {
-        // example.com host는 YouTube 도메인이 아니므로 거절되어야 함
+        // example.com host는 YouTube 도메인이 아니므로 oEmbed 호출 전에 거절되어야 한다.
         assertThatThrownBy(() -> youtubeValidationService.validateYoutubeUrl("https://example.com/watch?v=abc"))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("유효한 YouTube URL이 아닙니다.");
@@ -55,7 +68,7 @@ class YoutubeValidationServiceTest {
 
     @Test
     void validateYoutubeUrl_nonYoutubeDomainWithValidVideoId_badRequest() {
-        // 11자 유효 videoId가 있더라도 host가 YouTube 도메인이 아니면 거절되어야 함
+        // 11자 유효 videoId가 있더라도 host가 YouTube 도메인이 아니면 거절되어야 한다.
         assertThatThrownBy(() -> youtubeValidationService
                 .validateYoutubeUrl("https://example.com/watch?v=dQw4w9WgXcQ"))
                 .isInstanceOf(ResponseStatusException.class)
@@ -66,11 +79,10 @@ class YoutubeValidationServiceTest {
 
     @Test
     void validateYoutubeUrl_negativeCacheHit_blocksWithoutRevalidate() {
-        String url = "https://www.youtube.com/watch?v=abcde123456";
-        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey("abcde123456"))).thenReturn(null);
-        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey("abcde123456"))).thenReturn(true);
+        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(TEST_VIDEO_ID))).thenReturn(null);
+        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey(TEST_VIDEO_ID))).thenReturn(true);
 
-        assertThatThrownBy(() -> youtubeValidationService.validateYoutubeUrl(url))
+        assertThatThrownBy(() -> youtubeValidationService.validateYoutubeUrl(TEST_YOUTUBE_URL))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("임베드 가능한 YouTube 영상이 아닙니다.");
 
@@ -78,11 +90,10 @@ class YoutubeValidationServiceTest {
     }
 
     @Test
-    void validateYoutubeUrl_oembedReturnsBlankTitle_badRequestAndStoresFailureCache() {
-        String url = "https://www.youtube.com/watch?v=abcde123456";
-        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey("abcde123456"))).thenReturn(null);
-        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey("abcde123456"))).thenReturn(false);
-        when(youtubeOEmbedClient.fetchByVideoId("abcde123456"))
+    void validateYoutubeUrl_oembedReturnsBlankTitle_badRequestAndDoesNotStoreFailureCache() {
+        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(TEST_VIDEO_ID))).thenReturn(null);
+        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey(TEST_VIDEO_ID))).thenReturn(false);
+        when(youtubeOEmbedClient.fetchByVideoId(TEST_VIDEO_ID))
                 .thenReturn("""
                         {
                           "author_name":"artist",
@@ -90,19 +101,29 @@ class YoutubeValidationServiceTest {
                         }
                         """);
 
-        assertThatThrownBy(() -> youtubeValidationService.validateYoutubeUrl(url))
+        assertThatThrownBy(() -> youtubeValidationService.validateYoutubeUrl(TEST_YOUTUBE_URL))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("임베드 가능한 YouTube 영상이 아닙니다.");
 
-        verify(valueOperations).set(eq(RedisKeys.youtubeOembedFailureKey("abcde123456")), anyString(), any());
+        /*
+         * title 누락은 현재 요청에서는 사용할 수 없는 응답이지만,
+         * YouTube가 401/403/404를 반환한 영구적 임베드 불가 상태는 아니다.
+         *
+         * 따라서 Negative Cache에 저장하지 않아야 한다.
+         * 저장해버리면 일시적인 oEmbed 응답 이상이 30분 동안 영구 실패처럼 고정된다.
+         */
+        verify(valueOperations, never()).set(
+                eq(RedisKeys.youtubeOembedFailureKey(TEST_VIDEO_ID)),
+                anyString(),
+                any()
+        );
     }
 
     @Test
-    void validateYoutubeUrl_oembedReturnsBlankArtist_badRequestAndStoresFailureCache() {
-        String url = "https://www.youtube.com/watch?v=abcde123456";
-        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey("abcde123456"))).thenReturn(null);
-        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey("abcde123456"))).thenReturn(false);
-        when(youtubeOEmbedClient.fetchByVideoId("abcde123456"))
+    void validateYoutubeUrl_oembedReturnsBlankArtist_badRequestAndDoesNotStoreFailureCache() {
+        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(TEST_VIDEO_ID))).thenReturn(null);
+        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey(TEST_VIDEO_ID))).thenReturn(false);
+        when(youtubeOEmbedClient.fetchByVideoId(TEST_VIDEO_ID))
                 .thenReturn("""
                         {
                           "title":"title",
@@ -110,35 +131,42 @@ class YoutubeValidationServiceTest {
                         }
                         """);
 
-        assertThatThrownBy(() -> youtubeValidationService.validateYoutubeUrl(url))
+        assertThatThrownBy(() -> youtubeValidationService.validateYoutubeUrl(TEST_YOUTUBE_URL))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("임베드 가능한 YouTube 영상이 아닙니다.");
 
-        verify(valueOperations).set(eq(RedisKeys.youtubeOembedFailureKey("abcde123456")), anyString(), any());
+        /*
+         * author_name 누락도 title 누락과 동일하게 영구 실패로 단정하지 않는다.
+         * Negative Cache는 401/403/404처럼 임베드 불가가 명확한 경우에만 저장한다.
+         */
+        verify(valueOperations, never()).set(
+                eq(RedisKeys.youtubeOembedFailureKey(TEST_VIDEO_ID)),
+                anyString(),
+                any()
+        );
     }
 
     @Test
-    void validateYoutubeUrl_successCacheHit_returnsCachedMetadata() throws Exception {
-        YoutubeMetadata cached = new YoutubeMetadata("abcde123456", "title", "artist", "thumb");
+    void validateYoutubeUrl_successCacheHit_returnsCachedMetadata() {
+        YoutubeMetadata cached = new YoutubeMetadata(TEST_VIDEO_ID, "title", "artist", "thumb");
         String serialized = jsonMapper.writeValueAsString(cached);
 
-        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey("abcde123456"))).thenReturn(serialized);
+        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(TEST_VIDEO_ID))).thenReturn(serialized);
 
-        YoutubeMetadata result = youtubeValidationService
-                .validateYoutubeUrl("https://www.youtube.com/watch?v=abcde123456");
+        YoutubeMetadata result = youtubeValidationService.validateYoutubeUrl(TEST_YOUTUBE_URL);
 
-        assertThat(result.videoId()).isEqualTo("abcde123456");
+        assertThat(result.videoId()).isEqualTo(TEST_VIDEO_ID);
         assertThat(result.title()).isEqualTo("title");
         verify(youtubeOEmbedClient, never()).fetchByVideoId(anyString());
     }
 
     @Test
     void validateYoutubeUrl_successFetch_storesSuccessCache() {
-        String url = "https://youtu.be/abcde123456";
+        String url = "https://youtu.be/" + TEST_VIDEO_ID;
 
-        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey("abcde123456"))).thenReturn(null);
-        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey("abcde123456"))).thenReturn(false);
-        when(youtubeOEmbedClient.fetchByVideoId("abcde123456"))
+        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(TEST_VIDEO_ID))).thenReturn(null);
+        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey(TEST_VIDEO_ID))).thenReturn(false);
+        when(youtubeOEmbedClient.fetchByVideoId(TEST_VIDEO_ID))
                 .thenReturn("""
                         {
                           "title":"new title",
@@ -149,7 +177,7 @@ class YoutubeValidationServiceTest {
 
         YoutubeMetadata result = youtubeValidationService.validateYoutubeUrl(url);
 
-        assertThat(result.videoId()).isEqualTo("abcde123456");
+        assertThat(result.videoId()).isEqualTo(TEST_VIDEO_ID);
         assertThat(result.artist()).isEqualTo("new artist");
         verify(valueOperations).set(anyString(), anyString(), any());
     }
@@ -158,21 +186,13 @@ class YoutubeValidationServiceTest {
     // URL 형식별 videoId 추출 + 케이스 보존 검증
     // ─────────────────────────────────────────────
 
-    private static final String MIXED_CASE_ID = "dQw4w9WgXcQ";
-    private static final String OEMBED_RESPONSE =
-            "{\"title\":\"t\",\"author_name\":\"a\",\"thumbnail_url\":\"th\"}";
-
-    private void stubSuccess(String videoId) {
-        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(videoId))).thenReturn(null);
-        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey(videoId))).thenReturn(false);
-        when(youtubeOEmbedClient.fetchByVideoId(videoId)).thenReturn(OEMBED_RESPONSE);
-    }
-
     @Test
     void extractVideoId_standardUrl_extractsCorrectId() {
         stubSuccess(MIXED_CASE_ID);
+
         YoutubeMetadata result = youtubeValidationService
                 .validateYoutubeUrl("https://www.youtube.com/watch?v=" + MIXED_CASE_ID);
+
         assertThat(result.videoId()).isEqualTo(MIXED_CASE_ID);
         verify(youtubeOEmbedClient).fetchByVideoId(eq(MIXED_CASE_ID));
     }
@@ -180,8 +200,10 @@ class YoutubeValidationServiceTest {
     @Test
     void extractVideoId_shortUrl_extractsCorrectId() {
         stubSuccess(MIXED_CASE_ID);
+
         YoutubeMetadata result = youtubeValidationService
                 .validateYoutubeUrl("https://youtu.be/" + MIXED_CASE_ID);
+
         assertThat(result.videoId()).isEqualTo(MIXED_CASE_ID);
         verify(youtubeOEmbedClient).fetchByVideoId(eq(MIXED_CASE_ID));
     }
@@ -189,8 +211,10 @@ class YoutubeValidationServiceTest {
     @Test
     void extractVideoId_shortsUrl_extractsCorrectId() {
         stubSuccess(MIXED_CASE_ID);
+
         YoutubeMetadata result = youtubeValidationService
                 .validateYoutubeUrl("https://www.youtube.com/shorts/" + MIXED_CASE_ID);
+
         assertThat(result.videoId()).isEqualTo(MIXED_CASE_ID);
         verify(youtubeOEmbedClient).fetchByVideoId(eq(MIXED_CASE_ID));
     }
@@ -198,8 +222,10 @@ class YoutubeValidationServiceTest {
     @Test
     void extractVideoId_embedUrl_extractsCorrectId() {
         stubSuccess(MIXED_CASE_ID);
+
         YoutubeMetadata result = youtubeValidationService
                 .validateYoutubeUrl("https://www.youtube.com/embed/" + MIXED_CASE_ID);
+
         assertThat(result.videoId()).isEqualTo(MIXED_CASE_ID);
         verify(youtubeOEmbedClient).fetchByVideoId(eq(MIXED_CASE_ID));
     }
@@ -207,17 +233,21 @@ class YoutubeValidationServiceTest {
     @Test
     void extractVideoId_mobileUrl_extractsCorrectId() {
         stubSuccess(MIXED_CASE_ID);
+
         YoutubeMetadata result = youtubeValidationService
                 .validateYoutubeUrl("https://m.youtube.com/watch?v=" + MIXED_CASE_ID);
+
         assertThat(result.videoId()).isEqualTo(MIXED_CASE_ID);
         verify(youtubeOEmbedClient).fetchByVideoId(eq(MIXED_CASE_ID));
     }
 
     @Test
     void extractVideoId_preservesMixedCase_notLowercased() {
-        // URI 파싱 경로에서도 videoId가 소문자화되지 않는지 검증
+        // URI 파싱 경로에서도 videoId가 소문자화되지 않는지 검증한다.
         stubSuccess(MIXED_CASE_ID);
+
         youtubeValidationService.validateYoutubeUrl("https://youtu.be/" + MIXED_CASE_ID);
+
         verify(youtubeOEmbedClient, never()).fetchByVideoId(eq(MIXED_CASE_ID.toLowerCase()));
         verify(youtubeOEmbedClient).fetchByVideoId(eq(MIXED_CASE_ID));
     }
@@ -228,6 +258,7 @@ class YoutubeValidationServiceTest {
                 .validateYoutubeUrl("https://www.youtube.com/watch?v=abcdefg"))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("유효한 YouTube URL이 아닙니다.");
+
         verify(youtubeOEmbedClient, never()).fetchByVideoId(anyString());
     }
 
@@ -237,6 +268,21 @@ class YoutubeValidationServiceTest {
                 .validateYoutubeUrl("https://www.youtube.com/watch?v=abcdefghijklm"))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("유효한 YouTube URL이 아닙니다.");
+
         verify(youtubeOEmbedClient, never()).fetchByVideoId(anyString());
+    }
+
+    /**
+     * 정상 oEmbed 응답을 반환하도록 공통 mock을 구성한다.
+     *
+     * [사용 목적]
+     * videoId 추출 테스트들은 oEmbed 파싱 자체가 목적이 아니다.
+     * 따라서 성공 응답을 공통으로 stub 처리하고,
+     * 각 테스트에서는 URL 형식별 videoId 추출 결과만 검증한다.
+     */
+    private void stubSuccess(String videoId) {
+        when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(videoId))).thenReturn(null);
+        when(redisTemplate.hasKey(RedisKeys.youtubeOembedFailureKey(videoId))).thenReturn(false);
+        when(youtubeOEmbedClient.fetchByVideoId(videoId)).thenReturn(OEMBED_RESPONSE);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #64

## 📝 Summary

- 공개 로비 목록 조회 API에 검색/필터/정렬 조건을 추가했습니다.
- `GET /api/lobbies` 요청 파라미터를 추가했습니다.
  - `keyword`: 로비 제목 검색
  - `mapCategory`: 맵 카테고리 필터
  - `sort`: 정렬 기준
- 공개 로비 목록에서 `WAITING` 상태 로비만 노출되도록 정책을 적용했습니다.
  - `PLAYING`, `FINISHED` 상태 로비는 기본 목록에서 제외됩니다.
- 정렬 기준을 추가했습니다.
  - `latest`: 최신순
  - `most_players`: 현재 인원 많은 순
  - `most_available`: 빈자리 많은 순
- 최신순 정렬을 위해 Redis 로비 Hash에 `created_at_epoch_millis` 필드를 추가했습니다.
- 잘못된 `sort`, `mapCategory` 요청값은 `400 Bad Request`로 처리되도록 했습니다.
- 로비 목록 필터링/정렬 정책에 대한 단위 테스트를 추가했습니다.
- 기존 테스트 코드 중 현재 서비스 정책과 맞지 않던 부분을 보정했습니다.

## 🙏 PR point

- `PLAYING` 상태 로비는 현재 WebSocket 입장 단계에서 차단되므로, 기본 로비 목록에서는 제외하는 정책으로 구현했습니다.
- `latest` 정렬은 Redis `Set`의 순서를 신뢰하지 않고, 로비 생성 시점에 저장한 `created_at_epoch_millis` 값을 기준으로 정렬합니다.
- 기존 Redis 데이터에는 `created_at_epoch_millis`가 없을 수 있어, 해당 값이 없는 로비는 최신순 정렬에서 후순위로 처리됩니다.
- 카테고리 필터는 기존 `MapCategory.from()` 정규화 정책을 재사용하여 `K-POP`, `K_POP`, `kpop` 등 입력 차이를 허용합니다.
- Redis 조회는 기존처럼 `lobby:public` Set 기반으로 수행하고, 검색/필터/정렬 정책은 Service 계층에서 적용했습니다.

## 📬 Reference

- Redis `lobby:public` Set은 순서를 보장하지 않으므로 최신순 정렬을 위해 `created_at_epoch_millis` 필드를 추가했습니다.
- FE 로비 목록 화면에서 사용하는 검색/필터/정렬 조건에 맞춰 API 파라미터를 정의했습니다.