### PR TITLE
[Feat/#96] 로비 및 로비 유저 신고 기능 구현

### DIFF
--- a/docs/REPORT_API.md
+++ b/docs/REPORT_API.md
@@ -1,0 +1,255 @@
+# Report API
+
+로비 및 로비 내 유저 신고 기능 문서입니다.
+
+## 개요
+
+신고 기능은 부적절한 로비 제목 또는 로비 내 유저를 신고하기 위한 기능입니다.
+
+현재 지원하는 신고 대상은 다음과 같습니다.
+
+| targetType | 설명 |
+|---|---|
+| `LOBBY` | 로비 자체 신고 |
+| `LOBBY_USER` | 특정 로비 안의 유저 신고 |
+
+신고 상태는 다음과 같습니다.
+
+| status | 설명 |
+|---|---|
+| `PENDING` | 신고 접수 후 운영자 검토 대기 |
+| `RESOLVED` | 운영자가 신고를 유효한 신고로 처리 완료 |
+| `DISMISSED` | 운영자가 신고를 기각 |
+
+---
+
+## 공통 정책
+
+### 인증
+
+신고 API는 JWT 인증이 필요합니다.
+
+게스트와 정식 회원 모두 신고할 수 있습니다.
+
+### 신고 사유 검증
+
+`reason`은 필수입니다.
+
+검증 규칙은 다음과 같습니다.
+
+| 필드 | 규칙 |
+|---|---|
+| `reason` | 공백 불가 |
+| `reason` | 최대 500자 |
+
+서비스 레이어에서 `trim()` 정규화를 수행한 뒤 저장합니다.
+
+### 중복 신고 방지
+
+동일 사용자는 동일 로비의 동일 대상에 대해 `PENDING` 상태의 신고를 중복 생성할 수 없습니다.
+
+중복 기준은 다음과 같습니다.
+
+```text
+reporter_id + lobby_id + target_type + target_id + status(PENDING)
+```
+
+중복 신고 요청 시 `409 Conflict`를 반환합니다.
+
+### 자동 비공개 전환 정책
+
+현재 구현에서는 신고 누적 카운트 및 임계값 판단까지만 제공합니다.
+
+자동 비공개 전환은 아직 수행하지 않습니다.
+
+자동 비공개 전환은 다음 처리가 함께 필요하기 때문에 후속 이슈로 분리합니다.
+
+```text
+1. DB game_lobby.is_private 변경
+2. Redis lobby:{code}.is_private 변경
+3. Redis 공개 로비 인덱스 제거
+4. 로비 목록 refresh 이벤트 전파
+5. 운영 로그 기록
+```
+
+---
+
+## API
+
+## 1. 로비 신고
+
+```http
+POST /api/lobbies/{code}/reports
+```
+
+### Path Variable
+
+| 이름 | 타입 | 설명 |
+|---|---|---|
+| `code` | string | 로비 초대 코드 |
+
+### Request Body
+
+```json
+{
+  "reason": "부적절한 로비 제목입니다."
+}
+```
+
+### Response
+
+```http
+201 Created
+```
+
+```json
+{
+  "reportId": 1,
+  "reporterId": 3,
+  "lobbyId": 10,
+  "targetType": "LOBBY",
+  "targetId": 10,
+  "reason": "부적절한 로비 제목입니다.",
+  "status": "PENDING",
+  "createdAt": "2026-05-23T21:20:00"
+}
+```
+
+---
+
+## 2. 로비 내 유저 신고
+
+```http
+POST /api/lobbies/{code}/users/{targetUserId}/reports
+```
+
+### Path Variable
+
+| 이름 | 타입 | 설명 |
+|---|---|---|
+| `code` | string | 로비 초대 코드 |
+| `targetUserId` | number | 신고 대상 users.id |
+
+### Request Body
+
+```json
+{
+  "reason": "채팅 도배를 반복했습니다."
+}
+```
+
+### Response
+
+```http
+201 Created
+```
+
+```json
+{
+  "reportId": 2,
+  "reporterId": 3,
+  "lobbyId": 10,
+  "targetType": "LOBBY_USER",
+  "targetId": 7,
+  "reason": "채팅 도배를 반복했습니다.",
+  "status": "PENDING",
+  "createdAt": "2026-05-23T21:25:00"
+}
+```
+
+---
+
+## 에러 응답 정책
+
+| 상황 | HTTP Status | 메시지 |
+|---|---:|---|
+| 인증 정보 없음 또는 유효하지 않음 | `401 Unauthorized` | `유효하지 않은 인증 정보입니다. 다시 로그인해주세요.` |
+| 신고자 없음 | `404 Not Found` | `신고자를 찾을 수 없습니다.` |
+| 로비 없음 | `404 Not Found` | `신고 대상 로비를 찾을 수 없습니다.` |
+| 삭제된 로비 신고 | `409 Conflict` | `삭제된 로비는 신고할 수 없습니다.` |
+| 신고 대상 유저 없음 | `404 Not Found` | `신고 대상 유저를 찾을 수 없습니다.` |
+| 자기 자신 신고 | `400 Bad Request` | `자기 자신은 신고할 수 없습니다.` |
+| 신고 사유 공백 | `400 Bad Request` | `신고 사유는 비어 있을 수 없습니다.` |
+| 중복 신고 | `409 Conflict` | `이미 접수된 신고입니다.` |
+
+---
+
+## 신고 누적 정책
+
+신고 누적 정책은 설정값으로 관리합니다.
+
+```properties
+report.policy.lobby-review-threshold=${REPORT_POLICY_LOBBY_REVIEW_THRESHOLD:5}
+report.policy.auto-private-enabled=${REPORT_POLICY_AUTO_PRIVATE_ENABLED:false}
+```
+
+| 설정 | 기본값 | 설명 |
+|---|---:|---|
+| `report.policy.lobby-review-threshold` | `5` | 특정 로비의 PENDING 신고 수가 이 값 이상이면 관리자 검토 대상 |
+| `report.policy.auto-private-enabled` | `false` | 자동 비공개 전환 후보 판단 여부 |
+
+현재 단계에서는 자동 비공개 전환을 실제 수행하지 않습니다.
+
+---
+
+## Swagger 확인
+
+개발 서버 실행 후 Swagger UI에서 확인할 수 있습니다.
+
+```text
+http://localhost:8080/swagger-ui/index.html
+```
+
+확인 대상 API:
+
+```text
+POST /api/lobbies/{code}/reports
+POST /api/lobbies/{code}/users/{targetUserId}/reports
+```
+
+---
+
+## 테스트 방법
+
+### 1. 컴파일
+
+```bash
+./gradlew compileJava
+```
+
+### 2. 서비스 테스트
+
+```bash
+./gradlew test --tests "io.github.ascrew.monomatbe.domain.report.service.ReportServiceTest"
+```
+
+### 3. 서버 실행
+
+```bash
+./gradlew bootRun
+```
+
+### 4. DB 확인
+
+```sql
+USE MonomatDB;
+
+SHOW TABLES LIKE 'report';
+
+DESC report;
+
+SHOW INDEX FROM report;
+
+SELECT installed_rank, version, description, success
+FROM flyway_schema_history
+ORDER BY installed_rank DESC;
+```
+
+정상 상태:
+
+```text
+report 테이블 존재
+version = 4
+description = create report table
+success = 1
+```

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/config/ReportPolicyProperties.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/config/ReportPolicyProperties.java
@@ -1,0 +1,62 @@
+package io.github.ascrew.monomatbe.domain.report.config;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 신고 정책 설정
+ *
+ * [설계 의도]
+ * 신고 임계값과 자동 비공개 전환 여부는 운영 정책에 해당한다.
+ * 코드에 숫자를 하드코딩하지 않고 설정값으로 분리해,
+ * 운영 환경에서 환경변수만으로 정책을 조정할 수 있도록 한다.
+ *
+ * [현재 정책]
+ * - lobbyReviewThreshold:
+ *   특정 로비의 PENDING 신고 수가 이 값 이상이면 관리자 검토 대상이다.
+ *
+ * - autoPrivateEnabled:
+ *   true이면 추후 신고 임계값 초과 시 자동 비공개 전환을 수행할 수 있다.
+ *   현재 단계에서는 실제 자동 비공개 전환은 수행하지 않고 정책 판단 결과만 제공한다.
+ */
+@Validated
+@Component
+@ConfigurationProperties(prefix = "report.policy")
+public class ReportPolicyProperties {
+
+    /**
+     * 로비 관리자 검토 임계값
+     *
+     * 예:
+     * 5로 설정하면 특정 로비의 PENDING 신고가 5건 이상일 때
+     * 관리자 검토 대상이 된다.
+     */
+    @Min(value = 1, message = "로비 신고 검토 임계값은 1 이상이어야 합니다.")
+    private int lobbyReviewThreshold = 5;
+
+    /**
+     * 신고 임계값 초과 시 자동 비공개 전환을 허용할지 여부
+     *
+     * 현재 이슈에서는 실제 자동 비공개 전환을 수행하지 않고,
+     * 후속 이슈에서 이 값을 기준으로 정책을 연결할 수 있도록 한다.
+     */
+    private boolean autoPrivateEnabled = false;
+
+    public int getLobbyReviewThreshold() {
+        return lobbyReviewThreshold;
+    }
+
+    public void setLobbyReviewThreshold(int lobbyReviewThreshold) {
+        this.lobbyReviewThreshold = lobbyReviewThreshold;
+    }
+
+    public boolean isAutoPrivateEnabled() {
+        return autoPrivateEnabled;
+    }
+
+    public void setAutoPrivateEnabled(boolean autoPrivateEnabled) {
+        this.autoPrivateEnabled = autoPrivateEnabled;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/ReportController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/ReportController.java
@@ -1,0 +1,172 @@
+package io.github.ascrew.monomatbe.domain.report.controller;
+
+import io.github.ascrew.monomatbe.domain.report.dto.LobbyReportRequest;
+import io.github.ascrew.monomatbe.domain.report.dto.LobbyUserReportRequest;
+import io.github.ascrew.monomatbe.domain.report.dto.ReportResponse;
+import io.github.ascrew.monomatbe.domain.report.service.ReportService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 신고 REST API 컨트롤러
+ *
+ * [책임]
+ * - 로비 신고 요청 수신
+ * - 로비 내 유저 신고 요청 수신
+ * - 인증 주체에서 reporterId 추출
+ * - 요청 DTO 검증 위임
+ *
+ * [URL 설계]
+ * 신고 기능은 로비 화면에서 발생하므로 /api/lobbies 하위에 배치한다.
+ * 다만 도메인 책임은 report로 분리해 ReportController에서 처리한다.
+ */
+@Slf4j
+@Tag(name = "Report", description = "신고 REST API")
+@RestController
+@RequestMapping("/api/lobbies")
+@RequiredArgsConstructor
+public class ReportController {
+
+    // =========================================================
+    // 로그 메시지 상수
+    // =========================================================
+
+    private static final String LOG_LOBBY_REPORT_REQUEST =
+            "요청 수신: 로비 신고 [POST /api/lobbies/{code}/reports] - 코드: {}, 신고자: {}";
+    private static final String LOG_LOBBY_REPORT_RESPONSE =
+            "로비 신고 접수 응답 - reportId: {}, 코드: {}";
+    private static final String LOG_LOBBY_USER_REPORT_REQUEST =
+            "요청 수신: 로비 유저 신고 [POST /api/lobbies/{code}/users/{targetUserId}/reports] - 코드: {}, 신고자: {}, 대상 유저: {}";
+    private static final String LOG_LOBBY_USER_REPORT_RESPONSE =
+            "로비 유저 신고 접수 응답 - reportId: {}, 코드: {}, 대상 유저: {}";
+
+    private final ReportService reportService;
+
+    /**
+     * 로비 자체 신고 API
+     *
+     * [인증]
+     * JWT Access Token이 필요하다.
+     * 게스트와 정식 회원 모두 신고할 수 있다.
+     *
+     * [신고 대상]
+     * - targetType: LOBBY
+     * - targetId: game_lobby.id
+     *
+     * [중복 신고 정책]
+     * 동일 사용자가 동일 로비에 대해 PENDING 신고를 이미 생성했다면
+     * 409 Conflict를 반환한다.
+     *
+     * @param code      로비 초대 코드
+     * @param request   신고 요청 DTO
+     * @param principal JWT에서 추출한 인증 주체
+     * @return 201 Created + 신고 생성 응답
+     */
+    @Operation(
+            summary = "로비 신고",
+            description = """
+                    부적절한 로비 제목 또는 로비 설정을 신고합니다.
+                    동일 사용자가 같은 로비에 대해 처리되지 않은 신고를 중복 생성할 수 없습니다.
+                    JWT 인증이 필요합니다.
+                    """
+    )
+    @PostMapping("/{code}/reports")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ReportResponse> reportLobby(
+            @PathVariable String code,
+            @Valid @RequestBody LobbyReportRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(
+                LOG_LOBBY_REPORT_REQUEST,
+                code,
+                principal != null ? principal.userId() : null
+        );
+
+        ReportResponse response = reportService.reportLobby(
+                code,
+                principal != null ? principal.userId() : null,
+                request
+        );
+
+        log.info(LOG_LOBBY_REPORT_RESPONSE, response.reportId(), code);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 로비 내 특정 유저 신고 API
+     *
+     * [인증]
+     * JWT Access Token이 필요하다.
+     * 게스트와 정식 회원 모두 신고할 수 있다.
+     *
+     * [신고 대상]
+     * - targetType: LOBBY_USER
+     * - targetId: users.id
+     *
+     * [제한]
+     * 자기 자신은 신고할 수 없다.
+     * 동일 사용자가 동일 로비의 동일 유저에 대해 PENDING 신고를 이미 생성했다면
+     * 409 Conflict를 반환한다.
+     *
+     * @param code         로비 초대 코드
+     * @param targetUserId 신고 대상 users.id
+     * @param request      신고 요청 DTO
+     * @param principal    JWT에서 추출한 인증 주체
+     * @return 201 Created + 신고 생성 응답
+     */
+    @Operation(
+            summary = "로비 유저 신고",
+            description = """
+                    특정 로비 안의 유저를 신고합니다.
+                    자기 자신은 신고할 수 없으며,
+                    동일 사용자가 같은 로비의 같은 유저에 대해 처리되지 않은 신고를 중복 생성할 수 없습니다.
+                    JWT 인증이 필요합니다.
+                    """
+    )
+    @PostMapping("/{code}/users/{targetUserId}/reports")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ReportResponse> reportLobbyUser(
+            @PathVariable String code,
+            @PathVariable Long targetUserId,
+            @Valid @RequestBody LobbyUserReportRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(
+                LOG_LOBBY_USER_REPORT_REQUEST,
+                code,
+                principal != null ? principal.userId() : null,
+                targetUserId
+        );
+
+        ReportResponse response = reportService.reportLobbyUser(
+                code,
+                principal != null ? principal.userId() : null,
+                targetUserId,
+                request
+        );
+
+        log.info(
+                LOG_LOBBY_USER_REPORT_RESPONSE,
+                response.reportId(),
+                code,
+                targetUserId
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/LobbyReportRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/LobbyReportRequest.java
@@ -1,0 +1,22 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 로비 신고 요청 DTO
+ *
+ * [검증 규칙]
+ * - reason: 필수, 공백 불가, 최대 500자
+ *
+ * [정규화 책임]
+ * DTO는 입력 형식 검증만 담당한다.
+ * trim 처리는 서비스 레이어에서 수행해 저장값을 정규화한다.
+ */
+public record LobbyReportRequest(
+
+        @NotBlank(message = "신고 사유는 비어 있을 수 없습니다.")
+        @Size(max = 500, message = "신고 사유는 500자를 초과할 수 없습니다.")
+        String reason
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/LobbyUserReportRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/LobbyUserReportRequest.java
@@ -1,0 +1,22 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 로비 내 유저 신고 요청 DTO
+ *
+ * [신고 대상]
+ * 신고 대상 유저 ID는 URL PathVariable로 전달한다.
+ * 따라서 요청 body에는 신고 사유만 포함한다.
+ *
+ * [검증 규칙]
+ * - reason: 필수, 공백 불가, 최대 500자
+ */
+public record LobbyUserReportRequest(
+
+        @NotBlank(message = "신고 사유는 비어 있을 수 없습니다.")
+        @Size(max = 500, message = "신고 사유는 500자를 초과할 수 없습니다.")
+        String reason
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/ReportCountResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/ReportCountResponse.java
@@ -1,0 +1,23 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import lombok.Builder;
+
+/**
+ * 신고 누적 카운트 응답 DTO
+ *
+ * [사용 목적]
+ * - 특정 로비의 누적 신고 수 확인
+ * - 특정 신고 대상의 누적 신고 수 확인
+ * - 향후 관리자 검토 화면 또는 자동 비공개 정책 판단에 활용
+ *
+ * 현재 이슈에서는 내부 서비스 로직 위주로 사용하고, 관리자 API가 추가될 때 외부 응답으로 확장할 수 있다.
+ */
+@Builder
+public record ReportCountResponse(
+        String targetType,
+        Long targetId,
+        Long lobbyId,
+        String status,
+        long count
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/ReportModerationPolicyResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/ReportModerationPolicyResponse.java
@@ -1,0 +1,52 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import lombok.Builder;
+
+/**
+ * 신고 누적 정책 판단 결과 DTO
+ *
+ * [사용 목적]
+ * - 특정 로비의 PENDING 신고 수가 관리자 검토 임계값을 넘었는지 판단
+ * - 향후 관리자 검토 큐 또는 자동 비공개 전환 정책에 연결
+ *
+ * [주의]
+ * 이 DTO는 현재 단계에서 내부 서비스 판단 결과로 사용한다.
+ * 외부 관리자 API는 후속 이슈에서 분리해 추가하는 편이 안전하다.
+ */
+@Builder
+public record ReportModerationPolicyResponse(
+
+        /**
+         * 판단 대상 로비 ID
+         */
+        Long lobbyId,
+
+        /**
+         * 현재 PENDING 신고 수
+         */
+        long pendingReportCount,
+
+        /**
+         * 관리자 검토 대상이 되는 신고 임계값
+         */
+        int reviewThreshold,
+
+        /**
+         * 현재 신고 수가 관리자 검토 임계값 이상인지 여부
+         */
+        boolean reviewRequired,
+
+        /**
+         * 자동 비공개 전환 정책이 설정상 활성화되어 있는지 여부
+         */
+        boolean autoPrivateEnabled,
+
+        /**
+         * 현재 상태에서 자동 비공개 전환 후보인지 여부s
+         *
+         * 실제 비공개 전환을 수행했다는 뜻이 아니다.
+         * autoPrivateEnabled=true 이고 reviewRequired=true일 때 true가 된다.
+         */
+        boolean autoPrivateCandidate
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/ReportResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/ReportResponse.java
@@ -1,0 +1,45 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 신고 생성 응답 DTO
+ *
+ * [응답 설계]
+ * 신고 생성 직후 클라이언트는 상세 운영 정보를 알 필요는 없지만,
+ * 중복 제출 방지와 사용자 안내를 위해 생성된 신고 ID와 상태를 반환한다.
+ */
+@Builder
+public record ReportResponse(
+        Long reportId,
+        Long reporterId,
+        Long lobbyId,
+        String targetType,
+        Long targetId,
+        String reason,
+        String status,
+        LocalDateTime createdAt
+) {
+
+    /**
+     * Report 엔티티를 API 응답 DTO로 변환한다.
+     *
+     * LAZY 연관관계 접근은 reporter.id, lobby.id 정도로 제한한다.
+     * username, lobby title 등 추가 정보는 목록/관리자 API에서 별도 조회하는 편이 안전하다.
+     */
+    public static ReportResponse from(Report report) {
+        return ReportResponse.builder()
+                .reportId(report.getId())
+                .reporterId(report.getReporter().getId())
+                .lobbyId(report.getLobby().getId())
+                .targetType(report.getTargetType().name())
+                .targetId(report.getTargetId())
+                .reason(report.getReason())
+                .status(report.getStatus().name())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/entity/Report.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/entity/Report.java
@@ -1,0 +1,163 @@
+package io.github.ascrew.monomatbe.domain.report.entity;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 신고 엔티티
+ *
+ * [설계 의도]
+ * 로비 신고와 로비 내 유저 신고를 하나의 report 테이블에서 관리한다.
+ *
+ * [targetType / targetId]
+ * - LOBBY:
+ *   - targetId = GAME_LOBBY.id
+ *   - lobby = 신고 대상 로비
+ *
+ * - LOBBY_USER:
+ *   - targetId = 신고 대상 users.id
+ *   - lobby = 신고가 발생한 로비
+ *
+ * [lobby를 별도로 저장하는 이유]
+ * 로비 내 유저 신고에서 targetId만 저장하면 어느 로비에서 발생한 신고인지 알 수 없다.
+ * 운영자가 신고 맥락을 확인할 수 있도록 lobby를 별도 FK로 보관한다.
+ *
+ * [중복 신고 정책]
+ * 동일 사용자가 동일 로비에서 동일 대상에 대해 PENDING 신고를 중복 생성하지 못하도록
+ * 서비스 레이어와 Repository 조회 메서드에서 방어한다.
+ */
+@Getter
+@Entity
+@Builder
+@Table(name = "report")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 신고자
+     * 게스트와 정식 회원 모두 users 테이블에 존재하므로 User FK로 통합 관리한다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    /**
+     * 신고가 발생한 로비
+     *
+     * 로비 자체 신고에서는 신고 대상 로비이고,
+     * 로비 유저 신고에서는 해당 유저가 신고된 맥락의 로비이다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "lobby_id", nullable = false)
+    private GameLobby lobby;
+
+    /**
+     * 신고 대상 타입
+     *
+     * LOBBY      : 로비 자체 신고
+     * LOBBY_USER : 특정 로비 안의 유저 신고
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 30)
+    private ReportTargetType targetType;
+
+    /**
+     * 신고 대상 ID
+     *
+     * targetType에 따라 의미가 달라진다.
+     * - LOBBY      : GAME_LOBBY.id
+     * - LOBBY_USER : users.id
+     */
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    /**
+     * 신고 사유
+     *
+     * API 요청 DTO에서 @NotBlank, @Size로 1차 검증하고, 서비스 레이어에서 trim 정규화한 값을 저장한다.
+     */
+    @Column(name = "reason", nullable = false, length = 500)
+    private String reason;
+
+    /**
+     * 신고 처리 상태
+     * 생성 직후 기본값은 PENDING이다.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ReportStatus status;
+
+    /**
+     * 신고 접수 시각
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * 운영자가 신고를 처리한 시각
+     * PENDING 상태에서는 null이다.
+     */
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    /**
+     * 저장 직전 기본값을 보정한다.
+     *
+     * [기본값 정책]
+     * status와 createdAt은 엔티티 내부에서만 기본값을 설정해
+     * 서비스 레이어에 기본값 설정 책임이 퍼지지 않도록 한다.
+     */
+    @PrePersist
+    public void prePersist() {
+        if (this.status == null) {
+            this.status = ReportStatus.PENDING;
+        }
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * 신고를 처리 완료 상태로 변경한다.
+     *
+     * 관리자 기능 구현 시 사용한다.
+     */
+    public void resolve() {
+        this.status = ReportStatus.RESOLVED;
+        this.resolvedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 신고를 기각 상태로 변경한다.
+     *
+     * 관리자 기능 구현 시 사용한다.
+     */
+    public void dismiss() {
+        this.status = ReportStatus.DISMISSED;
+        this.resolvedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/entity/ReportStatus.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/entity/ReportStatus.java
@@ -1,0 +1,30 @@
+package io.github.ascrew.monomatbe.domain.report.entity;
+
+/**
+ * 신고 처리 상태
+ *
+ * [상태 흐름]
+ * PENDING   : 신고가 접수되어 운영자 검토를 기다리는 상태
+ * RESOLVED  : 운영자가 신고를 유효한 신고로 처리 완료한 상태
+ * DISMISSED : 운영자가 신고를 기각한 상태
+ */
+public enum ReportStatus {
+
+    /**
+     * 신고 접수 직후 기본 상태
+     *
+     * 동일 사용자의 동일 대상 중복 신고 방지는
+     * 기본적으로 PENDING 상태를 기준으로 판단한다.
+     */
+    PENDING,
+
+    /**
+     * 운영자가 신고를 확인하고 처리 완료한 상태
+     */
+    RESOLVED,
+
+    /**
+     * 운영자가 신고를 유효하지 않다고 판단해 기각한 상태
+     */
+    DISMISSED
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/entity/ReportTargetType.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/entity/ReportTargetType.java
@@ -1,0 +1,30 @@
+package io.github.ascrew.monomatbe.domain.report.entity;
+
+/**
+ * 신고 대상 타입
+ *
+ * [설계 의도]
+ * 신고 기능은 현재 로비 신고와 로비 내 유저 신고를 우선 지원한다.
+ * 이후 맵, 채팅 메시지, 일반 유저 신고로 확장될 수 있으므로
+ * targetType을 enum으로 분리해 문자열 하드코딩을 방지한다.
+ */
+public enum ReportTargetType {
+
+    /**
+     * 로비 자체 신고
+     *
+     * 예:
+     * - 부적절한 로비 제목
+     * - 부적절한 로비 설정
+     * - 신고 누적 시 로비 자동 비공개 전환 후보
+     */
+    LOBBY,
+
+    /**
+     * 특정 로비 안의 유저 신고
+     *
+     * targetId는 신고 대상 user.id를 의미하고,
+     * 신고가 발생한 로비는 Report.lobby로 별도 보관한다.
+     */
+    LOBBY_USER
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
@@ -1,0 +1,70 @@
+package io.github.ascrew.monomatbe.domain.report.repository;
+
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * report 테이블 접근 JPA 리포지토리
+ *
+ * [주요 책임]
+ * - 신고 저장
+ * - 동일 사용자의 동일 대상 PENDING 중복 신고 여부 확인
+ * - 신고 누적 카운트 조회
+ *
+ * [중복 신고 기준]
+ * 동일 사용자가 같은 로비에서 같은 targetType/targetId에 대해
+ * 아직 처리되지 않은 PENDING 신고를 이미 생성했다면 중복 신고로 본다.
+ */
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    /**
+     * 동일 사용자의 동일 대상 미처리 신고 존재 여부를 확인한다.
+     *
+     * 로비 자체 신고:
+     * - reporterId = 신고자 users.id
+     * - lobbyId = 신고 대상 GAME_LOBBY.id
+     * - targetType = LOBBY
+     * - targetId = GAME_LOBBY.id
+     * - status = PENDING
+     *
+     * 로비 유저 신고:
+     * - reporterId = 신고자 users.id
+     * - lobbyId = 신고가 발생한 GAME_LOBBY.id
+     * - targetType = LOBBY_USER
+     * - targetId = 신고 대상 users.id
+     * - status = PENDING
+     */
+    boolean existsByReporterIdAndLobbyIdAndTargetTypeAndTargetIdAndStatus(
+            Long reporterId,
+            Long lobbyId,
+            ReportTargetType targetType,
+            Long targetId,
+            ReportStatus status
+    );
+
+    /**
+     * 특정 신고 대상의 미처리 신고 누적 수를 조회한다.
+     *
+     * 예:
+     * - 특정 로비에 대한 PENDING 신고 수
+     * - 특정 유저에 대한 PENDING 신고 수
+     */
+    long countByTargetTypeAndTargetIdAndStatus(
+            ReportTargetType targetType,
+            Long targetId,
+            ReportStatus status
+    );
+
+    /**
+     * 특정 로비에서 발생한 미처리 신고 누적 수를 조회한다.
+     *
+     * 로비 자체 신고와 로비 유저 신고를 모두 포함해
+     * 해당 로비의 운영 위험도를 판단할 때 사용할 수 있다.
+     */
+    long countByLobbyIdAndStatus(
+            Long lobbyId,
+            ReportStatus status
+    );
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/ReportService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/ReportService.java
@@ -1,0 +1,356 @@
+package io.github.ascrew.monomatbe.domain.report.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.report.dto.LobbyReportRequest;
+import io.github.ascrew.monomatbe.domain.report.dto.LobbyUserReportRequest;
+import io.github.ascrew.monomatbe.domain.report.dto.ReportCountResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.ReportResponse;
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 신고 유스케이스 서비스
+ *
+ * [책임]
+ * - 로비 신고 생성
+ * - 로비 내 유저 신고 생성
+ * - 신고 사유 정규화
+ * - 동일 사용자의 동일 대상 PENDING 중복 신고 방지
+ * - 신고 누적 카운트 조회
+ *
+ * [로비 유저 신고 검증 범위]
+ * 현재 Redis 참여자 검증은 userIdentifier 기준으로 제공된다.
+ * 이번 신고 API는 targetUserId(Long)를 URL로 받으므로,
+ * 이 단계에서는 DB users 존재 여부까지만 검증한다.
+ *
+ * 추후 userId ↔ userIdentifier 매핑 정책이 명확해지면 Redis 참여자 여부 검증을 추가할 수 있다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    // =========================================================
+    // 에러 메시지 상수
+    // =========================================================
+
+    private static final String ERROR_INVALID_REPORTER =
+            "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
+    private static final String ERROR_REPORTER_NOT_FOUND =
+            "신고자를 찾을 수 없습니다.";
+    private static final String ERROR_LOBBY_NOT_FOUND =
+            "신고 대상 로비를 찾을 수 없습니다.";
+    private static final String ERROR_DELETED_LOBBY =
+            "삭제된 로비는 신고할 수 없습니다.";
+    private static final String ERROR_TARGET_USER_NOT_FOUND =
+            "신고 대상 유저를 찾을 수 없습니다.";
+    private static final String ERROR_SELF_REPORT =
+            "자기 자신은 신고할 수 없습니다.";
+    private static final String ERROR_DUPLICATE_REPORT =
+            "이미 접수된 신고입니다.";
+    private static final String ERROR_INVALID_REASON =
+            "신고 사유는 비어 있을 수 없습니다.";
+
+    // =========================================================
+    // 로그 메시지 상수
+    // =========================================================
+
+    private static final String LOG_LOBBY_REPORT_CREATED =
+            "로비 신고 접수 완료 - reportId: {}, reporterId: {}, lobbyId: {}, inviteCode: {}";
+    private static final String LOG_LOBBY_USER_REPORT_CREATED =
+            "로비 유저 신고 접수 완료 - reportId: {}, reporterId: {}, lobbyId: {}, inviteCode: {}, targetUserId: {}";
+    private static final String LOG_DUPLICATE_REPORT =
+            "중복 신고 요청 차단 - reporterId: {}, lobbyId: {}, targetType: {}, targetId: {}";
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final GameLobbyJpaRepository gameLobbyJpaRepository;
+
+    /**
+     * 로비 자체 신고를 생성한다.
+     *
+     * [처리 순서]
+     * 1. 신고자 ID 검증
+     * 2. 신고자 User 조회
+     * 3. inviteCode 기준 로비 조회
+     * 4. 삭제된 로비 여부 확인
+     * 5. 신고 사유 trim 정규화
+     * 6. 동일 사용자의 동일 로비 PENDING 신고 중복 확인
+     * 7. Report 저장
+     *
+     * @param inviteCode 로비 초대 코드
+     * @param reporterId 신고자 users.id
+     * @param request 신고 요청 DTO
+     * @return 생성된 신고 응답
+     */
+    @Transactional
+    public ReportResponse reportLobby(
+            String inviteCode,
+            Long reporterId,
+            LobbyReportRequest request
+    ) {
+        User reporter = getReporter(reporterId);
+        GameLobby lobby = getReportableLobby(inviteCode);
+        String reason = normalizeReason(request.reason());
+
+        Long lobbyId = lobby.getId();
+
+        validateDuplicatePendingReport(
+                reporter.getId(),
+                lobbyId,
+                ReportTargetType.LOBBY,
+                lobbyId
+        );
+
+        Report report = reportRepository.save(Report.builder()
+                .reporter(reporter)
+                .lobby(lobby)
+                .targetType(ReportTargetType.LOBBY)
+                .targetId(lobbyId)
+                .reason(reason)
+                .build());
+
+        log.info(
+                LOG_LOBBY_REPORT_CREATED,
+                report.getId(),
+                reporter.getId(),
+                lobbyId,
+                inviteCode
+        );
+
+        return ReportResponse.from(report);
+    }
+
+    /**
+     * 로비 내 특정 유저 신고를 생성한다.
+     *
+     * [처리 순서]
+     * 1. 신고자 ID 검증
+     * 2. 신고자 User 조회
+     * 3. 신고 대상 User 조회
+     * 4. 자기 자신 신고 차단
+     * 5. inviteCode 기준 로비 조회
+     * 6. 삭제된 로비 여부 확인
+     * 7. 신고 사유 trim 정규화
+     * 8. 동일 사용자의 동일 로비/동일 대상 PENDING 신고 중복 확인
+     * 9. Report 저장
+     *
+     * @param inviteCode 로비 초대 코드
+     * @param reporterId 신고자 users.id
+     * @param targetUserId 신고 대상 users.id
+     * @param request 신고 요청 DTO
+     * @return 생성된 신고 응답
+     */
+    @Transactional
+    public ReportResponse reportLobbyUser(
+            String inviteCode,
+            Long reporterId,
+            Long targetUserId,
+            LobbyUserReportRequest request
+    ) {
+        User reporter = getReporter(reporterId);
+        User targetUser = getTargetUser(targetUserId);
+
+        if (reporter.getId().equals(targetUser.getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_SELF_REPORT);
+        }
+
+        GameLobby lobby = getReportableLobby(inviteCode);
+        String reason = normalizeReason(request.reason());
+
+        validateDuplicatePendingReport(
+                reporter.getId(),
+                lobby.getId(),
+                ReportTargetType.LOBBY_USER,
+                targetUser.getId()
+        );
+
+        Report report = reportRepository.save(Report.builder()
+                .reporter(reporter)
+                .lobby(lobby)
+                .targetType(ReportTargetType.LOBBY_USER)
+                .targetId(targetUser.getId())
+                .reason(reason)
+                .build());
+
+        log.info(
+                LOG_LOBBY_USER_REPORT_CREATED,
+                report.getId(),
+                reporter.getId(),
+                lobby.getId(),
+                inviteCode,
+                targetUser.getId()
+        );
+
+        return ReportResponse.from(report);
+    }
+
+    /**
+     * 특정 신고 대상의 PENDING 신고 누적 수를 조회한다.
+     *
+     * 예:
+     * - 특정 로비 신고 누적 수
+     * - 특정 유저 신고 누적 수
+     *
+     * @param targetType 신고 대상 타입
+     * @param targetId 신고 대상 ID
+     * @return 신고 누적 카운트 응답
+     */
+    @Transactional(readOnly = true)
+    public ReportCountResponse countPendingReportsByTarget(
+            ReportTargetType targetType,
+            Long targetId
+    ) {
+        long count = reportRepository.countByTargetTypeAndTargetIdAndStatus(
+                targetType,
+                targetId,
+                ReportStatus.PENDING
+        );
+
+        return ReportCountResponse.builder()
+                .targetType(targetType.name())
+                .targetId(targetId)
+                .lobbyId(null)
+                .status(ReportStatus.PENDING.name())
+                .count(count)
+                .build();
+    }
+
+    /**
+     * 특정 로비에서 발생한 PENDING 신고 누적 수를 조회한다.
+     *
+     * 로비 자체 신고와 로비 유저 신고를 모두 포함한다.
+     *
+     * @param lobbyId GAME_LOBBY.id
+     * @return 신고 누적 카운트 응답
+     */
+    @Transactional(readOnly = true)
+    public ReportCountResponse countPendingReportsByLobby(Long lobbyId) {
+        long count = reportRepository.countByLobbyIdAndStatus(
+                lobbyId,
+                ReportStatus.PENDING
+        );
+
+        return ReportCountResponse.builder()
+                .targetType(null)
+                .targetId(null)
+                .lobbyId(lobbyId)
+                .status(ReportStatus.PENDING.name())
+                .count(count)
+                .build();
+    }
+
+    /**
+     * 신고자 ID를 검증하고 User 엔티티를 조회한다.
+     */
+    private User getReporter(Long reporterId) {
+        if (reporterId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_INVALID_REPORTER);
+        }
+
+        return userRepository.findById(reporterId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_REPORTER_NOT_FOUND
+                ));
+    }
+
+    /**
+     * 신고 대상 유저를 조회한다.
+     */
+    private User getTargetUser(Long targetUserId) {
+        if (targetUserId == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    ERROR_TARGET_USER_NOT_FOUND
+            );
+        }
+
+        return userRepository.findById(targetUserId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_TARGET_USER_NOT_FOUND
+                ));
+    }
+
+    /**
+     * 신고 가능한 로비를 조회한다.
+     *
+     * [삭제 로비 차단]
+     * 로비 폭파 후 Soft Delete된 DB 스냅샷은 신고 대상으로 받지 않는다.
+     * 신고는 로비가 존재하는 동안 접수하는 것을 기본 정책으로 둔다.
+     */
+    private GameLobby getReportableLobby(String inviteCode) {
+        GameLobby lobby = gameLobbyJpaRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_LOBBY_NOT_FOUND
+                ));
+
+        if (Boolean.TRUE.equals(lobby.getIsDeleted())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_DELETED_LOBBY);
+        }
+
+        return lobby;
+    }
+
+    /**
+     * 신고 사유를 정규화한다.
+     *
+     * DTO의 @NotBlank가 1차 검증을 수행하지만,
+     * 서비스가 다른 경로에서 호출될 수 있으므로 최소 방어선을 유지한다.
+     */
+    private String normalizeReason(String reason) {
+        if (reason == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_REASON);
+        }
+
+        String normalizedReason = reason.trim();
+
+        if (normalizedReason.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_REASON);
+        }
+
+        return normalizedReason;
+    }
+
+    /**
+     * 동일 사용자의 동일 로비/동일 대상 PENDING 신고 중복 여부를 확인한다.
+     */
+    private void validateDuplicatePendingReport(
+            Long reporterId,
+            Long lobbyId,
+            ReportTargetType targetType,
+            Long targetId
+    ) {
+        boolean duplicated = reportRepository.existsByReporterIdAndLobbyIdAndTargetTypeAndTargetIdAndStatus(
+                reporterId,
+                lobbyId,
+                targetType,
+                targetId,
+                ReportStatus.PENDING
+        );
+
+        if (duplicated) {
+            log.info(
+                    LOG_DUPLICATE_REPORT,
+                    reporterId,
+                    lobbyId,
+                    targetType,
+                    targetId
+            );
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_DUPLICATE_REPORT);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/ReportService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/ReportService.java
@@ -4,10 +4,12 @@ import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.report.config.ReportPolicyProperties;
 import io.github.ascrew.monomatbe.domain.report.dto.LobbyReportRequest;
 import io.github.ascrew.monomatbe.domain.report.dto.LobbyUserReportRequest;
 import io.github.ascrew.monomatbe.domain.report.dto.ReportCountResponse;
 import io.github.ascrew.monomatbe.domain.report.dto.ReportResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.ReportModerationPolicyResponse;
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
@@ -76,6 +78,7 @@ public class ReportService {
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
+    private final ReportPolicyProperties reportPolicyProperties;
 
     /**
      * 로비 자체 신고를 생성한다.
@@ -248,6 +251,38 @@ public class ReportService {
                 .lobbyId(lobbyId)
                 .status(ReportStatus.PENDING.name())
                 .count(count)
+                .build();
+    }
+
+    /**
+     * 특정 로비의 신고 누적 상태가 관리자 검토 임계값을 넘었는지 판단한다.
+     *
+     * [중요]
+     * 이 메서드는 실제 로비 상태를 변경하지 않는다.
+     * 자동 비공개 전환은 Redis public index, DB game_lobby.is_private,
+     * WebSocket refresh 이벤트까지 함께 처리해야 하므로 후속 이슈에서 분리한다.
+     *
+     * @param lobbyId game_lobby.id
+     * @return 신고 정책 판단 결과
+     */
+    @Transactional(readOnly = true)
+    public ReportModerationPolicyResponse evaluateLobbyModerationPolicy(Long lobbyId) {
+        long pendingReportCount = reportRepository.countByLobbyIdAndStatus(
+                lobbyId,
+                ReportStatus.PENDING
+        );
+
+        int reviewThreshold = reportPolicyProperties.getLobbyReviewThreshold();
+        boolean reviewRequired = pendingReportCount >= reviewThreshold;
+        boolean autoPrivateEnabled = reportPolicyProperties.isAutoPrivateEnabled();
+
+        return ReportModerationPolicyResponse.builder()
+                .lobbyId(lobbyId)
+                .pendingReportCount(pendingReportCount)
+                .reviewThreshold(reviewThreshold)
+                .reviewRequired(reviewRequired)
+                .autoPrivateEnabled(autoPrivateEnabled)
+                .autoPrivateCandidate(autoPrivateEnabled && reviewRequired)
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,12 @@ auth.network.trust-forwarded-headers=${AUTH_NETWORK_TRUST_FORWARDED_HEADERS:fals
 youtube.oembed.connect-timeout=${YOUTUBE_OEMBED_CONNECT_TIMEOUT:2s}
 youtube.oembed.request-timeout=${YOUTUBE_OEMBED_REQUEST_TIMEOUT:5s}
 
+# 신고 정책
+# lobby-review-threshold: 특정 로비의 PENDING 신고 수가 이 값 이상이면 관리자 검토 대상
+# auto-private-enabled: true일 경우 후속 정책에서 자동 비공개 전환 후보로 판단 가능
+report.policy.lobby-review-threshold=${REPORT_POLICY_LOBBY_REVIEW_THRESHOLD:5}
+report.policy.auto-private-enabled=${REPORT_POLICY_AUTO_PRIVATE_ENABLED:false}
+
 # Flyway: 모든 스키마 변경은 src/main/resources/db/migration 의 Vn__*.sql 로만 관리.
 # baseline-on-migrate=true: 기존 운영/dev DB(이미 ddl-auto/수동 ALTER 로 만들어진 스키마)에 처음 적용될 때
 #   schema_history 테이블만 생성하고 baseline-version까지를 실행 없이 baseline 으로 마킹한다.

--- a/src/main/resources/db/migration/V4__create_report_table.sql
+++ b/src/main/resources/db/migration/V4__create_report_table.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- V4__create_report_table.sql
+-- 신고 테이블 생성
+-- ============================================================================
+
+CREATE TABLE report (
+                        id           BIGINT       NOT NULL AUTO_INCREMENT COMMENT '신고 고유 식별자',
+                        reporter_id  BIGINT       NOT NULL COMMENT '신고자 users.id',
+                        lobby_id     BIGINT       NOT NULL COMMENT '신고가 발생한 game_lobby.id',
+                        target_type  VARCHAR(30)  NOT NULL COMMENT '신고 대상 타입: LOBBY, LOBBY_USER',
+                        target_id    BIGINT       NOT NULL COMMENT '신고 대상 ID: LOBBY=game_lobby.id, LOBBY_USER=users.id',
+                        reason       VARCHAR(500) NOT NULL COMMENT '신고 사유',
+                        status       VARCHAR(20)  NOT NULL COMMENT '신고 처리 상태: PENDING, RESOLVED, DISMISSED',
+                        created_at   DATETIME     NOT NULL COMMENT '신고 접수 일시',
+                        resolved_at  DATETIME     NULL COMMENT '신고 처리 완료 일시',
+
+                        CONSTRAINT pk_report PRIMARY KEY (id),
+
+                        CONSTRAINT fk_report_reporter
+                            FOREIGN KEY (reporter_id)
+                                REFERENCES users (id),
+
+                        CONSTRAINT fk_report_lobby
+                            FOREIGN KEY (lobby_id)
+                                REFERENCES game_lobby (id)
+);
+
+-- ============================================================================
+-- 중복 신고 확인용 인덱스
+-- ============================================================================
+-- 동일 사용자의 동일 로비/동일 대상 PENDING 신고 중복 여부를
+-- 서비스 레이어에서 빠르게 조회하기 위한 인덱스다.
+-- ============================================================================
+CREATE INDEX idx_report_duplicate_check
+    ON report (reporter_id, lobby_id, target_type, target_id, status);
+
+-- ============================================================================
+-- 조회 성능 인덱스
+-- ============================================================================
+
+CREATE INDEX idx_report_target_status
+    ON report (target_type, target_id, status);
+
+CREATE INDEX idx_report_lobby_status
+    ON report (lobby_id, status);
+
+CREATE INDEX idx_report_status_created_at
+    ON report (status, created_at);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/service/ReportServiceTest.java
@@ -1,0 +1,350 @@
+package io.github.ascrew.monomatbe.domain.report.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.report.config.ReportPolicyProperties;
+import io.github.ascrew.monomatbe.domain.report.dto.LobbyReportRequest;
+import io.github.ascrew.monomatbe.domain.report.dto.LobbyUserReportRequest;
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ReportService 단위 테스트
+ *
+ * [검증 범위]
+ * - 신고 생성 성공
+ * - 중복 PENDING 신고 차단
+ * - 자기 자신 신고 차단
+ * - 신고 사유 정규화 및 공백 차단
+ * - 신고 누적 카운트 조회
+ * - 신고 임계값 정책 판단
+ */
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    private static final String INVITE_CODE = "ABC123";
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GameLobbyJpaRepository gameLobbyJpaRepository;
+
+    private ReportPolicyProperties reportPolicyProperties;
+
+    private ReportService reportService;
+
+    @BeforeEach
+    void setUp() {
+        reportPolicyProperties = new ReportPolicyProperties();
+        reportPolicyProperties.setLobbyReviewThreshold(3);
+        reportPolicyProperties.setAutoPrivateEnabled(false);
+
+        reportService = new ReportService(
+                reportRepository,
+                userRepository,
+                gameLobbyJpaRepository,
+                reportPolicyProperties
+        );
+    }
+
+    @Test
+    void reportLobby_success() {
+        User reporter = createUser(1L, "reporter");
+        GameLobby lobby = createLobby(10L, INVITE_CODE, false);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(reporter));
+        when(gameLobbyJpaRepository.findByInviteCode(INVITE_CODE)).thenReturn(Optional.of(lobby));
+        when(reportRepository.existsByReporterIdAndLobbyIdAndTargetTypeAndTargetIdAndStatus(
+                1L,
+                10L,
+                ReportTargetType.LOBBY,
+                10L,
+                ReportStatus.PENDING
+        )).thenReturn(false);
+        when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> {
+            Report report = invocation.getArgument(0);
+            report.prePersist();
+
+            return Report.builder()
+                    .id(100L)
+                    .reporter(report.getReporter())
+                    .lobby(report.getLobby())
+                    .targetType(report.getTargetType())
+                    .targetId(report.getTargetId())
+                    .reason(report.getReason())
+                    .status(ReportStatus.PENDING)
+                    .createdAt(report.getCreatedAt())
+                    .build();
+        });
+
+        var response = reportService.reportLobby(
+                INVITE_CODE,
+                1L,
+                new LobbyReportRequest("  부적절한 로비 제목입니다.  ")
+        );
+
+        assertThat(response.reportId()).isEqualTo(100L);
+        assertThat(response.reporterId()).isEqualTo(1L);
+        assertThat(response.lobbyId()).isEqualTo(10L);
+        assertThat(response.targetType()).isEqualTo(ReportTargetType.LOBBY.name());
+        assertThat(response.targetId()).isEqualTo(10L);
+        assertThat(response.reason()).isEqualTo("부적절한 로비 제목입니다.");
+        assertThat(response.status()).isEqualTo(ReportStatus.PENDING.name());
+
+        verify(reportRepository).save(any(Report.class));
+    }
+
+    @Test
+    void reportLobby_duplicatePendingReport_throws409() {
+        User reporter = createUser(1L, "reporter");
+        GameLobby lobby = createLobby(10L, INVITE_CODE, false);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(reporter));
+        when(gameLobbyJpaRepository.findByInviteCode(INVITE_CODE)).thenReturn(Optional.of(lobby));
+        when(reportRepository.existsByReporterIdAndLobbyIdAndTargetTypeAndTargetIdAndStatus(
+                1L,
+                10L,
+                ReportTargetType.LOBBY,
+                10L,
+                ReportStatus.PENDING
+        )).thenReturn(true);
+
+        assertThatThrownBy(() -> reportService.reportLobby(
+                INVITE_CODE,
+                1L,
+                new LobbyReportRequest("중복 신고")
+        ))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+                .hasMessageContaining("이미 접수된 신고입니다.");
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    void reportLobbyUser_success() {
+        User reporter = createUser(1L, "reporter");
+        User targetUser = createUser(2L, "target");
+        GameLobby lobby = createLobby(10L, INVITE_CODE, false);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(reporter));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(targetUser));
+        when(gameLobbyJpaRepository.findByInviteCode(INVITE_CODE)).thenReturn(Optional.of(lobby));
+        when(reportRepository.existsByReporterIdAndLobbyIdAndTargetTypeAndTargetIdAndStatus(
+                1L,
+                10L,
+                ReportTargetType.LOBBY_USER,
+                2L,
+                ReportStatus.PENDING
+        )).thenReturn(false);
+        when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> {
+            Report report = invocation.getArgument(0);
+            report.prePersist();
+
+            return Report.builder()
+                    .id(101L)
+                    .reporter(report.getReporter())
+                    .lobby(report.getLobby())
+                    .targetType(report.getTargetType())
+                    .targetId(report.getTargetId())
+                    .reason(report.getReason())
+                    .status(ReportStatus.PENDING)
+                    .createdAt(report.getCreatedAt())
+                    .build();
+        });
+
+        var response = reportService.reportLobbyUser(
+                INVITE_CODE,
+                1L,
+                2L,
+                new LobbyUserReportRequest("채팅 도배")
+        );
+
+        assertThat(response.reportId()).isEqualTo(101L);
+        assertThat(response.reporterId()).isEqualTo(1L);
+        assertThat(response.lobbyId()).isEqualTo(10L);
+        assertThat(response.targetType()).isEqualTo(ReportTargetType.LOBBY_USER.name());
+        assertThat(response.targetId()).isEqualTo(2L);
+        assertThat(response.reason()).isEqualTo("채팅 도배");
+        assertThat(response.status()).isEqualTo(ReportStatus.PENDING.name());
+
+        verify(reportRepository).save(any(Report.class));
+    }
+
+    @Test
+    void reportLobbyUser_selfReport_throws400() {
+        User reporter = createUser(1L, "reporter");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(reporter));
+
+        assertThatThrownBy(() -> reportService.reportLobbyUser(
+                INVITE_CODE,
+                1L,
+                1L,
+                new LobbyUserReportRequest("자기 자신 신고")
+        ))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST))
+                .hasMessageContaining("자기 자신은 신고할 수 없습니다.");
+
+        verify(gameLobbyJpaRepository, never()).findByInviteCode(any());
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    void reportLobby_blankReason_throws400() {
+        User reporter = createUser(1L, "reporter");
+        GameLobby lobby = createLobby(10L, INVITE_CODE, false);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(reporter));
+        when(gameLobbyJpaRepository.findByInviteCode(INVITE_CODE)).thenReturn(Optional.of(lobby));
+
+        assertThatThrownBy(() -> reportService.reportLobby(
+                INVITE_CODE,
+                1L,
+                new LobbyReportRequest("   ")
+        ))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST))
+                .hasMessageContaining("신고 사유는 비어 있을 수 없습니다.");
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    void reportLobby_deletedLobby_throws409() {
+        User reporter = createUser(1L, "reporter");
+        GameLobby deletedLobby = createLobby(10L, INVITE_CODE, true);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(reporter));
+        when(gameLobbyJpaRepository.findByInviteCode(INVITE_CODE)).thenReturn(Optional.of(deletedLobby));
+
+        assertThatThrownBy(() -> reportService.reportLobby(
+                INVITE_CODE,
+                1L,
+                new LobbyReportRequest("삭제된 로비 신고")
+        ))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+                .hasMessageContaining("삭제된 로비는 신고할 수 없습니다.");
+
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    void countPendingReportsByTarget_success() {
+        when(reportRepository.countByTargetTypeAndTargetIdAndStatus(
+                ReportTargetType.LOBBY,
+                10L,
+                ReportStatus.PENDING
+        )).thenReturn(2L);
+
+        var response = reportService.countPendingReportsByTarget(
+                ReportTargetType.LOBBY,
+                10L
+        );
+
+        assertThat(response.targetType()).isEqualTo(ReportTargetType.LOBBY.name());
+        assertThat(response.targetId()).isEqualTo(10L);
+        assertThat(response.status()).isEqualTo(ReportStatus.PENDING.name());
+        assertThat(response.count()).isEqualTo(2L);
+    }
+
+    @Test
+    void evaluateLobbyModerationPolicy_underThreshold_reviewNotRequired() {
+        when(reportRepository.countByLobbyIdAndStatus(10L, ReportStatus.PENDING))
+                .thenReturn(2L);
+
+        var response = reportService.evaluateLobbyModerationPolicy(10L);
+
+        assertThat(response.lobbyId()).isEqualTo(10L);
+        assertThat(response.pendingReportCount()).isEqualTo(2L);
+        assertThat(response.reviewThreshold()).isEqualTo(3);
+        assertThat(response.reviewRequired()).isFalse();
+        assertThat(response.autoPrivateEnabled()).isFalse();
+        assertThat(response.autoPrivateCandidate()).isFalse();
+    }
+
+    @Test
+    void evaluateLobbyModerationPolicy_overThreshold_reviewRequired() {
+        when(reportRepository.countByLobbyIdAndStatus(10L, ReportStatus.PENDING))
+                .thenReturn(3L);
+
+        var response = reportService.evaluateLobbyModerationPolicy(10L);
+
+        assertThat(response.lobbyId()).isEqualTo(10L);
+        assertThat(response.pendingReportCount()).isEqualTo(3L);
+        assertThat(response.reviewThreshold()).isEqualTo(3);
+        assertThat(response.reviewRequired()).isTrue();
+        assertThat(response.autoPrivateEnabled()).isFalse();
+        assertThat(response.autoPrivateCandidate()).isFalse();
+    }
+
+    @Test
+    void evaluateLobbyModerationPolicy_autoPrivateCandidate_whenEnabledAndOverThreshold() {
+        reportPolicyProperties.setAutoPrivateEnabled(true);
+
+        when(reportRepository.countByLobbyIdAndStatus(10L, ReportStatus.PENDING))
+                .thenReturn(5L);
+
+        var response = reportService.evaluateLobbyModerationPolicy(10L);
+
+        assertThat(response.lobbyId()).isEqualTo(10L);
+        assertThat(response.pendingReportCount()).isEqualTo(5L);
+        assertThat(response.reviewThreshold()).isEqualTo(3);
+        assertThat(response.reviewRequired()).isTrue();
+        assertThat(response.autoPrivateEnabled()).isTrue();
+        assertThat(response.autoPrivateCandidate()).isTrue();
+    }
+
+    private User createUser(Long id, String username) {
+        return User.builder()
+                .id(id)
+                .username(username)
+                .userType(UserType.GUEST)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    private GameLobby createLobby(Long id, String inviteCode, boolean isDeleted) {
+        User host = createUser(99L, "host");
+
+        return GameLobby.builder()
+                .id(id)
+                .host(host)
+                .inviteCode(inviteCode)
+                .title("테스트 로비")
+                .maxPlayers(8)
+                .roundCount(5)
+                .timeLimitSeconds(30)
+                .isPrivate(false)
+                .isDeleted(isDeleted)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #96

## 📝 Summary

- 로비 및 로비 내 유저 신고 기능을 위한 `report` 도메인을 추가했습니다.
- 신고 대상 타입(`LOBBY`, `LOBBY_USER`)과 신고 처리 상태(`PENDING`, `RESOLVED`, `DISMISSED`)를 enum으로 정의했습니다.
- `Report` 엔티티와 `ReportRepository`를 추가하고, Flyway 마이그레이션으로 `report` 테이블을 생성했습니다.
- 로비 신고 API와 로비 유저 신고 API를 추가했습니다.
  - `POST /api/lobbies/{code}/reports`
  - `POST /api/lobbies/{code}/users/{targetUserId}/reports`
- 신고 사유 검증 및 trim 정규화를 적용했습니다.
- 동일 사용자의 동일 로비/동일 대상 `PENDING` 중복 신고를 차단했습니다.
- 자기 자신 신고를 차단했습니다.
- 신고 누적 카운트 조회 및 관리자 검토 임계값 판단 로직을 추가했습니다.
- 신고 정책 설정을 외부 설정값으로 분리했습니다.
  - `report.policy.lobby-review-threshold`
  - `report.policy.auto-private-enabled`
- 신고 서비스 단위 테스트를 추가했습니다.
- 신고 API 요청/응답, 에러 정책, DB 확인 방법을 `docs/REPORT_API.md`에 문서화했습니다.

## 🙏PR point

- 자동 비공개 전환은 이번 PR에서 실제로 수행하지 않습니다.
  - 현재는 신고 누적 카운트와 임계값 판단까지만 구현했습니다.
  - 자동 비공개 전환은 DB `game_lobby.is_private`, Redis 로비 상태, Redis 공개 로비 인덱스, WebSocket refresh 이벤트를 함께 처리해야 하므로 후속 이슈로 분리하는 것이 안전합니다.
- `report.lobby_id`는 실제 DB 테이블명인 `game_lobby`를 FK로 참조합니다.
- 중복 신고 방지는 DB unique 제약이 아니라 서비스 레이어에서 `PENDING` 상태 기준으로 처리합니다.
  - 추후 `RESOLVED` 또는 `DISMISSED` 처리 이후에는 동일 대상 재신고가 가능해야 하기 때문입니다.
- 로비 유저 신고에서 신고 대상 유저가 현재 Redis 로비 참여자인지 검증하는 로직은 아직 넣지 않았습니다.
  - 현재 Redis 참여자 검증은 `userIdentifier` 기준이고, API는 `targetUserId(users.id)` 기준이므로 매핑 정책 확정 후 추가하는 편이 안전합니다.

## 📬 Reference

- `LobbyCommandController`의 인증/응답 구조를 참고해 신고 API 컨트롤러 구조를 맞췄습니다.
- `GameLobbyJpaRepository.findByInviteCode()`를 사용해 초대 코드 기반 로비 신고 대상을 조회했습니다.
- `docs/REPORT_API.md`에 신고 API 계약과 에러 정책을 문서화했습니다.