### PR TITLE
[Feat/#97] 로비 상세 참여자 응답에 닉네임 추가

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -614,6 +614,7 @@ JWT Access Token이 필요합니다.
   "players": [
     {
       "userIdentifier": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+      "nickname": "방장닉네임",
       "host": true,
       "ready": false
     },
@@ -645,6 +646,7 @@ JWT Access Token이 필요합니다.
 | `players[].host`           | Boolean | 방장 여부                                |
 | `players[].ready`          | Boolean | ready 여부. 방장은 ready 대상이 아니므로 `false` |
 | `canStart`                 | Boolean | 조회 시점 기준 게임 시작 가능 여부                 |
+| `players[].nickname` | String | 참여자 닉네임 |
 
 **canStart 계산 조건**
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/GuestSessionRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/GuestSessionRepository.java
@@ -2,19 +2,42 @@ package io.github.ascrew.monomatbe.domain.auth.repository;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.GuestSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 /**
- * guest_sessions 접근 리포지토리.
+ * guest_sessions 접근 리포지토리
  */
 public interface GuestSessionRepository extends JpaRepository<GuestSession, Long> {
 
     /**
-     * 게스트 UUID 토큰으로 세션 조회.
+     * 게스트 UUID 토큰으로 세션 조회
      * 자동 로그인/세션 유효성 확인에 사용됩니다.
      */
     Optional<GuestSession> findByGuestToken(String guestToken);
 
-    java.util.List<GuestSession> findByGuestTokenIn(java.util.Collection<String> guestTokens);
+    List<GuestSession> findByGuestTokenIn(Collection<String> guestTokens);
+
+    /**
+     * 게스트 userIdentifier에 대응되는 닉네임을 Projection으로 조회한다.
+     *
+     * [N+1 방지]
+     * GuestSession.user는 LAZY 연관관계이므로 세션 엔티티 목록을 조회한 뒤
+     * getUser().getUsername()을 호출하면 참여자 수만큼 추가 쿼리가 발생할 수 있다.
+     * 따라서 join 쿼리로 userIdentifier와 nickname만 한 번에 조회한다.
+     */
+    @Query("""
+            select g.guestToken as userIdentifier,
+                   u.username as nickname
+            from GuestSession g
+            join g.user u
+            where g.guestToken in :guestTokens
+            """)
+    List<UserIdentifierNicknameProjection> findNicknamesByGuestTokenIn(
+            @Param("guestTokens") Collection<String> guestTokens
+    );
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserIdentifierNicknameProjection.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserIdentifierNicknameProjection.java
@@ -1,0 +1,21 @@
+package io.github.ascrew.monomatbe.domain.auth.repository;
+
+/**
+ * userIdentifier와 사용자 닉네임만 조회하기 위한 읽기 전용 Projection
+ *
+ * [사용 목적]
+ * 로비 상세 조회에서 참여자 닉네임을 표시할 때 세션 엔티티 전체를 로딩하지 않고,
+ * 화면 표시에 필요한 userIdentifier와 nickname만 조회한다.
+ */
+public interface UserIdentifierNicknameProjection {
+
+    /**
+     * Redis/WebSocket에서 사용하는 사용자 식별자
+     */
+    String getUserIdentifier();
+
+    /**
+     * FE 대기실 참여자 목록에 표시할 사용자 닉네임
+     */
+    String getNickname();
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserSessionRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserSessionRepository.java
@@ -14,21 +14,39 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * user_sessions 접근 리포지토리.
+ * user_sessions 접근 리포지토리
  *
- * JWT 단독 전략이더라도,
- * 강제 로그아웃/세션 추적 요구가 생기면 서버 세션 저장소로 확장할 수 있습니다.
+ * JWT 단독 전략이더라도, 강제 로그아웃/세션 추적 요구가 생기면 서버 세션 저장소로 확장할 수 있습니다.
  */
 public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
 
     /**
-     * 세션 토큰으로 세션 조회.
+     * 세션 토큰으로 세션 조회
      */
     Optional<UserSession> findBySessionToken(String sessionToken);
 
     Optional<UserSession> findBySessionId(String sessionId);
 
     List<UserSession> findBySessionIdIn(Collection<String> sessionIds);
+
+    /**
+     * 회원 userIdentifier에 대응되는 닉네임을 Projection으로 조회한다.
+     *
+     * [N+1 방지]
+     * UserSession.user는 LAZY 연관관계이므로 세션 엔티티 목록을 조회한 뒤
+     * getUser().getUsername()을 호출하면 참여자 수만큼 추가 쿼리가 발생할 수 있다.
+     * 따라서 join 쿼리로 userIdentifier와 nickname만 한 번에 조회한다.
+     */
+    @Query("""
+            select s.sessionId as userIdentifier,
+                   u.username as nickname
+            from UserSession s
+            join s.user u
+            where s.sessionId in :sessionIds
+            """)
+    List<UserIdentifierNicknameProjection> findNicknamesBySessionIdIn(
+            @Param("sessionIds") Collection<String> sessionIds
+    );
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select s from UserSession s where s.sessionId = :sessionId")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/UserNicknameLookupService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/UserNicknameLookupService.java
@@ -1,0 +1,114 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserIdentifierNicknameProjection;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * userIdentifier 기준 사용자 닉네임 조회를 담당하는 Auth 도메인 서비스
+ *
+ * [설계 이유]
+ * userIdentifier는 JWT, WebSocket, Redis 로비 상태에서 공통으로 사용하는 사용자 식별자다.
+ * 하지만 이 식별자가 guest_sessions.guest_token 또는 user_sessions.session_id에 저장된다는 사실은
+ * Auth 도메인의 내부 저장 구조다.
+ *
+ * 따라서 Lobby 도메인이 GuestSessionRepository / UserSessionRepository를 직접 참조하지 않도록
+ * 닉네임 조회 책임을 Auth 도메인 서비스로 모은다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserNicknameLookupService {
+
+    private final GuestSessionRepository guestSessionRepository;
+    private final UserSessionRepository userSessionRepository;
+
+    /**
+     * 여러 userIdentifier에 대응되는 닉네임을 한 번에 조회한다.
+     *
+     * [조회 정책]
+     * - 게스트: guest_sessions.guest_token 기준 조회
+     * - 회원: user_sessions.session_id 기준 조회
+     * - 두 조회 결과를 userIdentifier -> nickname Map으로 병합한다.
+     *
+     * [장애 처리]
+     * 대기실 상세 조회는 UI 표시 목적이므로, 한쪽 조회가 실패해도 예외를 전파하지 않는다.
+     * 가능한 조회 결과만 반환하고, 누락된 사용자는 상위 계층에서 fallback nickname을 사용한다.
+     *
+     * @param userIdentifiers 사용자 식별자 목록
+     * @return userIdentifier -> nickname Map
+     */
+    public Map<String, String> findNicknameMapByUserIdentifiers(Collection<String> userIdentifiers) {
+        if (userIdentifiers == null || userIdentifiers.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, String> nicknameMap = new HashMap<>();
+
+        resolveGuestNicknames(userIdentifiers, nicknameMap);
+        resolveRegisteredUserNicknames(userIdentifiers, nicknameMap);
+
+        return nicknameMap;
+    }
+
+    private void resolveGuestNicknames(
+            Collection<String> userIdentifiers,
+            Map<String, String> nicknameMap
+    ) {
+        try {
+            for (UserIdentifierNicknameProjection projection :
+                    guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers)) {
+                putIfValid(nicknameMap, projection);
+            }
+        } catch (RuntimeException e) {
+            log.warn(
+                    "게스트 닉네임 조회 실패 - fallback nickname 사용. targetCount: {}",
+                    userIdentifiers.size(),
+                    e
+            );
+        }
+    }
+
+    private void resolveRegisteredUserNicknames(
+            Collection<String> userIdentifiers,
+            Map<String, String> nicknameMap
+    ) {
+        try {
+            for (UserIdentifierNicknameProjection projection :
+                    userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers)) {
+                putIfValid(nicknameMap, projection);
+            }
+        } catch (RuntimeException e) {
+            log.warn(
+                    "회원 닉네임 조회 실패 - fallback nickname 사용. targetCount: {}",
+                    userIdentifiers.size(),
+                    e
+            );
+        }
+    }
+
+    private void putIfValid(
+            Map<String, String> nicknameMap,
+            UserIdentifierNicknameProjection projection
+    ) {
+        if (projection == null
+                || projection.getUserIdentifier() == null
+                || projection.getUserIdentifier().isBlank()
+                || projection.getNickname() == null
+                || projection.getNickname().isBlank()) {
+            return;
+        }
+
+        nicknameMap.put(
+                projection.getUserIdentifier(),
+                projection.getNickname()
+        );
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyPlayerResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyPlayerResponse.java
@@ -5,11 +5,13 @@ package io.github.ascrew.monomatbe.domain.lobby.dto;
  *
  * [정책]
  * - userIdentifier는 Redis와 WebSocket에서 사용하는 사용자 식별자이다.
+ * - nickname은 FE 대기실 참여자 목록 표시용 사용자 닉네임이다.
  * - 방장은 ready 대상에서 제외되므로 ready=false로 내려갈 수 있다.
  * - FE는 host=true 여부를 기준으로 방장 UI와 ready UI를 분리한다.
  */
 public record LobbyPlayerResponse(
         String userIdentifier,
+        String nickname,
         boolean host,
         boolean ready
 ) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
@@ -1,61 +1,40 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
-import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
-import io.github.ascrew.monomatbe.domain.auth.repository.UserIdentifierNicknameProjection;
-import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
  * 로비 참여자 userIdentifier를 사용자 닉네임으로 변환하는 컴포넌트
  *
  * [설계 이유]
- * LobbyQueryService가 게스트/회원 세션 저장 구조를 직접 알게 되면
- * 로비 조회 책임과 인증 세션 조회 책임이 섞인다.
- * 따라서 userIdentifier -> nickname 변환 책임을 이 컴포넌트로 분리한다.
+ * LobbyQueryService는 로비 상세 응답 조립 책임만 가진다.
+ * userIdentifier가 실제로 guest_sessions / user_sessions 중 어디에 저장되는지는
+ * Auth 도메인의 내부 구현이므로 UserNicknameLookupService에 위임한다.
  *
- * [조회 정책]
- * - 게스트: guest_sessions.guest_token 기준 조회
- * - 회원: user_sessions.session_id 기준 조회
- * - 두 경로를 모두 조회한 뒤 userIdentifier 기준으로 nickname Map을 만든다.
- * - 알 수 없는 userIdentifier는 null로 두지 않고 fallback 표시값을 반환한다.
+ * [역할]
+ * - Auth 도메인 서비스에서 userIdentifier -> nickname Map을 조회한다.
+ * - 조회되지 않은 사용자를 위한 fallback nickname을 제공한다.
  */
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LobbyPlayerNicknameResolver {
 
     private static final String UNKNOWN_NICKNAME_PREFIX = "Unknown-";
 
-    private final GuestSessionRepository guestSessionRepository;
-    private final UserSessionRepository userSessionRepository;
+    private final UserNicknameLookupService userNicknameLookupService;
 
     /**
      * 여러 userIdentifier에 대응되는 닉네임을 한 번에 조회한다.
-     *
-     * [N+1 방지]
-     * participants 수만큼 DB를 반복 조회하지 않고,
-     * guest_sessions / user_sessions를 각각 Projection 기반 IN query로 조회한다.
      *
      * @param userIdentifiers 로비 참여자 userIdentifier 목록
      * @return userIdentifier -> nickname Map
      */
     public Map<String, String> resolveNicknameMap(Collection<String> userIdentifiers) {
-        if (userIdentifiers == null || userIdentifiers.isEmpty()) {
-            return Map.of();
-        }
-
-        Map<String, String> nicknameMap = new HashMap<>();
-
-        resolveGuestNicknames(userIdentifiers, nicknameMap);
-        resolveRegisteredUserNicknames(userIdentifiers, nicknameMap);
-
-        return nicknameMap;
+        return userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers);
     }
 
     /**
@@ -77,51 +56,5 @@ public class LobbyPlayerNicknameResolver {
                 : compact.substring(0, 6);
 
         return UNKNOWN_NICKNAME_PREFIX + suffix;
-    }
-
-    private void resolveGuestNicknames(
-            Collection<String> userIdentifiers,
-            Map<String, String> nicknameMap
-    ) {
-        try {
-            for (UserIdentifierNicknameProjection projection :
-                    guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers)) {
-                putIfValid(nicknameMap, projection);
-            }
-        } catch (RuntimeException e) {
-            log.warn("로비 참여자 게스트 닉네임 조회 실패 - fallback nickname 사용", e);
-        }
-    }
-
-    private void resolveRegisteredUserNicknames(
-            Collection<String> userIdentifiers,
-            Map<String, String> nicknameMap
-    ) {
-        try {
-            for (UserIdentifierNicknameProjection projection :
-                    userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers)) {
-                putIfValid(nicknameMap, projection);
-            }
-        } catch (RuntimeException e) {
-            log.warn("로비 참여자 회원 닉네임 조회 실패 - fallback nickname 사용", e);
-        }
-    }
-
-    private void putIfValid(
-            Map<String, String> nicknameMap,
-            UserIdentifierNicknameProjection projection
-    ) {
-        if (projection == null
-                || projection.getUserIdentifier() == null
-                || projection.getUserIdentifier().isBlank()
-                || projection.getNickname() == null
-                || projection.getNickname().isBlank()) {
-            return;
-        }
-
-        nicknameMap.put(
-                projection.getUserIdentifier(),
-                projection.getNickname()
-        );
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
@@ -1,8 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
-import io.github.ascrew.monomatbe.domain.auth.entity.GuestSession;
-import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
 import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserIdentifierNicknameProjection;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +15,8 @@ import java.util.Map;
  * 로비 참여자 userIdentifier를 사용자 닉네임으로 변환하는 컴포넌트
  *
  * [설계 이유]
- * LobbyQueryService가 게스트/회원 세션 저장 구조를 직접 알게 되면 로비 조회 책임과 인증 세션 조회 책임이 섞인다.
+ * LobbyQueryService가 게스트/회원 세션 저장 구조를 직접 알게 되면
+ * 로비 조회 책임과 인증 세션 조회 책임이 섞인다.
  * 따라서 userIdentifier -> nickname 변환 책임을 이 컴포넌트로 분리한다.
  *
  * [조회 정책]
@@ -40,7 +40,7 @@ public class LobbyPlayerNicknameResolver {
      *
      * [N+1 방지]
      * participants 수만큼 DB를 반복 조회하지 않고,
-     * guest_sessions / user_sessions를 각각 IN query로 조회한다.
+     * guest_sessions / user_sessions를 각각 Projection 기반 IN query로 조회한다.
      *
      * @param userIdentifiers 로비 참여자 userIdentifier 목록
      * @return userIdentifier -> nickname Map
@@ -84,15 +84,9 @@ public class LobbyPlayerNicknameResolver {
             Map<String, String> nicknameMap
     ) {
         try {
-            for (GuestSession guestSession : guestSessionRepository.findByGuestTokenIn(userIdentifiers)) {
-                if (guestSession.getUser() == null) {
-                    continue;
-                }
-
-                nicknameMap.put(
-                        guestSession.getGuestToken(),
-                        guestSession.getUser().getUsername()
-                );
+            for (UserIdentifierNicknameProjection projection :
+                    guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers)) {
+                putIfValid(nicknameMap, projection);
             }
         } catch (RuntimeException e) {
             log.warn("로비 참여자 게스트 닉네임 조회 실패 - fallback nickname 사용", e);
@@ -104,18 +98,30 @@ public class LobbyPlayerNicknameResolver {
             Map<String, String> nicknameMap
     ) {
         try {
-            for (UserSession userSession : userSessionRepository.findBySessionIdIn(userIdentifiers)) {
-                if (userSession.getUser() == null) {
-                    continue;
-                }
-
-                nicknameMap.put(
-                        userSession.getSessionId(),
-                        userSession.getUser().getUsername()
-                );
+            for (UserIdentifierNicknameProjection projection :
+                    userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers)) {
+                putIfValid(nicknameMap, projection);
             }
         } catch (RuntimeException e) {
             log.warn("로비 참여자 회원 닉네임 조회 실패 - fallback nickname 사용", e);
         }
+    }
+
+    private void putIfValid(
+            Map<String, String> nicknameMap,
+            UserIdentifierNicknameProjection projection
+    ) {
+        if (projection == null
+                || projection.getUserIdentifier() == null
+                || projection.getUserIdentifier().isBlank()
+                || projection.getNickname() == null
+                || projection.getNickname().isBlank()) {
+            return;
+        }
+
+        nicknameMap.put(
+                projection.getUserIdentifier(),
+                projection.getNickname()
+        );
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
@@ -1,0 +1,121 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.GuestSession;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 로비 참여자 userIdentifier를 사용자 닉네임으로 변환하는 컴포넌트
+ *
+ * [설계 이유]
+ * LobbyQueryService가 게스트/회원 세션 저장 구조를 직접 알게 되면 로비 조회 책임과 인증 세션 조회 책임이 섞인다.
+ * 따라서 userIdentifier -> nickname 변환 책임을 이 컴포넌트로 분리한다.
+ *
+ * [조회 정책]
+ * - 게스트: guest_sessions.guest_token 기준 조회
+ * - 회원: user_sessions.session_id 기준 조회
+ * - 두 경로를 모두 조회한 뒤 userIdentifier 기준으로 nickname Map을 만든다.
+ * - 알 수 없는 userIdentifier는 null로 두지 않고 fallback 표시값을 반환한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LobbyPlayerNicknameResolver {
+
+    private static final String UNKNOWN_NICKNAME_PREFIX = "Unknown-";
+
+    private final GuestSessionRepository guestSessionRepository;
+    private final UserSessionRepository userSessionRepository;
+
+    /**
+     * 여러 userIdentifier에 대응되는 닉네임을 한 번에 조회한다.
+     *
+     * [N+1 방지]
+     * participants 수만큼 DB를 반복 조회하지 않고,
+     * guest_sessions / user_sessions를 각각 IN query로 조회한다.
+     *
+     * @param userIdentifiers 로비 참여자 userIdentifier 목록
+     * @return userIdentifier -> nickname Map
+     */
+    public Map<String, String> resolveNicknameMap(Collection<String> userIdentifiers) {
+        if (userIdentifiers == null || userIdentifiers.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, String> nicknameMap = new HashMap<>();
+
+        resolveGuestNicknames(userIdentifiers, nicknameMap);
+        resolveRegisteredUserNicknames(userIdentifiers, nicknameMap);
+
+        return nicknameMap;
+    }
+
+    /**
+     * 닉네임이 없는 식별자에 대한 fallback 값을 반환한다.
+     *
+     * [fallback 정책]
+     * Redis participants에는 남아 있지만 DB 세션이 이미 정리된 경우,
+     * 상세 조회 전체를 실패시키면 대기실 UI가 깨진다.
+     * 따라서 식별자 일부를 포함한 안전한 표시값으로 내려준다.
+     */
+    public String fallbackNickname(String userIdentifier) {
+        if (userIdentifier == null || userIdentifier.isBlank()) {
+            return UNKNOWN_NICKNAME_PREFIX + "user";
+        }
+
+        String compact = userIdentifier.replace("-", "");
+        String suffix = compact.length() <= 6
+                ? compact
+                : compact.substring(0, 6);
+
+        return UNKNOWN_NICKNAME_PREFIX + suffix;
+    }
+
+    private void resolveGuestNicknames(
+            Collection<String> userIdentifiers,
+            Map<String, String> nicknameMap
+    ) {
+        try {
+            for (GuestSession guestSession : guestSessionRepository.findByGuestTokenIn(userIdentifiers)) {
+                if (guestSession.getUser() == null) {
+                    continue;
+                }
+
+                nicknameMap.put(
+                        guestSession.getGuestToken(),
+                        guestSession.getUser().getUsername()
+                );
+            }
+        } catch (RuntimeException e) {
+            log.warn("로비 참여자 게스트 닉네임 조회 실패 - fallback nickname 사용", e);
+        }
+    }
+
+    private void resolveRegisteredUserNicknames(
+            Collection<String> userIdentifiers,
+            Map<String, String> nicknameMap
+    ) {
+        try {
+            for (UserSession userSession : userSessionRepository.findBySessionIdIn(userIdentifiers)) {
+                if (userSession.getUser() == null) {
+                    continue;
+                }
+
+                nicknameMap.put(
+                        userSession.getSessionId(),
+                        userSession.getUser().getUsername()
+                );
+            }
+        } catch (RuntimeException e) {
+            log.warn("로비 참여자 회원 닉네임 조회 실패 - fallback nickname 사용", e);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -755,10 +755,11 @@ public class LobbyQueryService {
     ) {
         boolean host = hostId != null && hostId.equals(participantIdentifier);
         boolean ready = !host && readyParticipantIdentifiers.contains(participantIdentifier);
-        String nickname = participantNicknameMap.getOrDefault(
-                participantIdentifier,
-                lobbyPlayerNicknameResolver.fallbackNickname(participantIdentifier)
-        );
+
+        String nickname = participantNicknameMap.get(participantIdentifier);
+        if (nickname == null || nickname.isBlank()) {
+            nickname = lobbyPlayerNicknameResolver.fallbackNickname(participantIdentifier);
+        }
 
         return new LobbyPlayerResponse(
                 participantIdentifier,
@@ -767,7 +768,7 @@ public class LobbyQueryService {
                 ready
         );
     }
-
+    
     /**
      * 로비 상세 응답에서 방장 정보가 누락되지 않도록 보정한다.
      *

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -768,7 +768,7 @@ public class LobbyQueryService {
                 ready
         );
     }
-    
+
     /**
      * 로비 상세 응답에서 방장 정보가 누락되지 않도록 보정한다.
      *

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -44,6 +44,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -70,6 +71,7 @@ public class LobbyQueryService {
     private final LobbyRepository lobbyRepository;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final LobbyCanStartPolicy lobbyCanStartPolicy;
+    private final LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver;
 
     /**
      * ZSET 기반 페이징 중 stale index를 감안해 추가 스캔할 배수.
@@ -671,12 +673,15 @@ public class LobbyQueryService {
         );
 
         Set<String> readyParticipantIdentifiers = lobbyRepository.getReadyParticipantIdentifiers(code);
+        Map<String, String> participantNicknameMap =
+                lobbyPlayerNicknameResolver.resolveNicknameMap(participantIdentifiers);
 
         List<LobbyPlayerResponse> players = participantIdentifiers.stream()
                 .map(participantIdentifier -> toLobbyPlayerResponse(
                         participantIdentifier,
                         lobbyInfo.hostId(),
-                        readyParticipantIdentifiers
+                        readyParticipantIdentifiers,
+                        participantNicknameMap
                 ))
                 .toList();
 
@@ -745,13 +750,19 @@ public class LobbyQueryService {
     private LobbyPlayerResponse toLobbyPlayerResponse(
             String participantIdentifier,
             String hostId,
-            Set<String> readyParticipantIdentifiers
+            Set<String> readyParticipantIdentifiers,
+            Map<String, String> participantNicknameMap
     ) {
         boolean host = hostId != null && hostId.equals(participantIdentifier);
         boolean ready = !host && readyParticipantIdentifiers.contains(participantIdentifier);
+        String nickname = participantNicknameMap.getOrDefault(
+                participantIdentifier,
+                lobbyPlayerNicknameResolver.fallbackNickname(participantIdentifier)
+        );
 
         return new LobbyPlayerResponse(
                 participantIdentifier,
+                nickname,
                 host,
                 ready
         );

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/UserNicknameLookupServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/UserNicknameLookupServiceTest.java
@@ -1,0 +1,187 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserIdentifierNicknameProjection;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * UserNicknameLookupService의 userIdentifier -> nickname 조회 정책을 검증한다.
+ */
+class UserNicknameLookupServiceTest {
+
+    private final GuestSessionRepository guestSessionRepository = mock(GuestSessionRepository.class);
+    private final UserSessionRepository userSessionRepository = mock(UserSessionRepository.class);
+
+    private final UserNicknameLookupService userNicknameLookupService = new UserNicknameLookupService(
+            guestSessionRepository,
+            userSessionRepository
+    );
+
+    @Test
+    @DisplayName("userIdentifiers가 null이면 빈 Map을 반환하고 Repository를 호출하지 않는다")
+    void findNicknameMapByUserIdentifiers_returnsEmptyMapWhenUserIdentifiersIsNull() {
+        // when
+        Map<String, String> result = userNicknameLookupService.findNicknameMapByUserIdentifiers(null);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(guestSessionRepository, never()).findNicknamesByGuestTokenIn(any());
+        verify(userSessionRepository, never()).findNicknamesBySessionIdIn(any());
+    }
+
+    @Test
+    @DisplayName("userIdentifiers가 비어 있으면 빈 Map을 반환하고 Repository를 호출하지 않는다")
+    void findNicknameMapByUserIdentifiers_returnsEmptyMapWhenUserIdentifiersIsEmpty() {
+        // when
+        Map<String, String> result = userNicknameLookupService.findNicknameMapByUserIdentifiers(List.of());
+
+        // then
+        assertThat(result).isEmpty();
+        verify(guestSessionRepository, never()).findNicknamesByGuestTokenIn(any());
+        verify(userSessionRepository, never()).findNicknamesBySessionIdIn(any());
+    }
+
+    @Test
+    @DisplayName("게스트와 회원 닉네임 Projection을 userIdentifier 기준 Map으로 변환한다")
+    void findNicknameMapByUserIdentifiers_resolvesGuestAndRegisteredUserNicknames() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "guest-identifier",
+                "registered-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenReturn(List.of(projection("guest-identifier", "게스트닉네임")));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenReturn(List.of(projection("registered-identifier", "회원닉네임")));
+
+        // when
+        Map<String, String> result =
+                userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("guest-identifier", "게스트닉네임")
+                .containsEntry("registered-identifier", "회원닉네임")
+                .hasSize(2);
+    }
+
+    @Test
+    @DisplayName("게스트 닉네임 조회가 실패해도 회원 닉네임 조회 결과는 반환한다")
+    void findNicknameMapByUserIdentifiers_continuesWhenGuestLookupFails() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "guest-identifier",
+                "registered-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenThrow(new RuntimeException("guest lookup failed"));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenReturn(List.of(projection("registered-identifier", "회원닉네임")));
+
+        // when
+        Map<String, String> result =
+                userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("registered-identifier", "회원닉네임")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("회원 닉네임 조회가 실패해도 게스트 닉네임 조회 결과는 반환한다")
+    void findNicknameMapByUserIdentifiers_continuesWhenRegisteredUserLookupFails() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "guest-identifier",
+                "registered-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenReturn(List.of(projection("guest-identifier", "게스트닉네임")));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenThrow(new RuntimeException("registered lookup failed"));
+
+        // when
+        Map<String, String> result =
+                userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("guest-identifier", "게스트닉네임")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("빈 userIdentifier 또는 빈 nickname Projection은 결과에서 제외한다")
+    void findNicknameMapByUserIdentifiers_ignoresInvalidProjectionValues() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "valid-identifier",
+                "blank-nickname",
+                "blank-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenReturn(List.of(
+                        projection("valid-identifier", "정상닉네임"),
+                        projection("blank-nickname", " "),
+                        projection(" ", "식별자없음")
+                ));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenReturn(List.of());
+
+        // when
+        Map<String, String> result =
+                userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("valid-identifier", "정상닉네임")
+                .hasSize(1);
+    }
+
+    private UserIdentifierNicknameProjection projection(
+            String userIdentifier,
+            String nickname
+    ) {
+        return new TestUserIdentifierNicknameProjection(
+                userIdentifier,
+                nickname
+        );
+    }
+
+    private record TestUserIdentifierNicknameProjection(
+            String userIdentifier,
+            String nickname
+    ) implements UserIdentifierNicknameProjection {
+
+        @Override
+        public String getUserIdentifier() {
+            return userIdentifier;
+        }
+
+        @Override
+        public String getNickname() {
+            return nickname;
+        }
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
@@ -1,0 +1,208 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserIdentifierNicknameProjection;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * LobbyPlayerNicknameResolver의 userIdentifier -> nickname 변환 정책을 검증한다.
+ *
+ * [검증 범위]
+ * - 빈 입력 처리
+ * - 게스트 닉네임 Projection 반영
+ * - 회원 닉네임 Projection 반영
+ * - 일부 조회 실패 시 예외 전파 방지
+ * - fallback nickname 생성 정책
+ */
+class LobbyPlayerNicknameResolverTest {
+
+    private final GuestSessionRepository guestSessionRepository = mock(GuestSessionRepository.class);
+    private final UserSessionRepository userSessionRepository = mock(UserSessionRepository.class);
+
+    private final LobbyPlayerNicknameResolver resolver = new LobbyPlayerNicknameResolver(
+            guestSessionRepository,
+            userSessionRepository
+    );
+
+    @Test
+    @DisplayName("userIdentifiers가 null이면 빈 Map을 반환하고 Repository를 호출하지 않는다")
+    void resolveNicknameMap_returnsEmptyMapWhenUserIdentifiersIsNull() {
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(null);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(guestSessionRepository, never()).findNicknamesByGuestTokenIn(List.of());
+        verify(userSessionRepository, never()).findNicknamesBySessionIdIn(List.of());
+    }
+
+    @Test
+    @DisplayName("userIdentifiers가 비어 있으면 빈 Map을 반환하고 Repository를 호출하지 않는다")
+    void resolveNicknameMap_returnsEmptyMapWhenUserIdentifiersIsEmpty() {
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(List.of());
+
+        // then
+        assertThat(result).isEmpty();
+        verify(guestSessionRepository, never()).findNicknamesByGuestTokenIn(List.of());
+        verify(userSessionRepository, never()).findNicknamesBySessionIdIn(List.of());
+    }
+
+    @Test
+    @DisplayName("게스트와 회원 닉네임 Projection을 userIdentifier 기준 Map으로 변환한다")
+    void resolveNicknameMap_resolvesGuestAndRegisteredUserNicknames() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "guest-identifier",
+                "registered-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenReturn(List.of(projection("guest-identifier", "게스트닉네임")));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenReturn(List.of(projection("registered-identifier", "회원닉네임")));
+
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("guest-identifier", "게스트닉네임")
+                .containsEntry("registered-identifier", "회원닉네임")
+                .hasSize(2);
+    }
+
+    @Test
+    @DisplayName("게스트 닉네임 조회가 실패해도 회원 닉네임 조회 결과는 반환한다")
+    void resolveNicknameMap_continuesWhenGuestLookupFails() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "guest-identifier",
+                "registered-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenThrow(new RuntimeException("guest lookup failed"));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenReturn(List.of(projection("registered-identifier", "회원닉네임")));
+
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("registered-identifier", "회원닉네임")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("회원 닉네임 조회가 실패해도 게스트 닉네임 조회 결과는 반환한다")
+    void resolveNicknameMap_continuesWhenRegisteredUserLookupFails() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "guest-identifier",
+                "registered-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenReturn(List.of(projection("guest-identifier", "게스트닉네임")));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenThrow(new RuntimeException("registered lookup failed"));
+
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("guest-identifier", "게스트닉네임")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("빈 userIdentifier 또는 빈 nickname Projection은 결과에서 제외한다")
+    void resolveNicknameMap_ignoresInvalidProjectionValues() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "valid-identifier",
+                "blank-nickname",
+                "blank-identifier"
+        );
+
+        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
+                .thenReturn(List.of(
+                        projection("valid-identifier", "정상닉네임"),
+                        projection("blank-nickname", " "),
+                        projection(" ", "식별자없음")
+                ));
+
+        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
+                .thenReturn(List.of());
+
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("valid-identifier", "정상닉네임")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("fallbackNickname은 null 또는 blank 식별자에 Unknown-user를 반환한다")
+    void fallbackNickname_returnsUnknownUserWhenIdentifierIsBlank() {
+        assertThat(resolver.fallbackNickname(null)).isEqualTo("Unknown-user");
+        assertThat(resolver.fallbackNickname("")).isEqualTo("Unknown-user");
+        assertThat(resolver.fallbackNickname("   ")).isEqualTo("Unknown-user");
+    }
+
+    @Test
+    @DisplayName("fallbackNickname은 식별자의 하이픈을 제거한 앞 6자리를 suffix로 사용한다")
+    void fallbackNickname_returnsPrefixWithIdentifierSuffix() {
+        String userIdentifier = "11111111-2222-3333-4444-555555555555";
+
+        String result = resolver.fallbackNickname(userIdentifier);
+
+        assertThat(result).isEqualTo("Unknown-111111");
+    }
+
+    private UserIdentifierNicknameProjection projection(
+            String userIdentifier,
+            String nickname
+    ) {
+        return new TestUserIdentifierNicknameProjection(
+                userIdentifier,
+                nickname
+        );
+    }
+
+    private record TestUserIdentifierNicknameProjection(
+            String userIdentifier,
+            String nickname
+    ) implements UserIdentifierNicknameProjection {
+
+        @Override
+        public String getUserIdentifier() {
+            return userIdentifier;
+        }
+
+        @Override
+        public String getNickname() {
+            return nickname;
+        }
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
@@ -1,79 +1,46 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
-import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
-import io.github.ascrew.monomatbe.domain.auth.repository.UserIdentifierNicknameProjection;
-import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * LobbyPlayerNicknameResolver의 userIdentifier -> nickname 변환 정책을 검증한다.
+ * LobbyPlayerNicknameResolver의 로비 응답용 닉네임 변환 정책을 검증한다.
  *
  * [검증 범위]
- * - 빈 입력 처리
- * - 게스트 닉네임 Projection 반영
- * - 회원 닉네임 Projection 반영
- * - 일부 조회 실패 시 예외 전파 방지
+ * - Auth 도메인 닉네임 조회 서비스로 위임하는지
  * - fallback nickname 생성 정책
  */
 class LobbyPlayerNicknameResolverTest {
 
-    private final GuestSessionRepository guestSessionRepository = mock(GuestSessionRepository.class);
-    private final UserSessionRepository userSessionRepository = mock(UserSessionRepository.class);
+    private final UserNicknameLookupService userNicknameLookupService = mock(UserNicknameLookupService.class);
 
     private final LobbyPlayerNicknameResolver resolver = new LobbyPlayerNicknameResolver(
-            guestSessionRepository,
-            userSessionRepository
+            userNicknameLookupService
     );
 
     @Test
-    @DisplayName("userIdentifiers가 null이면 빈 Map을 반환하고 Repository를 호출하지 않는다")
-    void resolveNicknameMap_returnsEmptyMapWhenUserIdentifiersIsNull() {
-        // when
-        Map<String, String> result = resolver.resolveNicknameMap(null);
-
-        // then
-        assertThat(result).isEmpty();
-        verify(guestSessionRepository, never()).findNicknamesByGuestTokenIn(List.of());
-        verify(userSessionRepository, never()).findNicknamesBySessionIdIn(List.of());
-    }
-
-    @Test
-    @DisplayName("userIdentifiers가 비어 있으면 빈 Map을 반환하고 Repository를 호출하지 않는다")
-    void resolveNicknameMap_returnsEmptyMapWhenUserIdentifiersIsEmpty() {
-        // when
-        Map<String, String> result = resolver.resolveNicknameMap(List.of());
-
-        // then
-        assertThat(result).isEmpty();
-        verify(guestSessionRepository, never()).findNicknamesByGuestTokenIn(List.of());
-        verify(userSessionRepository, never()).findNicknamesBySessionIdIn(List.of());
-    }
-
-    @Test
-    @DisplayName("게스트와 회원 닉네임 Projection을 userIdentifier 기준 Map으로 변환한다")
-    void resolveNicknameMap_resolvesGuestAndRegisteredUserNicknames() {
+    @DisplayName("resolveNicknameMap은 UserNicknameLookupService에 조회를 위임한다")
+    void resolveNicknameMap_delegatesToUserNicknameLookupService() {
         // given
         List<String> userIdentifiers = List.of(
                 "guest-identifier",
                 "registered-identifier"
         );
 
-        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
-                .thenReturn(List.of(projection("guest-identifier", "게스트닉네임")));
-
-        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
-                .thenReturn(List.of(projection("registered-identifier", "회원닉네임")));
+        when(userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers))
+                .thenReturn(Map.of(
+                        "guest-identifier", "게스트닉네임",
+                        "registered-identifier", "회원닉네임"
+                ));
 
         // when
         Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
@@ -83,83 +50,8 @@ class LobbyPlayerNicknameResolverTest {
                 .containsEntry("guest-identifier", "게스트닉네임")
                 .containsEntry("registered-identifier", "회원닉네임")
                 .hasSize(2);
-    }
 
-    @Test
-    @DisplayName("게스트 닉네임 조회가 실패해도 회원 닉네임 조회 결과는 반환한다")
-    void resolveNicknameMap_continuesWhenGuestLookupFails() {
-        // given
-        List<String> userIdentifiers = List.of(
-                "guest-identifier",
-                "registered-identifier"
-        );
-
-        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
-                .thenThrow(new RuntimeException("guest lookup failed"));
-
-        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
-                .thenReturn(List.of(projection("registered-identifier", "회원닉네임")));
-
-        // when
-        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
-
-        // then
-        assertThat(result)
-                .containsEntry("registered-identifier", "회원닉네임")
-                .hasSize(1);
-    }
-
-    @Test
-    @DisplayName("회원 닉네임 조회가 실패해도 게스트 닉네임 조회 결과는 반환한다")
-    void resolveNicknameMap_continuesWhenRegisteredUserLookupFails() {
-        // given
-        List<String> userIdentifiers = List.of(
-                "guest-identifier",
-                "registered-identifier"
-        );
-
-        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
-                .thenReturn(List.of(projection("guest-identifier", "게스트닉네임")));
-
-        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
-                .thenThrow(new RuntimeException("registered lookup failed"));
-
-        // when
-        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
-
-        // then
-        assertThat(result)
-                .containsEntry("guest-identifier", "게스트닉네임")
-                .hasSize(1);
-    }
-
-    @Test
-    @DisplayName("빈 userIdentifier 또는 빈 nickname Projection은 결과에서 제외한다")
-    void resolveNicknameMap_ignoresInvalidProjectionValues() {
-        // given
-        List<String> userIdentifiers = List.of(
-                "valid-identifier",
-                "blank-nickname",
-                "blank-identifier"
-        );
-
-        when(guestSessionRepository.findNicknamesByGuestTokenIn(userIdentifiers))
-                .thenReturn(List.of(
-                        projection("valid-identifier", "정상닉네임"),
-                        projection("blank-nickname", " "),
-                        projection(" ", "식별자없음")
-                ));
-
-        when(userSessionRepository.findNicknamesBySessionIdIn(userIdentifiers))
-                .thenReturn(List.of());
-
-        // when
-        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
-
-        // then
-        assertThat(result)
-                .containsEntry("valid-identifier", "정상닉네임")
-                .hasSize(1);
+        verify(userNicknameLookupService).findNicknameMapByUserIdentifiers(userIdentifiers);
     }
 
     @Test
@@ -178,31 +70,5 @@ class LobbyPlayerNicknameResolverTest {
         String result = resolver.fallbackNickname(userIdentifier);
 
         assertThat(result).isEqualTo("Unknown-111111");
-    }
-
-    private UserIdentifierNicknameProjection projection(
-            String userIdentifier,
-            String nickname
-    ) {
-        return new TestUserIdentifierNicknameProjection(
-                userIdentifier,
-                nickname
-        );
-    }
-
-    private record TestUserIdentifierNicknameProjection(
-            String userIdentifier,
-            String nickname
-    ) implements UserIdentifierNicknameProjection {
-
-        @Override
-        public String getUserIdentifier() {
-            return userIdentifier;
-        }
-
-        @Override
-        public String getNickname() {
-            return nickname;
-        }
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,6 +38,7 @@ class LobbyQueryServiceCanStartTest {
     private LobbyRepository lobbyRepository;
     private GameLobbyJpaRepository gameLobbyJpaRepository;
     private QuizMapJpaRepository quizMapJpaRepository;
+    private LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver;
     private LobbyQueryService lobbyQueryService;
 
     @BeforeEach
@@ -44,6 +46,7 @@ class LobbyQueryServiceCanStartTest {
         lobbyRepository = mock(LobbyRepository.class);
         gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
         quizMapJpaRepository = mock(QuizMapJpaRepository.class);
+        lobbyPlayerNicknameResolver = mock(LobbyPlayerNicknameResolver.class);
 
         LobbyCanStartPolicy lobbyCanStartPolicy = new LobbyCanStartPolicy(
                 quizMapJpaRepository
@@ -52,7 +55,8 @@ class LobbyQueryServiceCanStartTest {
         lobbyQueryService = new LobbyQueryService(
                 lobbyRepository,
                 gameLobbyJpaRepository,
-                lobbyCanStartPolicy
+                lobbyCanStartPolicy,
+                lobbyPlayerNicknameResolver
         );
     }
 
@@ -66,6 +70,10 @@ class LobbyQueryServiceCanStartTest {
         when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
         when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
         when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
+        when(lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(hostId, guestId))).thenReturn(Map.of(
+                hostId, "방장",
+                guestId, "참여자"
+        ));
         when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
         when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
 
@@ -87,6 +95,10 @@ class LobbyQueryServiceCanStartTest {
         when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
         when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
         when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of());
+        when(lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(hostId, guestId))).thenReturn(Map.of(
+                hostId, "방장",
+                guestId, "참여자"
+        ));
         when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
         when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(5)));
 
@@ -108,6 +120,10 @@ class LobbyQueryServiceCanStartTest {
         when(lobbyRepository.isParticipant(code, hostId)).thenReturn(true);
         when(lobbyRepository.getParticipantIdentifiers(code)).thenReturn(List.of(hostId, guestId));
         when(lobbyRepository.getReadyParticipantIdentifiers(code)).thenReturn(Set.of(guestId));
+        when(lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(hostId, guestId))).thenReturn(Map.of(
+                hostId, "방장",
+                guestId, "참여자"
+        ));
         when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby()));
         when(quizMapJpaRepository.findById(2L)).thenReturn(Optional.of(quizMap(4)));
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -1,29 +1,38 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyInt;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * LobbyQueryService의 공개 로비 목록 조회 정책을 검증한다.
+ * LobbyQueryService의 공개 로비 목록 조회 정책과 로비 상세 조회 응답 조립을 검증한다.
  *
  * [테스트 범위]
  * - Redis 조회 자체는 LobbyRepository의 책임이므로 mock 처리한다.
- * - 이 테스트는 Service 계층의 목록 노출 정책만 검증한다.
+ * - 이 테스트는 Service 계층의 목록 노출 정책과 상세 응답 조립 정책만 검증한다.
  *
  * [검증 정책]
  * - 비공개 로비가 공개 목록 원본에 섞여 있으면 제외한다.
@@ -34,17 +43,20 @@ import static org.mockito.Mockito.when;
  * - 카테고리 필터는 Repository에서 정규화된 FE 표시값(K-POP, J-POP, POP)을 기준으로 동작한다.
  * - 정원/현재 인원 값이 유효하지 않은 로비는 제외한다.
  * - 정렬은 최신순, 인원 많은 순, 빈자리 많은 순을 지원한다.
+ * - 로비 상세 조회 응답의 players에는 userIdentifier, nickname, host, ready가 포함된다.
  */
 class LobbyQueryServiceTest {
 
     private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
     private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
     private final LobbyCanStartPolicy lobbyCanStartPolicy = mock(LobbyCanStartPolicy.class);
+    private final LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver = mock(LobbyPlayerNicknameResolver.class);
 
     private final LobbyQueryService lobbyQueryService = new LobbyQueryService(
             lobbyRepository,
             gameLobbyJpaRepository,
-            lobbyCanStartPolicy
+            lobbyCanStartPolicy,
+            lobbyPlayerNicknameResolver
     );
 
     @Test
@@ -413,95 +425,130 @@ class LobbyQueryServiceTest {
                 .containsExactly("VALID");
     }
 
-    /**
-     * 테스트용 로비 DTO를 생성한다.
-     *
-     * [의도]
-     * 각 테스트에서 필요한 값만 명확히 드러내기 위해 fixture 생성 메서드를 둔다.
-     * 실제 Redis 조회 로직은 테스트 대상이 아니므로,
-     * LobbyRedisDto builder를 사용해 Service 정책 검증에 필요한 필드만 채운다.
-     */
-    private LobbyRedisDto lobby(
-            String code,
-            String title,
-            String mapCategory,
-            int currentPlayers,
-            int maxPlayers,
-            LobbyStatus status,
-            Long createdAtEpochMillis
-    ) {
-        return lobby(
+    @Test
+    @DisplayName("로비 상세 조회 응답의 참여자 목록에 닉네임을 포함한다")
+    void getLobbyDetail_includesPlayerNicknames() {
+        // given
+        String code = "ABC123";
+        String hostIdentifier = "host-user-identifier";
+        String participantIdentifier = "participant-user-identifier";
+
+        JoinLobbyResponse lobbyInfo = new JoinLobbyResponse(
                 code,
-                title,
-                mapCategory,
-                currentPlayers,
-                maxPlayers,
-                status,
-                createdAtEpochMillis,
-                false
+                "테스트 로비",
+                hostIdentifier,
+                8,
+                2,
+                LobbyStatus.WAITING.name(),
+                1L,
+                "테스트 맵",
+                "K-POP"
         );
+
+        when(lobbyRepository.findByInviteCode(code))
+                .thenReturn(Optional.of(lobbyInfo));
+
+        when(lobbyRepository.getParticipantIdentifiers(code))
+                .thenReturn(List.of(hostIdentifier, participantIdentifier));
+
+        when(lobbyRepository.getReadyParticipantIdentifiers(code))
+                .thenReturn(Set.of(participantIdentifier));
+
+        when(lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(hostIdentifier, participantIdentifier)))
+                .thenReturn(Map.of(
+                        hostIdentifier, "방장닉네임",
+                        participantIdentifier, "참여자닉네임"
+                ));
+
+        when(gameLobbyJpaRepository.findByInviteCode(code))
+                .thenReturn(Optional.empty());
+
+        when(lobbyCanStartPolicy.calculateCanStart(any(), any(), any()))
+                .thenReturn(false);
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                hostIdentifier,
+                UserType.REGISTERED
+        );
+
+        // when
+        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(code, principal);
+
+        // then
+        assertThat(response.players())
+                .extracting(LobbyPlayerResponse::nickname)
+                .containsExactly("방장닉네임", "참여자닉네임");
+
+        assertThat(response.players())
+                .extracting(LobbyPlayerResponse::userIdentifier)
+                .containsExactly(hostIdentifier, participantIdentifier);
+
+        assertThat(response.players())
+                .extracting(LobbyPlayerResponse::host)
+                .containsExactly(true, false);
+
+        assertThat(response.players())
+                .extracting(LobbyPlayerResponse::ready)
+                .containsExactly(false, true);
     }
 
-    /**
-     * 공개/비공개 여부를 직접 지정할 수 있는 테스트용 로비 DTO를 생성한다.
-     *
-     * [사용 목적]
-     * 정상 Redis 생성 경로에서는 비공개 로비가 lobby:public Set에 들어가지 않는다.
-     * 다만 운영 중 Redis 수동 조작이나 복구 과정에서 비공개 로비 코드가 섞일 수 있으므로,
-     * Service 계층의 최종 방어 필터를 검증하기 위해 isPrivate 값을 지정할 수 있게 한다.
-     */
-    private LobbyRedisDto lobby(
-            String code,
-            String title,
-            String mapCategory,
-            int currentPlayers,
-            int maxPlayers,
-            LobbyStatus status,
-            Long createdAtEpochMillis,
-            boolean isPrivate
-    ) {
-        return LobbyRedisDto.builder()
-                .code(code)
-                .hostId("host-user-id")
-                .title(title)
-                .mapId(1L)
-                .mapTitle("테스트 맵")
-                .mapCategory(mapCategory)
-                .currentPlayers(currentPlayers)
-                .maxPlayers(maxPlayers)
-                .isPrivate(isPrivate)
-                .status(status.name())
-                .createdAtEpochMillis(createdAtEpochMillis)
-                .build();
-    }
+    @Test
+    @DisplayName("로비 상세 조회 응답에서 닉네임을 찾지 못하면 fallback 닉네임을 사용한다")
+    void getLobbyDetail_usesFallbackNicknameWhenNicknameIsMissing() {
+        // given
+        String code = "ABC123";
+        String hostIdentifier = "host-user-identifier";
+        String participantIdentifier = "participant-user-identifier";
 
-    /**
-     * capacity 유효성 검증 테스트용 로비 DTO를 생성한다.
-     *
-     * [의도]
-     * 기존 lobby() fixture는 currentPlayers/maxPlayers를 primitive int로 받기 때문에
-     * null 값 검증에 사용할 수 없다.
-     * Redis 손상 데이터 방어 테스트에서는 null/0/음수 값을 명시적으로 만들 수 있어야 하므로
-     * Integer 기반 별도 fixture를 사용한다.
-     */
-    private LobbyRedisDto lobbyWithCapacity(
-            String code,
-            Integer currentPlayers,
-            Integer maxPlayers
-    ) {
-        return LobbyRedisDto.builder()
-                .code(code)
-                .hostId("host-user-id")
-                .title("테스트 로비")
-                .mapId(1L)
-                .mapTitle("테스트 맵")
-                .mapCategory("K-POP")
-                .currentPlayers(currentPlayers)
-                .maxPlayers(maxPlayers)
-                .isPrivate(false)
-                .status(LobbyStatus.WAITING.name())
-                .createdAtEpochMillis(1000L)
-                .build();
+        JoinLobbyResponse lobbyInfo = new JoinLobbyResponse(
+                code,
+                "테스트 로비",
+                hostIdentifier,
+                8,
+                2,
+                LobbyStatus.WAITING.name(),
+                null,
+                null,
+                null
+        );
+
+        when(lobbyRepository.findByInviteCode(code))
+                .thenReturn(Optional.of(lobbyInfo));
+
+        when(lobbyRepository.getParticipantIdentifiers(code))
+                .thenReturn(List.of(hostIdentifier, participantIdentifier));
+
+        when(lobbyRepository.getReadyParticipantIdentifiers(code))
+                .thenReturn(Set.of());
+
+        when(lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(hostIdentifier, participantIdentifier)))
+                .thenReturn(Map.of(
+                        hostIdentifier, "방장닉네임"
+                ));
+
+        when(lobbyPlayerNicknameResolver.fallbackNickname(participantIdentifier))
+                .thenReturn("Unknown-partic");
+
+        when(gameLobbyJpaRepository.findByInviteCode(code))
+                .thenReturn(Optional.empty());
+
+        when(lobbyCanStartPolicy.calculateCanStart(any(), any(), any()))
+                .thenReturn(false);
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                hostIdentifier,
+                UserType.REGISTERED
+        );
+
+        // when
+        LobbyDetailResponse response = lobbyQueryService.getLobbyDetail(code, principal);
+
+        // then
+        assertThat(response.players())
+                .extracting(LobbyPlayerResponse::nickname)
+                .containsExactly("방장닉네임", "Unknown-partic");
     }
 
     @Test
@@ -729,5 +776,96 @@ class LobbyQueryServiceTest {
                 .extracting(LobbyRedisDto::getCode)
                 .containsExactly("ONLY");
         assertThat(result.hasNext()).isFalse();
+    }
+
+    /**
+     * 테스트용 로비 DTO를 생성한다.
+     *
+     * [의도]
+     * 각 테스트에서 필요한 값만 명확히 드러내기 위해 fixture 생성 메서드를 둔다.
+     * 실제 Redis 조회 로직은 테스트 대상이 아니므로,
+     * LobbyRedisDto builder를 사용해 Service 정책 검증에 필요한 필드만 채운다.
+     */
+    private LobbyRedisDto lobby(
+            String code,
+            String title,
+            String mapCategory,
+            int currentPlayers,
+            int maxPlayers,
+            LobbyStatus status,
+            Long createdAtEpochMillis
+    ) {
+        return lobby(
+                code,
+                title,
+                mapCategory,
+                currentPlayers,
+                maxPlayers,
+                status,
+                createdAtEpochMillis,
+                false
+        );
+    }
+
+    /**
+     * 공개/비공개 여부를 직접 지정할 수 있는 테스트용 로비 DTO를 생성한다.
+     *
+     * [사용 목적]
+     * 정상 Redis 생성 경로에서는 비공개 로비가 lobby:public Set에 들어가지 않는다.
+     * 다만 운영 중 Redis 수동 조작이나 복구 과정에서 비공개 로비 코드가 섞일 수 있으므로,
+     * Service 계층의 최종 방어 필터를 검증하기 위해 isPrivate 값을 지정할 수 있게 한다.
+     */
+    private LobbyRedisDto lobby(
+            String code,
+            String title,
+            String mapCategory,
+            int currentPlayers,
+            int maxPlayers,
+            LobbyStatus status,
+            Long createdAtEpochMillis,
+            boolean isPrivate
+    ) {
+        return LobbyRedisDto.builder()
+                .code(code)
+                .hostId("host-user-id")
+                .title(title)
+                .mapId(1L)
+                .mapTitle("테스트 맵")
+                .mapCategory(mapCategory)
+                .currentPlayers(currentPlayers)
+                .maxPlayers(maxPlayers)
+                .isPrivate(isPrivate)
+                .status(status.name())
+                .createdAtEpochMillis(createdAtEpochMillis)
+                .build();
+    }
+
+    /**
+     * capacity 유효성 검증 테스트용 로비 DTO를 생성한다.
+     *
+     * [의도]
+     * 기존 lobby() fixture는 currentPlayers/maxPlayers를 primitive int로 받기 때문에
+     * null 값 검증에 사용할 수 없다.
+     * Redis 손상 데이터 방어 테스트에서는 null/0/음수 값을 명시적으로 만들 수 있어야 하므로
+     * Integer 기반 별도 fixture를 사용한다.
+     */
+    private LobbyRedisDto lobbyWithCapacity(
+            String code,
+            Integer currentPlayers,
+            Integer maxPlayers
+    ) {
+        return LobbyRedisDto.builder()
+                .code(code)
+                .hostId("host-user-id")
+                .title("테스트 로비")
+                .mapId(1L)
+                .mapTitle("테스트 맵")
+                .mapCategory("K-POP")
+                .currentPlayers(currentPlayers)
+                .maxPlayers(maxPlayers)
+                .isPrivate(false)
+                .status(LobbyStatus.WAITING.name())
+                .createdAtEpochMillis(1000L)
+                .build();
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #97

## 📝 Summary

- 로비 상세 조회 응답의 `players[]` 항목에 `nickname` 필드를 추가했습니다.
- `userIdentifier` 기준으로 게스트/회원 세션을 조회해 참여자 닉네임을 매핑하는 `LobbyPlayerNicknameResolver`를 추가했습니다.
- 닉네임 조회 실패 또는 stale session 상황에서도 로비 상세 조회 전체가 실패하지 않도록 fallback 닉네임을 사용하도록 처리했습니다.
- `LobbyQueryService`에서 참여자 목록을 조립할 때 닉네임을 함께 포함하도록 수정했습니다.
- 로비 상세 조회 관련 테스트와 canStart 테스트를 변경된 생성자 구조에 맞게 수정했습니다.
- `GET /api/lobbies/{code}` API 문서에 `players[].nickname` 응답 필드를 추가했습니다.

## 🙏PR point

- `nickname`은 FE 대기실 참여자 목록 표시용 필드입니다.
- `userIdentifier`는 기존과 동일하게 Redis/WebSocket 식별자로 유지됩니다.
- 닉네임 조회는 참여자별 단건 조회가 아니라 `guest_sessions.guest_token IN (...)`, `user_sessions.session_id IN (...)` 방식의 배치 조회로 처리했습니다.
- Redis participants에는 남아 있지만 DB 세션 정보가 없는 경우를 고려해 `Unknown-{prefix}` 형태의 fallback 닉네임을 반환합니다.
- FE는 앞으로 로비 상세 응답의 `players[].nickname`을 사용해 참여자 이름을 표시하면 됩니다.

## 📬 Reference
