### PR TITLE
[Feat/#75] 로비 맵 변경 기능 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ out/
 #Environment
 .env
 
+# Project running docs
+running/
+
 # macOS metadata
 .DS_Store
 **/.DS_Store

--- a/docs/API.md
+++ b/docs/API.md
@@ -720,6 +720,60 @@ JWT Access Token이 필요합니다.
 
 ---
 
+#### 로비 맵 변경
+
+```http
+PATCH /api/lobbies/{code}/map
+```
+
+방장이 로비 대기실에서 게임에 사용할 맵을 변경합니다.
+JWT Access Token이 필요합니다.
+
+**정책**
+
+* 로비 상태가 `WAITING`일 때만 변경할 수 있습니다.
+* 방장만 맵을 변경할 수 있습니다.
+* 공개 맵은 누구나 연결할 수 있습니다.
+* 비공개 맵은 소유자만 연결할 수 있습니다.
+* 맵 변경 성공 시 Redis `lobby:{code}` hash의 `map_id`, `map_title`, `map_category`와 DB `GAME_LOBBY.map_id`를 동기화합니다.
+* Redis 선갱신 후 DB 갱신에 실패하면 Redis를 이전 값으로 보상 복구합니다.
+* 변경 성공 시 `/topic/lobby/{code}/refresh`로 `REFRESH_LOBBY_INFO`가 브로드캐스트됩니다.
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+
+**Request Body**
+
+```json
+{
+  "mapId": 2
+}
+```
+
+| 필드      | 타입   | 필수 | 설명                  |
+| ------- | ---- | -- | ------------------- |
+| `mapId` | Long | ✅  | 연결할 맵 ID (양의 정수) |
+
+**Response `204 No Content`**
+
+응답 Body 없음.
+
+**Error**
+
+| 상태 코드                       | 설명                         |
+| --------------------------- | -------------------------- |
+| `400 Bad Request`           | `mapId`가 누락되었거나 양수가 아닌 경우  |
+| `401 Unauthorized`          | JWT 토큰 없음 또는 만료            |
+| `403 Forbidden`             | 방장이 아닌 사용자가 맵 변경 시도 또는 비공개 맵에 접근 권한 없음 |
+| `404 Not Found`             | 존재하지 않는 로비 또는 맵            |
+| `409 Conflict`              | `WAITING` 상태가 아닌 로비 또는 삭제된 맵 |
+| `500 Internal Server Error` | Redis-DB 동기화 실패             |
+
+---
+
 #### 로비 게임 시작
 
 ```http

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -939,10 +939,11 @@ lobbyCode|reason|attempt|nextRetryAtEpochMillis
 
 재처리 사유:
 
-| reason                        | 보정 정책                       |
-| ----------------------------- | --------------------------- |
-| `START_DB_SYNC_FAILED`        | Redis 상태를 `WAITING`으로 롤백    |
-| `START_DB_SNAPSHOT_NOT_FOUND` | DB 스냅샷이 없으므로 Redis 잔존 로비 삭제 |
+| reason                             | 보정 정책                       |
+| ---------------------------------- | --------------------------- |
+| `START_DB_SYNC_FAILED`             | Redis 상태를 `WAITING`으로 롤백    |
+| `START_DB_SNAPSHOT_NOT_FOUND`      | DB 스냅샷이 없으므로 Redis 잔존 로비 삭제 |
+| `MAP_UPDATE_DB_SNAPSHOT_NOT_FOUND` | 맵 변경 도중 DB 스냅샷 누락 감지, Redis 잔존 로비 삭제 |
 
 운영 모니터링 대상:
 
@@ -954,6 +955,53 @@ lobbyCode|reason|attempt|nextRetryAtEpochMillis
 | `metric:lobby:start:reconciliation:enqueued` | 재처리 큐 적재 횟수      |
 | `metric:lobby:start:reconciliation:success`  | 재처리 성공 횟수        |
 | `metric:lobby:start:reconciliation:failed`   | 재처리 실패 횟수        |
+
+### 로비 맵 변경 Redis-DB 정합성
+
+대기실에서 방장이 맵을 변경하는 흐름은 게임 시작과 동일한 `GAME_LOBBY` 행을 건드리므로
+두 유스케이스가 동시 실행될 때 Lost Update 또는 검증 우회가 발생할 수 있습니다.
+
+이를 방지하기 위해 다음 순서로 처리합니다.
+
+```text
+1. Redis 1차 조회 (존재 여부 / WAITING / 방장)
+2. GAME_LOBBY 행 PESSIMISTIC_WRITE 락 획득 (게임 시작 경로와 직렬화)
+3. 락 시점의 entity.status로 WAITING 재검증
+4. Redis 맵 메타데이터 선갱신 (source of truth 반영)
+5. DB GAME_LOBBY.map_id 조건부 갱신 (status = WAITING)
+6. DB 커밋 후 lobby info refresh 이벤트 발행
+```
+
+**Redis 선갱신 정당화:**
+
+Redis가 로비 실시간 상태의 source of truth입니다.
+맵 변경 결과를 클라이언트가 즉시 볼 수 있도록 Redis를 먼저 반영하고,
+DB는 영속/감사 스냅샷 역할로 뒤따라 동기화합니다.
+
+**보상 정책:**
+
+DB 갱신 실패(예외 또는 0행 반환) 시 `compensate_lobby_map.lua`가 실행됩니다.
+이 스크립트는 `status == WAITING`을 원자적으로 검증한 뒤에만
+`map_id / map_title / map_category` 필드를 이전 값으로 되돌립니다.
+
+| 반환값                  | 의미                                              |
+| -------------------- | ----------------------------------------------- |
+| `COMPENSATED`        | 보상 복구 성공                                        |
+| `SKIPPED_NOT_WAITING`| status가 이미 PLAYING 등으로 전환되어 보상을 안전상 건너뜀 (정상 경로) |
+| `LOBBY_NOT_FOUND`    | Redis 로비 자체가 없음 (이미 폭파/삭제됨)                     |
+
+**보상 실패 시 운영 대응:**
+
+`compensate Lua`가 `LOBBY_NOT_FOUND`를 반환하거나 예외가 발생하면
+`[MONITORING_REQUIRED]` 로그가 남습니다.
+운영자는 해당 로그로 Redis/DB `map_id` 불일치를 수동 확인하고 정리합니다.
+
+**Lock timeout 정책:**
+
+`findByInviteCodeForUpdate`에 `jakarta.persistence.lock.timeout = 3000` ms 힌트가 적용되어 있습니다.
+타임아웃 초과 시 `PessimisticLockingFailureException`이 던져지며,
+`LobbyMapUpdateService` / `LobbyStartService`는 이를 `409 CONFLICT`로 변환합니다.
+응답 메시지: `"다른 로비 상태 변경이 진행 중입니다. 잠시 후 다시 시도해주세요."`
 
 ### ready / participants 정합성 보정 정책
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/LobbyMapCompensationResult.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/LobbyMapCompensationResult.java
@@ -8,8 +8,9 @@ package io.github.ascrew.monomatbe.domain.lobby;
  * 그러나 보상 시점에 다른 트랜잭션(start_lobby.lua)이 status를 PLAYING으로 바꿨다면
  * 이미 시작된 로비의 맵 메타데이터를 임의로 되돌려서는 안 된다.
  *
- * 이 enum은 compensate_lobby_map.lua의 결과를 도메인 의미로 표현하여
- * 호출자가 "복구 성공 / 안전상 스킵 / 로비 없음"을 구분할 수 있게 한다.
+ * 이 enum은 compensate_lobby_map.lua가 정상 실행된 경우의 도메인 결과만 표현한다.
+ * Redis 연결 단절·타임아웃·Lua 스크립트 로딩 실패 등 인프라 예외는 enum 값이 아닌
+ * RuntimeException으로 전파되며, 호출자(LobbyMapUpdateService)가 별도로 처리한다.
  */
 public enum LobbyMapCompensationResult {
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/LobbyMapCompensationResult.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/LobbyMapCompensationResult.java
@@ -1,0 +1,24 @@
+package io.github.ascrew.monomatbe.domain.lobby;
+
+/**
+ * 로비 맵 변경 보상 복구 Lua 실행 결과
+ *
+ * [정책 배경]
+ * 맵 변경 트랜잭션 보상 복구는 항상 안전하게 동작해야 한다.
+ * 그러나 보상 시점에 다른 트랜잭션(start_lobby.lua)이 status를 PLAYING으로 바꿨다면
+ * 이미 시작된 로비의 맵 메타데이터를 임의로 되돌려서는 안 된다.
+ *
+ * 이 enum은 compensate_lobby_map.lua의 결과를 도메인 의미로 표현하여
+ * 호출자가 "복구 성공 / 안전상 스킵 / 로비 없음"을 구분할 수 있게 한다.
+ */
+public enum LobbyMapCompensationResult {
+
+    /** Redis 맵 메타데이터를 oldMetadata로 복구했다. */
+    COMPENSATED,
+
+    /** status가 더 이상 WAITING이 아니므로 안전을 위해 복구를 수행하지 않았다. */
+    SKIPPED_NOT_WAITING,
+
+    /** Redis 로비가 더 이상 존재하지 않는다 (이미 폭파/삭제됨). */
+    LOBBY_NOT_FOUND
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyCommandController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyCommandController.java
@@ -13,9 +13,11 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyMapRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyReadyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyCreateService;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyJoinService;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyMapUpdateService;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyReadyService;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyStartService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
@@ -62,11 +64,16 @@ public class LobbyCommandController {
             "요청 수신: 게임 시작 [POST /api/lobbies/{code}/start] - 코드: {}, 식별자: {}";
     private static final String LOG_START_LOBBY_RESPONSE =
             "게임 시작 처리 완료 - 코드: {}";
+    private static final String LOG_UPDATE_MAP_REQUEST =
+            "요청 수신: 로비 맵 변경 [PATCH /api/lobbies/{code}/map] - 코드: {}, 식별자: {}, mapId: {}";
+    private static final String LOG_UPDATE_MAP_RESPONSE =
+            "로비 맵 변경 완료 - 코드: {}";
 
     private final LobbyCreateService lobbyCreateService;
     private final LobbyJoinService lobbyJoinService;
     private final LobbyReadyService lobbyReadyService;
     private final LobbyStartService lobbyStartService;
+    private final LobbyMapUpdateService lobbyMapUpdateService;
 
     /**
      * 로비 생성 API
@@ -233,6 +240,45 @@ public class LobbyCommandController {
         lobbyStartService.startLobbyGame(code, principal);
 
         log.info(LOG_START_LOBBY_RESPONSE, code);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 로비 대기실 맵 변경 API
+     *
+     * [정책]
+     * - JWT 인증이 필요하다.
+     * - 방장만 맵을 변경할 수 있다.
+     * - 로비 상태가 WAITING일 때만 변경할 수 있다.
+     * - 맵 유효성(존재, 삭제, 접근 권한)은 서비스에서 검증한다.
+     *
+     * @param code      로비 초대 코드
+     * @param request   맵 변경 요청 DTO
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 204 No Content
+     */
+    @Operation(
+            summary = "로비 맵 변경",
+            description = "방장이 대기실에서 게임에 사용할 맵을 변경합니다. JWT 인증이 필요합니다."
+    )
+    @PatchMapping("/{code}/map")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> updateLobbyMap(
+            @PathVariable String code,
+            @Valid @RequestBody UpdateLobbyMapRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(
+                LOG_UPDATE_MAP_REQUEST,
+                code,
+                principal != null ? principal.userIdentifier() : "null",
+                request.mapId()
+        );
+
+        lobbyMapUpdateService.updateMap(code, request, principal);
+
+        log.info(LOG_UPDATE_MAP_RESPONSE, code);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/UpdateLobbyMapRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/UpdateLobbyMapRequest.java
@@ -1,0 +1,17 @@
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+/**
+ * 로비 맵 변경 요청 DTO.
+ *
+ * mapId 유효성(존재 여부, 삭제 여부, 접근 권한)은 LobbyMapPolicy에서 검증한다.
+ */
+public record UpdateLobbyMapRequest(
+
+        @NotNull(message = "맵 ID는 필수입니다.")
+        @Positive(message = "맵 ID는 양수여야 합니다.")
+        Long mapId
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
@@ -139,4 +139,12 @@ public class GameLobby {
     public void changeStatus(LobbyStatus status) {
         this.status = status;
     }
+
+    /**
+     * 로비에 연결된 맵을 변경한다.
+     * 대기실에서 방장이 맵을 변경할 때 사용한다.
+     */
+    public void updateMap(Long mapId) {
+        this.mapId = mapId;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
@@ -1,7 +1,11 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -30,4 +34,22 @@ public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
      * Redis SETNX와 이중 방어선으로 동작한다.
      */
     boolean existsByInviteCode(String inviteCode);
+
+    /**
+     * status 조건부 map_id 갱신.
+     *
+     * 맵 변경 시 status == WAITING인 경우에만 갱신하여 동시 게임 시작 레이스를 방지한다.
+     * 반환값이 0이면 이미 PLAYING이거나 초대 코드가 없는 경우다.
+     *
+     * @param code   로비 초대 코드
+     * @param mapId  새 맵 ID (null이면 맵 미선택 상태로 복원)
+     * @param status 갱신을 허용할 현재 상태 (호출 측에서 LobbyStatus.WAITING 전달)
+     * @return 갱신된 행 수 (0 또는 1)
+     */
+    @Modifying
+    @Query("UPDATE GameLobby g SET g.mapId = :mapId WHERE g.inviteCode = :code AND g.status = :status")
+    int updateMapIdIfWaiting(
+            @Param("code") String code,
+            @Param("mapId") Long mapId,
+            @Param("status") LobbyStatus status);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
@@ -1,8 +1,9 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
-import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,6 +30,24 @@ public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
     Optional<GameLobby> findByInviteCode(String inviteCode);
 
     /**
+     * 초대 코드로 로비를 조회하면서 행에 대한 PESSIMISTIC_WRITE 락을 획득한다.
+     *
+     * [필요 이유]
+     * 게임 시작(startLobbyGame)과 맵 변경(updateMap)이 동일 로비 row를 동시에 변경하면
+     * Lost Update가 발생할 수 있다.
+     *   - 게임 시작은 entity의 status를 PLAYING으로 변경한 뒤 saveAndFlush로 행 전체를 UPDATE한다.
+     *   - 그 사이 맵 변경이 conditional update로 mapId를 바꿔도, 게임 시작의 saveAndFlush가
+     *     T1 시점의 mapId로 덮어쓰면 검증한 맵과 실제 시작 맵이 어긋난다.
+     * 두 트랜잭션 모두 이 메서드로 행 락을 획득하여 직렬화한다.
+     *
+     * [참조 패턴]
+     * UserSessionRepository.findBySessionIdForUpdate 와 동일한 PESSIMISTIC_WRITE 패턴이다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM GameLobby g WHERE g.inviteCode = :code")
+    Optional<GameLobby> findByInviteCodeForUpdate(@Param("code") String code);
+
+    /**
      * 초대 코드 존재 여부를 확인한다.
      * 로비 생성 시 invite_code 중복 체크에 사용된다.
      * Redis SETNX와 이중 방어선으로 동작한다.
@@ -36,20 +55,25 @@ public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
     boolean existsByInviteCode(String inviteCode);
 
     /**
-     * status 조건부 map_id 갱신.
+     * status가 WAITING인 경우에만 map_id를 갱신한다.
      *
-     * 맵 변경 시 status == WAITING인 경우에만 갱신하여 동시 게임 시작 레이스를 방지한다.
-     * 반환값이 0이면 이미 PLAYING이거나 초대 코드가 없는 경우다.
+     * [정책]
+     * 맵 변경 시 status == WAITING 원자 검증으로 동시 게임 시작 레이스를 방지한다.
+     * 호출자가 WAITING 외 다른 상태로 갱신을 시도하는 유스케이스가 없으므로 조건을 메서드 내부에 고정한다.
      *
-     * @param code   로비 초대 코드
-     * @param mapId  새 맵 ID (null이면 맵 미선택 상태로 복원)
-     * @param status 갱신을 허용할 현재 상태 (호출 측에서 LobbyStatus.WAITING 전달)
+     * [0행 반환 의미]
+     * 반환값이 0이면 다음 두 경우 중 하나다.
+     *   1) 해당 초대 코드의 row가 더 이상 존재하지 않음 (DB 스냅샷 누락)
+     *   2) row는 있지만 status가 WAITING이 아님 (이미 PLAYING으로 전환됨)
+     * 호출자는 existsByInviteCode 등으로 두 경우를 구분하여 분기 처리해야 한다.
+     *
+     * @param code  로비 초대 코드
+     * @param mapId 새 맵 ID (null이면 맵 미선택 상태로 복원)
      * @return 갱신된 행 수 (0 또는 1)
      */
     @Modifying
-    @Query("UPDATE GameLobby g SET g.mapId = :mapId WHERE g.inviteCode = :code AND g.status = :status")
+    @Query("UPDATE GameLobby g SET g.mapId = :mapId WHERE g.inviteCode = :code AND g.status = io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus.WAITING")
     int updateMapIdIfWaiting(
             @Param("code") String code,
-            @Param("mapId") Long mapId,
-            @Param("status") LobbyStatus status);
+            @Param("mapId") Long mapId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
@@ -1,11 +1,14 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -40,10 +43,17 @@ public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
      *     T1 시점의 mapId로 덮어쓰면 검증한 맵과 실제 시작 맵이 어긋난다.
      * 두 트랜잭션 모두 이 메서드로 행 락을 획득하여 직렬화한다.
      *
+     * [Lock timeout 정책]
+     * jakarta.persistence.lock.timeout = 3000 ms.
+     * Hibernate가 MySQL InnoDB의 innodb_lock_wait_timeout 세션 변수에 반영한다.
+     * 타임아웃 초과 시 PessimisticLockingFailureException(LockTimeoutException 포함)이 던져진다.
+     * 호출자(LobbyMapUpdateService / LobbyStartService)는 이를 잡아 409 CONFLICT로 변환한다.
+     *
      * [참조 패턴]
      * UserSessionRepository.findBySessionIdForUpdate 와 동일한 PESSIMISTIC_WRITE 패턴이다.
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
     @Query("SELECT g FROM GameLobby g WHERE g.inviteCode = :code")
     Optional<GameLobby> findByInviteCodeForUpdate(@Param("code") String code);
 
@@ -55,25 +65,28 @@ public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
     boolean existsByInviteCode(String inviteCode);
 
     /**
-     * status가 WAITING인 경우에만 map_id를 갱신한다.
+     * status가 지정한 값인 경우에만 map_id를 갱신한다.
      *
      * [정책]
      * 맵 변경 시 status == WAITING 원자 검증으로 동시 게임 시작 레이스를 방지한다.
-     * 호출자가 WAITING 외 다른 상태로 갱신을 시도하는 유스케이스가 없으므로 조건을 메서드 내부에 고정한다.
+     * status 값은 호출자가 LobbyStatus.WAITING을 전달한다.
+     * JPQL 문자열에 enum 풀네임을 박지 않기 위해 파라미터로 받는다 (패키지 리네임 안전).
      *
      * [0행 반환 의미]
      * 반환값이 0이면 다음 두 경우 중 하나다.
      *   1) 해당 초대 코드의 row가 더 이상 존재하지 않음 (DB 스냅샷 누락)
-     *   2) row는 있지만 status가 WAITING이 아님 (이미 PLAYING으로 전환됨)
+     *   2) row는 있지만 status가 전달한 값과 다름 (이미 PLAYING으로 전환됨)
      * 호출자는 existsByInviteCode 등으로 두 경우를 구분하여 분기 처리해야 한다.
      *
-     * @param code  로비 초대 코드
-     * @param mapId 새 맵 ID (null이면 맵 미선택 상태로 복원)
+     * @param code   로비 초대 코드
+     * @param mapId  새 맵 ID (null이면 맵 미선택 상태로 복원)
+     * @param status 갱신을 허용할 현재 상태 (호출 측에서 LobbyStatus.WAITING 전달)
      * @return 갱신된 행 수 (0 또는 1)
      */
     @Modifying
-    @Query("UPDATE GameLobby g SET g.mapId = :mapId WHERE g.inviteCode = :code AND g.status = io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus.WAITING")
+    @Query("UPDATE GameLobby g SET g.mapId = :mapId WHERE g.inviteCode = :code AND g.status = :status")
     int updateMapIdIfWaiting(
             @Param("code") String code,
-            @Param("mapId") Long mapId);
+            @Param("mapId") Long mapId,
+            @Param("status") LobbyStatus status);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -6,6 +6,7 @@ package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.LobbyMapCompensationResult;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
@@ -252,4 +253,20 @@ public interface LobbyRepository {
    * @param metadata 새 맵 메타데이터 (null이면 맵 필드를 제거한다)
    */
   void updateMapMetadata(String code, LobbyMapMetadata metadata);
+
+  /**
+   * 로비 맵 변경 트랜잭션 보상 복구를 status==WAITING 원자 검증과 함께 수행한다.
+   *
+   * [필요 이유]
+   * 보상 시점에 다른 트랜잭션이 status를 PLAYING으로 바꿨다면 oldMetadata로 되돌리면 안 된다.
+   * Java에서 status 조회 후 분기하면 race window가 남으므로 compensate_lobby_map.lua로 원자 처리한다.
+   *
+   * @param code        로비 초대 코드
+   * @param oldMetadata 복구할 이전 맵 메타데이터 (null 또는 필드가 null이면 HDEL 처리)
+   * @return 보상 처리 결과 (COMPENSATED / SKIPPED_NOT_WAITING / LOBBY_NOT_FOUND)
+   */
+  LobbyMapCompensationResult compensateMapMetadataIfWaiting(
+          String code,
+          LobbyMapMetadata oldMetadata
+  );
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -244,4 +244,12 @@ public interface LobbyRepository {
    * @return 현재 참여 인원 수
    */
   int getCurrentPlayerCount(String inviteCode);
+
+  /**
+   * Redis 로비 Hash의 맵 메타데이터 3개 필드(map_id, map_title, map_category)를 갱신한다.
+   *
+   * @param code     로비 초대 코드
+   * @param metadata 새 맵 메타데이터 (null이면 맵 필드를 제거한다)
+   */
+  void updateMapMetadata(String code, LobbyMapMetadata metadata);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -261,9 +261,14 @@ public interface LobbyRepository {
    * 보상 시점에 다른 트랜잭션이 status를 PLAYING으로 바꿨다면 oldMetadata로 되돌리면 안 된다.
    * Java에서 status 조회 후 분기하면 race window가 남으므로 compensate_lobby_map.lua로 원자 처리한다.
    *
+   * [예외 정책]
+   * Redis 연결 단절·타임아웃·Lua 스크립트 로딩 실패 등 인프라 예외는 호출자에게 그대로 전파한다.
+   * 호출자(LobbyMapUpdateService)가 도메인 결과(LOBBY_NOT_FOUND)와 인프라 장애를 분리 처리한다.
+   *
    * @param code        로비 초대 코드
    * @param oldMetadata 복구할 이전 맵 메타데이터 (null 또는 필드가 null이면 HDEL 처리)
    * @return 보상 처리 결과 (COMPENSATED / SKIPPED_NOT_WAITING / LOBBY_NOT_FOUND)
+   * @throws RuntimeException Redis 인프라 오류 발생 시
    */
   LobbyMapCompensationResult compensateMapMetadataIfWaiting(
           String code,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -161,6 +161,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
     return lobbyRedisCommandRepository.rollbackStartedLobbyStatus(code);
   }
 
+  @Override
+  public void updateMapMetadata(String code, LobbyMapMetadata metadata) {
+    lobbyRedisCommandRepository.updateMapMetadata(code, metadata);
+  }
+
   // =========================================================
   // Lua-backed State Transition
   // =========================================================

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.LobbyMapCompensationResult;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
@@ -164,6 +165,25 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   @Override
   public void updateMapMetadata(String code, LobbyMapMetadata metadata) {
     lobbyRedisCommandRepository.updateMapMetadata(code, metadata);
+  }
+
+  @Override
+  public LobbyMapCompensationResult compensateMapMetadataIfWaiting(
+          String code,
+          LobbyMapMetadata oldMetadata
+  ) {
+    try {
+      String result = lobbyLuaScriptExecutor.executeCompensateLobbyMap(code, oldMetadata);
+      return lobbyLuaResultMapper.toLobbyMapCompensationResult(result, code);
+
+    } catch (Exception e) {
+      log.error(
+              "맵 변경 보상 Lua 스크립트 실행 중 예외 발생 - lobbyCode: {}",
+              code,
+              e
+      );
+      return LobbyMapCompensationResult.LOBBY_NOT_FOUND;
+    }
   }
 
   // =========================================================

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -172,18 +172,8 @@ public class LobbyRepositoryImpl implements LobbyRepository {
           String code,
           LobbyMapMetadata oldMetadata
   ) {
-    try {
-      String result = lobbyLuaScriptExecutor.executeCompensateLobbyMap(code, oldMetadata);
-      return lobbyLuaResultMapper.toLobbyMapCompensationResult(result, code);
-
-    } catch (Exception e) {
-      log.error(
-              "맵 변경 보상 Lua 스크립트 실행 중 예외 발생 - lobbyCode: {}",
-              code,
-              e
-      );
-      return LobbyMapCompensationResult.LOBBY_NOT_FOUND;
-    }
+    String result = lobbyLuaScriptExecutor.executeCompensateLobbyMap(code, oldMetadata);
+    return lobbyLuaResultMapper.toLobbyMapCompensationResult(result, code);
   }
 
   // =========================================================

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaResultMapper.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaResultMapper.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
 
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.LobbyMapCompensationResult;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyLuaResultCode;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
@@ -40,6 +41,13 @@ public class LobbyLuaResultMapper {
     private static final String RESULT_FORBIDDEN = "FORBIDDEN";
     private static final String RESULT_CANNOT_KICK_SELF = "CANNOT_KICK_SELF";
     private static final String RESULT_TARGET_NOT_PARTICIPANT = "TARGET_NOT_PARTICIPANT";
+
+    // =========================================================
+    // compensate_lobby_map.lua 반환값 상수
+    // =========================================================
+
+    private static final String RESULT_COMPENSATED = "COMPENSATED";
+    private static final String RESULT_SKIPPED_NOT_WAITING = "SKIPPED_NOT_WAITING";
 
     /**
      * 운영 확인이 필요한 Redis 정합성 문제 로그 식별자
@@ -339,6 +347,44 @@ public class LobbyLuaResultMapper {
                     e
             );
         }
+    }
+
+    /**
+     * compensate_lobby_map.lua 반환 문자열을 LobbyMapCompensationResult로 변환한다.
+     *
+     * @param result Lua 반환 문자열
+     * @param code 로비 초대 코드
+     * @return 도메인 보상 결과
+     */
+    public LobbyMapCompensationResult toLobbyMapCompensationResult(String result, String code) {
+        if (result == null) {
+            log.error(
+                    "{} compensate_lobby_map.lua null 반환값 - lobbyCode: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code
+            );
+            return LobbyMapCompensationResult.LOBBY_NOT_FOUND;
+        }
+
+        if (RESULT_COMPENSATED.equals(result)) {
+            return LobbyMapCompensationResult.COMPENSATED;
+        }
+
+        if (RESULT_SKIPPED_NOT_WAITING.equals(result)) {
+            return LobbyMapCompensationResult.SKIPPED_NOT_WAITING;
+        }
+
+        if (RESULT_LOBBY_NOT_FOUND.equals(result)) {
+            return LobbyMapCompensationResult.LOBBY_NOT_FOUND;
+        }
+
+        log.error(
+                "{} compensate_lobby_map.lua 알 수 없는 반환값 - lobbyCode: {}, result: {}",
+                LOG_MONITORING_REQUIRED,
+                code,
+                result
+        );
+        return LobbyMapCompensationResult.LOBBY_NOT_FOUND;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -37,19 +37,22 @@ public class LobbyLuaScriptExecutor {
     private final RedisScript<String> createLobbyScript;
     private final RedisScript<String> kickLobbyScript;
     private final RedisScript<String> startLobbyScript;
+    private final RedisScript<String> compensateLobbyMapScript;
 
     public LobbyLuaScriptExecutor(
             StringRedisTemplate redisTemplate,
             @Qualifier("leaveLobbyScript") RedisScript<String> leaveLobbyScript,
             @Qualifier("createLobbyScript") RedisScript<String> createLobbyScript,
             @Qualifier("kickLobbyScript") RedisScript<String> kickLobbyScript,
-            @Qualifier("startLobbyScript") RedisScript<String> startLobbyScript
+            @Qualifier("startLobbyScript") RedisScript<String> startLobbyScript,
+            @Qualifier("compensateLobbyMapScript") RedisScript<String> compensateLobbyMapScript
     ) {
         this.redisTemplate = redisTemplate;
         this.leaveLobbyScript = leaveLobbyScript;
         this.createLobbyScript = createLobbyScript;
         this.kickLobbyScript = kickLobbyScript;
         this.startLobbyScript = startLobbyScript;
+        this.compensateLobbyMapScript = compensateLobbyMapScript;
     }
 
     /**
@@ -247,6 +250,50 @@ public class LobbyLuaScriptExecutor {
                 RedisKeys.FIELD_MAP_ID,
                 LobbyStatus.WAITING.name(),
                 LobbyStatus.PLAYING.name()
+        );
+    }
+
+    /**
+     * compensate_lobby_map.lua를 실행한다.
+     *
+     * [KEYS 계약]
+     * KEYS[1] = lobby:{code}
+     *
+     * [ARGV 계약]
+     * ARGV[1] = status field name
+     * ARGV[2] = mapId field name
+     * ARGV[3] = mapTitle field name
+     * ARGV[4] = mapCategory field name
+     * ARGV[5] = WAITING status
+     * ARGV[6] = oldMapId (없으면 "")
+     * ARGV[7] = oldMapTitle (없으면 "")
+     * ARGV[8] = oldMapCategory (없으면 "")
+     *
+     * [null oldMetadata 처리]
+     * oldMetadata가 null이거나 필드가 일부 null이면 빈 문자열로 전달하여
+     * Lua가 HDEL로 처리하도록 한다. 이는 "이전이 맵 미선택 상태였음"을 의미한다.
+     *
+     * @return "COMPENSATED" | "SKIPPED_NOT_WAITING" | "LOBBY_NOT_FOUND"
+     */
+    public String executeCompensateLobbyMap(String code, LobbyMapMetadata oldMetadata) {
+        List<String> keys = List.of(RedisKeys.lobbyKey(code));
+
+        boolean restoreMap = oldMetadata != null
+                && oldMetadata.mapId() != null
+                && oldMetadata.mapTitle() != null
+                && oldMetadata.mapCategory() != null;
+
+        return redisTemplate.execute(
+                compensateLobbyMapScript,
+                keys,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_MAP_ID,
+                RedisKeys.FIELD_MAP_TITLE,
+                RedisKeys.FIELD_MAP_CATEGORY,
+                LobbyStatus.WAITING.name(),
+                restoreMap ? String.valueOf(oldMetadata.mapId()) : EMPTY_REDIS_VALUE,
+                restoreMap ? oldMetadata.mapTitle() : EMPTY_REDIS_VALUE,
+                restoreMap ? oldMetadata.mapCategory() : EMPTY_REDIS_VALUE
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
@@ -382,19 +382,28 @@ public class LobbyRedisCommandRepository {
      * Redis 로비 Hash의 맵 메타데이터 3개 필드를 갱신한다.
      *
      * [정책]
-     * - metadata != null → map_id, map_title, map_category를 새 값으로 HSET
-     * - metadata == null → 3개 필드를 HDEL (맵 미선택 상태로 복원)
+     * - metadata != null이고 모든 필드가 non-null → map_id, map_title, map_category를 단일 HSET으로 원자 갱신
+     * - metadata == null 또는 필드 중 하나라도 null → 3개 필드를 HDEL (맵 미선택 상태로 복원)
+     *
+     * [null 필드 처리]
+     * 보상 복구 경로에서 기존에 맵이 없던 로비의 oldMetadata는 필드가 모두 null일 수 있다.
+     * 이 경우 metadata == null과 동일하게 HDEL로 처리하여 "null" 문자열 오염을 방지한다.
      *
      * @param code     로비 초대 코드
-     * @param metadata 새 맵 메타데이터 (null이면 맵 필드를 제거한다)
+     * @param metadata 새 맵 메타데이터 (null 또는 필드가 하나라도 null이면 맵 필드를 제거한다)
      */
     public void updateMapMetadata(String code, LobbyMapMetadata metadata) {
         String lobbyKey = RedisKeys.lobbyKey(code);
 
-        if (metadata != null) {
-            redisTemplate.opsForHash().put(lobbyKey, RedisKeys.FIELD_MAP_ID, String.valueOf(metadata.mapId()));
-            redisTemplate.opsForHash().put(lobbyKey, RedisKeys.FIELD_MAP_TITLE, metadata.mapTitle());
-            redisTemplate.opsForHash().put(lobbyKey, RedisKeys.FIELD_MAP_CATEGORY, metadata.mapCategory());
+        if (metadata != null
+                && metadata.mapId() != null
+                && metadata.mapTitle() != null
+                && metadata.mapCategory() != null) {
+            redisTemplate.opsForHash().putAll(lobbyKey, Map.of(
+                    RedisKeys.FIELD_MAP_ID, String.valueOf(metadata.mapId()),
+                    RedisKeys.FIELD_MAP_TITLE, metadata.mapTitle(),
+                    RedisKeys.FIELD_MAP_CATEGORY, metadata.mapCategory()
+            ));
         } else {
             redisTemplate.opsForHash().delete(
                     lobbyKey,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.lobby.repository.redis;
 
 import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
@@ -373,6 +374,33 @@ public class LobbyRedisCommandRepository {
                     participantsKey,
                     readyKey,
                     e
+            );
+        }
+    }
+
+    /**
+     * Redis 로비 Hash의 맵 메타데이터 3개 필드를 갱신한다.
+     *
+     * [정책]
+     * - metadata != null → map_id, map_title, map_category를 새 값으로 HSET
+     * - metadata == null → 3개 필드를 HDEL (맵 미선택 상태로 복원)
+     *
+     * @param code     로비 초대 코드
+     * @param metadata 새 맵 메타데이터 (null이면 맵 필드를 제거한다)
+     */
+    public void updateMapMetadata(String code, LobbyMapMetadata metadata) {
+        String lobbyKey = RedisKeys.lobbyKey(code);
+
+        if (metadata != null) {
+            redisTemplate.opsForHash().put(lobbyKey, RedisKeys.FIELD_MAP_ID, String.valueOf(metadata.mapId()));
+            redisTemplate.opsForHash().put(lobbyKey, RedisKeys.FIELD_MAP_TITLE, metadata.mapTitle());
+            redisTemplate.opsForHash().put(lobbyKey, RedisKeys.FIELD_MAP_CATEGORY, metadata.mapCategory());
+        } else {
+            redisTemplate.opsForHash().delete(
+                    lobbyKey,
+                    RedisKeys.FIELD_MAP_ID,
+                    RedisKeys.FIELD_MAP_TITLE,
+                    RedisKeys.FIELD_MAP_CATEGORY
             );
         }
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -18,6 +18,20 @@
  * DB 락이 게임 시작 경로(LobbyStartService.findByInviteCodeForUpdate)와 직렬화를 보장한다.
  * 보상 복구는 항상 Lua로 status==WAITING 원자 검증과 함께 수행되어
  * 이미 PLAYING으로 전환된 로비의 맵 메타데이터를 절대 건드리지 않는다.
+ *
+ * [Redis 선갱신 정책]
+ * Redis가 로비 실시간 상태의 source of truth이므로 맵 변경도 Redis를 먼저 반영하여
+ * 클라이언트 가시성(STOMP refresh로 즉시 노출)을 우선한다. DB는 영속/감사 스냅샷 역할이며,
+ * DB 갱신 실패 시 compensate_lobby_map.lua가 status==WAITING 원자 검증 후 보상한다.
+ * 자세한 정책은 docs/ARCHITECTURE.md "로비 맵 변경 Redis-DB 정합성" 섹션 참고.
+ *
+ * [보상 실패 시 운영 대응]
+ * compensate Lua가 LOBBY_NOT_FOUND를 반환하거나 예외가 발생하면 [MONITORING_REQUIRED] 로그가
+ * 남는다. 운영자는 해당 로그로 Redis/DB mapId 불일치를 수동 확인하고 정리한다.
+ *
+ * [Lock timeout 정책]
+ * findByInviteCodeForUpdate에 jakarta.persistence.lock.timeout = 3000ms 힌트가 적용되어
+ * 있다. 타임아웃 초과 시 PessimisticLockingFailureException을 잡아 409 CONFLICT로 변환한다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
@@ -32,6 +46,7 @@ import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +77,8 @@ public class LobbyMapUpdateService {
             "맵 변경에 실패했습니다. 잠시 후 다시 시도해주세요.";
     private static final String ERROR_LOBBY_SNAPSHOT_NOT_FOUND =
             "로비 상태 정보가 일치하지 않습니다. 로비를 다시 생성해주세요.";
+    private static final String ERROR_LOBBY_LOCK_CONTENTION =
+            "다른 로비 상태 변경이 진행 중입니다. 잠시 후 다시 시도해주세요.";
 
     // =========================================================
     // 로그 메시지 상수
@@ -138,8 +155,7 @@ public class LobbyMapUpdateService {
                 ? null
                 : new LobbyMapMetadata(lobbyInfo.mapId(), lobbyInfo.mapTitle(), lobbyInfo.mapCategory());
 
-        GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCodeForUpdate(code)
-                .orElseGet(() -> handleMissingGameLobbySnapshot(code, principal.userIdentifier()));
+        GameLobby gameLobby = acquireGameLobbyRowLock(code, principal.userIdentifier());
 
         if (gameLobby.getStatus() != LobbyStatus.WAITING) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
@@ -150,7 +166,7 @@ public class LobbyMapUpdateService {
         Long newMapId = newMetadata != null ? newMetadata.mapId() : null;
         int updated;
         try {
-            updated = gameLobbyJpaRepository.updateMapIdIfWaiting(code, newMapId);
+            updated = gameLobbyJpaRepository.updateMapIdIfWaiting(code, newMapId, LobbyStatus.WAITING);
         } catch (Exception e) {
             log.error(LOG_DB_UPDATE_FAILED, code, e);
             compensateRedisMapMetadata(code, oldMetadata);
@@ -176,6 +192,29 @@ public class LobbyMapUpdateService {
         );
 
         registerMapChangedEventAfterCommit(code);
+    }
+
+    /**
+     * GAME_LOBBY 행에 대한 PESSIMISTIC_WRITE 락을 획득한다.
+     *
+     * [예외 처리]
+     * - row 부재 → handleMissingGameLobbySnapshot 분기 (409 SNAPSHOT_NOT_FOUND)
+     * - 락 획득 타임아웃(3초) → PessimisticLockingFailureException을 잡아 409 CONFLICT로 변환.
+     *   클라이언트가 "다른 상태 변경 진행 중" 의미를 명확히 받을 수 있게 한다.
+     */
+    private GameLobby acquireGameLobbyRowLock(String code, String requesterIdentifier) {
+        try {
+            return gameLobbyJpaRepository.findByInviteCodeForUpdate(code)
+                    .orElseGet(() -> handleMissingGameLobbySnapshot(code, requesterIdentifier));
+        } catch (PessimisticLockingFailureException e) {
+            log.warn(
+                    "로비 맵 변경 락 획득 타임아웃 - code: {}, requester: {}",
+                    code,
+                    requesterIdentifier,
+                    e
+            );
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_LOCK_CONTENTION);
+        }
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -260,17 +260,33 @@ public class LobbyMapUpdateService {
      * [안전 정책]
      * 보상 시점에 다른 트랜잭션이 status를 PLAYING으로 바꿨다면 oldMetadata로 되돌리면 안 된다.
      * Lua 내부에서 원자 검증하므로 SKIPPED_NOT_WAITING은 정상 경로로 간주하고 로그만 남긴다.
+     *
+     * [인프라 장애 분리]
+     * Lua 결과값(LOBBY_NOT_FOUND)은 로비 데이터가 Redis에 없는 정상 도메인 결과다.
+     * Redis 연결 단절·타임아웃·스크립트 로딩 실패 등 인프라 예외는 catch 블록에서 별도 처리하여
+     * 원인 분류와 운영 대응이 가능하도록 한다.
      */
     private void compensateRedisMapMetadata(String code, LobbyMapMetadata oldMetadata) {
-        LobbyMapCompensationResult result = lobbyRepository.compensateMapMetadataIfWaiting(code, oldMetadata);
+        try {
+            LobbyMapCompensationResult result =
+                    lobbyRepository.compensateMapMetadataIfWaiting(code, oldMetadata);
 
-        switch (result) {
-            case COMPENSATED -> log.info("Redis 맵 보상 복구 완료 - code: {}", code);
-            case SKIPPED_NOT_WAITING -> log.warn(LOG_COMPENSATION_SKIPPED, code);
-            case LOBBY_NOT_FOUND -> log.error(
-                    "{} Redis 맵 보상 복구 실패 - 로비 데이터 없음 또는 Lua 실행 실패. code: {}",
+            switch (result) {
+                case COMPENSATED -> log.info("Redis 맵 보상 복구 완료 - code: {}", code);
+                case SKIPPED_NOT_WAITING -> log.warn(LOG_COMPENSATION_SKIPPED, code);
+                case LOBBY_NOT_FOUND -> log.error(
+                        "{} Redis 맵 보상 복구 불가 - Redis에 로비 없음 (이미 삭제됨). code: {}",
+                        LOG_MONITORING_REQUIRED,
+                        code
+                );
+            }
+        } catch (Exception e) {
+            log.error(
+                    "{} Redis 맵 보상 복구 실패 - Redis 인프라 오류 (연결 단절/타임아웃/Lua 로딩 등). "
+                            + "Redis-DB mapId 불일치 가능성 있음. code: {}",
                     LOG_MONITORING_REQUIRED,
-                    code
+                    code,
+                    e
             );
         }
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -8,9 +8,9 @@
  * - 방장 여부 검증
  * - 선택된 맵 접근 가능 여부 검증 위임 (LobbyMapPolicy 재사용)
  * - Redis 맵 메타데이터 갱신
- * - DB GAME_LOBBY.map_id 갱신
+ * - DB GAME_LOBBY.map_id 조건부 갱신 (status=WAITING 원자 검증으로 레이스 방지)
  * - DB 갱신 실패 시 Redis 보상 복구
- * - 참여자 refresh 이벤트 발행
+ * - 참여자 refresh 이벤트 발행 (트랜잭션 커밋 후)
  *
  * [정합성 정책]
  * Redis 선갱신 후 DB를 갱신한다. DB 갱신 실패 시 Redis를 이전 값으로 보상 복구한다.
@@ -21,7 +21,6 @@ package io.github.ascrew.monomatbe.domain.lobby.service;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyMapRequest;
-import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
@@ -31,6 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
@@ -50,8 +51,6 @@ public class LobbyMapUpdateService {
             "게임이 이미 시작된 로비에서는 맵을 변경할 수 없습니다.";
     private static final String ERROR_NOT_HOST =
             "방장만 맵을 변경할 수 있습니다.";
-    private static final String ERROR_LOBBY_DB_NOT_FOUND =
-            "DB에서 로비를 찾을 수 없습니다.";
     private static final String ERROR_UPDATE_MAP_FAILED =
             "맵 변경에 실패했습니다. 잠시 후 다시 시도해주세요.";
 
@@ -65,7 +64,7 @@ public class LobbyMapUpdateService {
     private static final String LOG_COMPENSATION_SUCCESS =
             "Redis 맵 보상 복구 완료 - code: {}";
     private static final String LOG_COMPENSATION_FAILED =
-            "Redis 맵 보상 복구 실패 - code: {}. Redis-DB 불일치 상태. 수동 정리 필요. [모니터링 필요]";
+            "Redis 맵 보상 복구 실패 - code: {}. Redis-DB 불일치 상태. 수동 정리 필요.";
 
     private static final String LOBBY_STATUS_WAITING = LobbyStatus.WAITING.name();
 
@@ -83,9 +82,11 @@ public class LobbyMapUpdateService {
      * 3. WAITING 상태 검증
      * 4. 방장 여부 검증
      * 5. LobbyMapPolicy로 맵 존재/삭제/권한 검증
-     * 6. Redis 맵 메타데이터 갱신 (선반영)
-     * 7. DB GAME_LOBBY.map_id 갱신 (실패 시 Redis 보상 복구)
-     * 8. 참여자 refresh 이벤트 발행
+     * 6. Redis 맵 메타데이터 선갱신
+     * 7. DB GAME_LOBBY.map_id 조건부 갱신 (status=WAITING 원자 검증)
+     *    - 갱신 행 0 → 동시 게임 시작 레이스: Redis 보상 복구 후 409
+     *    - DB 예외 → Redis 보상 복구 후 500
+     * 8. 트랜잭션 커밋 후 참여자 refresh 이벤트 발행
      *
      * @param code      로비 초대 코드
      * @param request   맵 변경 요청 DTO
@@ -121,51 +122,61 @@ public class LobbyMapUpdateService {
                 principal.userId()
         );
 
-        LobbyMapMetadata oldMetadata = new LobbyMapMetadata(
-                lobbyInfo.mapId(),
-                lobbyInfo.mapTitle(),
-                lobbyInfo.mapCategory()
-        );
+        LobbyMapMetadata oldMetadata = lobbyInfo.mapId() == null
+                ? null
+                : new LobbyMapMetadata(lobbyInfo.mapId(), lobbyInfo.mapTitle(), lobbyInfo.mapCategory());
 
         lobbyRepository.updateMapMetadata(code, newMetadata);
 
+        Long newMapId = newMetadata != null ? newMetadata.mapId() : null;
+        int updated;
         try {
-            GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCode(code)
-                    .orElseThrow(() -> new ResponseStatusException(
-                            HttpStatus.NOT_FOUND,
-                            ERROR_LOBBY_DB_NOT_FOUND
-                    ));
-
-            gameLobby.updateMap(newMetadata != null ? newMetadata.mapId() : null);
-            gameLobbyJpaRepository.saveAndFlush(gameLobby);
-
-            log.info(
-                    "로비 맵 변경 완료 - code: {}, host: {}, oldMapId: {}, newMapId: {}",
-                    code,
-                    principal.userIdentifier(),
-                    oldMetadata.mapId(),
-                    newMetadata != null ? newMetadata.mapId() : null
-            );
-
+            updated = gameLobbyJpaRepository.updateMapIdIfWaiting(code, newMapId, LobbyStatus.WAITING);
         } catch (Exception e) {
             log.error(LOG_DB_UPDATE_FAILED, code, e);
-
-            try {
-                lobbyRepository.updateMapMetadata(code, oldMetadata);
-                log.info(LOG_COMPENSATION_SUCCESS, code);
-            } catch (Exception compensationException) {
-                log.error(
-                        "{} {} code: {}",
-                        LOG_MONITORING_REQUIRED,
-                        LOG_COMPENSATION_FAILED,
-                        code,
-                        compensationException
-                );
-            }
-
+            compensateRedis(code, oldMetadata);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ERROR_UPDATE_MAP_FAILED);
         }
 
-        lobbyRealtimeNotifier.notifyLobbyInfoRefresh(code);
+        if (updated == 0) {
+            compensateRedis(code, oldMetadata);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
+        }
+
+        log.info(
+                "로비 맵 변경 완료 - code: {}, host: {}, oldMapId: {}, newMapId: {}",
+                code,
+                principal.userIdentifier(),
+                oldMetadata != null ? oldMetadata.mapId() : null,
+                newMapId
+        );
+
+        registerMapChangedEventAfterCommit(code);
+    }
+
+    private void compensateRedis(String code, LobbyMapMetadata oldMetadata) {
+        try {
+            lobbyRepository.updateMapMetadata(code, oldMetadata);
+            log.info(LOG_COMPENSATION_SUCCESS, code);
+        } catch (Exception e) {
+            log.error(LOG_MONITORING_REQUIRED + " " + LOG_COMPENSATION_FAILED, code, e);
+        }
+    }
+
+    private void registerMapChangedEventAfterCommit(String code) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            log.error(
+                    "{} 맵 변경 이벤트 afterCommit 등록 실패 - 트랜잭션 동기화 비활성. code: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code
+            );
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ERROR_UPDATE_MAP_FAILED);
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                lobbyRealtimeNotifier.notifyLobbyInfoRefresh(code);
+            }
+        });
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -2,25 +2,30 @@
  * 로비 대기실 맵 변경 유스케이스를 담당하는 서비스.
  *
  * [책임]
- * - 인증 주체 검증
- * - 로비 존재 여부 조회
- * - WAITING 상태 검증
- * - 방장 여부 검증
+ * - 인증 주체 검증 (userId / userIdentifier null 모두 차단)
+ * - Redis 로비 1차 조회 (존재 여부 / WAITING 상태 / 방장 여부)
  * - 선택된 맵 접근 가능 여부 검증 위임 (LobbyMapPolicy 재사용)
+ * - DB GAME_LOBBY 행에 대한 PESSIMISTIC_WRITE 락 획득 (게임 시작 경로와 직렬화)
+ * - 락 획득 후 entity.status로 WAITING 재검증
  * - Redis 맵 메타데이터 갱신
- * - DB GAME_LOBBY.map_id 조건부 갱신 (status=WAITING 원자 검증으로 레이스 방지)
- * - DB 갱신 실패 시 Redis 보상 복구
+ * - DB GAME_LOBBY.map_id 조건부 갱신
+ * - 보상 복구를 status==WAITING 원자 조건으로 처리 (compensate_lobby_map.lua)
+ * - DB row 누락 시 LobbyStartService와 동일한 reconciliation 패턴 적용
  * - 참여자 refresh 이벤트 발행 (트랜잭션 커밋 후)
  *
  * [정합성 정책]
- * Redis 선갱신 후 DB를 갱신한다. DB 갱신 실패 시 Redis를 이전 값으로 보상 복구한다.
- * 보상 복구도 실패하면 [MONITORING_REQUIRED] 로그를 남기고 운영자 수동 처리에 위임한다.
+ * Redis 1차 조회 → DB 행 락 → Redis 선갱신 → DB 조건부 갱신 순으로 진행한다.
+ * DB 락이 게임 시작 경로(LobbyStartService.findByInviteCodeForUpdate)와 직렬화를 보장한다.
+ * 보상 복구는 항상 Lua로 status==WAITING 원자 검증과 함께 수행되어
+ * 이미 PLAYING으로 전환된 로비의 맵 메타데이터를 절대 건드리지 않는다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
+import io.github.ascrew.monomatbe.domain.lobby.LobbyMapCompensationResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyMapRequest;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
@@ -33,6 +38,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -53,20 +60,22 @@ public class LobbyMapUpdateService {
             "방장만 맵을 변경할 수 있습니다.";
     private static final String ERROR_UPDATE_MAP_FAILED =
             "맵 변경에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    private static final String ERROR_LOBBY_SNAPSHOT_NOT_FOUND =
+            "로비 상태 정보가 일치하지 않습니다. 로비를 다시 생성해주세요.";
 
     // =========================================================
     // 로그 메시지 상수
     // =========================================================
 
+    private static final String LOG_ALERT_REQUIRED = "[ALERT_REQUIRED]";
     private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
     private static final String LOG_DB_UPDATE_FAILED =
             "DB 맵 갱신 실패 - Redis 보상 복구 시작. code: {}";
-    private static final String LOG_COMPENSATION_SUCCESS =
-            "Redis 맵 보상 복구 완료 - code: {}";
-    private static final String LOG_COMPENSATION_FAILED =
-            "Redis 맵 보상 복구 실패 - code: {}. Redis-DB 불일치 상태. 수동 정리 필요.";
+    private static final String LOG_COMPENSATION_SKIPPED =
+            "Redis 맵 보상 복구 스킵 (status가 더 이상 WAITING이 아님) - code: {}";
 
-    private static final String LOBBY_STATUS_WAITING = LobbyStatus.WAITING.name();
+    private static final String RECONCILIATION_REASON_MAP_UPDATE_SNAPSHOT_NOT_FOUND =
+            "MAP_UPDATE_DB_SNAPSHOT_NOT_FOUND";
 
     private final LobbyRepository lobbyRepository;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
@@ -77,16 +86,17 @@ public class LobbyMapUpdateService {
      * 로비 대기실에서 방장의 맵 변경 요청을 처리한다.
      *
      * [처리 순서]
-     * 1. principal null 및 userId null 검증
-     * 2. Redis에서 로비 조회 (존재 여부 및 상태 확인)
-     * 3. WAITING 상태 검증
-     * 4. 방장 여부 검증
-     * 5. LobbyMapPolicy로 맵 존재/삭제/권한 검증
-     * 6. Redis 맵 메타데이터 선갱신
-     * 7. DB GAME_LOBBY.map_id 조건부 갱신 (status=WAITING 원자 검증)
-     *    - 갱신 행 0 → 동시 게임 시작 레이스: Redis 보상 복구 후 409
-     *    - DB 예외 → Redis 보상 복구 후 500
-     * 8. 트랜잭션 커밋 후 참여자 refresh 이벤트 발행
+     * 1. principal / userId / userIdentifier null 검증
+     * 2. Redis 1차 조회 (존재 / WAITING / 방장 검증)
+     * 3. LobbyMapPolicy로 맵 존재/삭제/권한 검증 (newMetadata 결정)
+     * 4. DB GAME_LOBBY 행 PESSIMISTIC_WRITE 락 획득
+     *    - row 없음 → handleMissingGameLobbySnapshot (409 SNAPSHOT_NOT_FOUND + reconciliation)
+     *    - status != WAITING → 409 NOT_WAITING (락 시점의 진실)
+     * 5. Redis 맵 메타데이터 선갱신
+     * 6. DB GAME_LOBBY.map_id 조건부 갱신 (방어용 - 락 보장으로 사실상 항상 1)
+     *    - 갱신 행 0 → 안전 보상 (compensateMapMetadataIfWaiting) 후 409
+     *    - DB 예외 → 안전 보상 후 500
+     * 7. 트랜잭션 커밋 후 참여자 refresh 이벤트 발행
      *
      * @param code      로비 초대 코드
      * @param request   맵 변경 요청 DTO
@@ -95,9 +105,11 @@ public class LobbyMapUpdateService {
     @Transactional
     public void updateMap(String code, UpdateLobbyMapRequest request, CustomPrincipal principal) {
 
-        if (principal == null || principal.userId() == null) {
+        if (principal == null
+                || principal.userId() == null
+                || principal.userIdentifier() == null) {
             log.warn(
-                    "로비 맵 변경 요청 거부 - principal 또는 userId가 null. code: {}",
+                    "로비 맵 변경 요청 거부 - principal/userId/userIdentifier null. code: {}",
                     code
             );
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
@@ -109,11 +121,11 @@ public class LobbyMapUpdateService {
                         ERROR_LOBBY_NOT_FOUND
                 ));
 
-        if (!LOBBY_STATUS_WAITING.equals(lobbyInfo.status())) {
+        if (!LobbyStatus.WAITING.name().equals(lobbyInfo.status())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
         }
 
-        if (!principal.userIdentifier().equals(lobbyInfo.hostId())) {
+        if (!Objects.equals(principal.userIdentifier(), lobbyInfo.hostId())) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_NOT_HOST);
         }
 
@@ -126,20 +138,32 @@ public class LobbyMapUpdateService {
                 ? null
                 : new LobbyMapMetadata(lobbyInfo.mapId(), lobbyInfo.mapTitle(), lobbyInfo.mapCategory());
 
+        GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCodeForUpdate(code)
+                .orElseGet(() -> handleMissingGameLobbySnapshot(code, principal.userIdentifier()));
+
+        if (gameLobby.getStatus() != LobbyStatus.WAITING) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
+        }
+
         lobbyRepository.updateMapMetadata(code, newMetadata);
 
         Long newMapId = newMetadata != null ? newMetadata.mapId() : null;
         int updated;
         try {
-            updated = gameLobbyJpaRepository.updateMapIdIfWaiting(code, newMapId, LobbyStatus.WAITING);
+            updated = gameLobbyJpaRepository.updateMapIdIfWaiting(code, newMapId);
         } catch (Exception e) {
             log.error(LOG_DB_UPDATE_FAILED, code, e);
-            compensateRedis(code, oldMetadata);
+            compensateRedisMapMetadata(code, oldMetadata);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ERROR_UPDATE_MAP_FAILED);
         }
 
         if (updated == 0) {
-            compensateRedis(code, oldMetadata);
+            log.error(
+                    "{} 락 보유 중에 updateMapIdIfWaiting이 0행 반환 - 정합성 이상. code: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code
+            );
+            compensateRedisMapMetadata(code, oldMetadata);
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
         }
 
@@ -154,12 +178,61 @@ public class LobbyMapUpdateService {
         registerMapChangedEventAfterCommit(code);
     }
 
-    private void compensateRedis(String code, LobbyMapMetadata oldMetadata) {
-        try {
-            lobbyRepository.updateMapMetadata(code, oldMetadata);
-            log.info(LOG_COMPENSATION_SUCCESS, code);
-        } catch (Exception e) {
-            log.error(LOG_MONITORING_REQUIRED + " " + LOG_COMPENSATION_FAILED, code, e);
+    /**
+     * Redis 로비는 존재하지만 DB GAME_LOBBY 스냅샷이 없는 정합성 이상 상태를 처리한다.
+     *
+     * LobbyStartService.handleMissingGameLobbySnapshot과 동일한 패턴:
+     * Redis 잔존 로비 보상 삭제를 시도하고, 실패하면 reconciliation 큐에 적재한다.
+     */
+    private GameLobby handleMissingGameLobbySnapshot(String code, String requesterIdentifier) {
+        log.error(
+                "{} Redis 로비는 존재하지만 DB GAME_LOBBY 스냅샷이 없습니다. "
+                        + "맵 변경 경로에서 감지 - Redis 잔존 로비 보상 삭제를 시도합니다. code: {}, requester: {}",
+                LOG_ALERT_REQUIRED,
+                code,
+                requesterIdentifier
+        );
+
+        boolean deleted = lobbyRepository.deleteFromRedis(code);
+
+        if (!deleted) {
+            lobbyRepository.enqueueStartReconciliation(
+                    code,
+                    RECONCILIATION_REASON_MAP_UPDATE_SNAPSHOT_NOT_FOUND
+            );
+
+            log.error(
+                    "{} DB 스냅샷 누락 로비 Redis 삭제 실패 - 재처리 큐 적재 완료. code: {}, requester: {}",
+                    LOG_ALERT_REQUIRED,
+                    code,
+                    requesterIdentifier
+            );
+        }
+
+        throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                ERROR_LOBBY_SNAPSHOT_NOT_FOUND
+        );
+    }
+
+    /**
+     * Redis 맵 메타데이터를 status==WAITING 원자 조건으로 보상 복구한다.
+     *
+     * [안전 정책]
+     * 보상 시점에 다른 트랜잭션이 status를 PLAYING으로 바꿨다면 oldMetadata로 되돌리면 안 된다.
+     * Lua 내부에서 원자 검증하므로 SKIPPED_NOT_WAITING은 정상 경로로 간주하고 로그만 남긴다.
+     */
+    private void compensateRedisMapMetadata(String code, LobbyMapMetadata oldMetadata) {
+        LobbyMapCompensationResult result = lobbyRepository.compensateMapMetadataIfWaiting(code, oldMetadata);
+
+        switch (result) {
+            case COMPENSATED -> log.info("Redis 맵 보상 복구 완료 - code: {}", code);
+            case SKIPPED_NOT_WAITING -> log.warn(LOG_COMPENSATION_SKIPPED, code);
+            case LOBBY_NOT_FOUND -> log.error(
+                    "{} Redis 맵 보상 복구 실패 - 로비 데이터 없음 또는 Lua 실행 실패. code: {}",
+                    LOG_MONITORING_REQUIRED,
+                    code
+            );
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -1,0 +1,171 @@
+/*
+ * 로비 대기실 맵 변경 유스케이스를 담당하는 서비스.
+ *
+ * [책임]
+ * - 인증 주체 검증
+ * - 로비 존재 여부 조회
+ * - WAITING 상태 검증
+ * - 방장 여부 검증
+ * - 선택된 맵 접근 가능 여부 검증 위임 (LobbyMapPolicy 재사용)
+ * - Redis 맵 메타데이터 갱신
+ * - DB GAME_LOBBY.map_id 갱신
+ * - DB 갱신 실패 시 Redis 보상 복구
+ * - 참여자 refresh 이벤트 발행
+ *
+ * [정합성 정책]
+ * Redis 선갱신 후 DB를 갱신한다. DB 갱신 실패 시 Redis를 이전 값으로 보상 복구한다.
+ * 보상 복구도 실패하면 [MONITORING_REQUIRED] 로그를 남기고 운영자 수동 처리에 위임한다.
+ */
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
+import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyMapRequest;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LobbyMapUpdateService {
+
+    // =========================================================
+    // 에러 메시지 상수
+    // =========================================================
+
+    private static final String ERROR_INVALID_PRINCIPAL =
+            "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
+    private static final String ERROR_LOBBY_NOT_FOUND =
+            "존재하지 않는 로비입니다.";
+    private static final String ERROR_LOBBY_NOT_WAITING =
+            "게임이 이미 시작된 로비에서는 맵을 변경할 수 없습니다.";
+    private static final String ERROR_NOT_HOST =
+            "방장만 맵을 변경할 수 있습니다.";
+    private static final String ERROR_LOBBY_DB_NOT_FOUND =
+            "DB에서 로비를 찾을 수 없습니다.";
+    private static final String ERROR_UPDATE_MAP_FAILED =
+            "맵 변경에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
+    // =========================================================
+    // 로그 메시지 상수
+    // =========================================================
+
+    private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
+    private static final String LOG_DB_UPDATE_FAILED =
+            "DB 맵 갱신 실패 - Redis 보상 복구 시작. code: {}";
+    private static final String LOG_COMPENSATION_SUCCESS =
+            "Redis 맵 보상 복구 완료 - code: {}";
+    private static final String LOG_COMPENSATION_FAILED =
+            "Redis 맵 보상 복구 실패 - code: {}. Redis-DB 불일치 상태. 수동 정리 필요. [모니터링 필요]";
+
+    private static final String LOBBY_STATUS_WAITING = LobbyStatus.WAITING.name();
+
+    private final LobbyRepository lobbyRepository;
+    private final GameLobbyJpaRepository gameLobbyJpaRepository;
+    private final LobbyMapPolicy lobbyMapPolicy;
+    private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
+
+    /**
+     * 로비 대기실에서 방장의 맵 변경 요청을 처리한다.
+     *
+     * [처리 순서]
+     * 1. principal null 및 userId null 검증
+     * 2. Redis에서 로비 조회 (존재 여부 및 상태 확인)
+     * 3. WAITING 상태 검증
+     * 4. 방장 여부 검증
+     * 5. LobbyMapPolicy로 맵 존재/삭제/권한 검증
+     * 6. Redis 맵 메타데이터 갱신 (선반영)
+     * 7. DB GAME_LOBBY.map_id 갱신 (실패 시 Redis 보상 복구)
+     * 8. 참여자 refresh 이벤트 발행
+     *
+     * @param code      로비 초대 코드
+     * @param request   맵 변경 요청 DTO
+     * @param principal JWT에서 추출한 인증 주체
+     */
+    @Transactional
+    public void updateMap(String code, UpdateLobbyMapRequest request, CustomPrincipal principal) {
+
+        if (principal == null || principal.userId() == null) {
+            log.warn(
+                    "로비 맵 변경 요청 거부 - principal 또는 userId가 null. code: {}",
+                    code
+            );
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_PRINCIPAL);
+        }
+
+        JoinLobbyResponse lobbyInfo = lobbyRepository.findByInviteCode(code)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_LOBBY_NOT_FOUND
+                ));
+
+        if (!LOBBY_STATUS_WAITING.equals(lobbyInfo.status())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
+        }
+
+        if (!principal.userIdentifier().equals(lobbyInfo.hostId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_NOT_HOST);
+        }
+
+        LobbyMapMetadata newMetadata = lobbyMapPolicy.resolveLobbyMapMetadata(
+                request.mapId(),
+                principal.userId()
+        );
+
+        LobbyMapMetadata oldMetadata = new LobbyMapMetadata(
+                lobbyInfo.mapId(),
+                lobbyInfo.mapTitle(),
+                lobbyInfo.mapCategory()
+        );
+
+        lobbyRepository.updateMapMetadata(code, newMetadata);
+
+        try {
+            GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCode(code)
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.NOT_FOUND,
+                            ERROR_LOBBY_DB_NOT_FOUND
+                    ));
+
+            gameLobby.updateMap(newMetadata != null ? newMetadata.mapId() : null);
+            gameLobbyJpaRepository.saveAndFlush(gameLobby);
+
+            log.info(
+                    "로비 맵 변경 완료 - code: {}, host: {}, oldMapId: {}, newMapId: {}",
+                    code,
+                    principal.userIdentifier(),
+                    oldMetadata.mapId(),
+                    newMetadata != null ? newMetadata.mapId() : null
+            );
+
+        } catch (Exception e) {
+            log.error(LOG_DB_UPDATE_FAILED, code, e);
+
+            try {
+                lobbyRepository.updateMapMetadata(code, oldMetadata);
+                log.info(LOG_COMPENSATION_SUCCESS, code);
+            } catch (Exception compensationException) {
+                log.error(
+                        "{} {} code: {}",
+                        LOG_MONITORING_REQUIRED,
+                        LOG_COMPENSATION_FAILED,
+                        code,
+                        compensationException
+                );
+            }
+
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ERROR_UPDATE_MAP_FAILED);
+        }
+
+        lobbyRealtimeNotifier.notifyLobbyInfoRefresh(code);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
@@ -27,6 +27,7 @@ import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,6 +64,8 @@ public class LobbyStartService {
             "게임 시작 이벤트 발행을 위한 트랜잭션 동기화가 활성화되어 있지 않습니다.";
     private static final String ERROR_LOBBY_SNAPSHOT_NOT_FOUND =
             "로비 상태 정보가 일치하지 않습니다. 로비를 다시 생성해주세요.";
+    private static final String ERROR_LOBBY_LOCK_CONTENTION =
+            "다른 로비 상태 변경이 진행 중입니다. 잠시 후 다시 시도해주세요.";
 
     private static final String RECONCILIATION_REASON_DB_SYNC_FAILED =
             "START_DB_SYNC_FAILED";
@@ -105,8 +108,7 @@ public class LobbyStartService {
             );
         }
 
-        GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCodeForUpdate(code)
-                .orElseGet(() -> handleMissingGameLobbySnapshot(code, requesterIdentifier));
+        GameLobby gameLobby = acquireGameLobbyRowLock(code, requesterIdentifier);
 
         QuizMap quizMap = lobbyStartPolicy.validateStartableMap(gameLobby);
 
@@ -154,6 +156,29 @@ public class LobbyStartService {
                 quizMap.getId(),
                 gameLobby.getRoundCount()
         );
+    }
+
+    /**
+     * GAME_LOBBY 행에 대한 PESSIMISTIC_WRITE 락을 획득한다.
+     *
+     * [예외 처리]
+     * - row 부재 → handleMissingGameLobbySnapshot 분기 (Redis 보상 삭제 + reconciliation)
+     * - 락 획득 타임아웃(3초) → PessimisticLockingFailureException을 잡아 409 CONFLICT로 변환.
+     *   동시 맵 변경(LobbyMapUpdateService)이 진행 중일 때 명확한 신호를 클라이언트에게 준다.
+     */
+    private GameLobby acquireGameLobbyRowLock(String code, String requesterIdentifier) {
+        try {
+            return gameLobbyJpaRepository.findByInviteCodeForUpdate(code)
+                    .orElseGet(() -> handleMissingGameLobbySnapshot(code, requesterIdentifier));
+        } catch (PessimisticLockingFailureException e) {
+            log.warn(
+                    "게임 시작 락 획득 타임아웃 - code: {}, requester: {}",
+                    code,
+                    requesterIdentifier,
+                    e
+            );
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_LOCK_CONTENTION);
+        }
     }
 
     private GameLobby handleMissingGameLobbySnapshot(

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
@@ -105,7 +105,7 @@ public class LobbyStartService {
             );
         }
 
-        GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCode(code)
+        GameLobby gameLobby = gameLobbyJpaRepository.findByInviteCodeForUpdate(code)
                 .orElseGet(() -> handleMissingGameLobbySnapshot(code, requesterIdentifier));
 
         QuizMap quizMap = lobbyStartPolicy.validateStartableMap(gameLobby);

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -94,4 +94,24 @@ public class RedisScriptConfig {
         redisScript.setResultType(String.class);
         return redisScript;
     }
+
+    /**
+     * 로비 맵 변경 보상 복구 Lua 스크립트
+     *
+     * [처리 내용]
+     * - 로비 존재 여부 확인
+     * - status == WAITING 원자 검증
+     * - 조건 만족 시 map_id/map_title/map_category 복구 (oldMetadata가 비어있으면 HDEL)
+     *
+     * [필요 이유]
+     * 보상 시점에 다른 트랜잭션이 status를 PLAYING으로 바꿨다면 맵 메타데이터를 되돌리면 안 된다.
+     * Java에서 status 조회 후 분기하면 race window가 남으므로 Lua로 원자 처리한다.
+     */
+    @Bean
+    public RedisScript<String> compensateLobbyMapScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/compensate_lobby_map.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
 }

--- a/src/main/resources/scripts/compensate_lobby_map.lua
+++ b/src/main/resources/scripts/compensate_lobby_map.lua
@@ -1,0 +1,54 @@
+---@diagnostic disable: undefined-global
+--
+-- [역할]
+-- 로비 맵 변경 트랜잭션 보상 복구 전용 스크립트.
+-- DB 갱신 실패 또는 0행 반환 시 호출자가 Redis 맵 메타데이터를 이전 값으로 되돌리려고 한다.
+-- 그러나 그 사이 start_lobby.lua에 의해 status가 이미 PLAYING으로 전환되었을 수 있으므로,
+-- 반드시 status == WAITING일 때만 원자적으로 복구한다.
+--
+-- [정책]
+-- - status != WAITING (PLAYING 등) → 'SKIPPED_NOT_WAITING' 반환. Redis 맵 메타데이터 변경 없음.
+-- - oldMapId가 빈 문자열 → 이전이 "맵 미선택" 상태였음. map_id/map_title/map_category HDEL.
+-- - oldMapId가 있음 → 3개 필드 HSET.
+--
+-- [KEYS]
+-- KEYS[1] = lobby:{code}
+--
+-- [ARGV]
+-- ARGV[1] = fieldStatus
+-- ARGV[2] = fieldMapId
+-- ARGV[3] = fieldMapTitle
+-- ARGV[4] = fieldMapCategory
+-- ARGV[5] = waitingStatus
+-- ARGV[6] = oldMapId or ""
+-- ARGV[7] = oldMapTitle or ""
+-- ARGV[8] = oldMapCategory or ""
+
+local lobbyKey = KEYS[1]
+
+local fieldStatus = ARGV[1]
+local fieldMapId = ARGV[2]
+local fieldMapTitle = ARGV[3]
+local fieldMapCategory = ARGV[4]
+local waitingStatus = ARGV[5]
+local oldMapId = ARGV[6]
+local oldMapTitle = ARGV[7]
+local oldMapCategory = ARGV[8]
+
+if redis.call('EXISTS', lobbyKey) == 0 then
+    return 'LOBBY_NOT_FOUND'
+end
+
+local currentStatus = redis.call('HGET', lobbyKey, fieldStatus)
+
+if currentStatus ~= waitingStatus then
+    return 'SKIPPED_NOT_WAITING'
+end
+
+if oldMapId == nil or oldMapId == '' then
+    redis.call('HDEL', lobbyKey, fieldMapId, fieldMapTitle, fieldMapCategory)
+else
+    redis.call('HSET', lobbyKey, fieldMapId, oldMapId, fieldMapTitle, oldMapTitle, fieldMapCategory, oldMapCategory)
+end
+
+return 'COMPENSATED'

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
@@ -13,6 +13,7 @@ import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -212,6 +213,29 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.FORBIDDEN));
     }
 
+    // ─── 락 충돌 ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("DB row lock 획득이 타임아웃되면 409 CONFLICT로 변환한다")
+    void updateMap_throwsConflict_whenLockAcquisitionTimesOut() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
+                .thenThrow(new PessimisticLockingFailureException("lock wait timeout"));
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rse = (ResponseStatusException) ex;
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(rse.getReason()).contains("진행 중");
+                });
+
+        verify(lobbyRepository, never()).updateMapMetadata(any(), any());
+        verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any());
+    }
+
     // ─── DB 스냅샷 누락 ─────────────────────────────────
 
     @Test
@@ -262,12 +286,12 @@ class LobbyMapUpdateServiceTest {
             when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
             when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                     .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-            when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L)).thenReturn(1);
+            when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(1);
 
             sut.updateMap(CODE, request(2L), hostPrincipal());
 
             verify(lobbyRepository).updateMapMetadata(CODE, newMetadata);
-            verify(gameLobbyJpaRepository).updateMapIdIfWaiting(CODE, 2L);
+            verify(gameLobbyJpaRepository).updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING);
             verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any());
 
             TransactionSynchronizationManager.getSynchronizations()
@@ -288,7 +312,7 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(2L)))
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(2L), eq(LobbyStatus.WAITING)))
                 .thenThrow(new RuntimeException("DB 장애"));
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
@@ -312,7 +336,7 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(1L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, null)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(1L)))
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(1L), eq(LobbyStatus.WAITING)))
                 .thenThrow(new RuntimeException("DB 장애"));
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
@@ -334,7 +358,7 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L)).thenReturn(0);
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(0);
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
 
@@ -355,7 +379,7 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L)).thenReturn(0);
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(0);
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.SKIPPED_NOT_WAITING);
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
@@ -1,0 +1,198 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
+import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyMapRequest;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * LobbyMapUpdateService의 맵 변경 정책을 검증한다.
+ *
+ * [테스트 범위]
+ * - principal/userId 검증
+ * - 로비 미존재 처리
+ * - WAITING 상태 제한
+ * - 방장 권한 제한
+ * - 정상 변경 시 Redis/DB 갱신 및 realtime 이벤트 발행
+ * - DB 갱신 실패 시 Redis 보상 복구
+ */
+class LobbyMapUpdateServiceTest {
+
+    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
+    private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
+    private final LobbyMapPolicy lobbyMapPolicy = mock(LobbyMapPolicy.class);
+    private final LobbyRealtimeNotifier lobbyRealtimeNotifier = mock(LobbyRealtimeNotifier.class);
+
+    private final LobbyMapUpdateService sut = new LobbyMapUpdateService(
+            lobbyRepository,
+            gameLobbyJpaRepository,
+            lobbyMapPolicy,
+            lobbyRealtimeNotifier
+    );
+
+    private static final String CODE = "ABC123";
+    private static final String HOST_ID = "host-uuid";
+    private static final Long USER_ID = 1L;
+
+    private CustomPrincipal hostPrincipal() {
+        return new CustomPrincipal(USER_ID, HOST_ID, UserType.REGISTERED);
+    }
+
+    private JoinLobbyResponse waitingLobby() {
+        return JoinLobbyResponse.builder()
+                .inviteCode(CODE)
+                .title("테스트 로비")
+                .hostId(HOST_ID)
+                .maxPlayers(6)
+                .currentPlayers(2)
+                .status("WAITING")
+                .mapId(10L)
+                .mapTitle("K-POP 구곡")
+                .mapCategory("K-POP")
+                .build();
+    }
+
+    private UpdateLobbyMapRequest request(long mapId) {
+        return new UpdateLobbyMapRequest(mapId);
+    }
+
+    // ─── principal 검증 ───────────────────────────────────
+
+    @Test
+    @DisplayName("principal이 null이면 401 Unauthorized를 던진다")
+    void updateMap_throwsUnauthorized_whenPrincipalIsNull() {
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), null))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.UNAUTHORIZED));
+    }
+
+    @Test
+    @DisplayName("principal.userId()가 null이면 401 Unauthorized를 던진다")
+    void updateMap_throwsUnauthorized_whenUserIdIsNull() {
+        CustomPrincipal principal = new CustomPrincipal(null, HOST_ID, UserType.REGISTERED);
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), principal))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.UNAUTHORIZED));
+    }
+
+    // ─── 로비 조회 검증 ──────────────────────────────────
+
+    @Test
+    @DisplayName("Redis에 로비가 없으면 404 Not Found를 던진다")
+    void updateMap_throwsNotFound_whenLobbyNotFound() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.NOT_FOUND));
+    }
+
+    // ─── 상태 검증 ────────────────────────────────────────
+
+    @Test
+    @DisplayName("로비 상태가 PLAYING이면 409 Conflict를 던진다")
+    void updateMap_throwsConflict_whenLobbyNotWaiting() {
+        JoinLobbyResponse playingLobby = JoinLobbyResponse.builder()
+                .inviteCode(CODE)
+                .title("테스트 로비")
+                .hostId(HOST_ID)
+                .maxPlayers(6)
+                .currentPlayers(4)
+                .status("PLAYING")
+                .build();
+
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(playingLobby));
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+    }
+
+    // ─── 방장 검증 ────────────────────────────────────────
+
+    @Test
+    @DisplayName("방장이 아닌 사용자가 요청하면 403 Forbidden을 던진다")
+    void updateMap_throwsForbidden_whenRequesterIsNotHost() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+
+        CustomPrincipal nonHost = new CustomPrincipal(2L, "other-uuid", UserType.REGISTERED);
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), nonHost))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.FORBIDDEN));
+    }
+
+    // ─── 정상 변경 ───────────────────────────────────────
+
+    @Test
+    @DisplayName("정상 요청 시 Redis/DB를 갱신하고 참여자에게 refresh 이벤트를 발행한다")
+    void updateMap_updatesRedisAndDb_andPublishesRefreshEvent() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+
+        GameLobby gameLobby = mock(GameLobby.class);
+        when(gameLobbyJpaRepository.findByInviteCode(CODE)).thenReturn(Optional.of(gameLobby));
+        when(gameLobbyJpaRepository.saveAndFlush(gameLobby)).thenReturn(gameLobby);
+
+        sut.updateMap(CODE, request(2L), hostPrincipal());
+
+        verify(lobbyRepository).updateMapMetadata(CODE, newMetadata);
+        verify(gameLobby).updateMap(2L);
+        verify(gameLobbyJpaRepository).saveAndFlush(gameLobby);
+        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(CODE);
+    }
+
+    // ─── DB 실패 시 보상 복구 ──────────────────────────────
+
+    @Test
+    @DisplayName("DB 갱신 실패 시 Redis를 이전 맵 메타데이터로 보상 복구하고 500을 던진다")
+    void updateMap_rollbacksRedis_whenDbSaveFails() {
+        JoinLobbyResponse lobby = waitingLobby(); // 이전 맵: id=10, title="K-POP 구곡", category="K-POP"
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(lobby));
+
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+
+        GameLobby gameLobby = mock(GameLobby.class);
+        when(gameLobbyJpaRepository.findByInviteCode(CODE)).thenReturn(Optional.of(gameLobby));
+        doThrow(new RuntimeException("DB 장애")).when(gameLobbyJpaRepository).saveAndFlush(any());
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        // Redis 선갱신(newMetadata) 후 보상 복구(oldMetadata) 순서로 호출되어야 한다
+        LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
+        var inOrder = inOrder(lobbyRepository);
+        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
+        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(oldMetadata));
+
+        // refresh 이벤트는 발행되면 안 된다
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
@@ -1,9 +1,12 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.lobby.LobbyMapCompensationResult;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyMapRequest;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
@@ -27,14 +30,15 @@ import static org.mockito.Mockito.*;
  * LobbyMapUpdateService의 맵 변경 정책을 검증한다.
  *
  * [테스트 범위]
- * - principal/userId 검증
+ * - principal / userId / userIdentifier 검증
  * - 로비 미존재 처리
- * - WAITING 상태 제한
+ * - WAITING 상태 제한 (Redis 1차 / DB 락 후 재검증)
  * - 방장 권한 제한
  * - 정상 변경 시 Redis/DB 갱신 및 realtime 이벤트 등록
- * - DB 갱신 실패 시 Redis 보상 복구
- * - DB 조건부 갱신 0행(레이스) 시 Redis 보상 복구 + 409
- * - 기존 맵 미선택 로비에서 DB 실패 시 보상 복구가 null로 호출됨
+ * - DB 갱신 실패 시 compensateMapMetadataIfWaiting 호출
+ * - DB 조건부 갱신 0행 시 보상 + 409
+ * - 기존 맵 미선택 로비에서 DB 실패 시 보상이 null oldMetadata로 호출됨
+ * - DB GAME_LOBBY 스냅샷 누락 시 reconciliation 패턴 적용
  */
 class LobbyMapUpdateServiceTest {
 
@@ -86,6 +90,22 @@ class LobbyMapUpdateServiceTest {
                 .build();
     }
 
+    private GameLobby gameLobbyWith(LobbyStatus status, Long mapId) {
+        return GameLobby.builder()
+                .id(100L)
+                .host(User.builder().id(USER_ID).build())
+                .mapId(mapId)
+                .inviteCode(CODE)
+                .title("테스트 로비")
+                .maxPlayers(6)
+                .roundCount(5)
+                .timeLimitSeconds(30)
+                .isPrivate(false)
+                .status(status)
+                .isDeleted(false)
+                .build();
+    }
+
     private UpdateLobbyMapRequest request(long mapId) {
         return new UpdateLobbyMapRequest(mapId);
     }
@@ -112,6 +132,17 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.UNAUTHORIZED));
     }
 
+    @Test
+    @DisplayName("principal.userIdentifier()가 null이면 NPE 없이 401 Unauthorized를 던진다")
+    void updateMap_throwsUnauthorized_whenUserIdentifierIsNull() {
+        CustomPrincipal principal = new CustomPrincipal(USER_ID, null, UserType.REGISTERED);
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), principal))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.UNAUTHORIZED));
+    }
+
     // ─── 로비 조회 검증 ──────────────────────────────────
 
     @Test
@@ -128,7 +159,7 @@ class LobbyMapUpdateServiceTest {
     // ─── 상태 검증 ────────────────────────────────────────
 
     @Test
-    @DisplayName("로비 상태가 PLAYING이면 409 Conflict를 던진다")
+    @DisplayName("Redis 상태가 PLAYING이면 409 Conflict를 던진다 (DB 락 획득 전 차단)")
     void updateMap_throwsConflict_whenLobbyNotWaiting() {
         JoinLobbyResponse playingLobby = JoinLobbyResponse.builder()
                 .inviteCode(CODE)
@@ -145,6 +176,25 @@ class LobbyMapUpdateServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
                         .isEqualTo(HttpStatus.CONFLICT));
+
+        verify(gameLobbyJpaRepository, never()).findByInviteCodeForUpdate(any());
+    }
+
+    @Test
+    @DisplayName("Redis는 WAITING이지만 DB 락 획득 후 status가 PLAYING이면 409를 던진다")
+    void updateMap_throwsConflict_whenDbStatusIsPlayingAfterLockAcquired() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
+                .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.PLAYING, 10L)));
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+
+        verify(lobbyRepository, never()).updateMapMetadata(any(), any());
     }
 
     // ─── 방장 검증 ────────────────────────────────────────
@@ -162,6 +212,44 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.FORBIDDEN));
     }
 
+    // ─── DB 스냅샷 누락 ─────────────────────────────────
+
+    @Test
+    @DisplayName("DB GAME_LOBBY 스냅샷이 없으면 Redis 보상 삭제 후 409를 던진다")
+    void updateMap_handlesMissingDbSnapshot_byDeletingRedisAndThrowingConflict() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE)).thenReturn(Optional.empty());
+        when(lobbyRepository.deleteFromRedis(CODE)).thenReturn(true);
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+
+        verify(lobbyRepository).deleteFromRedis(CODE);
+        verify(lobbyRepository, never()).enqueueStartReconciliation(any(), any());
+        verify(lobbyRepository, never()).updateMapMetadata(any(), any());
+    }
+
+    @Test
+    @DisplayName("DB 스냅샷 누락 + Redis 삭제 실패 시 reconciliation 큐에 적재한다")
+    void updateMap_enqueuesReconciliation_whenSnapshotMissingAndRedisDeleteFails() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE)).thenReturn(Optional.empty());
+        when(lobbyRepository.deleteFromRedis(CODE)).thenReturn(false);
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+
+        verify(lobbyRepository).enqueueStartReconciliation(eq(CODE), eq("MAP_UPDATE_DB_SNAPSHOT_NOT_FOUND"));
+    }
+
     // ─── 정상 변경 ───────────────────────────────────────
 
     @Test
@@ -170,16 +258,18 @@ class LobbyMapUpdateServiceTest {
         TransactionSynchronizationManager.initSynchronization();
         try {
             when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-
             LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
             when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
-            when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(1);
+            when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
+                    .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
+            when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L)).thenReturn(1);
 
             sut.updateMap(CODE, request(2L), hostPrincipal());
 
             verify(lobbyRepository).updateMapMetadata(CODE, newMetadata);
-            verify(gameLobbyJpaRepository).updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING);
-            // afterCommit 등록 후 커밋 시뮬레이션
+            verify(gameLobbyJpaRepository).updateMapIdIfWaiting(CODE, 2L);
+            verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any());
+
             TransactionSynchronizationManager.getSynchronizations()
                     .forEach(TransactionSynchronization::afterCommit);
             verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(CODE);
@@ -191,14 +281,17 @@ class LobbyMapUpdateServiceTest {
     // ─── DB 실패 시 보상 복구 ──────────────────────────────
 
     @Test
-    @DisplayName("DB 갱신 실패 시 Redis를 이전 맵 메타데이터로 보상 복구하고 500을 던진다")
+    @DisplayName("DB 갱신 실패 시 compensateMapMetadataIfWaiting으로 Redis 보상을 시도하고 500을 던진다")
     void updateMap_rollbacksRedis_whenDbSaveFails() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-
         LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(2L), eq(LobbyStatus.WAITING)))
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
+                .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(2L)))
                 .thenThrow(new RuntimeException("DB 장애"));
+        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
+                .thenReturn(LobbyMapCompensationResult.COMPENSATED);
 
         assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
                 .isInstanceOf(ResponseStatusException.class)
@@ -206,43 +299,44 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
         LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
-        var inOrder = inOrder(lobbyRepository);
-        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
-        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(oldMetadata));
-
+        verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), eq(oldMetadata));
         verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
     }
 
     @Test
-    @DisplayName("기존 맵 미선택 로비에서 DB 갱신 실패 시 보상 복구가 updateMapMetadata(code, null)로 호출된다")
+    @DisplayName("기존 맵 미선택 로비에서 DB 실패 시 보상이 null oldMetadata로 호출된다")
     void updateMap_rollbacksRedisWithNull_whenNoMapLobbyAndDbFails() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobbyWithNoMap()));
-
         LobbyMapMetadata newMetadata = new LobbyMapMetadata(1L, "K-POP 히트곡", "K-POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(1L, USER_ID)).thenReturn(newMetadata);
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(1L), eq(LobbyStatus.WAITING)))
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
+                .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, null)));
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(1L)))
                 .thenThrow(new RuntimeException("DB 장애"));
+        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
+                .thenReturn(LobbyMapCompensationResult.COMPENSATED);
 
         assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), hostPrincipal()))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
                         .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
-        var inOrder = inOrder(lobbyRepository);
-        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
-        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), (LobbyMapMetadata) isNull());
-
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
+        verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), (LobbyMapMetadata) isNull());
     }
 
     @Test
-    @DisplayName("DB 조건부 갱신이 0행 반환(레이스 컨디션)이면 Redis를 보상 복구하고 409를 던진다")
+    @DisplayName("DB 조건부 갱신이 0행 반환이면 Redis를 보상 복구하고 409를 던진다")
     void updateMap_rollbacksRedisAndThrowsConflict_whenDbUpdatedZeroRows() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-
         LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(0);
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
+                .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L)).thenReturn(0);
+        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
+                .thenReturn(LobbyMapCompensationResult.COMPENSATED);
 
         assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
                 .isInstanceOf(ResponseStatusException.class)
@@ -250,10 +344,26 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.CONFLICT));
 
         LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
-        var inOrder = inOrder(lobbyRepository);
-        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
-        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(oldMetadata));
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), eq(oldMetadata));
+    }
 
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
+    @Test
+    @DisplayName("보상 Lua가 SKIPPED_NOT_WAITING을 반환해도 호출자 예외 응답은 그대로 유지된다")
+    void updateMap_handlesSkippedCompensation_whenStatusNoLongerWaiting() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
+                .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L)).thenReturn(0);
+        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
+                .thenReturn(LobbyMapCompensationResult.SKIPPED_NOT_WAITING);
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), any());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
@@ -4,13 +4,15 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.dto.UpdateLobbyMapRequest;
-import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
@@ -29,8 +31,10 @@ import static org.mockito.Mockito.*;
  * - 로비 미존재 처리
  * - WAITING 상태 제한
  * - 방장 권한 제한
- * - 정상 변경 시 Redis/DB 갱신 및 realtime 이벤트 발행
+ * - 정상 변경 시 Redis/DB 갱신 및 realtime 이벤트 등록
  * - DB 갱신 실패 시 Redis 보상 복구
+ * - DB 조건부 갱신 0행(레이스) 시 Redis 보상 복구 + 409
+ * - 기존 맵 미선택 로비에서 DB 실패 시 보상 복구가 null로 호출됨
  */
 class LobbyMapUpdateServiceTest {
 
@@ -65,6 +69,20 @@ class LobbyMapUpdateServiceTest {
                 .mapId(10L)
                 .mapTitle("K-POP 구곡")
                 .mapCategory("K-POP")
+                .build();
+    }
+
+    private JoinLobbyResponse waitingLobbyWithNoMap() {
+        return JoinLobbyResponse.builder()
+                .inviteCode(CODE)
+                .title("테스트 로비")
+                .hostId(HOST_ID)
+                .maxPlayers(6)
+                .currentPlayers(2)
+                .status("WAITING")
+                .mapId(null)
+                .mapTitle(null)
+                .mapCategory(null)
                 .build();
     }
 
@@ -147,23 +165,27 @@ class LobbyMapUpdateServiceTest {
     // ─── 정상 변경 ───────────────────────────────────────
 
     @Test
-    @DisplayName("정상 요청 시 Redis/DB를 갱신하고 참여자에게 refresh 이벤트를 발행한다")
-    void updateMap_updatesRedisAndDb_andPublishesRefreshEvent() {
-        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+    @DisplayName("정상 요청 시 Redis/DB를 갱신하고 afterCommit 이벤트를 등록한다")
+    void updateMap_updatesRedisAndDb_andRegistersAfterCommitEvent() {
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
 
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
-        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+            LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+            when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+            when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(1);
 
-        GameLobby gameLobby = mock(GameLobby.class);
-        when(gameLobbyJpaRepository.findByInviteCode(CODE)).thenReturn(Optional.of(gameLobby));
-        when(gameLobbyJpaRepository.saveAndFlush(gameLobby)).thenReturn(gameLobby);
+            sut.updateMap(CODE, request(2L), hostPrincipal());
 
-        sut.updateMap(CODE, request(2L), hostPrincipal());
-
-        verify(lobbyRepository).updateMapMetadata(CODE, newMetadata);
-        verify(gameLobby).updateMap(2L);
-        verify(gameLobbyJpaRepository).saveAndFlush(gameLobby);
-        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(CODE);
+            verify(lobbyRepository).updateMapMetadata(CODE, newMetadata);
+            verify(gameLobbyJpaRepository).updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING);
+            // afterCommit 등록 후 커밋 시뮬레이션
+            TransactionSynchronizationManager.getSynchronizations()
+                    .forEach(TransactionSynchronization::afterCommit);
+            verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(CODE);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     // ─── DB 실패 시 보상 복구 ──────────────────────────────
@@ -171,28 +193,67 @@ class LobbyMapUpdateServiceTest {
     @Test
     @DisplayName("DB 갱신 실패 시 Redis를 이전 맵 메타데이터로 보상 복구하고 500을 던진다")
     void updateMap_rollbacksRedis_whenDbSaveFails() {
-        JoinLobbyResponse lobby = waitingLobby(); // 이전 맵: id=10, title="K-POP 구곡", category="K-POP"
-        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(lobby));
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
 
         LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
-
-        GameLobby gameLobby = mock(GameLobby.class);
-        when(gameLobbyJpaRepository.findByInviteCode(CODE)).thenReturn(Optional.of(gameLobby));
-        doThrow(new RuntimeException("DB 장애")).when(gameLobbyJpaRepository).saveAndFlush(any());
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(2L), eq(LobbyStatus.WAITING)))
+                .thenThrow(new RuntimeException("DB 장애"));
 
         assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
                         .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
-        // Redis 선갱신(newMetadata) 후 보상 복구(oldMetadata) 순서로 호출되어야 한다
         LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
         var inOrder = inOrder(lobbyRepository);
         inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
         inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(oldMetadata));
 
-        // refresh 이벤트는 발행되면 안 된다
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
+    }
+
+    @Test
+    @DisplayName("기존 맵 미선택 로비에서 DB 갱신 실패 시 보상 복구가 updateMapMetadata(code, null)로 호출된다")
+    void updateMap_rollbacksRedisWithNull_whenNoMapLobbyAndDbFails() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobbyWithNoMap()));
+
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(1L, "K-POP 히트곡", "K-POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(1L, USER_ID)).thenReturn(newMetadata);
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(1L), eq(LobbyStatus.WAITING)))
+                .thenThrow(new RuntimeException("DB 장애"));
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        var inOrder = inOrder(lobbyRepository);
+        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
+        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), (LobbyMapMetadata) isNull());
+
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
+    }
+
+    @Test
+    @DisplayName("DB 조건부 갱신이 0행 반환(레이스 컨디션)이면 Redis를 보상 복구하고 409를 던진다")
+    void updateMap_rollbacksRedisAndThrowsConflict_whenDbUpdatedZeroRows() {
+        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
+
+        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(0);
+
+        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+
+        LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
+        var inOrder = inOrder(lobbyRepository);
+        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
+        inOrder.verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(oldMetadata));
+
         verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
     }
 }


### PR DESCRIPTION
  ## 📣 Related Issue
  - #75
  
  ## 📝 Summary
  - `PATCH /api/lobbies/{code}/map` 엔드포인트 구현
  - 방장 권한 및 `WAITING` 상태 검증 후 맵 변경 처리
  - Redis `map_id` / `map_title` / `map_category` 선갱신 → DB `GAME_LOBBY.map_id` 동기화
  - DB 갱신 실패 시 Redis를 이전 값으로 보상 복구 (`[MONITORING_REQUIRED]` 로그 포함)
  - 맵 유효성 검증(`LobbyMapPolicy`) 재사용 — 존재 여부(404) / 삭제 여부(409) / 비공개 접근
  권한(403)
  - 변경 완료 후 `/topic/lobby/{code}/refresh`로 `REFRESH_LOBBY_INFO` 브로드캐스트

  ## 🙏 PR point
  - Redis 선갱신 후 DB 갱신 실패 시 보상 복구를 `catch` 블록에서 처리합니다. 보상 복구마저
  실패하면 `[MONITORING_REQUIRED]` 로그를 남기고 500을 반환하므로, 해당 로그 발생 시 Redis-DB
  수동 정합성 확인이 필요합니다.
  - `LobbyMapUpdateService`는 `@Transactional` 범위 안에서 Redis를 먼저 갱신합니다. DB
  트랜잭션 롤백으로 Redis가 되돌아가지 않으므로 보상 복구가 필수입니다. (기존
  `LobbyStartService` 구조와 동일한 정책)
  
  ## 📬 Reference
  - 맵 유효성 검증: `LobbyMapPolicy#resolveLobbyMapMetadata` (로비 생성 시 사용하던 로직
  재사용)
  - Redis-DB 정합성 정책: `LobbyStartService` 보상 롤백 패턴 참고