### PR TITLE
[Feat/#93] 로비 입장 및 WebSocket 실패 케이스 정리

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -345,7 +345,7 @@ POST /api/lobbies/join
 초대 코드로 로비 입장 가능 여부를 검증하고 로비 기본 정보를 반환합니다.
 JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 가능합니다.
 
-> 이 API는 입장 허가 사전 검증만 수행합니다.
+> 이 API는 입장 허가 사전 검증만 수행합니다.  
 > 실제 참여자 등록은 응답 수신 후 WebSocket `/topic/lobby/{inviteCode}` 구독 시점에 처리됩니다.
 
 클라이언트 처리 순서:
@@ -427,6 +427,35 @@ JWT Access Token이 필요합니다. 게스트와 정식 회원 모두 입장 �
 | `401 Unauthorized` | JWT 토큰 없음 또는 만료           |
 | `404 Not Found`    | 존재하지 않는 초대 코드             |
 | `409 Conflict`     | 게임이 이미 시작된 로비 또는 최대 인원 초과 |
+
+**REST join 성공 후 WebSocket SUBSCRIBE 실패 처리 기준**
+
+`POST /api/lobbies/join`은 UX용 사전 검증입니다.  
+실제 참여자 등록은 `SUBSCRIBE /topic/lobby/{inviteCode}` 시점에 `enter_lobby.lua`로 원자 처리됩니다.
+
+따라서 REST join이 성공했더라도 WebSocket SUBSCRIBE 시점에 로비 상태가 바뀌면 STOMP ERROR가 발생할 수 있습니다.
+
+클라이언트는 로비 입장을 다음 순서로 처리해야 합니다.
+
+```text
+1. POST /api/lobbies/join 호출
+2. 응답 성공 시 WebSocket CONNECT
+3. SUBSCRIBE /topic/lobby/{inviteCode}
+4. SUBSCRIBE 성공 후 로비 상세 조회 또는 refresh 이벤트 대기
+5. SUBSCRIBE 실패 시 STOMP ERROR payload의 action 기준으로 처리
+```
+
+| 상황 | 이유 | FE 처리 |
+| --- | --- | --- |
+| REST join 성공 후 다른 사용자가 먼저 입장 | SUBSCRIBE 시점에 `FULL` 발생 | `RETURN_TO_LOBBY_LIST` |
+| REST join 성공 후 방장이 게임 시작 | SUBSCRIBE 시점에 `LOBBY_NOT_WAITING` 발생 | `RETURN_TO_LOBBY_LIST` |
+| REST join 성공 후 로비 삭제 | SUBSCRIBE 시점에 `LOBBY_NOT_FOUND` 발생 | `RETURN_TO_LOBBY_LIST` |
+| 강퇴된 유저가 재입장 시도 | kicked Set 기준으로 `KICKED_USER` 발생 | `RETURN_TO_LOBBY_LIST` |
+| 같은 userIdentifier로 여러 세션이 경합 | 최신 sessionSequence 기준 stale 세션 차단 | `RECONNECT` |
+| Redis/Lua 일시 장애 | 최종 입장 상태 확인 불가 | `REFRESH_AND_RETRY` |
+
+> FE는 `POST /api/lobbies/join` 성공만으로 사용자를 로비 참여자로 확정하면 안 됩니다.  
+> 실제 로비 참여 확정 기준은 `SUBSCRIBE /topic/lobby/{code}` 성공입니다.
 
 ---
 
@@ -546,6 +575,7 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available&page=0&siz
 | `hasNext` | Boolean | 다음 페이지 존재 여부      |
 
 **`items[]` Fields**
+
 | 필드                     | 타입      | 설명                                                                                                      |
 | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `code`                 | String  | 로비 초대 코드                                                                                                |
@@ -559,7 +589,6 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available&page=0&siz
 | `isPrivate`            | Boolean | 비공개 여부. 공개 로비 목록에서는 `false`                                                                             |
 | `status`               | String  | 로비 상태. 공개 로비 목록에서는 `WAITING`, `PLAYING`만 반환. `WAITING`은 입장 가능, `PLAYING`은 진행 중으로 목록에는 노출되지만 입장은 허용하지 않음 |
 | `createdAtEpochMillis` | Long    | 로비 생성 시각. Redis `TIME` 기준 epoch milliseconds                                                            |
-
 
 **Error**
 
@@ -620,6 +649,7 @@ JWT Access Token이 필요합니다.
     },
     {
       "userIdentifier": "b17f7ee0-614f-4f5f-b770-83f6d4b85f4a",
+      "nickname": "참여자닉네임",
       "host": false,
       "ready": true
     }
@@ -643,10 +673,10 @@ JWT Access Token이 필요합니다.
 | `timeLimitSeconds`         | Integer | 라운드 제한 시간                            |
 | `players`                  | Array   | 현재 로비 참여자 목록                         |
 | `players[].userIdentifier` | String  | 참여자 식별자                              |
+| `players[].nickname`       | String  | 참여자 닉네임                              |
 | `players[].host`           | Boolean | 방장 여부                                |
 | `players[].ready`          | Boolean | ready 여부. 방장은 ready 대상이 아니므로 `false` |
 | `canStart`                 | Boolean | 조회 시점 기준 게임 시작 가능 여부                 |
-| `players[].nickname` | String | 참여자 닉네임 |
 
 **canStart 계산 조건**
 
@@ -1092,15 +1122,113 @@ SEND /app/lobby/{code}/kick
 
 ### STOMP ERROR 프레임
 
-인증 실패 또는 유효하지 않은 요청 시 STOMP ERROR 프레임으로 응답합니다.
+인증 실패, 유효하지 않은 요청, 로비 입장 실패 등 WebSocket 처리 중 클라이언트가 복구 가능한 방식으로 판단해야 하는 오류는 STOMP `ERROR` 프레임으로 응답합니다.
 
-| 상황                          | 메시지                                              |
-| --------------------------- | ------------------------------------------------ |
-| `userIdentifier` 헤더 누락      | `STOMP CONNECT: 사용자 식별자가 없습니다. 연결이 거부되었습니다.`     |
-| 유효하지 않은 `userIdentifier` 형식 | `STOMP CONNECT: 유효하지 않은 식별자 형식입니다. 연결이 거부되었습니다.` |
-| 인증 없이 SEND/SUBSCRIBE 시도     | `인증 정보가 존재하지 않습니다.`                              |
-| 최대 인원 초과 로비 구독 시도           | `로비 입장 실패: 최대 인원에 도달했습니다.`                       |
-| 존재하지 않는 로비 구독 시도            | `로비 입장 실패: 존재하지 않는 로비입니다.`                       |
+기존에는 ERROR body에 문자열 메시지만 내려갔지만, 로비 입장 실패 케이스를 FE가 안정적으로 처리할 수 있도록 JSON payload를 표준 응답 형식으로 사용합니다.
+
+#### STOMP ERROR Payload
+
+```json
+{
+  "type": "STOMP_ERROR",
+  "code": "LOBBY_NOT_FOUND",
+  "message": "존재하지 않는 로비입니다.",
+  "action": "RETURN_TO_LOBBY_LIST",
+  "recoverable": false,
+  "timestamp": "2026-05-25T00:00:00Z"
+}
+```
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `type` | String | 고정값 `STOMP_ERROR` |
+| `code` | String | 클라이언트 분기용 에러 코드 |
+| `message` | String | 사용자에게 표시 가능한 메시지 |
+| `action` | String | FE가 수행해야 하는 후속 동작 |
+| `recoverable` | Boolean | 같은 화면에서 재시도 가능한 오류인지 여부 |
+| `timestamp` | String | 서버에서 ERROR payload를 생성한 시각 |
+
+#### FE 처리 원칙
+
+FE는 `message` 문자열을 파싱하지 말고, 반드시 `code`, `action`, `recoverable` 기준으로 분기해야 합니다.
+
+| action | FE 권장 처리 |
+| --- | --- |
+| `RETURN_TO_LOBBY_LIST` | 현재 로비 입장을 중단하고 로비 목록 또는 이전 화면으로 복귀 |
+| `RETRY_CONNECT` | WebSocket 연결 자체를 다시 시도 |
+| `REFRESH_AND_RETRY` | 현재 화면 상태를 새로고침한 뒤 다시 시도 |
+| `RECONNECT` | 현재 WebSocket 세션을 폐기하고 새 세션으로 재연결 |
+| `NONE` | 별도 화면 전환 없이 현재 상태 유지 |
+
+#### CONNECT 실패 코드
+
+| code | message | action | recoverable |
+| --- | --- | --- | --- |
+| `CONNECT_USER_IDENTIFIER_MISSING` | 사용자 식별자가 없습니다. 다시 로그인 후 접속해주세요. | `RETRY_CONNECT` | `true` |
+| `CONNECT_USER_IDENTIFIER_INVALID` | 유효하지 않은 사용자 식별자입니다. 다시 로그인 후 접속해주세요. | `RETRY_CONNECT` | `true` |
+| `CONNECT_SESSION_SEQUENCE_FAILED` | WebSocket 세션 생성에 실패했습니다. 다시 접속해주세요. | `RETRY_CONNECT` | `true` |
+| `CONNECT_WS_SESSION_ID_MISSING` | WebSocket 세션 ID가 없습니다. 다시 접속해주세요. | `RETRY_CONNECT` | `true` |
+| `CONNECT_ONLINE_STATUS_FAILED` | 사용자 온라인 상태 저장에 실패했습니다. 잠시 후 다시 접속해주세요. | `RETRY_CONNECT` | `true` |
+
+#### 인증/세션 실패 코드
+
+| code | message | action | recoverable |
+| --- | --- | --- | --- |
+| `SESSION_UNAUTHENTICATED` | 인증 정보가 존재하지 않습니다. 다시 접속해주세요. | `RETRY_CONNECT` | `true` |
+| `LOBBY_ENTER_WS_SESSION_MISSING` | 로비 입장에 필요한 WebSocket 세션 ID가 없습니다. 다시 접속해주세요. | `RECONNECT` | `true` |
+| `LOBBY_ENTER_SESSION_ATTRIBUTES_MISSING` | 로비 입장에 필요한 세션 정보가 없습니다. 새로고침 후 다시 시도해주세요. | `REFRESH_AND_RETRY` | `true` |
+| `LOBBY_ENTER_SEQUENCE_MISSING` | WebSocket 세션 순서 정보가 없습니다. 새로고침 후 다시 시도해주세요. | `REFRESH_AND_RETRY` | `true` |
+
+#### 로비 입장 실패 코드
+
+`POST /api/lobbies/join`은 입장 가능 여부를 확인하는 사전 검증 API입니다.  
+실제 참여자 등록은 WebSocket `SUBSCRIBE /topic/lobby/{code}` 시점에 `enter_lobby.lua`로 원자 처리됩니다.
+
+따라서 REST join이 성공했더라도, WebSocket SUBSCRIBE 시점의 최종 상태가 달라지면 STOMP ERROR가 발생할 수 있습니다.
+
+| code | 발생 조건 | message | action | recoverable |
+| --- | --- | --- | --- | --- |
+| `LOBBY_NOT_FOUND` | 로비가 삭제되었거나 존재하지 않음 | 존재하지 않는 로비입니다. | `RETURN_TO_LOBBY_LIST` | `false` |
+| `LOBBY_FULL` | REST join 이후 다른 사용자가 먼저 입장하여 정원이 찬 경우 | 로비 최대 인원에 도달했습니다. | `RETURN_TO_LOBBY_LIST` | `false` |
+| `LOBBY_NOT_WAITING` | 로비가 이미 `PLAYING` 또는 `FINISHED` 상태로 변경된 경우 | 이미 시작되었거나 입장할 수 없는 로비입니다. | `RETURN_TO_LOBBY_LIST` | `false` |
+| `LOBBY_INVALID_CAPACITY` | Redis 로비 정원 정보가 없거나 유효하지 않은 경우 | 로비 정원 정보가 유효하지 않습니다. | `RETURN_TO_LOBBY_LIST` | `false` |
+| `LOBBY_STALE_SESSION` | 더 최신 WebSocket 세션이 이미 존재하는 경우 | 더 최신 WebSocket 세션이 이미 존재합니다. 다시 접속해주세요. | `RECONNECT` | `true` |
+| `LOBBY_KICKED_USER` | 강퇴된 사용자가 같은 로비에 재입장하려는 경우 | 강퇴된 로비에는 재입장할 수 없습니다. | `RETURN_TO_LOBBY_LIST` | `false` |
+| `LOBBY_INVALID_SEQUENCE` | WebSocket sessionSequence가 유효하지 않은 경우 | 로비 입장 세션 상태가 유효하지 않습니다. 새로고침 후 다시 시도해주세요. | `REFRESH_AND_RETRY` | `true` |
+| `LOBBY_ENTER_UNKNOWN_RESULT` | `enter_lobby.lua`가 알 수 없는 반환값을 반환한 경우 | 로비 입장 중 알 수 없는 서버 응답이 발생했습니다. 새로고침 후 다시 시도해주세요. | `REFRESH_AND_RETRY` | `true` |
+| `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` | Redis/Lua 실행이 일시적으로 실패한 경우 | 일시적으로 로비 입장 상태를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요. | `REFRESH_AND_RETRY` | `true` |
+
+#### 서버 내부 오류 코드
+
+| code | message | action | recoverable |
+| --- | --- | --- | --- |
+| `INTERNAL_STOMP_ERROR` | WebSocket 처리 중 서버 오류가 발생했습니다. | `REFRESH_AND_RETRY` | `true` |
+
+#### REST join 성공 후 WebSocket SUBSCRIBE 실패 처리 기준
+
+클라이언트는 로비 입장을 다음 순서로 처리해야 합니다.
+
+```text
+1. POST /api/lobbies/join 호출
+2. 응답 성공 시 WebSocket CONNECT
+3. SUBSCRIBE /topic/lobby/{inviteCode}
+4. SUBSCRIBE 성공 후 로비 상세 조회 또는 refresh 이벤트 대기
+5. SUBSCRIBE 실패 시 STOMP ERROR payload의 action 기준으로 처리
+```
+
+REST join 성공 후에도 다음 상황에서는 WebSocket SUBSCRIBE가 실패할 수 있습니다.
+
+| 상황 | 이유 | FE 처리 |
+| --- | --- | --- |
+| REST join 성공 후 다른 사용자가 먼저 입장 | SUBSCRIBE 시점에 `FULL` 발생 | `RETURN_TO_LOBBY_LIST` |
+| REST join 성공 후 방장이 게임 시작 | SUBSCRIBE 시점에 `LOBBY_NOT_WAITING` 발생 | `RETURN_TO_LOBBY_LIST` |
+| REST join 성공 후 로비 삭제 | SUBSCRIBE 시점에 `LOBBY_NOT_FOUND` 발생 | `RETURN_TO_LOBBY_LIST` |
+| 강퇴된 유저가 재입장 시도 | kicked Set 기준으로 `KICKED_USER` 발생 | `RETURN_TO_LOBBY_LIST` |
+| 같은 userIdentifier로 여러 세션이 경합 | 최신 sessionSequence 기준 stale 세션 차단 | `RECONNECT` |
+| Redis/Lua 일시 장애 | 최종 입장 상태 확인 불가 | `REFRESH_AND_RETRY` |
+
+> FE는 `POST /api/lobbies/join` 성공만으로 사용자를 로비 참여자로 확정하면 안 됩니다.  
+> 실제 로비 참여 확정 기준은 `SUBSCRIBE /topic/lobby/{code}` 성공입니다.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,71 +67,80 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
 │   │   │   ├── LobbyRepositoryImpl.java            # 로비 Repository Facade
 │   │   │   └── redis/
-│   │   │       ├── LobbyLuaScriptExecutor.java
-│   │   │       ├── LobbyLuaResultMapper.java
-│   │   │       ├── LobbyRedisCommandRepository.java
-│   │   │       ├── LobbyRedisQueryRepository.java
-│   │   │       └── LobbyStartReconciliationRepository.java
+│   │   │       ├── LobbyLuaScriptExecutor.java     # 로비 Lua 스크립트 실행 컴포넌트
+│   │   │       ├── LobbyLuaResultMapper.java       # Lua 반환 문자열 → 도메인 결과 매핑
+│   │   │       ├── LobbyRedisCommandRepository.java # Redis 로비 명령 처리
+│   │   │       ├── LobbyRedisQueryRepository.java  # Redis 로비 조회 처리
+│   │   │       └── LobbyStartReconciliationRepository.java # start 상태 불일치 재처리 큐 접근
 │   │   └── service/
-│   │       ├── LobbyCanStartPolicy.java
-│   │       ├── LobbyCreateService.java
-│   │       ├── LobbyJoinService.java
-│   │       ├── LobbyQueryService.java
-│   │       ├── LobbyReadyService.java
-│   │       ├── LobbyStartService.java
-│   │       ├── LobbyRealtimeNotifier.java
-│   │       └── LobbyStartReconciliationService.java
+│   │       ├── LobbyCanStartPolicy.java            # 조회 시점 canStart 계산 정책
+│   │       ├── LobbyCreateService.java             # 로비 생성 유스케이스
+│   │       ├── LobbyJoinService.java               # 초대 코드 기반 입장 사전 검증 유스케이스
+│   │       ├── LobbyQueryService.java              # 로비 목록/상세 조회 유스케이스
+│   │       ├── LobbyReadyService.java              # ready 상태 변경 유스케이스
+│   │       ├── LobbyStartService.java              # 게임 시작 유스케이스
+│   │       ├── LobbyRealtimeNotifier.java          # 로비 refresh/STOMP 브로드캐스트
+│   │       └── LobbyStartReconciliationService.java # 게임 시작 Redis-DB 상태 불일치 재처리 스케줄러
 │   │
 │   ├── map/                                        # 퀴즈 맵 도메인
 │   │   ├── controller/
-│   │   │   └── QuizMapController.java
+│   │   │   └── MapController.java                  # 맵 REST API
 │   │   ├── dto/
+│   │   │   └── ...                                 # 맵 생성/수정/조회 DTO
 │   │   ├── entity/
-│   │   │   ├── QuizMap.java
-│   │   │   └── MapCategory.java
+│   │   │   ├── QuizMap.java                        # map 테이블 엔티티
+│   │   │   └── MapCategory.java                    # 맵 카테고리 enum (kpop, jpop, pop)
 │   │   ├── repository/
-│   │   │   └── QuizMapJpaRepository.java
+│   │   │   └── QuizMapJpaRepository.java           # 맵 JPA 리포지토리
 │   │   └── service/
-│   │       └── QuizMapService.java
+│   │       └── MapService.java                     # 맵 생성/수정/삭제/조회 비즈니스 로직
 │   │
-│   └── game/                                       # 인게임 도메인
-│       ├── controller/
-│       ├── dto/
-│       ├── entity/
-│       ├── repository/
-│       └── service/
+│   └── ...
 │
 └── global/                                         # 전역 인프라 레이어
-    ├── config/
-    │   ├── RedisConfig.java
-    │   ├── RedisScriptConfig.java
-    │   ├── SchedulingConfig.java
-    │   ├── WebSocketConfig.java
+    ├── config/                                     # 애플리케이션 설정
+    │   ├── RedisConfig.java                        # Redis 연결, 직렬화, Pub/Sub 설정
+    │   ├── RedisScriptConfig.java                  # create/enter/leave/kick/start Lua 스크립트 Bean 등록
+    │   ├── SchedulingConfig.java                   # @Scheduled 기반 재처리 작업 활성화
+    │   ├── WebSocketConfig.java                    # STOMP 엔드포인트 및 브로커 설정
     │   └── SecurityConfig/
-    ├── constant/
-    │   ├── RedisKeys.java
-    │   ├── StompDestinations.java
-    │   └── WebSocketHeaders.java
-    ├── redis/
-    │   ├── RedisPublisher.java
-    │   └── RedisSubscriber.java
-    ├── websocket/
-    │   ├── CustomStompErrorHandler.java
-    │   ├── StompChannelInterceptor.java
-    │   ├── WebSocketEventListener.java
-    │   ├── WebSocketMetric.java
-    │   ├── WebSocketSessionUtils.java
+    │       ├── SecurityConfigDev.java              # 개발 환경 (인증 없이 전체 허용)
+    │       └── SecurityConfigProd.java             # 운영 환경 (전체 인증 필요)
+    │
+    ├── constant/                                   # 전역 상수 클래스
+    │   ├── RedisKeys.java                          # Redis 키 패턴 및 Hash 필드명 상수
+    │   ├── StompDestinations.java                  # STOMP 송신/구독 경로 상수
+    │   └── WebSocketHeaders.java                   # WebSocket 헤더 키 및 세션 속성 키 상수
+    │
+    ├── redis/                                      # Redis Pub/Sub 인프라
+    │   ├── RedisPublisher.java                     # Redis 채널 메시지 발행
+    │   └── RedisSubscriber.java                    # Redis 채널 메시지 수신 → WebSocket 브로드캐스트
+    │
+    ├── websocket/                                  # WebSocket 인프라
+    │   ├── CustomStompErrorHandler.java            # STOMP ERROR 프레임 핸들러
+    │   ├── StompChannelInterceptor.java            # CONNECT/SUBSCRIBE/SEND 인증 검증
+    │   ├── WebSocketEventListener.java             # WebSocket 연결 생명주기 이벤트 처리
+    │   ├── WebSocketMetric.java                    # 활성 세션 수 Prometheus 메트릭
+    │   ├── WebSocketSessionUtils.java              # 세션 식별자 추출 공통 유틸
+    │   ├── dto/
+    │   │   └── ChatMessageDto.java                 # WebSocket 채팅 메시지 DTO
     │   ├── error/
-    │   │   ├── StompErrorAction.java
-    │   │   ├── StompErrorCode.java
-    │   │   ├── StompErrorException.java
-    │   │   └── StompErrorPayload.java
+    │   │   ├── StompErrorAction.java               # FE 후속 동작 enum
+    │   │   ├── StompErrorCode.java                 # STOMP ERROR 코드 계약 enum
+    │   │   ├── StompErrorException.java            # STOMP 표준 에러 예외
+    │   │   └── StompErrorPayload.java              # STOMP ERROR JSON payload
     │   └── event/
-    │       └── PlayerLeaveEvent.java
+    │       └── PlayerLeaveEvent.java               # 플레이어 퇴장 Spring 이벤트 객체
+    │
     └── security/
-        ├── SecurityEndpoints.java
+        ├── SecurityEndpoints.java                  # Security 경로 상수 중앙화
         └── jwt/
-```
+            ├── CustomPrincipal.java                # JWT 인증 주체 (userId + userIdentifier)
+            ├── JwtAuthenticationFilter.java        # Bearer 토큰 검증 및 SecurityContext 저장
+            ├── JwtClaims.java                      # JWT 클레임 키 상수 (발급/검증 공유)
+            ├── JwtTokenProvider.java               # JWT Access/Refresh 토큰 발급
+            └── TokenWithExpiry.java                # 토큰 + 만료시각 DTO
+````
 
 ---
 
@@ -144,12 +153,12 @@ domain  →  global  (허용 ✅)
 global  →  domain  (금지 ❌)
 ```
 
-`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.  
+`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.
 `global`이 `domain`을 직접 참조하면 의존 방향이 역전되어 순환 의존 및 결합도 증가 문제가 발생합니다.
 
-### 이벤트 기반 의존 역전 해소
+### 의존 방향 역전 해결 사례 — Spring ApplicationEventPublisher
 
-`WebSocketEventListener(global)`가 로비 도메인을 직접 호출하지 않도록 `ApplicationEventPublisher`를 사용합니다.
+`WebSocketEventListener(global)`가 `LobbyEventService(domain)`를 직접 호출하던 문제를 아래와 같이 해결했습니다.
 
 ```text
 [기존 — 의존 방향 역전]
@@ -161,24 +170,26 @@ global/WebSocketEventListener → ApplicationEventPublisher.publishEvent(PlayerL
                                domain/LobbyEventService @EventListener  ✅
 ```
 
-`PlayerLeaveEvent`는 `global/websocket/event`에 위치하고, 도메인 레이어가 이 이벤트를 구독합니다.
+`PlayerLeaveEvent`는 `global/websocket/event`에 위치하여 `domain → global` 단방향 의존을 유지합니다.
 
 ### 도메인 간 의존 규칙
 
 동일한 `domain` 하위 도메인 간 참조는 비즈니스 흐름상 허용하지만, 직접 엔티티 결합은 최소화합니다.
 
-예를 들어 로비 생성 시 맵을 연결할 때 `LobbyCreateService`는 맵 접근 권한을 검증합니다.  
-하지만 Redis 저장 계층은 `QuizMap` 엔티티에 직접 의존하지 않고 `LobbyMapMetadata`만 전달받습니다.
+예를 들어 로비 생성 시 맵을 연결할 때 `LobbyService`는 `QuizMapJpaRepository`로 맵 접근 권한을 검증합니다.
+하지만 Redis 저장 계층인 `LobbyRepositoryImpl`은 `QuizMap` 엔티티에 직접 의존하지 않고, `LobbyMapMetadata`라는 최소 DTO만 전달받습니다.
 
 ```text
-LobbyCreateService
-    ├── QuizMap 조회
+LobbyService
+    ├── QuizMapJpaRepository 조회
     ├── 맵 존재/삭제/권한 검증
     └── LobbyMapMetadata 생성
             ↓
 LobbyRepositoryImpl
     └── Redis 저장에 필요한 mapId, mapTitle, mapCategory만 사용
 ```
+
+이 구조를 통해 맵 도메인의 영속성 모델 변경이 Redis 저장 계층으로 직접 전파되는 것을 방지합니다.
 
 ---
 
@@ -195,9 +206,19 @@ Client
     ▼
 LobbyQueryController
     │ 요청 파라미터 수집
+    │ - keyword
+    │ - mapCategory
+    │ - sort
+    │ - page
+    │ - size
     ▼
 LobbySearchCondition
     │ 요청 조건 정규화
+    │ - keyword trim + lower-case
+    │ - mapCategory MapCategory.from()으로 검증
+    │ - sort LobbySortType으로 검증
+    │ - page 기본값/범위 검증
+    │ - size 기본값/최대값 검증
     ▼
 LobbyQueryService
     │ 로비 목록 노출 정책 적용
@@ -218,18 +239,19 @@ LobbyQueryService
 LobbyRepository
     ▼
 LobbyRedisQueryRepository
+    │ Redis Hash / Set / ZSET 조회
     ▼
 Redis
 ```
 
 ### 책임 분리
 
-| 계층 | 책임 |
-| --- | --- |
-| `LobbyQueryController` | HTTP 요청 파라미터 수집 |
-| `LobbySearchCondition` | 요청값 정규화 및 검증 |
-| `LobbyPageRequest` | `page`, `size` 기본값/범위 검증 |
-| `LobbyQueryService` | 로비 목록 노출 정책, 검색, 필터링, 정렬, 페이징, 인덱스 사용 여부 결정 |
+| 계층                          | 책임                                                 |
+| --------------------------- | -------------------------------------------------- |
+| `LobbyQueryController`      | HTTP 요청 파라미터 수집                                    |
+| `LobbySearchCondition`      | 요청값 정규화 및 검증                                       |
+| `LobbyPageRequest`          | `page`, `size` 기본값/범위 검증                           |
+| `LobbyQueryService`         | 로비 목록 노출 정책, 검색, 필터링, 정렬, 페이징, 인덱스 사용 여부 결정        |
 | `LobbyRedisQueryRepository` | Redis 원본 공개 로비 데이터 조회, ZSET 인덱스 조회, stale index 정리 |
 
 ### 노출 정책
@@ -242,45 +264,125 @@ Redis
 
 ### 페이징 정책
 
-| 항목 | 정책 |
-| --- | --- |
-| `page` | 0-based 페이지 번호 |
-| `page` 기본값 | `0` |
-| `size` 기본값 | `20` |
-| `size` 최소값 | `1` |
-| `size` 최대값 | `100` |
-| 응답 구조 | `items`, `page`, `size`, `hasNext` |
+| 항목         | 정책                                 |
+| ---------- | ---------------------------------- |
+| `page`     | 0-based 페이지 번호                     |
+| `page` 기본값 | `0`                                |
+| `size` 기본값 | `20`                               |
+| `size` 최소값 | `1`                                |
+| `size` 최대값 | `100`                              |
+| 응답 구조      | `items`, `page`, `size`, `hasNext` |
 
 ### 정렬 정책
 
-| 정렬 기준 | 설명 | Redis 인덱스 |
-| --- | --- | --- |
-| `latest` | `createdAtEpochMillis` 내림차순 | `lobby:public:latest` |
-| `most_players` | `currentPlayers` 내림차순 | `lobby:public:most_players` |
-| `most_available` | `maxPlayers - currentPlayers` 내림차순 | `lobby:public:most_available` |
+| 정렬 기준            | 설명                                           | Redis 인덱스                     |
+| ---------------- | -------------------------------------------- | ----------------------------- |
+| `latest`         | `createdAtEpochMillis` 내림차순                  | `lobby:public:latest`         |
+| `most_players`   | `currentPlayers` 내림차순, 동률이면 최신순              | `lobby:public:most_players`   |
+| `most_available` | `maxPlayers - currentPlayers` 내림차순, 동률이면 최신순 | `lobby:public:most_available` |
 
-`lobby:public`은 Redis Set이므로 삽입 순서가 보장되지 않습니다.  
-따라서 로비 생성 시 Redis Hash에 `created_at_epoch_millis`를 저장하고, 이 값을 기준으로 최신순 정렬을 수행합니다.
+`lobby:public`은 Redis Set이므로 삽입 순서가 보장되지 않습니다. 따라서 로비 생성 시 Redis Hash에 `created_at_epoch_millis`를 저장하고, 이 값을 기준으로 최신순 정렬을 수행합니다.
 
-### Redis 정렬 인덱스
+**Redis 정렬 인덱스**
 
-| Redis Key | Type | Member | Score | 갱신 시점 |
-| --- | --- | --- | --- | --- |
-| `lobby:public:latest` | ZSET | lobby code | `created_at_epoch_millis` | 공개 로비 생성 시 `ZADD`, 로비 폭파/삭제 시 `ZREM` |
-| `lobby:public:most_players` | ZSET | lobby code | `current_players` | 공개 로비 생성/입장/퇴장/강퇴 시 갱신 |
-| `lobby:public:most_available` | ZSET | lobby code | `max_players - current_players` | 공개 로비 생성/입장/퇴장/강퇴 시 갱신 |
+| Redis Key                     | Type | Member     | Score                           | 갱신 시점                                |
+| ----------------------------- | ---- | ---------- | ------------------------------- | ------------------------------------ |
+| `lobby:public:latest`         | ZSET | lobby code | `created_at_epoch_millis`       | 공개 로비 생성 시 `ZADD`, 로비 폭파/삭제 시 `ZREM` |
+| `lobby:public:most_players`   | ZSET | lobby code | `current_players`               | 공개 로비 생성/입장/퇴장/강퇴 시 갱신               |
+| `lobby:public:most_available` | ZSET | lobby code | `max_players - current_players` | 공개 로비 생성/입장/퇴장/강퇴 시 갱신               |
 
-### 정렬 인덱스 사용 조건
+**정렬 인덱스 사용 조건**
 
-| 조건 | 조회 방식 |
-| --- | --- |
-| `keyword` 없음 + `mapCategory` 없음 + 정렬 인덱스 존재 | Redis ZSET에서 page 범위의 lobbyCode만 조회 |
-| `keyword` 있음 | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
-| `mapCategory` 있음 | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
-| 정렬 인덱스 없음 | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
+| 조건                                          | 조회 방식                                 |
+| ------------------------------------------- | ------------------------------------- |
+| `keyword` 없음 + `mapCategory` 없음 + 정렬 인덱스 존재 | Redis ZSET에서 page 범위의 lobbyCode만 조회   |
+| `keyword` 있음                                | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
+| `mapCategory` 있음                            | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
+| 정렬 인덱스 없음                                   | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
 
-필터가 있는 경우 ZSET page 범위를 먼저 자르면 전체 필터링 결과 기준의 page가 깨질 수 있습니다.  
+필터가 있는 경우 ZSET page 범위를 먼저 자르면 전체 필터링 결과 기준의 page가 깨질 수 있습니다.
+예를 들어 ZSET 상위 20개에는 `K-POP` 로비가 없지만 21번째 이후에 `K-POP` 로비가 있을 수 있습니다.
 따라서 `keyword`, `mapCategory` 필터가 있는 경우는 안전하게 기존 전체 조회 경로로 폴백합니다.
+
+### 생성 시각 기준
+
+로비 생성 시각은 Java 애플리케이션 서버 시간이 아니라 Redis `TIME` 명령을 기준으로 생성합니다.
+
+```lua
+local redisTime = redis.call('TIME')
+local createdAtEpochMillis = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
+```
+
+멀티 인스턴스 운영 환경에서는 애플리케이션 서버 간 시간 편차가 발생할 수 있습니다.  
+따라서 Redis 서버 기준 단일 시간원을 사용해 최신순 정렬 기준을 일관되게 유지합니다.
+
+### 현재 인원 캐싱 정책
+
+`current_players`는 `lobby:{code}:participants` Set과 중복 상태입니다.
+따라서 Java 서비스에서 직접 증가/감소시키지 않고, participants 변경을 수행하는 Lua 스크립트 내부에서만 갱신합니다.
+
+| 이벤트       | 처리                                                          |
+| --------- | ----------------------------------------------------------- |
+| 로비 생성     | `current_players = 0`                                       |
+| 입장        | `SCARD lobby:{code}:participants` 결과를 `current_players`에 저장 |
+| 퇴장        | 남은 participants 수를 `current_players`에 저장                    |
+| 강퇴        | 남은 participants 수를 `current_players`에 저장                    |
+| 마지막 인원 퇴장 | 로비 Hash 삭제. 별도 `current_players = 0` 저장 불필요                 |
+
+조회 시에는 `lobby:{code}.current_players`를 우선 사용합니다.
+다만 배포 전 생성된 기존 Redis 데이터에는 해당 필드가 없을 수 있으므로, 누락 시 `SCARD lobby:{code}:participants` 결과로 fallback합니다.
+
+### Redis Hash 필드
+
+`lobby:{code}` Hash에는 공개 로비 목록 조회 및 정렬을 위해 다음 필드가 포함됩니다.
+
+| 필드                        | 설명                                           |
+| ------------------------- | -------------------------------------------- |
+| `created_at_epoch_millis` | Redis `TIME` 기준 로비 생성 시각. epoch milliseconds |
+| `current_players`         | 현재 참여 인원 캐시. participants Set 변경 Lua에서만 갱신   |
+| `map_category`            | 선택된 맵 카테고리. `K-POP`, `J-POP`, `POP`          |
+| `status`                  | 로비 상태. 목록에서는 `WAITING`, `PLAYING`만 노출        |
+| `is_private`              | 비공개 여부. 공개 로비 목록은 `false`만 노출                |
+| `max_players`             | 최대 참여 인원                                     |
+
+### Redis 정합성 방어
+
+공개 로비 인덱스에는 남아 있지만 `lobby:{code}` Hash가 TTL 만료, 수동 삭제, 과거 버전 로직 등으로 사라질 수 있습니다.
+
+이 경우 공개 로비 목록 조회 경로에서는 해당 code를 응답에서 제외만 합니다.  
+조회 요청 중 즉시 인덱스를 삭제하지 않습니다.
+
+인덱스 정리는 `LobbyPublicIndexCleanupScheduler`가 주기적으로 수행합니다.
+
+```text
+LobbyPublicIndexCleanupScheduler
+    │ fixedDelay 기반 주기 실행
+    ▼
+lobby:public Set에서 일부 code 샘플 조회
+    ▼
+각 code에 대해 lobby:{code} Hash 존재 여부 확인
+    ▼
+Hash가 없으면 아래 공개 인덱스에서 제거
+```
+정리 대상은 다음과 같습니다.
+
+```
+lobby:public
+lobby:public:latest
+lobby:public:most_players
+lobby:public:most_available
+```
+
+이 구조는 조회 경로와 정리 경로를 분리하기 위한 설계입니다.
+
+| 구분                                                    | 책임                                      |
+| ----------------------------------------------------- | --------------------------------------- |
+| `LobbyRedisQueryRepository#getPublicLobbiesByCodes()` | stale code를 응답에서 제외                     |
+| `LobbyPublicIndexCleanupScheduler`                    | stale code를 public Set/ZSET 인덱스에서 배치 정리 |
+| `removePublicLobbyIndexes()`                          | 보정/정리 경로에서 특정 lobbyCode를 공개 인덱스에서 제거    |
+
+정렬 인덱스 기반 조회 중 stale code가 섞이면 `LobbyQueryService`는 요청한 page size를 최대한 채우기 위해 추가 범위를 스캔합니다.
+스캔 상한은 `targetItemCount * 5` 기준으로 제한하여 stale index가 누적된 상황에서도 무한 조회를 방지합니다.
 
 ---
 
@@ -290,23 +392,28 @@ Redis
 
 ```text
 클라이언트
-    │ STOMP /app/chat/global 또는 /app/chat/lobby/{code}
+    │ STOMP /app/chat/global (또는 /app/chat/lobby/{code})
     ▼
 ChatController
+    │
     ▼
 ChatService
     │ sender 위변조 방지 — 클라이언트 sender 무시, 세션 식별자로 교체
+    │
     ▼
 RedisPublisher.publish()
+    │ Redis Pub/Sub 발행
     ▼
-Redis Pub/Sub
+Redis
+    │
     ▼
 RedisSubscriber.onMessage()
     │ JSON 문자열 그대로 WebSocket 브로드캐스트
     ▼
 SimpMessagingTemplate.convertAndSend()
+    │ STOMP /topic/chat/global (또는 /topic/lobby/{code})
     ▼
-클라이언트
+클라이언트 (구독자 전체)
 ```
 
 ### WebSocket 로비 입장 흐름
@@ -315,40 +422,78 @@ SimpMessagingTemplate.convertAndSend()
 클라이언트
     │ STOMP SUBSCRIBE /topic/lobby/{code}
     ▼
-StompChannelInterceptor.preSend()
-    │ enter_lobby.lua 실행
-    │ Redis 입장 상태가 확정된 경우에만 SUBSCRIBE 통과
+WebSocketEventListener.handleSubscribeEvent()
+    │ 1. 로비 채팅 채널 구독 여부 확인
+    │    - /topic/lobby/{code}         → 입장 처리 대상
+    │    - /topic/lobby/{code}/refresh → 입장 처리 대상 아님
+    │ 2. 세션에서 userIdentifier 추출
+    │ 3. wsSessionId 추출
+    │
     ▼
 enter_lobby.lua
-    ├── lobby:{code} 존재 여부 확인
-    ├── WAITING 상태 확인
-    ├── kicked Set 확인
-    ├── sessionSequence 비교
-    ├── 최대 인원 검증
+    │ Redis Lua 스크립트로 입장 상태를 원자적으로 저장
+    │
     ├── lobby:{code}:participants Set에 userIdentifier 저장
     ├── lobby:{code}:order List에 userIdentifier 저장
     ├── lobby:{code}:user_session:{userIdentifier}에 현재 wsSessionId 저장
     ├── lobby:{code}:user_session_seq:{userIdentifier}에 현재 세션 sequence 저장
     ├── ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
     └── 중복 구독 시 order List 중복 저장 방지
+    │
     ▼
-SessionSubscribeEvent
+RedisPublisher.publish()
+    │ ENTER 시스템 메시지 발행
     ▼
-WebSocketEventListener.handleSubscribeEvent()
-    │ 세션에 저장된 LOBBY_ENTER_RESULT 기반 후처리
-    ├── ENTERED → ENTER 메시지 발행 + 로비 refresh
-    ├── ALREADY_JOINED → ENTER 메시지 생략
-    └── SESSION_REPLACED → 최신 세션 유지
+Redis Pub/Sub
+    │
+    ▼
+RedisSubscriber.onMessage()
+    │ JSON 문자열 그대로 WebSocket 브로드캐스트
     ▼
 클라이언트
+    │ /topic/lobby/{code} 구독자로 ENTER 메시지 수신
+
+### 게임 세션 및 라운드 시작 흐름
+
+```text
+클라이언트 (방장)
+    │ POST /api/lobbies/{code}/start
+    ▼
+LobbyStartService
+    │ 1. start_lobby.lua 로 Redis 로비 상태 검증 및 PLAYING 변경
+    │ 2. DB 트랜잭션 시작 (@Transactional)
+    │ 3. DB 로비 상태 PLAYING 변경
+    │ 4. GameSessionCreateService 호출
+    ▼
+GameSessionCreateService
+    │ 1. MapItem 조회 및 셔플 (라운드 수만큼 선택)
+    │ 2. DB GameSession, GameSessionPlayer 스냅샷 생성 (Bulk Insert)
+    │ 3. init_game_session.lua 로 Redis 인게임 세션 데이터 초기화 (2시간 TTL 적용)
+    │ 4. 첫 라운드 정보(RoundStartDto) 반환
+    ▼
+LobbyStartService
+    │ TransactionSynchronizationManager.registerSynchronization (afterCommit)
+    │ DB 트랜잭션 정상 커밋 대기
+    ▼
+DB Commit 완료
+    │
+    ▼
+GameRealtimeNotifier / LobbyRealtimeNotifier
+    │ 1. /topic/lobby/{code}/game 으로 GAME_STARTED 브로드캐스트
+    │ 2. /topic/game/{code}/round 로 첫 번째 라운드 RoundStartDto 브로드캐스트
+    ▼
+클라이언트 (전체)
+    │ 게임 화면 전환 및 유튜브 플레이어 재생
 ```
 
-> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.  
+* **트랜잭션-웹소켓 동기화**: DB 커밋 전에 웹소켓 이벤트가 발송되어 클라이언트가 아직 DB에 반영되지 않은 상태를 조회하는 Race Condition을 방지하기 위해 `afterCommit` 훅을 사용합니다.
+* **보상 트랜잭션(Rollback)**: 게임 세션 생성이나 Redis 스크립트 실행 중 예외가 발생하면 DB 트랜잭션이 롤백되며, 로비 상태도 `WAITING`으로 안전하게 복구됩니다.
+```
+
+> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
 > `/topic/lobby/{code}/refresh` 구독은 로비 정보 갱신 신호 수신용이며, 입장 처리 대상이 아닙니다.
 
----
-
-## WebSocket 로비 입장 실패 처리 정책
+### WebSocket 로비 입장 실패 처리 정책
 
 로비 입장은 REST와 WebSocket이 역할을 나누어 처리합니다.
 
@@ -368,24 +513,22 @@ SUBSCRIBE /topic/lobby/{code}
     - ENTER 메시지 및 refresh 후처리
 ```
 
-`POST /api/lobbies/join`은 UX용 사전 검증입니다.  
+`POST /api/lobbies/join`은 UX용 사전 검증입니다.
 실제 참여자 등록은 `SUBSCRIBE /topic/lobby/{code}` 시점에 `enter_lobby.lua`로 처리합니다.
 
 따라서 REST join 성공 후에도 아래 상황에서는 WebSocket SUBSCRIBE가 실패할 수 있습니다.
+| 상황                           | Lua 반환값                       | STOMP ERROR code                      | 처리 기준          |
+| ---------------------------- | ----------------------------- | ------------------------------------- | -------------- |
+| 로비가 삭제됨                      | `LOBBY_NOT_FOUND`             | `LOBBY_NOT_FOUND`                     | 로비 목록으로 복귀     |
+| REST join 이후 정원이 참           | `FULL`                        | `LOBBY_FULL`                          | 로비 목록으로 복귀     |
+| 방장이 게임을 시작함                  | `LOBBY_NOT_WAITING`           | `LOBBY_NOT_WAITING`                   | 로비 목록으로 복귀     |
+| 강퇴된 유저 재입장                   | `KICKED_USER`                 | `LOBBY_KICKED_USER`                   | 로비 목록으로 복귀     |
+| 더 최신 세션이 존재함                 | `STALE_SESSION:{wsSessionId}` | `LOBBY_STALE_SESSION`                 | 현재 세션 폐기 후 재연결 |
+| 세션 sequence 누락/비정상           | `INVALID_SEQUENCE`            | `LOBBY_INVALID_SEQUENCE`              | 새로고침 후 재시도     |
+| Redis 로비 정원 데이터 손상           | `INVALID_LOBBY_CAPACITY`      | `LOBBY_INVALID_CAPACITY`              | 로비 목록으로 복귀     |
+| Lua null/unknown/Redis 일시 장애 | `null` 또는 unknown             | `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` | 새로고침 후 재시도     |
 
-| 상황 | Lua 반환값 | STOMP ERROR code | 처리 기준 |
-| --- | --- | --- | --- |
-| 로비가 삭제됨 | `LOBBY_NOT_FOUND` | `LOBBY_NOT_FOUND` | 로비 목록으로 복귀 |
-| REST join 이후 정원이 참 | `FULL` | `LOBBY_FULL` | 로비 목록으로 복귀 |
-| 방장이 게임을 시작함 | `LOBBY_NOT_WAITING` | `LOBBY_NOT_WAITING` | 로비 목록으로 복귀 |
-| 강퇴된 유저 재입장 | `KICKED_USER` | `LOBBY_KICKED_USER` | 로비 목록으로 복귀 |
-| 더 최신 세션이 존재함 | `STALE_SESSION:{wsSessionId}` | `LOBBY_STALE_SESSION` | 현재 세션 폐기 후 재연결 |
-| 세션 sequence 누락/비정상 | `INVALID_SEQUENCE` | `LOBBY_INVALID_SEQUENCE` | 새로고침 후 재시도 |
-| Redis 로비 정원 데이터 손상 | `INVALID_LOBBY_CAPACITY` | `LOBBY_INVALID_CAPACITY` | 로비 목록으로 복귀 |
-| Lua null/unknown/Redis 일시 장애 | `null` 또는 unknown | `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` | 새로고침 후 재시도 |
-
-### 실패 처리 흐름
-
+#### 실패 처리 흐름
 ```text
 Client
     │ SUBSCRIBE /topic/lobby/{code}
@@ -410,8 +553,7 @@ Client
     │ code/action/recoverable 기준으로 화면 처리
 ```
 
-### STOMP ERROR payload 계약
-
+#### STOMP ERROR payload 계약
 ```json
 {
   "type": "STOMP_ERROR",
@@ -422,79 +564,57 @@ Client
   "timestamp": "2026-05-25T00:00:00Z"
 }
 ```
-
-FE는 `message` 문자열을 파싱하지 않습니다.  
+FE는 `message` 문자열을 파싱하지 않습니다.
 반드시 `code`, `action`, `recoverable` 기준으로 화면 복귀, 재연결, 새로고침 재시도를 결정합니다.
 
-### 성공 반환값 처리
-
-| Lua 반환값 | 의미 | 후처리 |
-| --- | --- | --- |
-| `ENTERED` | 신규 입장 성공 | ENTER 메시지 발행, 로비 refresh |
-| `ALREADY_JOINED` | 같은 세션의 중복 구독 | ENTER 메시지 생략 |
+#### 성공 반환값 처리
+| Lua 반환값                                  | 의미                                 | 후처리                                   |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- |
+| `ENTERED`                                | 신규 입장 성공                           | ENTER 메시지 발행, 로비 refresh              |
+| `ALREADY_JOINED`                         | 같은 세션의 중복 구독                       | ENTER 메시지 생략                          |
 | `SESSION_REPLACED:{previousWsSessionId}` | 같은 userIdentifier의 새 세션이 기존 세션을 대체 | 최신 세션 유지, 기존 세션 disconnect 시 stale 처리 |
 
-### 최신 세션 유지 정책
-
-동일한 userIdentifier가 같은 로비에 여러 WebSocket 세션으로 진입할 경우, `CONNECT` 시 Redis `INCR`로 발급한 `sessionSequence`가 더 큰 세션을 최신 세션으로 봅니다.
-
+#### 최신 세션 유지 정책
+동일한 userIdentifier가 같은 로비에 여러 WebSocket 세션으로 진입할 경우, `CONNECT` 시 Redis INCR로 발급한 `sessionSequence`가 더 큰 세션을 최신 세션으로 봅니다.
 ```text
 lobby:{code}:user_session:{userIdentifier}
 lobby:{code}:user_session_seq:{userIdentifier}
 ```
-
 이 정책으로 오래된 세션의 늦은 SUBSCRIBE 또는 늦은 DISCONNECT가 최신 세션 상태를 덮어쓰지 못하게 막습니다.
 
-### 보상 삭제 정책
-
+#### 보상 삭제 정책
 SUBSCRIBE 실패 시 현재 요청의 `ws:connection:{wsSessionId}`는 보상 삭제합니다.
-
-```text
+```
 ws:connection:{wsSessionId}
 ```
-
 다만 `participants`, `order`, `user_session`, `user_session_seq`는 Lua 성공 전 실패한 경우 생성되지 않았거나, stale 세션인 경우 최신 세션의 상태일 수 있으므로 Java에서 직접 삭제하지 않습니다.
 
 이 원칙을 지켜야 정상 사용자의 최신 세션을 실수로 제거하지 않습니다.
 
----
 
-## WebSocket 연결 해제 흐름
+### WebSocket 연결 해제 흐름
 
 ```text
 클라이언트 연결 해제
+    │
     ▼
 WebSocketEventListener.handleDisconnectEvent()
     │ 1. Redis ws:connection:{wsSessionId} 에서 lobbyCode 역추적
-    │ 2. stale 세션 여부 확인
-    │ 3. 최신 세션이면 PlayerLeaveEvent 발행
-    │ 4. LEAVE 메시지 브로드캐스트
-    │ 5. Redis 키 정리
-    ▼
+    │ 2. ApplicationEventPublisher.publishEvent(PlayerLeaveEvent)
+    │ 3. LEAVE 메시지 브로드캐스트
+    │ 4. Redis 키 정리 (user_status, ws:connection)
+    │
+    ▼ (이벤트 전달)
 LobbyEventService.handlePlayerLeave(@EventListener)
+    │ Lua 스크립트로 원자적 퇴장 처리
     ▼
 leave_lobby.lua
     ├── DESTROYED → 전역 로비 리스트 새로고침
-    ├── DELEGATED → 로비 내부 새로고침
+    ├── DELEGATED → 로비 내부 새로고침 (새 방장 ID 포함)
     └── LEFT      → 로비 내부 새로고침
 ```
 
-### stale DISCONNECT 정책
-
-동일 userIdentifier의 새 WebSocket 세션이 기존 세션을 대체한 후, 이전 세션의 DISCONNECT가 늦게 도착할 수 있습니다.
-
-이 경우 이전 세션은 최신 유효 세션이 아니므로 실제 퇴장 처리를 수행하지 않습니다.
-
-```text
-if lobby:{code}:user_session:{userIdentifier} != disconnectedWsSessionId
-    → stale 세션으로 판단
-    → PlayerLeaveEvent 발행 생략
-    → ws:connection:{oldWsSessionId}만 삭제
-```
-
----
-
-## 로비 강퇴 흐름
+### 로비 강퇴 흐름
 
 ```text
 방장 클라이언트
@@ -509,14 +629,15 @@ LobbyEventService.kickLobbyPlayer()
     │ 3. 강퇴 대상 식별자 검증
     ▼
 kick_lobby.lua
-    ├── 로비 존재 여부 확인
-    ├── 방장 정보 존재 여부 확인
-    ├── 요청자가 방장인지 검증
-    ├── 자기 자신 강퇴 요청인지 검증
-    ├── 강퇴 대상이 참여자인지 검증
-    ├── participants/order에서 강퇴 대상 제거
-    ├── kicked Set에 강퇴 대상 추가
+    │ Redis Lua 스크립트로 강퇴 상태를 원자적으로 변경
+    │
+    ├── 방장 권한 검증
+    ├── 자기 자신 강퇴 방지
+    ├── 참여자 여부 검증
+    ├── participants/order에서 대상 제거
+    ├── kicked Set에 대상 추가
     └── 대상의 현재 wsSessionId 반환
+    │
     ▼
 LobbyEventService.handleKickSuccess()
     │ 1. 대상 ws:connection 키 삭제
@@ -524,17 +645,16 @@ LobbyEventService.handleKickSuccess()
     │ 3. 로비 내부 refresh 브로드캐스트
 ```
 
-강퇴된 사용자는 `lobby:{code}:kicked` Set에 저장되며, 같은 로비에 다시 `SUBSCRIBE /topic/lobby/{code}`를 시도하면 `enter_lobby.lua`에서 `KICKED_USER`로 차단됩니다.
-
----
-
-## 로비 게임 시작 흐름
+### 로비 게임 시작 흐름
 
 ```text
 방장 클라이언트
     │ REST POST /api/lobbies/{code}/start
     ▼
-LobbyStartService
+LobbyController.startLobbyGame()
+    │ @AuthenticationPrincipal CustomPrincipal 전달
+    ▼
+LobbyService.startLobbyGame()
     │ 1. 인증 정보 확인
     │ 2. Redis 로비 존재 여부 확인
     │ 3. DB GAME_LOBBY 스냅샷 조회
@@ -557,114 +677,142 @@ start_lobby.lua
     ├── lobby:{code}.status = PLAYING
     └── lobby:public에서 code 제거
     ▼
-DB GAME_LOBBY.status = PLAYING 저장
-    ▼
-afterCommit
-    ├── /topic/lobby/{code}/game → GAME_STARTED
-    └── /topic/game/{code}/round → RoundStartDto
-```
-
-`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.  
-트랜잭션 동기화가 비활성인 경우 즉시 발행하지 않고 서버 오류로 처리하여 DB 커밋 전 이벤트 발행을 방지합니다.
-
----
-
-## 게임 세션 및 라운드 시작 흐름
-
-```text
-클라이언트 (방장)
-    │ POST /api/lobbies/{code}/start
-    ▼
-LobbyStartService
-    │ Redis 로비 상태 검증 및 PLAYING 변경
-    │ DB 트랜잭션 시작
-    │ DB 로비 상태 PLAYING 변경
-    │ GameSessionCreateService 호출
-    ▼
-GameSessionCreateService
-    │ 1. MapItem 조회 및 셔플
-    │ 2. DB GameSession, GameSessionPlayer 스냅샷 생성
-    │ 3. init_game_session.lua 로 Redis 인게임 세션 데이터 초기화
-    │ 4. 첫 라운드 정보(RoundStartDto) 반환
-    ▼
-DB Commit 완료
-    ▼
-GameRealtimeNotifier / LobbyRealtimeNotifier
-    │ 1. /topic/lobby/{code}/game 으로 GAME_STARTED 브로드캐스트
-    │ 2. /topic/game/{code}/round 로 첫 번째 라운드 RoundStartDto 브로드캐스트
+LobbyService
+    │ DB GAME_LOBBY.status = PLAYING 저장
+    │ afterCommit에서 GAME_STARTED / REFRESH_LOBBY_INFO 브로드캐스트 등록
     ▼
 클라이언트
-    │ 게임 화면 전환 및 YouTube IFrame API 재생
+    │ /topic/lobby/{code}/game에서 GAME_STARTED 수신
+    ▼
+인게임 화면 전환
 ```
 
-### 트랜잭션-웹소켓 동기화
-
-DB 커밋 전에 웹소켓 이벤트가 발송되면 클라이언트가 아직 DB에 반영되지 않은 상태를 조회할 수 있습니다.  
-이를 방지하기 위해 `afterCommit` 훅을 사용합니다.
-
-### 보상 트랜잭션
-
-게임 세션 생성이나 Redis 스크립트 실행 중 예외가 발생하면 DB 트랜잭션은 롤백되며, 로비 상태도 `WAITING`으로 복구합니다.  
-Redis 롤백까지 실패한 경우 재처리 큐에 적재합니다.
+`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.
+트랜잭션 동기화가 비활성인 경우 즉시 발행하지 않고 서버 오류로 처리하여 DB 커밋 전 이벤트 발행을 방지합니다.
 
 ---
 
 ## 🗄️ Redis 데이터 구조
 
-| 키 패턴 | 타입 | 설명 |
-| --- | --- | --- |
-| `lobby:{code}` | Hash | 로비 메타 정보 |
-| `lobby:{code}:participants` | Set | 로비 참여자 식별자 목록 |
-| `lobby:{code}:ready` | Set | ready 상태인 로비 참여자 userIdentifier 목록 |
-| `lobby:{code}:order` | List | 입장 순서 |
-| `lobby:{code}:kicked` | Set | 강퇴된 사용자 식별자 목록 |
-| `lobby:{code}:user_session:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID |
-| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence |
-| `lobby:public` | Set | 공개 로비 코드 목록 |
-| `lobby:public:latest` | ZSET | 공개 로비 최신순 정렬 인덱스 |
-| `lobby:public:most_players` | ZSET | 공개 로비 현재 인원순 정렬 인덱스 |
-| `lobby:public:most_available` | ZSET | 공개 로비 빈자리순 정렬 인덱스 |
-| `lobby:start:reconciliation` | List | 게임 시작 Redis-DB 상태 불일치 재처리 큐 |
-| `auth:guest:session:{token}` | Hash | 게스트 세션 정보 |
-| `auth:refresh:{sessionId}` | String | Refresh Token |
-| `user_status:{userIdentifier}` | String | 사용자 온라인 상태 |
-| `user_status:{userIdentifier}:sessions` | Set | 사용자별 활성 WebSocket 세션 목록 |
-| `ws:connection:{wsSessionId}` | Hash | WebSocket 세션 → userId, lobbyCode 매핑 |
-| `map:public:list:v:{version}:p:{page}:s:{size}` | String | 공개 맵 목록 페이지 캐시 |
-| `map:public:{mapId}` | String | 공개 맵 단건 캐시 |
-| `map:public:list:version` | String | 공개 맵 목록 캐시 버전 |
+| 키 패턴                                             | 타입     | 설명                                                                        |
+| ------------------------------------------------ | ------ | ------------------------------------------------------------------------- |
+| `lobby:{code}`                                   | Hash   | 로비 메타 정보 (title, status, host_user_id, map_id, map_title, map_category 등) |
+| `lobby:{code}:participants`                      | Set    | 로비 참여자 식별자 목록                                                             |
+| `lobby:{code}:ready`                             | Set    | ready 상태인 로비 참여자 userIdentifier 목록                                        |
+| `lobby:{code}:order`                             | List   | 입장 순서 (방장 위임 시 LINDEX 0 사용)                                               |
+| `lobby:{code}:kicked`                            | Set    | 강퇴된 사용자 식별자 목록                                                            |
+| `lobby:{code}:user_session:{userIdentifier}`     | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID                                        |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence                                  |
+| `lobby:public`                                   | Set    | 공개 로비 코드 목록 (고속 필터링용)                                                     |
+| `lobby:start:reconciliation`                     | List   | 게임 시작 Redis-DB 상태 불일치 재처리 큐                                               |
+| `metric:lobby:start:reconciliation:enqueued`     | String | 게임 시작 상태 재처리 큐 적재 횟수                                                      |
+| `metric:lobby:start:reconciliation:success`      | String | 게임 시작 상태 재처리 성공 횟수                                                        |
+| `metric:lobby:start:reconciliation:failed`       | String | 게임 시작 상태 재처리 실패 횟수                                                        |
+| `metric:lobby:start:unknown-result`              | String | `start_lobby.lua` 알 수 없는 반환값 발생 횟수                                        |
+| `metric:lobby:ready:stale-cleanup`               | String | 게임 시작 전 stale ready 데이터 정리 횟수                                             |
+| `metric:lobby:ready:consistency-failure`         | String | 게임 시작 실패 시 ready/participants/session 정합성 진단 발생 횟수                        |
+| `auth:guest:session:{token}`                     | Hash   | 게스트 세션 정보 (userId, username, userType, TTL 30일)                           |
+| `auth:refresh:{sessionId}`                       | String | Refresh Token (TTL 30일)                                                   |
+| `user_status:{userIdentifier}`                   | String | 사용자 온라인 상태 (`ONLINE`, TTL 2시간)                                            |
+| `user_status:{userIdentifier}:sessions`          | Set    | 사용자별 활성 WebSocket 세션 목록                                                   |
+| `ws:connection:{wsSessionId}`                    | Hash   | WebSocket 세션 → userId, lobbyCode 매핑                                       |
+| `map:public:list:v:{version}:p:{page}:s:{size}`  | String | 공개 맵 목록 페이지 캐시                                                            |
+| `map:public:{mapId}`                             | String | 공개 맵 단건 캐시                                                                |
+| `map:public:list:version`                        | String | 공개 맵 목록 캐시 버전                                                             |
 
-> `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`, `start_lobby.lua`와 맞춰 관리해야 합니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
+> ⚠️ `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`, `start_lobby.lua`와 맞춰 관리해야 합니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
 
 ### `lobby:{code}` Hash 구조
 
-| 필드 | 값 예시 | 설명 |
-| --- | --- | --- |
-| `code` | `ABC123` | 로비 초대 코드 |
-| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier |
-| `title` | `K-POP 퀴즈방` | 로비 제목 |
-| `max_players` | `8` | 최대 참여 인원 |
-| `current_players` | `3` | 현재 참여 인원 캐시 |
-| `is_private` | `false` | 비공개 여부 |
-| `status` | `WAITING` | 로비 상태 |
-| `map_id` | `1` | 선택된 맵 ID |
-| `map_title` | `K-POP 2세대` | 선택된 맵 제목 |
-| `map_category` | `kpop` | 선택된 맵 카테고리 원본 값 |
-| `created_at_epoch_millis` | `1778990123456` | Redis TIME 기준 생성 시각 |
+로비 메타 정보는 Redis Hash로 저장합니다.
 
-`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.  
+| 필드             | 값 예시                                   | 설명                                                          |
+| -------------- | -------------------------------------- | ----------------------------------------------------------- |
+| `code`         | `ABC123`                               | 로비 초대 코드                                                    |
+| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier                                        |
+| `title`        | `K-POP 퀴즈방`                            | 로비 제목                                                       |
+| `max_players`  | `8`                                    | 최대 참여 인원                                                    |
+| `is_private`   | `false`                                | 비공개 여부. `true` = 비공개                                        |
+| `status`       | `WAITING`                              | 로비 상태                                                       |
+| `map_id`       | `1`                                    | 선택된 맵 ID                                                    |
+| `map_title`    | `K-POP 2세대`                            | 선택된 맵 제목                                                    |
+| `map_category` | `jpop`                                 | 선택된 맵 카테고리 원본 값. HTTP 응답 시 `K-POP`, `J-POP`, `POP` 형식으로 정규화 |
+
+`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.
 맵이 선택되지 않은 로비는 위 세 필드를 저장하지 않습니다.
 
----
+Redis에 `"null"` 문자열을 저장하지 않고, 응답 DTO에서만 `null`로 표현합니다.
 
-## 로비 ready 상태 저장 구조
+### Redis Hash 필드 상수 (`RedisKeys.FIELD_*`)
+
+로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.
+문자열 리터럴 직접 사용 시 오타가 런타임에서야 발견되는 문제를 컴파일 타임에 방지합니다.
+
+로비 맵 연결 기능에서 사용하는 주요 필드는 다음과 같습니다.
+
+| 필드 상수                | Redis Hash 필드명 | 설명                |
+| -------------------- | -------------- | ----------------- |
+| `FIELD_MAP_ID`       | `map_id`       | 선택된 맵 ID          |
+| `FIELD_MAP_TITLE`    | `map_title`    | 선택된 맵 제목          |
+| `FIELD_MAP_CATEGORY` | `map_category` | 선택된 맵 카테고리        |
+| `FIELD_STATUS`       | `status`       | 로비 상태             |
+| `FIELD_HOST_USER_ID` | `host_user_id` | 방장 userIdentifier |
+
+맵 미선택 로비에서는 맵 관련 필드를 저장하지 않습니다.
+
+### WebSocket 로비 입장 저장 구조
+
+로비 입장 상태는 `enter_lobby.lua`에서 원자적으로 저장합니다.
+
+| 키 패턴                                             | 타입     | 저장 시점                      | 설명                                                      |
+| ------------------------------------------------ | ------ | -------------------------- | ------------------------------------------------------- |
+| `lobby:{code}:participants`                      | Set    | `/topic/lobby/{code}` 구독 시 | 현재 로비에 참여 중인 userIdentifier 목록                          |
+| `lobby:{code}:order`                             | List   | `/topic/lobby/{code}` 구독 시 | 입장 순서. 방장 퇴장 시 다음 방장 위임 기준                              |
+| `lobby:{code}:user_session:{userIdentifier}`     | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 wsSessionId                                |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 세션 sequence                                |
+| `ws:connection:{wsSessionId}`                    | Hash   | `/topic/lobby/{code}` 구독 시 | WebSocket 세션 ID로 userIdentifier와 lobbyCode를 역추적하기 위한 매핑 |
+
+`ws:connection:{wsSessionId}` Hash 필드:
+
+| 필드          | 값                | 설명                             |
+| ----------- | ---------------- | ------------------------------ |
+| `userId`    | `userIdentifier` | Redis/WebSocket에서 사용하는 사용자 식별자 |
+| `lobbyCode` | `{code}`         | 현재 WebSocket 세션이 참여 중인 로비 코드   |
+
+정상 저장 예시:
+
+```redis
+SMEMBERS lobby:R2VJW5:participants
+1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
+
+LRANGE lobby:R2VJW5:order 0 -1
+1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
+
+GET lobby:R2VJW5:user_session:9746cc76-f8f2-4859-b602-df6e1032fea4
+"mhrg4it0"
+
+GET lobby:R2VJW5:user_session_seq:9746cc76-f8f2-4859-b602-df6e1032fea4
+"1"
+
+HGETALL ws:connection:mhrg4it0
+1) "userId"
+2) "9746cc76-f8f2-4859-b602-df6e1032fea4"
+3) "lobbyCode"
+4) "R2VJW5"
+```
+
+중복 구독 시 `participants`는 Set 구조로 중복 저장되지 않으며, `order` List도 `enter_lobby.lua`에서 신규 입장자일 때만 `RPUSH`하여 중복 저장을 방지합니다.
+
+### 로비 ready 상태 저장 구조
+
+로비 참여자의 ready 상태는 Redis Set으로 관리합니다.
 
 ```text
 lobby:{code}:ready
 ```
 
-| 키 패턴 | 타입 | 설명 |
-| --- | --- | --- |
+| 키 패턴                 | 타입  | 설명                                  |
+| -------------------- | --- | ----------------------------------- |
 | `lobby:{code}:ready` | Set | ready 상태인 일반 참여자의 userIdentifier 목록 |
 
 정책:
@@ -686,31 +834,92 @@ ready 상태는 `canStart` 계산과 `start_lobby.lua`의 최종 시작 조건 �
 
 ### Java 21 Virtual Thread + Lettuce
 
-가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 Lettuce를 사용합니다.
+가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 **Lettuce**를 사용합니다.
+Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,
+Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
 
-Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝할 수 있으나, Lettuce는 Netty 기반 비동기 드라이버로 핀닝 위험을 줄입니다.
+### 로비 생성 시 맵 연결 정책
 
-### Redis Pub/Sub + WebSocket 브로드캐스트
-
-멀티 인스턴스 환경에서는 특정 서버에 연결된 WebSocket 세션만 로컬 메모리에 존재합니다.
-
-따라서 로비 채팅, ENTER, LEAVE, KICK 등 실시간 메시지는 Redis Pub/Sub으로 발행한 뒤 각 서버의 `RedisSubscriber`가 자기 서버에 연결된 클라이언트에게 브로드캐스트합니다.
+로비 생성 시 `mapId`는 선택 사항입니다.
 
 ```text
-Server A
-    │ RedisPublisher.publish()
-    ▼
-Redis Pub/Sub
-    ├── Server A RedisSubscriber → local clients
-    ├── Server B RedisSubscriber → local clients
-    └── Server C RedisSubscriber → local clients
+로비 생성: mapId 선택 사항
+게임 시작: mapId 필수
 ```
 
-### Lua 스크립트 기반 원자 처리
+이 구조를 선택한 이유는 로비가 게임 시작 전 대기실 역할을 하기 때문입니다.
+방장은 먼저 로비를 만들고 참여자를 모은 뒤, 로비 내부에서 맵을 선택하거나 변경할 수 있습니다.
 
-로비 생성, 입장, 퇴장, 강퇴, 시작은 Redis Lua 스크립트로 원자 처리합니다.
+`mapId`가 전달된 경우 `LobbyService`에서 다음 순서로 검증합니다.
 
-Java에서 Redis 명령을 여러 번 나누어 실행하면 중간 실패 시 상태 불일치가 발생할 수 있습니다.
+```text
+1. 맵 존재 여부 확인
+2. 삭제된 맵 여부 확인
+3. 공개 맵이면 허용
+4. 비공개 맵이면 소유자만 허용
+```
+
+검증 결과에 따른 HTTP 상태 코드는 다음과 같습니다.
+
+| 상황                  | 상태 코드           |
+| ------------------- | --------------- |
+| 존재하지 않는 맵           | `404 Not Found` |
+| 삭제된 맵               | `409 Conflict`  |
+| 타인 소유 비공개 맵         | `403 Forbidden` |
+| 공개 맵 또는 본인 소유 비공개 맵 | 로비 생성 허용        |
+
+검증이 끝난 맵 정보는 `LobbyMapMetadata`로 변환하여 Redis 저장 계층에 전달합니다.
+이를 통해 `LobbyRepositoryImpl`이 `QuizMap` 엔티티에 직접 의존하지 않도록 분리합니다.
+
+### Lua 스크립트 기반 원자적 로비 생성
+
+`create_lobby.lua`는 초대 코드 선점과 로비 Hash 저장을 원자적으로 처리합니다.
+
+처리 대상:
+
+```text
+lobby:code:lock:{code}
+lobby:{code}
+lobby:public
+```
+
+로비 생성 시 아래 정보를 저장합니다.
+
+```text
+code
+host_user_id
+title
+max_players
+is_private
+status
+```
+
+이슈 #62 이후 선택된 맵이 있는 경우 아래 필드도 같은 Lua 스크립트 안에서 함께 저장합니다.
+
+```text
+map_id
+map_title
+map_category
+```
+
+맵 미선택 로비의 경우 Java에서 빈 문자열을 전달하고, Lua 스크립트는 `mapId`가 빈 문자열이면 맵 관련 필드를 저장하지 않습니다.
+이 방식으로 Redis Hash에 `"null"` 문자열이 저장되는 것을 방지합니다.
+
+### Lua 스크립트 기반 원자적 입장 처리
+
+`enter_lobby.lua`는 WebSocket 로비 입장 시 필요한 Redis 상태 변경을 단일 원자 연산으로 처리합니다.
+
+처리 대상:
+
+```text
+lobby:{code}:participants
+lobby:{code}:order
+lobby:{code}:user_session:{userIdentifier}
+lobby:{code}:user_session_seq:{userIdentifier}
+ws:connection:{wsSessionId}
+```
+
+Java 코드에서 위 Redis 명령을 개별적으로 실행하면 중간 실패 시 다음과 같은 상태 불일치가 발생할 수 있습니다.
 
 ```text
 participants에는 추가됐지만 order에는 없음
@@ -718,11 +927,123 @@ order에는 추가됐지만 ws:connection 매핑이 없음
 ws:connection은 있지만 participants에는 없음
 ```
 
-이를 방지하기 위해 상태 변경을 Lua 내부에서 하나의 원자 연산으로 처리합니다.
+이를 방지하기 위해 `enter_lobby.lua`에서 아래 작업을 한 번에 수행합니다.
 
----
+```text
+1. lobby:{code} 존재 여부 확인
+2. participants Set에 userIdentifier 추가
+3. 신규 입장자인 경우에만 order List에 userIdentifier 추가
+4. ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
+5. 로비 내 유저별 현재 유효 wsSessionId 저장
+6. 로비 내 유저별 현재 유효 세션 sequence 저장
+7. 관련 키 TTL 설정
+```
 
-## 게임 시작 Redis-DB 상태 불일치 재처리
+반환값은 다음과 같습니다.
+
+| 반환값                         | 의미                                 |
+| --------------------------- | ---------------------------------- |
+| `ENTERED:{sequence}`        | 신규 입장 처리 완료                        |
+| `ALREADY_JOINED:{sequence}` | 이미 참여 중인 유저의 중복 구독. order 중복 저장 없음 |
+| `LOBBY_NOT_FOUND`           | 존재하지 않는 로비 코드로 구독 요청               |
+
+입장 처리는 반드시 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
+`/topic/lobby/{code}/refresh`는 입장 처리를 트리거하지 않습니다.
+
+### Lua 스크립트 기반 원자적 퇴장 처리
+
+`leave_lobby.lua`는 참여자 제거 → 방장 위임 → 로비 폭파를 단일 트랜잭션으로 처리합니다.
+Redis는 싱글 스레드로 Lua 스크립트를 실행하므로 다수의 동시 퇴장 시에도 Race Condition이 발생하지 않습니다.
+
+반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,
+`LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여
+서비스 레이어가 Redis 반환 포맷을 알 필요 없도록 캡슐화합니다.
+
+### Lua 스크립트 기반 원자적 강퇴 처리
+
+`kick_lobby.lua`는 방장의 강퇴 요청을 원자적으로 처리합니다.
+
+처리 대상:
+
+```text
+lobby:{code}
+lobby:{code}:participants
+lobby:{code}:order
+lobby:{code}:kicked
+lobby:{code}:user_session:{targetUserIdentifier}
+lobby:{code}:user_session_seq:{targetUserIdentifier}
+```
+
+처리 순서:
+
+```text
+1. 로비 존재 여부 확인
+2. 방장 정보 존재 여부 확인
+3. 요청자가 방장인지 검증
+4. 자기 자신 강퇴 요청인지 검증
+5. 강퇴 대상이 참여자인지 검증
+6. participants/order에서 강퇴 대상 제거
+7. kicked Set에 강퇴 대상 추가
+8. 강퇴 대상의 현재 wsSessionId 반환
+9. 강퇴 대상의 user_session / user_session_seq 키 삭제
+```
+
+반환값은 다음과 같습니다.
+
+| 반환값                          | 의미                |
+| ---------------------------- | ----------------- |
+| `KICKED:{targetWsSessionId}` | 강퇴 성공             |
+| `LOBBY_NOT_FOUND`            | 존재하지 않는 로비        |
+| `HOST_NOT_FOUND`             | 로비 방장 정보 없음       |
+| `FORBIDDEN`                  | 요청자가 방장이 아님       |
+| `CANNOT_KICK_SELF`           | 자기 자신 강퇴 시도       |
+| `TARGET_NOT_PARTICIPANT`     | 강퇴 대상이 로비 참여자가 아님 |
+
+강퇴 성공 후 `LobbyEventService`는 `KICK` 메시지를 로비 채팅 채널로 브로드캐스트하고, 로비 내부 refresh 이벤트를 발행합니다.
+
+### Lua 스크립트 기반 원자적 게임 시작 처리
+
+`start_lobby.lua`는 게임 시작 조건 중 Redis 기준으로 원자 검증 가능한 조건을 처리합니다.
+
+처리 대상:
+
+```text
+lobby:{code}
+lobby:{code}:participants
+lobby:{code}:ready
+lobby:public
+```
+
+검증 조건:
+
+```text
+1. 로비가 존재해야 한다.
+2. 방장 정보가 존재해야 한다.
+3. 요청자가 방장이어야 한다.
+4. 로비 상태가 WAITING이어야 한다.
+5. map_id가 존재해야 한다.
+6. 방장 제외 참여자가 1명 이상이어야 한다.
+7. 방장 제외 참여자의 활성 로비 세션 키가 존재해야 한다.
+8. 방장 제외 모든 참여자가 ready 상태여야 한다.
+```
+
+반환값 계약은 `StartLobbyLuaResultCode` enum과 `StartLobbyLuaResultCodeContractTest`로 고정합니다.
+
+| 반환값                                  | 의미                                             |
+| ------------------------------------ | ---------------------------------------------- |
+| `STARTED`                            | 게임 시작 성공                                       |
+| `LOBBY_NOT_FOUND`                    | 로비 없음                                          |
+| `HOST_NOT_FOUND`                     | 방장 정보 없음                                       |
+| `FORBIDDEN`                          | 요청자가 방장이 아님                                    |
+| `LOBBY_NOT_WAITING`                  | 로비 상태가 WAITING이 아님                             |
+| `MAP_NOT_SELECTED`                   | 맵이 선택되지 않음                                     |
+| `NO_PLAYER`                          | 방장 제외 참여자 없음                                   |
+| `NOT_READY:{userIdentifier}`         | 준비하지 않은 참여자 존재                                 |
+| `STALE_PARTICIPANT:{userIdentifier}` | participants에는 있지만 활성 로비 세션 키가 없는 stale 참여자 존재 |
+
+알 수 없는 반환값 또는 `null` 반환값은 generic error로 처리하고, `[MONITORING_REQUIRED]` 로그와 metric을 남깁니다.
+
+### 게임 시작 Redis-DB 상태 불일치 재처리
 
 게임 시작은 Redis Lua가 먼저 원자 검증 및 Redis 상태 전환을 수행하고, 이후 DB `GAME_LOBBY` 상태를 `PLAYING`으로 동기화합니다.
 
@@ -759,92 +1080,365 @@ lobbyCode|reason|attempt|nextRetryAtEpochMillis
 
 재처리 사유:
 
-| reason | 보정 정책 |
-| --- | --- |
-| `START_DB_SYNC_FAILED` | Redis 상태를 `WAITING`으로 롤백 |
+| reason                        | 보정 정책                       |
+| ----------------------------- | --------------------------- |
+| `START_DB_SYNC_FAILED`        | Redis 상태를 `WAITING`으로 롤백    |
+| `START_DB_SNAPSHOT_NOT_FOUND` | DB 스냅샷이 없으므로 Redis 잔존 로비 삭제 |
+
+운영 모니터링 대상:
+
+| 항목                                           | 설명               |
+| -------------------------------------------- | ---------------- |
+| `lobby:start:reconciliation`                 | 재처리 큐 길이         |
+| `[ALERT_REQUIRED]`                           | 즉시 운영 확인이 필요한 로그 |
+| `[MONITORING_REQUIRED]`                      | 모니터링 연계가 필요한 로그  |
+| `metric:lobby:start:reconciliation:enqueued` | 재처리 큐 적재 횟수      |
+| `metric:lobby:start:reconciliation:success`  | 재처리 성공 횟수        |
+| `metric:lobby:start:reconciliation:failed`   | 재처리 실패 횟수        |
+
+### ready / participants 정합성 보정 정책
+
+게임 시작 조건은 `participants`, `ready`, `user_session` 키의 정합성에 영향을 받습니다.
+
+정책:
+
+```text
+1. participants Set을 현재 로비 참여자의 source of truth로 사용한다.
+2. ready Set에는 있지만 participants Set에는 없는 값은 stale ready 데이터로 보고 게임 시작 직전에 제거한다.
+3. participants Set에는 있지만 user_session 키가 없는 값은 stale participant로 보고 게임 시작을 거부한다.
+4. participants Set에 있고 user_session 키도 있지만 ready가 아닌 값은 실제 미준비 유저로 보고 NOT_READY 처리한다.
+5. NOT_READY 또는 STALE_PARTICIPANT 발생 시 ready/participants/session 정합성 진단 로그를 남긴다.
+```
+
+이 정책은 정상 참여자를 임의 삭제하지 않기 위한 선택입니다.
+participants에 남아 있는 유저가 실제 미준비 유저인지 stale 유저인지 Lua 내부에서 완전히 판단하기 어렵기 때문에, user_session 키가 없는 경우만 `STALE_PARTICIPANT`로 분리합니다.
+
+### Redis 직렬화 JsonMapper와 HTTP 응답 JsonMapper 분리
+
+RedisTemplate은 타입 정보가 필요한 `GenericJacksonJsonRedisSerializer`를 사용합니다.
+기존처럼 타입 정보가 포함된 `JsonMapper`를 Spring Bean으로 노출하면 Spring MVC HTTP 응답 직렬화에 해당 Mapper가 개입할 수 있습니다.
+
+그 결과 REST 응답이 아래처럼 Jackson 타입 정보를 포함하는 형태로 내려갈 수 있습니다.
+
+```json
+[
+  "java.util.ArrayList",
+  [
+    [
+      "io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto",
+      {
+        "code": "ABC123",
+        "title": "K-POP 퀴즈방"
+      }
+    ]
+  ]
+]
+```
+
+이를 방지하기 위해 Redis 전용 JsonMapper는 `RedisConfig#createRedisJsonMapper()` private 메서드 내부에서만 생성합니다.
+
+정책:
+
+```text
+1. RedisTemplate 값 직렬화:
+   - 타입 정보 포함 JsonMapper 사용
+   - Spring Bean으로 노출하지 않음
+
+2. Pub/Sub 메시지 직렬화:
+   - 타입 정보 없는 pubSubJsonMapper Bean 사용
+
+3. HTTP 응답 직렬화:
+   - Redis 직렬화용 JsonMapper가 개입하지 않음
+   - 순수 DTO JSON 배열로 반환
+```
+
+기존 `jsonMapper` Bean 직접 주입 사용처는 없어야 하며, JsonMapper가 필요한 신규 코드에서는 목적에 맞는 Bean을 명시적으로 주입해야 합니다.
+
+### ChatMessageDto 위치
+
+`ChatMessageDto`는 채팅 도메인 전용 객체가 아닌 WebSocket 통신 전반에서 사용되는 메시지 포맷입니다.
+`domain/chat/dto`가 아닌 `global/websocket/dto`에 위치하여
+`global` 레이어의 `RedisPublisher`, `RedisSubscriber`, `WebSocketEventListener`가
+`domain`을 역참조하는 의존 방향 역전을 방지합니다.
+
+### Redis Pub/Sub 직렬화 분리
+
+Redis Pub/Sub 메시지는 WebSocket 클라이언트에게 그대로 전달될 수 있으므로, 일반 Redis 객체 저장용 `RedisTemplate<String, Object>`와 분리하여 처리합니다.
+
+#### 일반 Redis 데이터 저장
+
+`RedisTemplate<String, Object>`는 Redis Hash/Value에 객체 타입 정보를 보존하기 위해 `GenericJacksonJsonRedisSerializer`와 `activateDefaultTyping`을 사용합니다.
+
+사용 예:
+
+```text
+lobby:{code}
+auth:guest:session:{token}
+```
+
+#### Pub/Sub 메시지 발행
+
+Pub/Sub 메시지는 `StringRedisTemplate`과 Pub/Sub 전용 `JsonMapper`를 사용합니다.
+
+이유:
+
+```text
+RedisTemplate<String, Object>로 ChatMessageDto를 발행하면
+WebSocket 클라이언트가 ["클래스명", {...}] 형태의 메시지를 받게 됨
+```
+
+기존 문제 형태:
+
+```json
+["io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto",{"type":"ENTER","roomId":"R2VJW5"}]
+```
+
+수정 후 형태:
+
+```json
+{"type":"ENTER","roomId":"R2VJW5","sender":"...","content":"...","timestamp":"..."}
+```
+
+`RedisSubscriber`는 Pub/Sub 메시지를 DTO로 역직렬화하지 않고, JSON 문자열 그대로 `SimpMessagingTemplate.convertAndSend()`로 WebSocket 클라이언트에게 전달합니다.
+
+### 참여자 키 단일 진실의 원천
+
+기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로
+동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.
+
+`lobby:{code}:participants`를 단일 진실의 원천으로 통일하여
+입장(Lua) → 퇴장(Lua) → 강퇴(Lua) → ready/start 검증 모두 동일한 키를 사용합니다.
+
+### SETNX 기반 초대 코드 중복 방지
+
+`LobbyRepositoryImpl`은 6자리 초대 코드를 생성할 때
+`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.
+선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`까지 재시도합니다.
+
+락 TTL은 `LobbyDefaults.INVITE_CODE_LOCK_TTL`을 따르며, 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
+
+### JWT 인증 구조
+
+`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.
+파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.
+컨트롤러에서는 `@AuthenticationPrincipal CustomPrincipal`로 주입받아 사용합니다.
+
+[식별자 분리]
+
+* `userId` (Long) : DB users.id FK 참조용
+* `userIdentifier` (UUID String) : Redis/WebSocket 식별자
 
 ---
 
-## 운영 및 관측성 기준
+## 🌐 STOMP 채널 구조
 
-### WebSocket Metric
+| 방향         | 경로                            | 설명                          |
+| ---------- | ----------------------------- | --------------------------- |
+| 클라이언트 → 서버 | `/app/chat/global`            | 전체 채팅 메시지 송신                |
+| 클라이언트 → 서버 | `/app/chat/lobby/{code}`      | 로비 채팅 메시지 송신                |
+| 클라이언트 → 서버 | `/app/lobby/create`           | 로비 생성 이벤트 송신                |
+| 클라이언트 → 서버 | `/app/lobby/{code}/update`    | 로비 정보 변경 이벤트 송신             |
+| 클라이언트 → 서버 | `/app/lobby/{code}/kick`      | 방장의 로비 유저 강퇴 요청             |
+| 서버 → 클라이언트 | `/topic/chat/global`          | 전체 채팅 메시지 수신                |
+| 서버 → 클라이언트 | `/topic/lobby/{code}`         | 로비 채팅 메시지 수신 및 로비 입장 처리 트리거 |
+| 서버 → 클라이언트 | `/topic/lobby/{code}/refresh` | 로비 내부 정보 새로고침 신호            |
+| 서버 → 클라이언트 | `/topic/lobby/{code}/game`    | 게임 시작 이벤트 (`GAME_STARTED`)  |
+| 서버 → 클라이언트 | `/topic/lobby/refresh`        | 전역 로비 리스트 새로고침 신호           |
 
-`WebSocketMetric`은 활성 WebSocket 세션 수를 Prometheus에 노출합니다.
-
-```text
-CONNECT 성공 → increment
-DISCONNECT 처리 → decrement
-```
-
-### Redis 장애 처리
-
-Redis는 로비/세션/실시간 동기화의 핵심 저장소입니다.  
-Redis 장애는 대부분 실시간 기능 장애로 이어지므로 다음 기준을 따릅니다.
-
-| 영역 | 장애 처리 |
-| --- | --- |
-| 인증 refresh 저장소 | `503 Service Unavailable` |
-| WebSocket CONNECT 온라인 상태 저장 실패 | STOMP ERROR `CONNECT_ONLINE_STATUS_FAILED` |
-| 로비 입장 Lua 실패 | STOMP ERROR `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` |
-| Pub/Sub 발행 실패 | 로컬 WebSocket fallback 또는 로그/관측성 처리 |
-| 게임 시작 Redis-DB 불일치 | 보상 롤백 또는 reconciliation 큐 적재 |
-
-### 로그 기준
-
-로비 상태 정합성에 영향을 주는 오류는 단순 warn으로 묻지 않습니다.
-
-| 상황 | 로그 기준 |
-| --- | --- |
-| Lua 알 수 없는 반환값 | `error` + monitoring required |
-| Redis-DB 게임 시작 불일치 | `error` + reconciliation enqueue |
-| 최대 재시도 초과 | `error` + alert required |
-| stale 세션 disconnect | `info` |
-| 중복 구독 | `info` |
+> `/topic/lobby/{code}`는 로비 채팅 메시지 수신 채널이면서 WebSocket 입장 처리 트리거입니다.
+> `/topic/lobby/{code}/refresh`는 로비 정보 새로고침 신호 수신 전용이며, 입장 처리 트리거가 아닙니다.
 
 ---
 
-## FE 연동 핵심 계약
+## 🔐 인증 구조
 
-### 로비 입장
+### 정식 회원 (Member)
 
-FE는 REST join 성공만으로 사용자를 로비 참여자로 확정하면 안 됩니다.
+로그인 성공 시 JWT를 발급하고 `user_sessions`에 서버 세션 추적 정보를 저장합니다.
+맵 생성, 로비 호스팅 등 전체 기능에 접근할 수 있습니다.
+
+### 게스트 (Guest)
+
+닉네임 입력만으로 진입하며, 백엔드에서 UUID를 발급하여 `localStorage`에 저장합니다.
+재방문 시 UUID로 자동 복원됩니다. 퀴즈 플레이 참여만 가능합니다.
+
+### WebSocket 인증 흐름
 
 ```text
-1. POST /api/lobbies/join
-2. WebSocket CONNECT
-3. SUBSCRIBE /topic/lobby/{code}
-4. SUBSCRIBE 성공 후 GET /api/lobbies/{code}
+STOMP CONNECT 헤더: { userIdentifier: "UUID" }
+    │
+    ▼
+StompChannelInterceptor.handleConnect()
+    │ UUID 형식 검증 (8-4-4-4-12 포맷)
+    │ 세션에 userIdentifier 저장
+    ▼
+이후 모든 STOMP 명령에서 세션의 userIdentifier 검증
 ```
 
-### 로비 목록
+### REST API 인증 흐름
 
-`PLAYING` 로비는 목록에 노출될 수 있으나 입장 버튼은 비활성화해야 합니다.
+```text
+HTTP 요청 (Authorization: Bearer {accessToken})
+    │
+    ▼
+JwtAuthenticationFilter
+    │ 1. Authorization 헤더에서 Bearer 토큰 추출
+    │ 2. JWT 서명 검증 (secretKey)
+    │ 3. userId, userIdentifier, userType 클레임 추출 (JwtClaims 상수)
+    │ 4. CustomPrincipal 생성 → SecurityContext 저장
+    ▼
+Controller
+    │ @AuthenticationPrincipal CustomPrincipal로 주입
+    │ - principal.userId()          → DB Insert FK 용도
+    │ - principal.userIdentifier()  → Redis 저장 식별자 용도
+    ▼
+Service
+```
 
-### 로비 상세
+---
 
-`canStart`는 snapshot 값입니다.  
-실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 최종 검증됩니다.
+## 🧩 로비 생성 시 맵 연결 흐름
 
-### STOMP ERROR
+```text
+클라이언트
+    │ POST /api/lobbies
+    │ Body: { title, maxPlayers, isPrivate, mapId?, roundCount?, timeLimitSeconds? }
+    ▼
+LobbyController.createLobby()
+    │ @AuthenticationPrincipal CustomPrincipal 주입
+    ▼
+LobbyService.createLobby()
+    │ 1. principal 검증
+    │ 2. host User 조회
+    │ 3. mapId가 있으면 QuizMap 조회 및 권한 검증
+    │ 4. LobbyMapMetadata 생성
+    ▼
+LobbyRepository.saveToRedis()
+    │ create_lobby.lua 실행
+    │ 초대 코드 선점 + Redis Hash 저장
+    ▼
+GameLobbyJpaRepository.save()
+    │ GAME_LOBBY 스냅샷 저장
+    ▼
+CreateLobbyResponse 반환
+```
 
-FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
+### 맵 미선택 로비
+
+`mapId`가 없으면 맵 검증을 수행하지 않습니다.
 
 ```json
 {
-  "type": "STOMP_ERROR",
-  "code": "LOBBY_NOT_FOUND",
-  "message": "존재하지 않는 로비입니다.",
-  "action": "RETURN_TO_LOBBY_LIST",
-  "recoverable": false,
-  "timestamp": "2026-05-25T00:00:00Z"
+  "mapId": null,
+  "mapTitle": null,
+  "mapCategory": null
 }
 ```
 
-분기는 다음 기준으로 처리합니다.
+Redis Hash에는 `map_id`, `map_title`, `map_category` 필드를 저장하지 않습니다.
 
-| 필드 | 사용 목적 |
-| --- | --- |
-| `code` | 구체적인 실패 원인 분기 |
-| `action` | 화면 이동/재연결/재시도 정책 |
-| `recoverable` | 같은 화면에서 재시도 가능한지 판단 |
-| `message` | 사용자에게 표시할 문구 |
+### 맵 선택 로비
+
+`mapId`가 있으면 검증 후 Redis Hash와 DB 스냅샷에 반영합니다.
+
+```json
+{
+  "mapId": 1,
+  "mapTitle": "K-POP 2세대",
+  "mapCategory": "K-POP"
+}
+```
+
+Redis Hash에는 아래 필드를 저장합니다.
+
+```text
+map_id
+map_title
+map_category
+```
+
+---
+
+## 🧩 로비 ready 및 게임 시작 흐름
+
+### ready 상태 변경
+
+```text
+클라이언트
+    │ PATCH /api/lobbies/{code}/ready
+    │ Body: { ready: true }
+    ▼
+LobbyController.updateReadyStatus()
+    │ @AuthenticationPrincipal CustomPrincipal 주입
+    ▼
+LobbyService.updateReadyStatus()
+    │ 1. principal 검증
+    │ 2. Redis 로비 존재 여부 확인
+    │ 3. 로비 상태 WAITING 확인
+    │ 4. 참여자 여부 확인
+    │ 5. 방장 ready 요청 차단
+    ▼
+LobbyRepository.updateReadyStatus()
+    │ ready=true  → SADD lobby:{code}:ready userIdentifier
+    │ ready=false → SREM lobby:{code}:ready userIdentifier
+    ▼
+LobbyEventService.notifyLobbyInfoRefresh()
+    │ /topic/lobby/{code}/refresh 로 REFRESH_LOBBY_INFO 브로드캐스트
+```
+
+### canStart 계산
+
+`GET /api/lobbies/{code}` 응답의 `canStart`는 FE의 게임 시작 버튼 활성화 기준입니다.
+
+계산 조건:
+
+```text
+1. Redis 로비 상태가 WAITING
+2. Redis map_id 존재
+3. DB 기준 맵 문제 수가 roundCount 이상
+4. Redis participants 기준 방장 제외 참여자 1명 이상
+5. Redis ready Set 기준 방장 제외 모든 참여자가 ready
+```
+
+`canStart`는 조회 시점의 snapshot입니다.
+실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 `start_lobby.lua`가 최종 검증합니다.
+
+---
+
+## 🧪 주요 검증 시나리오
+
+### 로비 생성
+
+| 시나리오                       | 기대 결과                      |
+| -------------------------- | -------------------------- |
+| `mapId` 없이 로비 생성           | `201 Created`, 맵 정보 `null` |
+| 공개 맵 `mapId`로 로비 생성        | `201 Created`, 맵 정보 포함     |
+| 본인 소유 비공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함     |
+| 타인 소유 비공개 맵 `mapId`로 로비 생성 | `403 Forbidden`            |
+| 삭제된 맵 `mapId`로 로비 생성       | `409 Conflict`             |
+| 존재하지 않는 `mapId`로 로비 생성     | `404 Not Found`            |
+| 음수 또는 0 `mapId`로 로비 생성     | `400 Bad Request`          |
+
+### Redis 저장
+
+| 시나리오     | 기대 결과                                       |
+| -------- | ------------------------------------------- |
+| 맵 미선택 로비 | `map_id`, `map_title`, `map_category` 필드 없음 |
+| 맵 선택 로비  | `map_id`, `map_title`, `map_category` 필드 있음 |
+| 맵 미선택 로비 | `"null"` 문자열 저장 없음                          |
+| ready 변경 | `lobby:{code}:ready` Set 추가/삭제              |
+| 퇴장/강퇴    | ready Set에서 해당 userIdentifier 제거            |
+
+### 로비 상세 / ready / start
+
+| 시나리오                                | 기대 결과                                                |
+| ----------------------------------- | ---------------------------------------------------- |
+| 로비 상세 조회                            | 참여자 목록, ready 상태, canStart 반환                        |
+| 방장이 ready 요청                        | `400 Bad Request`                                    |
+| 일반 참여자가 ready 요청                    | `204 No Content`, refresh 브로드캐스트                     |
+| canStart=true 상태에서 start 요청         | `204 No Content`, `GAME_STARTED` 브로드캐스트              |
+| ready 미완료 상태에서 start 요청             | `409 Conflict`                                       |
+| 맵 미선택 상태에서 start 요청                 | `409 Conflict`                                       |
+| 맵 문제 수 부족 상태에서 start 요청             | `409 Conflict`                                       |
+| stale participant가 있는 상태에서 start 요청 | `409 Conflict`, ready/participants/session 정합성 로그 기록 |
+| Redis Lua 성공 후 DB 동기화 실패            | Redis rollback 또는 reconciliation queue 적재            |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,135 +12,139 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   └── AuthController.java                 # REST 인증 엔드포인트 (/api/auth/**)
 │   │   ├── dto/
 │   │   │   ├── GuestLoginRequest.java              # 게스트 로그인 요청 DTO
-│   │   │   ├── GuestLoginResponse.java             # 게스트 로그인 응답 DTO (JWT 포함)
+│   │   │   ├── GuestLoginResponse.java             # 게스트 로그인 응답 DTO
 │   │   │   ├── LoginRequest.java                   # 자체 로그인 요청 DTO
-│   │   │   └── LoginResponse.java                  # 자체 로그인 응답 DTO (JWT + 세션 식별자)
+│   │   │   └── LoginResponse.java                  # 자체 로그인 응답 DTO
 │   │   ├── entity/
-│   │   │   ├── User.java                           # 사용자 엔티티 (게스트/회원 통합)
-│   │   │   ├── GuestSession.java                   # 게스트 세션 엔티티
-│   │   │   ├── UserCredential.java                 # 회원 인증정보 엔티티
-│   │   │   └── UserSession.java                    # 회원 세션 엔티티
+│   │   │   ├── User.java
+│   │   │   ├── GuestSession.java
+│   │   │   ├── UserCredential.java
+│   │   │   └── UserSession.java
 │   │   ├── repository/
 │   │   │   ├── UserRepository.java
 │   │   │   ├── GuestSessionRepository.java
 │   │   │   ├── UserCredentialRepository.java
 │   │   │   └── UserSessionRepository.java
 │   │   └── service/
-│   │       ├── GuestAuthService.java               # 게스트 로그인/세션 발급 로직
-│   │       ├── RegisterAuthService.java            # 회원가입 로직
-│   │       └── LoginAuthService.java               # 자체 로그인/잠금 정책/세션 발급 로직
+│   │       ├── GuestAuthService.java
+│   │       ├── RegisterAuthService.java
+│   │       └── LoginAuthService.java
 │   │
 │   ├── chat/                                       # 채팅 도메인
 │   │   ├── controller/
-│   │   │   └── ChatController.java                 # STOMP 채팅 메시지 수신 및 라우팅
+│   │   │   └── ChatController.java
 │   │   └── service/
-│   │       └── ChatService.java                    # 채팅 메시지 처리 및 발행
+│   │       └── ChatService.java
 │   │
 │   ├── lobby/                                      # 로비 도메인
-│   │   ├── KickLobbyResult.java                    # 강퇴 처리 결과 (sealed interface)
-│   │   ├── LeaveLobbyResult.java                   # 퇴장 처리 결과 (sealed interface)
-│   │   ├── StartLobbyResult.java                   # 게임 시작 처리 결과 (sealed interface)
-│   │   ├── StartLobbyLuaResultCode.java            # start_lobby.lua 반환 문자열 계약 enum
+│   │   ├── KickLobbyResult.java
+│   │   ├── LeaveLobbyResult.java
+│   │   ├── StartLobbyResult.java
+│   │   ├── StartLobbyLuaResultCode.java
 │   │   ├── controller/
-│   │   │   ├── LobbyCommandController.java         # 로비 생성, 입장 사전 검증, ready, start REST API
-│   │   │   ├── LobbyQueryController.java           # 공개 로비 목록 및 로비 상세 조회 REST API
-│   │   │   └── LobbyEventController.java           # STOMP 로비 이벤트 수신
+│   │   │   ├── LobbyCommandController.java
+│   │   │   ├── LobbyQueryController.java
+│   │   │   └── LobbyEventController.java
 │   │   ├── dto/
-│   │   │   ├── CreateLobbyRequest.java             # 로비 생성 요청 DTO
-│   │   │   ├── CreateLobbyResponse.java            # 로비 생성 응답 DTO
-│   │   │   ├── JoinLobbyRequest.java               # 초대 코드 기반 로비 입장 요청 DTO
-│   │   │   ├── JoinLobbyResponse.java              # 초대 코드 기반 로비 입장 응답 DTO
-│   │   │   ├── KickLobbyPlayerRequest.java         # 로비 유저 강퇴 요청 DTO
-│   │   │   ├── LobbyDetailResponse.java            # 로비 상세 조회 응답 DTO
-│   │   │   ├── LobbyPlayerResponse.java            # 로비 상세 참여자 응답 DTO
-│   │   │   ├── LobbyMapMetadata.java               # Redis 저장용 로비 맵 메타데이터 DTO
-│   │   │   ├── LobbyRedisDto.java                  # 공개 로비 목록 조회 응답 DTO
-│   │   │   ├── LobbySearchCondition.java           # 공개 로비 목록 검색/필터/정렬 조건 DTO
-│   │   │   ├── LobbySortType.java                  # 공개 로비 목록 정렬 기준 enum
-│   │   │   └── UpdateLobbyReadyRequest.java        # ready 상태 변경 요청 DTO
+│   │   │   ├── CreateLobbyRequest.java
+│   │   │   ├── CreateLobbyResponse.java
+│   │   │   ├── JoinLobbyRequest.java
+│   │   │   ├── JoinLobbyResponse.java
+│   │   │   ├── KickLobbyPlayerRequest.java
+│   │   │   ├── LobbyDetailResponse.java
+│   │   │   ├── LobbyPlayerResponse.java
+│   │   │   ├── LobbyMapMetadata.java
+│   │   │   ├── LobbyRedisDto.java
+│   │   │   ├── LobbySearchCondition.java
+│   │   │   ├── LobbySortType.java
+│   │   │   └── UpdateLobbyReadyRequest.java
 │   │   ├── entity/
-│   │   │   ├── GameLobby.java                      # GAME_LOBBY 테이블 엔티티
-│   │   │   ├── LobbyDefaults.java                  # 로비 생성 기본값 및 상수
-│   │   │   └── LobbyStatus.java                    # 로비 상태 열거형 (WAITING, PLAYING, FINISHED)
+│   │   │   ├── GameLobby.java
+│   │   │   ├── LobbyDefaults.java
+│   │   │   └── LobbyStatus.java
 │   │   ├── repository/
-│   │   │   ├── GameLobbyJpaRepository.java         # GAME_LOBBY JPA 리포지토리
-│   │   │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
-│   │   │   ├── LobbyRepositoryImpl.java            # 로비 Repository Facade
+│   │   │   ├── GameLobbyJpaRepository.java
+│   │   │   ├── LobbyRepository.java
+│   │   │   ├── LobbyRepositoryImpl.java
 │   │   │   └── redis/
-│   │   │       ├── LobbyLuaScriptExecutor.java     # 로비 Lua 스크립트 실행 컴포넌트
-│   │   │       ├── LobbyLuaResultMapper.java       # Lua 반환 문자열 → 도메인 결과 매핑
-│   │   │       ├── LobbyRedisCommandRepository.java # Redis 로비 명령 처리
-│   │   │       ├── LobbyRedisQueryRepository.java  # Redis 로비 조회 처리
-│   │   │       └── LobbyStartReconciliationRepository.java # start 상태 불일치 재처리 큐 접근
+│   │   │       ├── LobbyLuaScriptExecutor.java
+│   │   │       ├── LobbyLuaResultMapper.java
+│   │   │       ├── LobbyRedisCommandRepository.java
+│   │   │       ├── LobbyRedisQueryRepository.java
+│   │   │       └── LobbyStartReconciliationRepository.java
 │   │   └── service/
-│   │       ├── LobbyCanStartPolicy.java            # 조회 시점 canStart 계산 정책
-│   │       ├── LobbyCreateService.java             # 로비 생성 유스케이스
-│   │       ├── LobbyJoinService.java               # 초대 코드 기반 입장 사전 검증 유스케이스
-│   │       ├── LobbyQueryService.java              # 로비 목록/상세 조회 유스케이스
-│   │       ├── LobbyReadyService.java              # ready 상태 변경 유스케이스
-│   │       ├── LobbyStartService.java              # 게임 시작 유스케이스
-│   │       ├── LobbyRealtimeNotifier.java          # 로비 refresh/STOMP 브로드캐스트
-│   │       └── LobbyStartReconciliationService.java # 게임 시작 Redis-DB 상태 불일치 재처리 스케줄러
+│   │       ├── LobbyCanStartPolicy.java
+│   │       ├── LobbyCreateService.java
+│   │       ├── LobbyJoinService.java
+│   │       ├── LobbyQueryService.java
+│   │       ├── LobbyReadyService.java
+│   │       ├── LobbyStartService.java
+│   │       ├── LobbyRealtimeNotifier.java
+│   │       └── LobbyStartReconciliationService.java
 │   │
 │   ├── map/                                        # 퀴즈 맵 도메인
 │   │   ├── controller/
-│   │   │   └── MapController.java                  # 맵 REST API
+│   │   │   └── MapController.java
 │   │   ├── dto/
-│   │   │   └── ...                                 # 맵 생성/수정/조회 DTO
+│   │   │   └── ...
 │   │   ├── entity/
-│   │   │   ├── QuizMap.java                        # map 테이블 엔티티
-│   │   │   └── MapCategory.java                    # 맵 카테고리 enum (kpop, jpop, pop)
+│   │   │   ├── QuizMap.java
+│   │   │   └── MapCategory.java
 │   │   ├── repository/
-│   │   │   └── QuizMapJpaRepository.java           # 맵 JPA 리포지토리
+│   │   │   └── QuizMapJpaRepository.java
 │   │   └── service/
-│   │       └── MapService.java                     # 맵 생성/수정/삭제/조회 비즈니스 로직
+│   │       └── MapService.java
 │   │
-│   └── ...
+│   └── game/                                       # 인게임 도메인
+│       ├── controller/
+│       ├── dto/
+│       ├── entity/
+│       ├── repository/
+│       └── service/
 │
 └── global/                                         # 전역 인프라 레이어
-    ├── config/                                     # 애플리케이션 설정
-    │   ├── RedisConfig.java                        # Redis 연결, 직렬화, Pub/Sub 설정
-    │   ├── RedisScriptConfig.java                  # create/enter/leave/kick/start Lua 스크립트 Bean 등록
-    │   ├── SchedulingConfig.java                   # @Scheduled 기반 재처리 작업 활성화
-    │   ├── WebSocketConfig.java                    # STOMP 엔드포인트 및 브로커 설정
+    ├── config/
+    │   ├── RedisConfig.java
+    │   ├── RedisScriptConfig.java
+    │   ├── SchedulingConfig.java
+    │   ├── WebSocketConfig.java
     │   └── SecurityConfig/
-    │       ├── SecurityConfigDev.java              # 개발 환경 (인증 없이 전체 허용)
-    │       └── SecurityConfigProd.java             # 운영 환경 (전체 인증 필요)
     │
-    ├── constant/                                   # 전역 상수 클래스
-    │   ├── RedisKeys.java                          # Redis 키 패턴 및 Hash 필드명 상수
-    │   ├── StompDestinations.java                  # STOMP 송신/구독 경로 상수
-    │   └── WebSocketHeaders.java                   # WebSocket 헤더 키 및 세션 속성 키 상수
+    ├── constant/
+    │   ├── RedisKeys.java
+    │   ├── StompDestinations.java
+    │   └── WebSocketHeaders.java
     │
-    ├── redis/                                      # Redis Pub/Sub 인프라
-    │   ├── RedisPublisher.java                     # Redis 채널 메시지 발행
-    │   └── RedisSubscriber.java                    # Redis 채널 메시지 수신 → WebSocket 브로드캐스트
+    ├── redis/
+    │   ├── RedisPublisher.java
+    │   └── RedisSubscriber.java
     │
-    ├── websocket/                                  # WebSocket 인프라
-    │   ├── CustomStompErrorHandler.java            # STOMP ERROR 프레임 핸들러
-    │   ├── StompChannelInterceptor.java            # CONNECT/SUBSCRIBE/SEND 인증 검증
-    │   ├── WebSocketEventListener.java             # WebSocket 연결 생명주기 이벤트 처리
-    │   ├── WebSocketMetric.java                    # 활성 세션 수 Prometheus 메트릭
-    │   ├── WebSocketSessionUtils.java              # 세션 식별자 추출 공통 유틸
+    ├── websocket/
+    │   ├── CustomStompErrorHandler.java
+    │   ├── LobbyEnterResultMapper.java
+    │   ├── StompChannelInterceptor.java
+    │   ├── WebSocketEventListener.java
+    │   ├── WebSocketMetric.java
+    │   ├── WebSocketSessionUtils.java
     │   ├── dto/
-    │   │   └── ChatMessageDto.java                 # WebSocket 채팅 메시지 DTO
+    │   │   └── ChatMessageDto.java
     │   ├── error/
-    │   │   ├── StompErrorAction.java               # FE 후속 동작 enum
-    │   │   ├── StompErrorCode.java                 # STOMP ERROR 코드 계약 enum
-    │   │   ├── StompErrorException.java            # STOMP 표준 에러 예외
-    │   │   └── StompErrorPayload.java              # STOMP ERROR JSON payload
+    │   │   ├── StompErrorAction.java
+    │   │   ├── StompErrorCode.java
+    │   │   ├── StompErrorException.java
+    │   │   └── StompErrorPayload.java
     │   └── event/
-    │       └── PlayerLeaveEvent.java               # 플레이어 퇴장 Spring 이벤트 객체
+    │       └── PlayerLeaveEvent.java
     │
     └── security/
-        ├── SecurityEndpoints.java                  # Security 경로 상수 중앙화
+        ├── SecurityEndpoints.java
         └── jwt/
-            ├── CustomPrincipal.java                # JWT 인증 주체 (userId + userIdentifier)
-            ├── JwtAuthenticationFilter.java        # Bearer 토큰 검증 및 SecurityContext 저장
-            ├── JwtClaims.java                      # JWT 클레임 키 상수 (발급/검증 공유)
-            ├── JwtTokenProvider.java               # JWT Access/Refresh 토큰 발급
-            └── TokenWithExpiry.java                # 토큰 + 만료시각 DTO
-````
+            ├── CustomPrincipal.java
+            ├── JwtAuthenticationFilter.java
+            ├── JwtClaims.java
+            ├── JwtTokenProvider.java
+            └── TokenWithExpiry.java
+```
 
 ---
 
@@ -149,79 +153,55 @@ src/main/java/io/github/ascrew/monomatbe/
 ### 의존 방향 규칙
 
 ```text
-domain  →  global  (허용 ✅)
-global  →  domain  (금지 ❌)
+domain  →  global  (허용)
+global  →  domain  (금지)
 ```
 
-`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.
-`global`이 `domain`을 직접 참조하면 의존 방향이 역전되어 순환 의존 및 결합도 증가 문제가 발생합니다.
+`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.  
+`global`이 `domain`을 직접 참조하면 순환 의존과 결합도 증가가 발생합니다.
 
-### 의존 방향 역전 해결 사례 — Spring ApplicationEventPublisher
+### 의존 방향 역전 해결 사례
 
-`WebSocketEventListener(global)`가 `LobbyEventService(domain)`를 직접 호출하던 문제를 아래와 같이 해결했습니다.
+`WebSocketEventListener`는 `LobbyEventService`를 직접 호출하지 않고 `ApplicationEventPublisher`로 `PlayerLeaveEvent`를 발행합니다.
 
 ```text
-[기존 — 의존 방향 역전]
-global/WebSocketEventListener → domain/LobbyEventService  ❌
-
-[변경 — 이벤트 기반 분리]
-global/WebSocketEventListener → ApplicationEventPublisher.publishEvent(PlayerLeaveEvent)
-                                            ↓
-                               domain/LobbyEventService @EventListener  ✅
+global/WebSocketEventListener
+    │ publishEvent(PlayerLeaveEvent)
+    ▼
+domain/LobbyEventService @EventListener
 ```
-
-`PlayerLeaveEvent`는 `global/websocket/event`에 위치하여 `domain → global` 단방향 의존을 유지합니다.
 
 ### 도메인 간 의존 규칙
 
-동일한 `domain` 하위 도메인 간 참조는 비즈니스 흐름상 허용하지만, 직접 엔티티 결합은 최소화합니다.
+동일한 `domain` 하위 도메인 간 참조는 비즈니스 흐름상 허용하지만, 영속성 엔티티 직접 결합은 최소화합니다.
 
-예를 들어 로비 생성 시 맵을 연결할 때 `LobbyService`는 `QuizMapJpaRepository`로 맵 접근 권한을 검증합니다.
-하지만 Redis 저장 계층인 `LobbyRepositoryImpl`은 `QuizMap` 엔티티에 직접 의존하지 않고, `LobbyMapMetadata`라는 최소 DTO만 전달받습니다.
+예를 들어 로비 생성 시 맵을 연결할 때는 맵 접근 권한을 서비스 계층에서 검증한 뒤, Redis 저장 계층에는 `LobbyMapMetadata`만 전달합니다.
 
 ```text
-LobbyService
-    ├── QuizMapJpaRepository 조회
+LobbyCreateService
+    ├── QuizMap 조회
     ├── 맵 존재/삭제/권한 검증
     └── LobbyMapMetadata 생성
-            ↓
+            ▼
 LobbyRepositoryImpl
     └── Redis 저장에 필요한 mapId, mapTitle, mapCategory만 사용
 ```
-
-이 구조를 통해 맵 도메인의 영속성 모델 변경이 Redis 저장 계층으로 직접 전파되는 것을 방지합니다.
 
 ---
 
 ## 📋 공개 로비 목록 조회 정책
 
-공개 로비 목록 조회는 `GET /api/lobbies`에서 처리합니다.  
-이 API는 FE 로비 목록 화면에서 사용자가 입장 가능한 공개 로비를 빠르게 찾기 위한 조회 API입니다.
-
-이슈 #88 이후 공개 로비 목록 조회는 페이징 응답을 반환하며, 필터가 없는 경우 Redis Sorted Set 정렬 인덱스를 사용해 필요한 범위의 로비 코드만 조회합니다.
+공개 로비 목록 조회는 `GET /api/lobbies`에서 처리합니다.
 
 ```text
 Client
     │ GET /api/lobbies?keyword=&mapCategory=&sort=&page=&size=
     ▼
 LobbyQueryController
-    │ 요청 파라미터 수집
-    │ - keyword
-    │ - mapCategory
-    │ - sort
-    │ - page
-    │ - size
     ▼
 LobbySearchCondition
-    │ 요청 조건 정규화
-    │ - keyword trim + lower-case
-    │ - mapCategory MapCategory.from()으로 검증
-    │ - sort LobbySortType으로 검증
-    │ - page 기본값/범위 검증
-    │ - size 기본값/최대값 검증
     ▼
 LobbyQueryService
-    │ 로비 목록 노출 정책 적용
     │ - WAITING / PLAYING 상태 노출
     │ - FINISHED 상태 제외
     │ - keyword 제목 검색
@@ -231,7 +211,7 @@ LobbyQueryService
     │ - Redis 손상 mapCategory 로비 제외
     │
     ├─ [필터 없음 + 정렬 인덱스 존재]
-    │      Redis ZSET 인덱스에서 필요한 범위의 lobbyCode만 조회
+    │      Redis ZSET 인덱스에서 page 범위의 lobbyCode만 조회
     │
     └─ [필터 있음 또는 정렬 인덱스 없음]
            lobby:public 전체 조회 후 Java 필터/정렬/페이징
@@ -239,150 +219,28 @@ LobbyQueryService
 LobbyRepository
     ▼
 LobbyRedisQueryRepository
-    │ Redis Hash / Set / ZSET 조회
     ▼
 Redis
 ```
 
-### 책임 분리
-
-| 계층                          | 책임                                                 |
-| --------------------------- | -------------------------------------------------- |
-| `LobbyQueryController`      | HTTP 요청 파라미터 수집                                    |
-| `LobbySearchCondition`      | 요청값 정규화 및 검증                                       |
-| `LobbyPageRequest`          | `page`, `size` 기본값/범위 검증                           |
-| `LobbyQueryService`         | 로비 목록 노출 정책, 검색, 필터링, 정렬, 페이징, 인덱스 사용 여부 결정        |
-| `LobbyRedisQueryRepository` | Redis 원본 공개 로비 데이터 조회, ZSET 인덱스 조회, stale index 정리 |
-
 ### 노출 정책
 
-* 공개 로비 목록에는 `WAITING`, `PLAYING` 상태 로비가 노출됩니다.
-* `FINISHED` 상태 로비는 목록에서 제외됩니다.
-* `WAITING` 로비는 입장 가능한 로비입니다.
-* `PLAYING` 로비는 진행 중 상태로 목록에는 노출되지만, 현재 입장은 허용하지 않습니다.
-* 클라이언트는 `status=PLAYING` 로비를 “진행 중” 상태로 표시하고 입장 버튼을 비활성화해야 합니다.
+- 공개 로비 목록에는 `WAITING`, `PLAYING` 상태 로비가 노출됩니다.
+- `FINISHED` 상태 로비는 목록에서 제외됩니다.
+- `WAITING` 로비는 입장 가능한 로비입니다.
+- `PLAYING` 로비는 목록에는 노출되지만 입장은 허용하지 않습니다.
+- 클라이언트는 `status=PLAYING` 로비를 “진행 중”으로 표시하고 입장 버튼을 비활성화해야 합니다.
 
-### 페이징 정책
+### 정렬 인덱스
 
-| 항목         | 정책                                 |
-| ---------- | ---------------------------------- |
-| `page`     | 0-based 페이지 번호                     |
-| `page` 기본값 | `0`                                |
-| `size` 기본값 | `20`                               |
-| `size` 최소값 | `1`                                |
-| `size` 최대값 | `100`                              |
-| 응답 구조      | `items`, `page`, `size`, `hasNext` |
+| Redis Key | Type | Member | Score | 갱신 시점 |
+| --- | --- | --- | --- | --- |
+| `lobby:public:latest` | ZSET | lobby code | `created_at_epoch_millis` | 공개 로비 생성/삭제 |
+| `lobby:public:most_players` | ZSET | lobby code | `current_players` | 생성/입장/퇴장/강퇴 |
+| `lobby:public:most_available` | ZSET | lobby code | `max_players - current_players` | 생성/입장/퇴장/강퇴 |
 
-### 정렬 정책
-
-| 정렬 기준            | 설명                                           | Redis 인덱스                     |
-| ---------------- | -------------------------------------------- | ----------------------------- |
-| `latest`         | `createdAtEpochMillis` 내림차순                  | `lobby:public:latest`         |
-| `most_players`   | `currentPlayers` 내림차순, 동률이면 최신순              | `lobby:public:most_players`   |
-| `most_available` | `maxPlayers - currentPlayers` 내림차순, 동률이면 최신순 | `lobby:public:most_available` |
-
-`lobby:public`은 Redis Set이므로 삽입 순서가 보장되지 않습니다. 따라서 로비 생성 시 Redis Hash에 `created_at_epoch_millis`를 저장하고, 이 값을 기준으로 최신순 정렬을 수행합니다.
-
-**Redis 정렬 인덱스**
-
-| Redis Key                     | Type | Member     | Score                           | 갱신 시점                                |
-| ----------------------------- | ---- | ---------- | ------------------------------- | ------------------------------------ |
-| `lobby:public:latest`         | ZSET | lobby code | `created_at_epoch_millis`       | 공개 로비 생성 시 `ZADD`, 로비 폭파/삭제 시 `ZREM` |
-| `lobby:public:most_players`   | ZSET | lobby code | `current_players`               | 공개 로비 생성/입장/퇴장/강퇴 시 갱신               |
-| `lobby:public:most_available` | ZSET | lobby code | `max_players - current_players` | 공개 로비 생성/입장/퇴장/강퇴 시 갱신               |
-
-**정렬 인덱스 사용 조건**
-
-| 조건                                          | 조회 방식                                 |
-| ------------------------------------------- | ------------------------------------- |
-| `keyword` 없음 + `mapCategory` 없음 + 정렬 인덱스 존재 | Redis ZSET에서 page 범위의 lobbyCode만 조회   |
-| `keyword` 있음                                | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
-| `mapCategory` 있음                            | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
-| 정렬 인덱스 없음                                   | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
-
-필터가 있는 경우 ZSET page 범위를 먼저 자르면 전체 필터링 결과 기준의 page가 깨질 수 있습니다.
-예를 들어 ZSET 상위 20개에는 `K-POP` 로비가 없지만 21번째 이후에 `K-POP` 로비가 있을 수 있습니다.
-따라서 `keyword`, `mapCategory` 필터가 있는 경우는 안전하게 기존 전체 조회 경로로 폴백합니다.
-
-### 생성 시각 기준
-
-로비 생성 시각은 Java 애플리케이션 서버 시간이 아니라 Redis `TIME` 명령을 기준으로 생성합니다.
-
-```lua
-local redisTime = redis.call('TIME')
-local createdAtEpochMillis = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
-```
-
-멀티 인스턴스 운영 환경에서는 애플리케이션 서버 간 시간 편차가 발생할 수 있습니다.  
-따라서 Redis 서버 기준 단일 시간원을 사용해 최신순 정렬 기준을 일관되게 유지합니다.
-
-### 현재 인원 캐싱 정책
-
-`current_players`는 `lobby:{code}:participants` Set과 중복 상태입니다.
-따라서 Java 서비스에서 직접 증가/감소시키지 않고, participants 변경을 수행하는 Lua 스크립트 내부에서만 갱신합니다.
-
-| 이벤트       | 처리                                                          |
-| --------- | ----------------------------------------------------------- |
-| 로비 생성     | `current_players = 0`                                       |
-| 입장        | `SCARD lobby:{code}:participants` 결과를 `current_players`에 저장 |
-| 퇴장        | 남은 participants 수를 `current_players`에 저장                    |
-| 강퇴        | 남은 participants 수를 `current_players`에 저장                    |
-| 마지막 인원 퇴장 | 로비 Hash 삭제. 별도 `current_players = 0` 저장 불필요                 |
-
-조회 시에는 `lobby:{code}.current_players`를 우선 사용합니다.
-다만 배포 전 생성된 기존 Redis 데이터에는 해당 필드가 없을 수 있으므로, 누락 시 `SCARD lobby:{code}:participants` 결과로 fallback합니다.
-
-### Redis Hash 필드
-
-`lobby:{code}` Hash에는 공개 로비 목록 조회 및 정렬을 위해 다음 필드가 포함됩니다.
-
-| 필드                        | 설명                                           |
-| ------------------------- | -------------------------------------------- |
-| `created_at_epoch_millis` | Redis `TIME` 기준 로비 생성 시각. epoch milliseconds |
-| `current_players`         | 현재 참여 인원 캐시. participants Set 변경 Lua에서만 갱신   |
-| `map_category`            | 선택된 맵 카테고리. `K-POP`, `J-POP`, `POP`          |
-| `status`                  | 로비 상태. 목록에서는 `WAITING`, `PLAYING`만 노출        |
-| `is_private`              | 비공개 여부. 공개 로비 목록은 `false`만 노출                |
-| `max_players`             | 최대 참여 인원                                     |
-
-### Redis 정합성 방어
-
-공개 로비 인덱스에는 남아 있지만 `lobby:{code}` Hash가 TTL 만료, 수동 삭제, 과거 버전 로직 등으로 사라질 수 있습니다.
-
-이 경우 공개 로비 목록 조회 경로에서는 해당 code를 응답에서 제외만 합니다.  
-조회 요청 중 즉시 인덱스를 삭제하지 않습니다.
-
-인덱스 정리는 `LobbyPublicIndexCleanupScheduler`가 주기적으로 수행합니다.
-
-```text
-LobbyPublicIndexCleanupScheduler
-    │ fixedDelay 기반 주기 실행
-    ▼
-lobby:public Set에서 일부 code 샘플 조회
-    ▼
-각 code에 대해 lobby:{code} Hash 존재 여부 확인
-    ▼
-Hash가 없으면 아래 공개 인덱스에서 제거
-```
-정리 대상은 다음과 같습니다.
-
-```
-lobby:public
-lobby:public:latest
-lobby:public:most_players
-lobby:public:most_available
-```
-
-이 구조는 조회 경로와 정리 경로를 분리하기 위한 설계입니다.
-
-| 구분                                                    | 책임                                      |
-| ----------------------------------------------------- | --------------------------------------- |
-| `LobbyRedisQueryRepository#getPublicLobbiesByCodes()` | stale code를 응답에서 제외                     |
-| `LobbyPublicIndexCleanupScheduler`                    | stale code를 public Set/ZSET 인덱스에서 배치 정리 |
-| `removePublicLobbyIndexes()`                          | 보정/정리 경로에서 특정 lobbyCode를 공개 인덱스에서 제거    |
-
-정렬 인덱스 기반 조회 중 stale code가 섞이면 `LobbyQueryService`는 요청한 page size를 최대한 채우기 위해 추가 범위를 스캔합니다.
-스캔 상한은 `targetItemCount * 5` 기준으로 제한하여 stale index가 누적된 상황에서도 무한 조회를 방지합니다.
+필터가 있는 경우 ZSET page 범위를 먼저 자르면 전체 필터링 결과 기준의 page가 깨질 수 있습니다.  
+따라서 `keyword`, `mapCategory` 필터가 있는 경우는 전체 공개 로비 조회 후 Java 필터/정렬/페이징으로 처리합니다.
 
 ---
 
@@ -392,106 +250,68 @@ lobby:public:most_available
 
 ```text
 클라이언트
-    │ STOMP /app/chat/global (또는 /app/chat/lobby/{code})
+    │ STOMP SEND /app/chat/global 또는 /app/chat/lobby/{code}
     ▼
 ChatController
-    │
     ▼
 ChatService
-    │ sender 위변조 방지 — 클라이언트 sender 무시, 세션 식별자로 교체
-    │
+    │ sender 위변조 방지
+    │ 클라이언트 sender 무시, 세션 식별자로 교체
     ▼
 RedisPublisher.publish()
-    │ Redis Pub/Sub 발행
     ▼
-Redis
-    │
+Redis Pub/Sub
     ▼
 RedisSubscriber.onMessage()
-    │ JSON 문자열 그대로 WebSocket 브로드캐스트
     ▼
 SimpMessagingTemplate.convertAndSend()
-    │ STOMP /topic/chat/global (또는 /topic/lobby/{code})
     ▼
-클라이언트 (구독자 전체)
+클라이언트
 ```
 
-### WebSocket 로비 입장 흐름
+---
+
+## WebSocket 로비 입장 흐름
+
+로비 입장은 `SessionSubscribeEvent` 이후가 아니라, `StompChannelInterceptor.preSend()`에서 SUBSCRIBE 통과 전에 처리합니다.
 
 ```text
 클라이언트
     │ STOMP SUBSCRIBE /topic/lobby/{code}
     ▼
-WebSocketEventListener.handleSubscribeEvent()
-    │ 1. 로비 채팅 채널 구독 여부 확인
-    │    - /topic/lobby/{code}         → 입장 처리 대상
-    │    - /topic/lobby/{code}/refresh → 입장 처리 대상 아님
-    │ 2. 세션에서 userIdentifier 추출
-    │ 3. wsSessionId 추출
+StompChannelInterceptor.preSend()
+    │ 1. SUBSCRIBE 명령 검증
+    │ 2. /topic/lobby/{code} 구독인지 확인
+    │ 3. 세션에서 userIdentifier 추출
+    │ 4. wsSessionId 추출
+    │ 5. sessionSequence 추출
+    │ 6. enter_lobby.lua 실행
     │
-    ▼
-enter_lobby.lua
-    │ Redis Lua 스크립트로 입장 상태를 원자적으로 저장
+    ├─ 성공
+    │   ├─ ENTERED
+    │   ├─ ALREADY_JOINED
+    │   └─ SESSION_REPLACED:{previousWsSessionId}
+    │        ▼
+    │      SUBSCRIBE 프레임 통과
+    │        ▼
+    │      SessionSubscribeEvent 발생
+    │        ▼
+    │      WebSocketEventListener 후처리
+    │        ├─ ENTER 메시지 발행
+    │        └─ 로비 refresh 브로드캐스트
     │
-    ├── lobby:{code}:participants Set에 userIdentifier 저장
-    ├── lobby:{code}:order List에 userIdentifier 저장
-    ├── lobby:{code}:user_session:{userIdentifier}에 현재 wsSessionId 저장
-    ├── lobby:{code}:user_session_seq:{userIdentifier}에 현재 세션 sequence 저장
-    ├── ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
-    └── 중복 구독 시 order List 중복 저장 방지
-    │
-    ▼
-RedisPublisher.publish()
-    │ ENTER 시스템 메시지 발행
-    ▼
-Redis Pub/Sub
-    │
-    ▼
-RedisSubscriber.onMessage()
-    │ JSON 문자열 그대로 WebSocket 브로드캐스트
-    ▼
-클라이언트
-    │ /topic/lobby/{code} 구독자로 ENTER 메시지 수신
-
-### 게임 세션 및 라운드 시작 흐름
-
-```text
-클라이언트 (방장)
-    │ POST /api/lobbies/{code}/start
-    ▼
-LobbyStartService
-    │ 1. start_lobby.lua 로 Redis 로비 상태 검증 및 PLAYING 변경
-    │ 2. DB 트랜잭션 시작 (@Transactional)
-    │ 3. DB 로비 상태 PLAYING 변경
-    │ 4. GameSessionCreateService 호출
-    ▼
-GameSessionCreateService
-    │ 1. MapItem 조회 및 셔플 (라운드 수만큼 선택)
-    │ 2. DB GameSession, GameSessionPlayer 스냅샷 생성 (Bulk Insert)
-    │ 3. init_game_session.lua 로 Redis 인게임 세션 데이터 초기화 (2시간 TTL 적용)
-    │ 4. 첫 라운드 정보(RoundStartDto) 반환
-    ▼
-LobbyStartService
-    │ TransactionSynchronizationManager.registerSynchronization (afterCommit)
-    │ DB 트랜잭션 정상 커밋 대기
-    ▼
-DB Commit 완료
-    │
-    ▼
-GameRealtimeNotifier / LobbyRealtimeNotifier
-    │ 1. /topic/lobby/{code}/game 으로 GAME_STARTED 브로드캐스트
-    │ 2. /topic/game/{code}/round 로 첫 번째 라운드 RoundStartDto 브로드캐스트
-    ▼
-클라이언트 (전체)
-    │ 게임 화면 전환 및 유튜브 플레이어 재생
+    └─ 실패
+        ├─ Lua 반환값을 StompErrorCode로 변환
+        ├─ ws:connection:{wsSessionId} 보상 삭제
+        └─ StompErrorException 발생
+              ▼
+           CustomStompErrorHandler
+              ▼
+           STOMP ERROR JSON payload 응답
 ```
 
-* **트랜잭션-웹소켓 동기화**: DB 커밋 전에 웹소켓 이벤트가 발송되어 클라이언트가 아직 DB에 반영되지 않은 상태를 조회하는 Race Condition을 방지하기 위해 `afterCommit` 훅을 사용합니다.
-* **보상 트랜잭션(Rollback)**: 게임 세션 생성이나 Redis 스크립트 실행 중 예외가 발생하면 DB 트랜잭션이 롤백되며, 로비 상태도 `WAITING`으로 안전하게 복구됩니다.
-```
-
-> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
-> `/topic/lobby/{code}/refresh` 구독은 로비 정보 갱신 신호 수신용이며, 입장 처리 대상이 아닙니다.
+> 로비 입장 처리는 `/topic/lobby/{code}` 구독 통과 전에만 수행합니다.  
+> `/topic/lobby/{code}/refresh`, `/topic/lobby/{code}/game` 구독은 로비 정보 갱신/게임 시작 이벤트 수신용이며, 입장 처리 대상이 아닙니다.
 
 ### WebSocket 로비 입장 실패 처리 정책
 
@@ -513,47 +333,22 @@ SUBSCRIBE /topic/lobby/{code}
     - ENTER 메시지 및 refresh 후처리
 ```
 
-`POST /api/lobbies/join`은 UX용 사전 검증입니다.
-실제 참여자 등록은 `SUBSCRIBE /topic/lobby/{code}` 시점에 `enter_lobby.lua`로 처리합니다.
+`POST /api/lobbies/join`은 UX용 사전 검증입니다.  
+실제 참여자 등록은 `SUBSCRIBE /topic/lobby/{code}` 시점에 `enter_lobby.lua`로 원자 처리합니다.
 
-따라서 REST join 성공 후에도 아래 상황에서는 WebSocket SUBSCRIBE가 실패할 수 있습니다.
-| 상황                           | Lua 반환값                       | STOMP ERROR code                      | 처리 기준          |
-| ---------------------------- | ----------------------------- | ------------------------------------- | -------------- |
-| 로비가 삭제됨                      | `LOBBY_NOT_FOUND`             | `LOBBY_NOT_FOUND`                     | 로비 목록으로 복귀     |
-| REST join 이후 정원이 참           | `FULL`                        | `LOBBY_FULL`                          | 로비 목록으로 복귀     |
-| 방장이 게임을 시작함                  | `LOBBY_NOT_WAITING`           | `LOBBY_NOT_WAITING`                   | 로비 목록으로 복귀     |
-| 강퇴된 유저 재입장                   | `KICKED_USER`                 | `LOBBY_KICKED_USER`                   | 로비 목록으로 복귀     |
-| 더 최신 세션이 존재함                 | `STALE_SESSION:{wsSessionId}` | `LOBBY_STALE_SESSION`                 | 현재 세션 폐기 후 재연결 |
-| 세션 sequence 누락/비정상           | `INVALID_SEQUENCE`            | `LOBBY_INVALID_SEQUENCE`              | 새로고침 후 재시도     |
-| Redis 로비 정원 데이터 손상           | `INVALID_LOBBY_CAPACITY`      | `LOBBY_INVALID_CAPACITY`              | 로비 목록으로 복귀     |
-| Lua null/unknown/Redis 일시 장애 | `null` 또는 unknown             | `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` | 새로고침 후 재시도     |
+| 상황 | Lua 반환값 | STOMP ERROR code | 처리 기준 |
+| --- | --- | --- | --- |
+| 로비가 삭제됨 | `LOBBY_NOT_FOUND` | `LOBBY_NOT_FOUND` | 로비 목록으로 복귀 |
+| REST join 이후 정원이 참 | `FULL` | `LOBBY_FULL` | 로비 목록으로 복귀 |
+| 방장이 게임을 시작함 | `LOBBY_NOT_WAITING` | `LOBBY_NOT_WAITING` | 로비 목록으로 복귀 |
+| 강퇴된 유저 재입장 | `KICKED_USER` | `LOBBY_KICKED_USER` | 로비 목록으로 복귀 |
+| 더 최신 세션이 존재함 | `STALE_SESSION:{wsSessionId}` | `LOBBY_STALE_SESSION` | 현재 세션 폐기 후 재연결 |
+| 세션 sequence 누락/비정상 | `INVALID_SEQUENCE` | `LOBBY_INVALID_SEQUENCE` | 새로고침 후 재시도 |
+| Redis 로비 정원 데이터 손상 | `INVALID_LOBBY_CAPACITY` | `LOBBY_INVALID_CAPACITY` | 로비 목록으로 복귀 |
+| Lua null/unknown/Redis 일시 장애 | `null` 또는 unknown | `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` | 새로고침 후 재시도 |
 
-#### 실패 처리 흐름
-```text
-Client
-    │ SUBSCRIBE /topic/lobby/{code}
-    ▼
-StompChannelInterceptor.preSend()
-    │ enter_lobby.lua 실행
-    │
-    ├─ 성공
-    │   ├─ ENTERED
-    │   ├─ ALREADY_JOINED
-    │   └─ SESSION_REPLACED:{previousWsSessionId}
-    │
-    └─ 실패
-        ├─ Lua 반환값을 StompErrorCode로 변환
-        ├─ ws:connection 보상 삭제
-        └─ StompErrorException 발생
-                ▼
-CustomStompErrorHandler
-    │ STOMP ERROR JSON payload 생성
-    ▼
-Client
-    │ code/action/recoverable 기준으로 화면 처리
-```
+### STOMP ERROR payload 계약
 
-#### STOMP ERROR payload 계약
 ```json
 {
   "type": "STOMP_ERROR",
@@ -564,97 +359,103 @@ Client
   "timestamp": "2026-05-25T00:00:00Z"
 }
 ```
-FE는 `message` 문자열을 파싱하지 않습니다.
+
+FE는 `message` 문자열을 파싱하지 않습니다.  
 반드시 `code`, `action`, `recoverable` 기준으로 화면 복귀, 재연결, 새로고침 재시도를 결정합니다.
 
-#### 성공 반환값 처리
-| Lua 반환값                                  | 의미                                 | 후처리                                   |
-| ---------------------------------------- | ---------------------------------- | ------------------------------------- |
-| `ENTERED`                                | 신규 입장 성공                           | ENTER 메시지 발행, 로비 refresh              |
-| `ALREADY_JOINED`                         | 같은 세션의 중복 구독                       | ENTER 메시지 생략                          |
-| `SESSION_REPLACED:{previousWsSessionId}` | 같은 userIdentifier의 새 세션이 기존 세션을 대체 | 최신 세션 유지, 기존 세션 disconnect 시 stale 처리 |
+### 최신 세션 유지 정책
 
-#### 최신 세션 유지 정책
-동일한 userIdentifier가 같은 로비에 여러 WebSocket 세션으로 진입할 경우, `CONNECT` 시 Redis INCR로 발급한 `sessionSequence`가 더 큰 세션을 최신 세션으로 봅니다.
+동일한 `userIdentifier`가 같은 로비에 여러 WebSocket 세션으로 진입할 경우, `CONNECT` 시 Redis `INCR`로 발급한 `sessionSequence`가 더 큰 세션을 최신 세션으로 봅니다.
+
 ```text
 lobby:{code}:user_session:{userIdentifier}
 lobby:{code}:user_session_seq:{userIdentifier}
 ```
+
 이 정책으로 오래된 세션의 늦은 SUBSCRIBE 또는 늦은 DISCONNECT가 최신 세션 상태를 덮어쓰지 못하게 막습니다.
 
-#### 보상 삭제 정책
+### 보상 삭제 정책
+
 SUBSCRIBE 실패 시 현재 요청의 `ws:connection:{wsSessionId}`는 보상 삭제합니다.
-```
+
+```text
 ws:connection:{wsSessionId}
 ```
+
 다만 `participants`, `order`, `user_session`, `user_session_seq`는 Lua 성공 전 실패한 경우 생성되지 않았거나, stale 세션인 경우 최신 세션의 상태일 수 있으므로 Java에서 직접 삭제하지 않습니다.
 
-이 원칙을 지켜야 정상 사용자의 최신 세션을 실수로 제거하지 않습니다.
+---
 
-
-### WebSocket 연결 해제 흐름
+## WebSocket 연결 해제 흐름
 
 ```text
 클라이언트 연결 해제
-    │
     ▼
 WebSocketEventListener.handleDisconnectEvent()
     │ 1. Redis ws:connection:{wsSessionId} 에서 lobbyCode 역추적
-    │ 2. ApplicationEventPublisher.publishEvent(PlayerLeaveEvent)
-    │ 3. LEAVE 메시지 브로드캐스트
-    │ 4. Redis 키 정리 (user_status, ws:connection)
-    │
-    ▼ (이벤트 전달)
+    │ 2. stale 세션 여부 확인
+    │ 3. 최신 세션이면 PlayerLeaveEvent 발행
+    │ 4. LEAVE 메시지 브로드캐스트
+    │ 5. Redis 키 정리
+    ▼
 LobbyEventService.handlePlayerLeave(@EventListener)
-    │ Lua 스크립트로 원자적 퇴장 처리
     ▼
 leave_lobby.lua
     ├── DESTROYED → 전역 로비 리스트 새로고침
-    ├── DELEGATED → 로비 내부 새로고침 (새 방장 ID 포함)
+    ├── DELEGATED → 로비 내부 새로고침
     └── LEFT      → 로비 내부 새로고침
 ```
 
-### 로비 강퇴 흐름
+### stale DISCONNECT 정책
+
+동일 userIdentifier의 새 WebSocket 세션이 기존 세션을 대체한 후, 이전 세션의 DISCONNECT가 늦게 도착할 수 있습니다.
+
+```text
+if lobby:{code}:user_session:{userIdentifier} != disconnectedWsSessionId
+    → stale 세션으로 판단
+    → PlayerLeaveEvent 발행 생략
+    → ws:connection:{oldWsSessionId}만 삭제
+```
+
+---
+
+## 로비 강퇴 흐름
 
 ```text
 방장 클라이언트
     │ STOMP SEND /app/lobby/{code}/kick
     ▼
 LobbyEventController.kickLobbyPlayer()
-    │ 세션에서 requesterIdentifier 추출
     ▼
 LobbyEventService.kickLobbyPlayer()
-    │ 1. 로비 코드 형식 검증
-    │ 2. 요청자 인증 정보 검증
-    │ 3. 강퇴 대상 식별자 검증
     ▼
 kick_lobby.lua
-    │ Redis Lua 스크립트로 강퇴 상태를 원자적으로 변경
-    │
-    ├── 방장 권한 검증
-    ├── 자기 자신 강퇴 방지
-    ├── 참여자 여부 검증
-    ├── participants/order에서 대상 제거
-    ├── kicked Set에 대상 추가
+    ├── 로비 존재 여부 확인
+    ├── 방장 정보 존재 여부 확인
+    ├── 요청자가 방장인지 검증
+    ├── 자기 자신 강퇴 요청인지 검증
+    ├── 강퇴 대상이 참여자인지 검증
+    ├── participants/order에서 강퇴 대상 제거
+    ├── kicked Set에 강퇴 대상 추가
     └── 대상의 현재 wsSessionId 반환
-    │
     ▼
 LobbyEventService.handleKickSuccess()
-    │ 1. 대상 ws:connection 키 삭제
-    │ 2. KICK 메시지 로비 채팅 채널로 브로드캐스트
-    │ 3. 로비 내부 refresh 브로드캐스트
+    ├── 대상 ws:connection 키 삭제
+    ├── KICK 메시지 로비 채팅 채널로 브로드캐스트
+    └── 로비 내부 refresh 브로드캐스트
 ```
 
-### 로비 게임 시작 흐름
+강퇴된 사용자는 `lobby:{code}:kicked` Set에 저장되며, 같은 로비에 다시 `SUBSCRIBE /topic/lobby/{code}`를 시도하면 `enter_lobby.lua`에서 `KICKED_USER`로 차단됩니다.
+
+---
+
+## 로비 게임 시작 흐름
 
 ```text
 방장 클라이언트
     │ REST POST /api/lobbies/{code}/start
     ▼
-LobbyController.startLobbyGame()
-    │ @AuthenticationPrincipal CustomPrincipal 전달
-    ▼
-LobbyService.startLobbyGame()
+LobbyStartService
     │ 1. 인증 정보 확인
     │ 2. Redis 로비 존재 여부 확인
     │ 3. DB GAME_LOBBY 스냅샷 조회
@@ -677,143 +478,96 @@ start_lobby.lua
     ├── lobby:{code}.status = PLAYING
     └── lobby:public에서 code 제거
     ▼
-LobbyService
-    │ DB GAME_LOBBY.status = PLAYING 저장
-    │ afterCommit에서 GAME_STARTED / REFRESH_LOBBY_INFO 브로드캐스트 등록
+DB GAME_LOBBY.status = PLAYING 저장
     ▼
-클라이언트
-    │ /topic/lobby/{code}/game에서 GAME_STARTED 수신
-    ▼
-인게임 화면 전환
+afterCommit
+    ├── /topic/lobby/{code}/game → GAME_STARTED
+    └── /topic/game/{code}/round → RoundStartDto
 ```
 
-`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.
+`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.  
 트랜잭션 동기화가 비활성인 경우 즉시 발행하지 않고 서버 오류로 처리하여 DB 커밋 전 이벤트 발행을 방지합니다.
+
+---
+
+## 게임 세션 및 라운드 시작 흐름
+
+```text
+클라이언트 (방장)
+    │ POST /api/lobbies/{code}/start
+    ▼
+LobbyStartService
+    │ Redis 로비 상태 검증 및 PLAYING 변경
+    │ DB 트랜잭션 시작
+    │ DB 로비 상태 PLAYING 변경
+    │ GameSessionCreateService 호출
+    ▼
+GameSessionCreateService
+    │ 1. MapItem 조회 및 셔플
+    │ 2. DB GameSession, GameSessionPlayer 스냅샷 생성
+    │ 3. init_game_session.lua 로 Redis 인게임 세션 데이터 초기화
+    │ 4. 첫 라운드 정보(RoundStartDto) 반환
+    ▼
+DB Commit 완료
+    ▼
+GameRealtimeNotifier / LobbyRealtimeNotifier
+    ├── /topic/lobby/{code}/game 으로 GAME_STARTED 브로드캐스트
+    └── /topic/game/{code}/round 로 첫 번째 라운드 RoundStartDto 브로드캐스트
+```
 
 ---
 
 ## 🗄️ Redis 데이터 구조
 
-| 키 패턴                                             | 타입     | 설명                                                                        |
-| ------------------------------------------------ | ------ | ------------------------------------------------------------------------- |
-| `lobby:{code}`                                   | Hash   | 로비 메타 정보 (title, status, host_user_id, map_id, map_title, map_category 등) |
-| `lobby:{code}:participants`                      | Set    | 로비 참여자 식별자 목록                                                             |
-| `lobby:{code}:ready`                             | Set    | ready 상태인 로비 참여자 userIdentifier 목록                                        |
-| `lobby:{code}:order`                             | List   | 입장 순서 (방장 위임 시 LINDEX 0 사용)                                               |
-| `lobby:{code}:kicked`                            | Set    | 강퇴된 사용자 식별자 목록                                                            |
-| `lobby:{code}:user_session:{userIdentifier}`     | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID                                        |
-| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence                                  |
-| `lobby:public`                                   | Set    | 공개 로비 코드 목록 (고속 필터링용)                                                     |
-| `lobby:start:reconciliation`                     | List   | 게임 시작 Redis-DB 상태 불일치 재처리 큐                                               |
-| `metric:lobby:start:reconciliation:enqueued`     | String | 게임 시작 상태 재처리 큐 적재 횟수                                                      |
-| `metric:lobby:start:reconciliation:success`      | String | 게임 시작 상태 재처리 성공 횟수                                                        |
-| `metric:lobby:start:reconciliation:failed`       | String | 게임 시작 상태 재처리 실패 횟수                                                        |
-| `metric:lobby:start:unknown-result`              | String | `start_lobby.lua` 알 수 없는 반환값 발생 횟수                                        |
-| `metric:lobby:ready:stale-cleanup`               | String | 게임 시작 전 stale ready 데이터 정리 횟수                                             |
-| `metric:lobby:ready:consistency-failure`         | String | 게임 시작 실패 시 ready/participants/session 정합성 진단 발생 횟수                        |
-| `auth:guest:session:{token}`                     | Hash   | 게스트 세션 정보 (userId, username, userType, TTL 30일)                           |
-| `auth:refresh:{sessionId}`                       | String | Refresh Token (TTL 30일)                                                   |
-| `user_status:{userIdentifier}`                   | String | 사용자 온라인 상태 (`ONLINE`, TTL 2시간)                                            |
-| `user_status:{userIdentifier}:sessions`          | Set    | 사용자별 활성 WebSocket 세션 목록                                                   |
-| `ws:connection:{wsSessionId}`                    | Hash   | WebSocket 세션 → userId, lobbyCode 매핑                                       |
-| `map:public:list:v:{version}:p:{page}:s:{size}`  | String | 공개 맵 목록 페이지 캐시                                                            |
-| `map:public:{mapId}`                             | String | 공개 맵 단건 캐시                                                                |
-| `map:public:list:version`                        | String | 공개 맵 목록 캐시 버전                                                             |
-
-> ⚠️ `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`, `start_lobby.lua`와 맞춰 관리해야 합니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
+| 키 패턴 | 타입 | 설명 |
+| --- | --- | --- |
+| `lobby:{code}` | Hash | 로비 메타 정보 |
+| `lobby:{code}:participants` | Set | 로비 참여자 식별자 목록 |
+| `lobby:{code}:ready` | Set | ready 상태인 로비 참여자 userIdentifier 목록 |
+| `lobby:{code}:order` | List | 입장 순서 |
+| `lobby:{code}:kicked` | Set | 강퇴된 사용자 식별자 목록 |
+| `lobby:{code}:user_session:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence |
+| `lobby:public` | Set | 공개 로비 코드 목록 |
+| `lobby:public:latest` | ZSET | 공개 로비 최신순 정렬 인덱스 |
+| `lobby:public:most_players` | ZSET | 공개 로비 현재 인원순 정렬 인덱스 |
+| `lobby:public:most_available` | ZSET | 공개 로비 빈자리순 정렬 인덱스 |
+| `lobby:start:reconciliation` | List | 게임 시작 Redis-DB 상태 불일치 재처리 큐 |
+| `auth:guest:session:{token}` | Hash | 게스트 세션 정보 |
+| `auth:refresh:{sessionId}` | String | Refresh Token |
+| `user_status:{userIdentifier}` | String | 사용자 온라인 상태 |
+| `user_status:{userIdentifier}:sessions` | Set | 사용자별 활성 WebSocket 세션 목록 |
+| `ws:connection:{wsSessionId}` | Hash | WebSocket 세션 → userId, lobbyCode 매핑 |
+| `map:public:list:v:{version}:p:{page}:s:{size}` | String | 공개 맵 목록 페이지 캐시 |
+| `map:public:{mapId}` | String | 공개 맵 단건 캐시 |
+| `map:public:list:version` | String | 공개 맵 목록 캐시 버전 |
 
 ### `lobby:{code}` Hash 구조
 
-로비 메타 정보는 Redis Hash로 저장합니다.
+| 필드 | 설명 |
+| --- | --- |
+| `code` | 로비 초대 코드 |
+| `host_user_id` | 현재 방장 userIdentifier |
+| `title` | 로비 제목 |
+| `max_players` | 최대 참여 인원 |
+| `current_players` | 현재 참여 인원 캐시 |
+| `is_private` | 비공개 여부 |
+| `status` | 로비 상태 |
+| `map_id` | 선택된 맵 ID |
+| `map_title` | 선택된 맵 제목 |
+| `map_category` | 선택된 맵 카테고리 원본 값 |
+| `created_at_epoch_millis` | Redis TIME 기준 생성 시각 |
 
-| 필드             | 값 예시                                   | 설명                                                          |
-| -------------- | -------------------------------------- | ----------------------------------------------------------- |
-| `code`         | `ABC123`                               | 로비 초대 코드                                                    |
-| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier                                        |
-| `title`        | `K-POP 퀴즈방`                            | 로비 제목                                                       |
-| `max_players`  | `8`                                    | 최대 참여 인원                                                    |
-| `is_private`   | `false`                                | 비공개 여부. `true` = 비공개                                        |
-| `status`       | `WAITING`                              | 로비 상태                                                       |
-| `map_id`       | `1`                                    | 선택된 맵 ID                                                    |
-| `map_title`    | `K-POP 2세대`                            | 선택된 맵 제목                                                    |
-| `map_category` | `jpop`                                 | 선택된 맵 카테고리 원본 값. HTTP 응답 시 `K-POP`, `J-POP`, `POP` 형식으로 정규화 |
-
-`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.
+`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.  
 맵이 선택되지 않은 로비는 위 세 필드를 저장하지 않습니다.
 
-Redis에 `"null"` 문자열을 저장하지 않고, 응답 DTO에서만 `null`로 표현합니다.
+---
 
-### Redis Hash 필드 상수 (`RedisKeys.FIELD_*`)
-
-로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.
-문자열 리터럴 직접 사용 시 오타가 런타임에서야 발견되는 문제를 컴파일 타임에 방지합니다.
-
-로비 맵 연결 기능에서 사용하는 주요 필드는 다음과 같습니다.
-
-| 필드 상수                | Redis Hash 필드명 | 설명                |
-| -------------------- | -------------- | ----------------- |
-| `FIELD_MAP_ID`       | `map_id`       | 선택된 맵 ID          |
-| `FIELD_MAP_TITLE`    | `map_title`    | 선택된 맵 제목          |
-| `FIELD_MAP_CATEGORY` | `map_category` | 선택된 맵 카테고리        |
-| `FIELD_STATUS`       | `status`       | 로비 상태             |
-| `FIELD_HOST_USER_ID` | `host_user_id` | 방장 userIdentifier |
-
-맵 미선택 로비에서는 맵 관련 필드를 저장하지 않습니다.
-
-### WebSocket 로비 입장 저장 구조
-
-로비 입장 상태는 `enter_lobby.lua`에서 원자적으로 저장합니다.
-
-| 키 패턴                                             | 타입     | 저장 시점                      | 설명                                                      |
-| ------------------------------------------------ | ------ | -------------------------- | ------------------------------------------------------- |
-| `lobby:{code}:participants`                      | Set    | `/topic/lobby/{code}` 구독 시 | 현재 로비에 참여 중인 userIdentifier 목록                          |
-| `lobby:{code}:order`                             | List   | `/topic/lobby/{code}` 구독 시 | 입장 순서. 방장 퇴장 시 다음 방장 위임 기준                              |
-| `lobby:{code}:user_session:{userIdentifier}`     | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 wsSessionId                                |
-| `lobby:{code}:user_session_seq:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 세션 sequence                                |
-| `ws:connection:{wsSessionId}`                    | Hash   | `/topic/lobby/{code}` 구독 시 | WebSocket 세션 ID로 userIdentifier와 lobbyCode를 역추적하기 위한 매핑 |
-
-`ws:connection:{wsSessionId}` Hash 필드:
-
-| 필드          | 값                | 설명                             |
-| ----------- | ---------------- | ------------------------------ |
-| `userId`    | `userIdentifier` | Redis/WebSocket에서 사용하는 사용자 식별자 |
-| `lobbyCode` | `{code}`         | 현재 WebSocket 세션이 참여 중인 로비 코드   |
-
-정상 저장 예시:
-
-```redis
-SMEMBERS lobby:R2VJW5:participants
-1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
-
-LRANGE lobby:R2VJW5:order 0 -1
-1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
-
-GET lobby:R2VJW5:user_session:9746cc76-f8f2-4859-b602-df6e1032fea4
-"mhrg4it0"
-
-GET lobby:R2VJW5:user_session_seq:9746cc76-f8f2-4859-b602-df6e1032fea4
-"1"
-
-HGETALL ws:connection:mhrg4it0
-1) "userId"
-2) "9746cc76-f8f2-4859-b602-df6e1032fea4"
-3) "lobbyCode"
-4) "R2VJW5"
-```
-
-중복 구독 시 `participants`는 Set 구조로 중복 저장되지 않으며, `order` List도 `enter_lobby.lua`에서 신규 입장자일 때만 `RPUSH`하여 중복 저장을 방지합니다.
-
-### 로비 ready 상태 저장 구조
-
-로비 참여자의 ready 상태는 Redis Set으로 관리합니다.
+## 로비 ready 상태 저장 구조
 
 ```text
 lobby:{code}:ready
 ```
-
-| 키 패턴                 | 타입  | 설명                                  |
-| -------------------- | --- | ----------------------------------- |
-| `lobby:{code}:ready` | Set | ready 상태인 일반 참여자의 userIdentifier 목록 |
 
 정책:
 
@@ -826,100 +580,35 @@ lobby:{code}:ready
 6. 게임 시작 직전 ready Set에는 있지만 participants Set에는 없는 stale ready 데이터를 정리한다.
 ```
 
-ready 상태는 `canStart` 계산과 `start_lobby.lua`의 최종 시작 조건 검증에 사용됩니다.
-
 ---
 
 ## ⚡ 핵심 설계 결정
 
 ### Java 21 Virtual Thread + Lettuce
 
-가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 **Lettuce**를 사용합니다.
-Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,
-Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
+가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 Lettuce를 사용합니다.
 
-### 로비 생성 시 맵 연결 정책
+Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝할 수 있으나, Lettuce는 Netty 기반 비동기 드라이버로 핀닝 위험을 줄입니다.
 
-로비 생성 시 `mapId`는 선택 사항입니다.
+### Redis Pub/Sub + WebSocket 브로드캐스트
 
-```text
-로비 생성: mapId 선택 사항
-게임 시작: mapId 필수
-```
-
-이 구조를 선택한 이유는 로비가 게임 시작 전 대기실 역할을 하기 때문입니다.
-방장은 먼저 로비를 만들고 참여자를 모은 뒤, 로비 내부에서 맵을 선택하거나 변경할 수 있습니다.
-
-`mapId`가 전달된 경우 `LobbyService`에서 다음 순서로 검증합니다.
+멀티 인스턴스 환경에서는 특정 서버에 연결된 WebSocket 세션만 로컬 메모리에 존재합니다.
 
 ```text
-1. 맵 존재 여부 확인
-2. 삭제된 맵 여부 확인
-3. 공개 맵이면 허용
-4. 비공개 맵이면 소유자만 허용
+Server A
+    │ RedisPublisher.publish()
+    ▼
+Redis Pub/Sub
+    ├── Server A RedisSubscriber → local clients
+    ├── Server B RedisSubscriber → local clients
+    └── Server C RedisSubscriber → local clients
 ```
 
-검증 결과에 따른 HTTP 상태 코드는 다음과 같습니다.
+### Lua 스크립트 기반 원자 처리
 
-| 상황                  | 상태 코드           |
-| ------------------- | --------------- |
-| 존재하지 않는 맵           | `404 Not Found` |
-| 삭제된 맵               | `409 Conflict`  |
-| 타인 소유 비공개 맵         | `403 Forbidden` |
-| 공개 맵 또는 본인 소유 비공개 맵 | 로비 생성 허용        |
+로비 생성, 입장, 퇴장, 강퇴, 시작은 Redis Lua 스크립트로 원자 처리합니다.
 
-검증이 끝난 맵 정보는 `LobbyMapMetadata`로 변환하여 Redis 저장 계층에 전달합니다.
-이를 통해 `LobbyRepositoryImpl`이 `QuizMap` 엔티티에 직접 의존하지 않도록 분리합니다.
-
-### Lua 스크립트 기반 원자적 로비 생성
-
-`create_lobby.lua`는 초대 코드 선점과 로비 Hash 저장을 원자적으로 처리합니다.
-
-처리 대상:
-
-```text
-lobby:code:lock:{code}
-lobby:{code}
-lobby:public
-```
-
-로비 생성 시 아래 정보를 저장합니다.
-
-```text
-code
-host_user_id
-title
-max_players
-is_private
-status
-```
-
-이슈 #62 이후 선택된 맵이 있는 경우 아래 필드도 같은 Lua 스크립트 안에서 함께 저장합니다.
-
-```text
-map_id
-map_title
-map_category
-```
-
-맵 미선택 로비의 경우 Java에서 빈 문자열을 전달하고, Lua 스크립트는 `mapId`가 빈 문자열이면 맵 관련 필드를 저장하지 않습니다.
-이 방식으로 Redis Hash에 `"null"` 문자열이 저장되는 것을 방지합니다.
-
-### Lua 스크립트 기반 원자적 입장 처리
-
-`enter_lobby.lua`는 WebSocket 로비 입장 시 필요한 Redis 상태 변경을 단일 원자 연산으로 처리합니다.
-
-처리 대상:
-
-```text
-lobby:{code}:participants
-lobby:{code}:order
-lobby:{code}:user_session:{userIdentifier}
-lobby:{code}:user_session_seq:{userIdentifier}
-ws:connection:{wsSessionId}
-```
-
-Java 코드에서 위 Redis 명령을 개별적으로 실행하면 중간 실패 시 다음과 같은 상태 불일치가 발생할 수 있습니다.
+Java에서 Redis 명령을 여러 번 나누어 실행하면 중간 실패 시 상태 불일치가 발생할 수 있습니다.
 
 ```text
 participants에는 추가됐지만 order에는 없음
@@ -927,139 +616,17 @@ order에는 추가됐지만 ws:connection 매핑이 없음
 ws:connection은 있지만 participants에는 없음
 ```
 
-이를 방지하기 위해 `enter_lobby.lua`에서 아래 작업을 한 번에 수행합니다.
+이를 방지하기 위해 상태 변경을 Lua 내부에서 하나의 원자 연산으로 처리합니다.
 
-```text
-1. lobby:{code} 존재 여부 확인
-2. participants Set에 userIdentifier 추가
-3. 신규 입장자인 경우에만 order List에 userIdentifier 추가
-4. ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
-5. 로비 내 유저별 현재 유효 wsSessionId 저장
-6. 로비 내 유저별 현재 유효 세션 sequence 저장
-7. 관련 키 TTL 설정
-```
+---
 
-반환값은 다음과 같습니다.
-
-| 반환값                         | 의미                                 |
-| --------------------------- | ---------------------------------- |
-| `ENTERED:{sequence}`        | 신규 입장 처리 완료                        |
-| `ALREADY_JOINED:{sequence}` | 이미 참여 중인 유저의 중복 구독. order 중복 저장 없음 |
-| `LOBBY_NOT_FOUND`           | 존재하지 않는 로비 코드로 구독 요청               |
-
-입장 처리는 반드시 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
-`/topic/lobby/{code}/refresh`는 입장 처리를 트리거하지 않습니다.
-
-### Lua 스크립트 기반 원자적 퇴장 처리
-
-`leave_lobby.lua`는 참여자 제거 → 방장 위임 → 로비 폭파를 단일 트랜잭션으로 처리합니다.
-Redis는 싱글 스레드로 Lua 스크립트를 실행하므로 다수의 동시 퇴장 시에도 Race Condition이 발생하지 않습니다.
-
-반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,
-`LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여
-서비스 레이어가 Redis 반환 포맷을 알 필요 없도록 캡슐화합니다.
-
-### Lua 스크립트 기반 원자적 강퇴 처리
-
-`kick_lobby.lua`는 방장의 강퇴 요청을 원자적으로 처리합니다.
-
-처리 대상:
-
-```text
-lobby:{code}
-lobby:{code}:participants
-lobby:{code}:order
-lobby:{code}:kicked
-lobby:{code}:user_session:{targetUserIdentifier}
-lobby:{code}:user_session_seq:{targetUserIdentifier}
-```
-
-처리 순서:
-
-```text
-1. 로비 존재 여부 확인
-2. 방장 정보 존재 여부 확인
-3. 요청자가 방장인지 검증
-4. 자기 자신 강퇴 요청인지 검증
-5. 강퇴 대상이 참여자인지 검증
-6. participants/order에서 강퇴 대상 제거
-7. kicked Set에 강퇴 대상 추가
-8. 강퇴 대상의 현재 wsSessionId 반환
-9. 강퇴 대상의 user_session / user_session_seq 키 삭제
-```
-
-반환값은 다음과 같습니다.
-
-| 반환값                          | 의미                |
-| ---------------------------- | ----------------- |
-| `KICKED:{targetWsSessionId}` | 강퇴 성공             |
-| `LOBBY_NOT_FOUND`            | 존재하지 않는 로비        |
-| `HOST_NOT_FOUND`             | 로비 방장 정보 없음       |
-| `FORBIDDEN`                  | 요청자가 방장이 아님       |
-| `CANNOT_KICK_SELF`           | 자기 자신 강퇴 시도       |
-| `TARGET_NOT_PARTICIPANT`     | 강퇴 대상이 로비 참여자가 아님 |
-
-강퇴 성공 후 `LobbyEventService`는 `KICK` 메시지를 로비 채팅 채널로 브로드캐스트하고, 로비 내부 refresh 이벤트를 발행합니다.
-
-### Lua 스크립트 기반 원자적 게임 시작 처리
-
-`start_lobby.lua`는 게임 시작 조건 중 Redis 기준으로 원자 검증 가능한 조건을 처리합니다.
-
-처리 대상:
-
-```text
-lobby:{code}
-lobby:{code}:participants
-lobby:{code}:ready
-lobby:public
-```
-
-검증 조건:
-
-```text
-1. 로비가 존재해야 한다.
-2. 방장 정보가 존재해야 한다.
-3. 요청자가 방장이어야 한다.
-4. 로비 상태가 WAITING이어야 한다.
-5. map_id가 존재해야 한다.
-6. 방장 제외 참여자가 1명 이상이어야 한다.
-7. 방장 제외 참여자의 활성 로비 세션 키가 존재해야 한다.
-8. 방장 제외 모든 참여자가 ready 상태여야 한다.
-```
-
-반환값 계약은 `StartLobbyLuaResultCode` enum과 `StartLobbyLuaResultCodeContractTest`로 고정합니다.
-
-| 반환값                                  | 의미                                             |
-| ------------------------------------ | ---------------------------------------------- |
-| `STARTED`                            | 게임 시작 성공                                       |
-| `LOBBY_NOT_FOUND`                    | 로비 없음                                          |
-| `HOST_NOT_FOUND`                     | 방장 정보 없음                                       |
-| `FORBIDDEN`                          | 요청자가 방장이 아님                                    |
-| `LOBBY_NOT_WAITING`                  | 로비 상태가 WAITING이 아님                             |
-| `MAP_NOT_SELECTED`                   | 맵이 선택되지 않음                                     |
-| `NO_PLAYER`                          | 방장 제외 참여자 없음                                   |
-| `NOT_READY:{userIdentifier}`         | 준비하지 않은 참여자 존재                                 |
-| `STALE_PARTICIPANT:{userIdentifier}` | participants에는 있지만 활성 로비 세션 키가 없는 stale 참여자 존재 |
-
-알 수 없는 반환값 또는 `null` 반환값은 generic error로 처리하고, `[MONITORING_REQUIRED]` 로그와 metric을 남깁니다.
-
-### 게임 시작 Redis-DB 상태 불일치 재처리
+## 게임 시작 Redis-DB 상태 불일치 재처리
 
 게임 시작은 Redis Lua가 먼저 원자 검증 및 Redis 상태 전환을 수행하고, 이후 DB `GAME_LOBBY` 상태를 `PLAYING`으로 동기화합니다.
-
-이 구조에서는 아래와 같은 불일치가 발생할 수 있습니다.
 
 ```text
 Redis: PLAYING
 DB: WAITING
-```
-
-발생 가능한 상황:
-
-```text
-1. start_lobby.lua 성공
-2. Redis lobby:{code}.status = PLAYING
-3. DB GAME_LOBBY.status 변경 실패
 ```
 
 보정 정책:
@@ -1078,367 +645,83 @@ DB: WAITING
 lobbyCode|reason|attempt|nextRetryAtEpochMillis
 ```
 
-재처리 사유:
+---
 
-| reason                        | 보정 정책                       |
-| ----------------------------- | --------------------------- |
-| `START_DB_SYNC_FAILED`        | Redis 상태를 `WAITING`으로 롤백    |
-| `START_DB_SNAPSHOT_NOT_FOUND` | DB 스냅샷이 없으므로 Redis 잔존 로비 삭제 |
+## 운영 및 관측성 기준
 
-운영 모니터링 대상:
+### WebSocket Metric
 
-| 항목                                           | 설명               |
-| -------------------------------------------- | ---------------- |
-| `lobby:start:reconciliation`                 | 재처리 큐 길이         |
-| `[ALERT_REQUIRED]`                           | 즉시 운영 확인이 필요한 로그 |
-| `[MONITORING_REQUIRED]`                      | 모니터링 연계가 필요한 로그  |
-| `metric:lobby:start:reconciliation:enqueued` | 재처리 큐 적재 횟수      |
-| `metric:lobby:start:reconciliation:success`  | 재처리 성공 횟수        |
-| `metric:lobby:start:reconciliation:failed`   | 재처리 실패 횟수        |
-
-### ready / participants 정합성 보정 정책
-
-게임 시작 조건은 `participants`, `ready`, `user_session` 키의 정합성에 영향을 받습니다.
-
-정책:
+`WebSocketMetric`은 활성 WebSocket 세션 수를 Prometheus에 노출합니다.
 
 ```text
-1. participants Set을 현재 로비 참여자의 source of truth로 사용한다.
-2. ready Set에는 있지만 participants Set에는 없는 값은 stale ready 데이터로 보고 게임 시작 직전에 제거한다.
-3. participants Set에는 있지만 user_session 키가 없는 값은 stale participant로 보고 게임 시작을 거부한다.
-4. participants Set에 있고 user_session 키도 있지만 ready가 아닌 값은 실제 미준비 유저로 보고 NOT_READY 처리한다.
-5. NOT_READY 또는 STALE_PARTICIPANT 발생 시 ready/participants/session 정합성 진단 로그를 남긴다.
+CONNECT 성공 → increment
+DISCONNECT 처리 → decrement
 ```
 
-이 정책은 정상 참여자를 임의 삭제하지 않기 위한 선택입니다.
-participants에 남아 있는 유저가 실제 미준비 유저인지 stale 유저인지 Lua 내부에서 완전히 판단하기 어렵기 때문에, user_session 키가 없는 경우만 `STALE_PARTICIPANT`로 분리합니다.
+### Redis 장애 처리
 
-### Redis 직렬화 JsonMapper와 HTTP 응답 JsonMapper 분리
+| 영역 | 장애 처리 |
+| --- | --- |
+| 인증 refresh 저장소 | `503 Service Unavailable` |
+| WebSocket CONNECT 온라인 상태 저장 실패 | STOMP ERROR `CONNECT_ONLINE_STATUS_FAILED` |
+| 로비 입장 Lua 실패 | STOMP ERROR `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` |
+| Pub/Sub 발행 실패 | 로컬 WebSocket fallback 또는 로그/관측성 처리 |
+| 게임 시작 Redis-DB 불일치 | 보상 롤백 또는 reconciliation 큐 적재 |
 
-RedisTemplate은 타입 정보가 필요한 `GenericJacksonJsonRedisSerializer`를 사용합니다.
-기존처럼 타입 정보가 포함된 `JsonMapper`를 Spring Bean으로 노출하면 Spring MVC HTTP 응답 직렬화에 해당 Mapper가 개입할 수 있습니다.
+### 로그 기준
 
-그 결과 REST 응답이 아래처럼 Jackson 타입 정보를 포함하는 형태로 내려갈 수 있습니다.
-
-```json
-[
-  "java.util.ArrayList",
-  [
-    [
-      "io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto",
-      {
-        "code": "ABC123",
-        "title": "K-POP 퀴즈방"
-      }
-    ]
-  ]
-]
-```
-
-이를 방지하기 위해 Redis 전용 JsonMapper는 `RedisConfig#createRedisJsonMapper()` private 메서드 내부에서만 생성합니다.
-
-정책:
-
-```text
-1. RedisTemplate 값 직렬화:
-   - 타입 정보 포함 JsonMapper 사용
-   - Spring Bean으로 노출하지 않음
-
-2. Pub/Sub 메시지 직렬화:
-   - 타입 정보 없는 pubSubJsonMapper Bean 사용
-
-3. HTTP 응답 직렬화:
-   - Redis 직렬화용 JsonMapper가 개입하지 않음
-   - 순수 DTO JSON 배열로 반환
-```
-
-기존 `jsonMapper` Bean 직접 주입 사용처는 없어야 하며, JsonMapper가 필요한 신규 코드에서는 목적에 맞는 Bean을 명시적으로 주입해야 합니다.
-
-### ChatMessageDto 위치
-
-`ChatMessageDto`는 채팅 도메인 전용 객체가 아닌 WebSocket 통신 전반에서 사용되는 메시지 포맷입니다.
-`domain/chat/dto`가 아닌 `global/websocket/dto`에 위치하여
-`global` 레이어의 `RedisPublisher`, `RedisSubscriber`, `WebSocketEventListener`가
-`domain`을 역참조하는 의존 방향 역전을 방지합니다.
-
-### Redis Pub/Sub 직렬화 분리
-
-Redis Pub/Sub 메시지는 WebSocket 클라이언트에게 그대로 전달될 수 있으므로, 일반 Redis 객체 저장용 `RedisTemplate<String, Object>`와 분리하여 처리합니다.
-
-#### 일반 Redis 데이터 저장
-
-`RedisTemplate<String, Object>`는 Redis Hash/Value에 객체 타입 정보를 보존하기 위해 `GenericJacksonJsonRedisSerializer`와 `activateDefaultTyping`을 사용합니다.
-
-사용 예:
-
-```text
-lobby:{code}
-auth:guest:session:{token}
-```
-
-#### Pub/Sub 메시지 발행
-
-Pub/Sub 메시지는 `StringRedisTemplate`과 Pub/Sub 전용 `JsonMapper`를 사용합니다.
-
-이유:
-
-```text
-RedisTemplate<String, Object>로 ChatMessageDto를 발행하면
-WebSocket 클라이언트가 ["클래스명", {...}] 형태의 메시지를 받게 됨
-```
-
-기존 문제 형태:
-
-```json
-["io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto",{"type":"ENTER","roomId":"R2VJW5"}]
-```
-
-수정 후 형태:
-
-```json
-{"type":"ENTER","roomId":"R2VJW5","sender":"...","content":"...","timestamp":"..."}
-```
-
-`RedisSubscriber`는 Pub/Sub 메시지를 DTO로 역직렬화하지 않고, JSON 문자열 그대로 `SimpMessagingTemplate.convertAndSend()`로 WebSocket 클라이언트에게 전달합니다.
-
-### 참여자 키 단일 진실의 원천
-
-기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로
-동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.
-
-`lobby:{code}:participants`를 단일 진실의 원천으로 통일하여
-입장(Lua) → 퇴장(Lua) → 강퇴(Lua) → ready/start 검증 모두 동일한 키를 사용합니다.
-
-### SETNX 기반 초대 코드 중복 방지
-
-`LobbyRepositoryImpl`은 6자리 초대 코드를 생성할 때
-`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.
-선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`까지 재시도합니다.
-
-락 TTL은 `LobbyDefaults.INVITE_CODE_LOCK_TTL`을 따르며, 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
-
-### JWT 인증 구조
-
-`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.
-파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.
-컨트롤러에서는 `@AuthenticationPrincipal CustomPrincipal`로 주입받아 사용합니다.
-
-[식별자 분리]
-
-* `userId` (Long) : DB users.id FK 참조용
-* `userIdentifier` (UUID String) : Redis/WebSocket 식별자
+| 상황 | 로그 기준 |
+| --- | --- |
+| Lua 알 수 없는 반환값 | `error` + monitoring required |
+| Redis-DB 게임 시작 불일치 | `error` + reconciliation enqueue |
+| 최대 재시도 초과 | `error` + alert required |
+| stale 세션 disconnect | `info` |
+| 중복 구독 | `info` |
 
 ---
 
-## 🌐 STOMP 채널 구조
+## FE 연동 핵심 계약
 
-| 방향         | 경로                            | 설명                          |
-| ---------- | ----------------------------- | --------------------------- |
-| 클라이언트 → 서버 | `/app/chat/global`            | 전체 채팅 메시지 송신                |
-| 클라이언트 → 서버 | `/app/chat/lobby/{code}`      | 로비 채팅 메시지 송신                |
-| 클라이언트 → 서버 | `/app/lobby/create`           | 로비 생성 이벤트 송신                |
-| 클라이언트 → 서버 | `/app/lobby/{code}/update`    | 로비 정보 변경 이벤트 송신             |
-| 클라이언트 → 서버 | `/app/lobby/{code}/kick`      | 방장의 로비 유저 강퇴 요청             |
-| 서버 → 클라이언트 | `/topic/chat/global`          | 전체 채팅 메시지 수신                |
-| 서버 → 클라이언트 | `/topic/lobby/{code}`         | 로비 채팅 메시지 수신 및 로비 입장 처리 트리거 |
-| 서버 → 클라이언트 | `/topic/lobby/{code}/refresh` | 로비 내부 정보 새로고침 신호            |
-| 서버 → 클라이언트 | `/topic/lobby/{code}/game`    | 게임 시작 이벤트 (`GAME_STARTED`)  |
-| 서버 → 클라이언트 | `/topic/lobby/refresh`        | 전역 로비 리스트 새로고침 신호           |
+### 로비 입장
 
-> `/topic/lobby/{code}`는 로비 채팅 메시지 수신 채널이면서 WebSocket 입장 처리 트리거입니다.
-> `/topic/lobby/{code}/refresh`는 로비 정보 새로고침 신호 수신 전용이며, 입장 처리 트리거가 아닙니다.
-
----
-
-## 🔐 인증 구조
-
-### 정식 회원 (Member)
-
-로그인 성공 시 JWT를 발급하고 `user_sessions`에 서버 세션 추적 정보를 저장합니다.
-맵 생성, 로비 호스팅 등 전체 기능에 접근할 수 있습니다.
-
-### 게스트 (Guest)
-
-닉네임 입력만으로 진입하며, 백엔드에서 UUID를 발급하여 `localStorage`에 저장합니다.
-재방문 시 UUID로 자동 복원됩니다. 퀴즈 플레이 참여만 가능합니다.
-
-### WebSocket 인증 흐름
+FE는 REST join 성공만으로 사용자를 로비 참여자로 확정하면 안 됩니다.
 
 ```text
-STOMP CONNECT 헤더: { userIdentifier: "UUID" }
-    │
-    ▼
-StompChannelInterceptor.handleConnect()
-    │ UUID 형식 검증 (8-4-4-4-12 포맷)
-    │ 세션에 userIdentifier 저장
-    ▼
-이후 모든 STOMP 명령에서 세션의 userIdentifier 검증
+1. POST /api/lobbies/join
+2. WebSocket CONNECT
+3. SUBSCRIBE /topic/lobby/{code}
+4. SUBSCRIBE 성공 후 GET /api/lobbies/{code}
 ```
 
-### REST API 인증 흐름
+### 로비 목록
 
-```text
-HTTP 요청 (Authorization: Bearer {accessToken})
-    │
-    ▼
-JwtAuthenticationFilter
-    │ 1. Authorization 헤더에서 Bearer 토큰 추출
-    │ 2. JWT 서명 검증 (secretKey)
-    │ 3. userId, userIdentifier, userType 클레임 추출 (JwtClaims 상수)
-    │ 4. CustomPrincipal 생성 → SecurityContext 저장
-    ▼
-Controller
-    │ @AuthenticationPrincipal CustomPrincipal로 주입
-    │ - principal.userId()          → DB Insert FK 용도
-    │ - principal.userIdentifier()  → Redis 저장 식별자 용도
-    ▼
-Service
-```
+`PLAYING` 로비는 목록에 노출될 수 있으나 입장 버튼은 비활성화해야 합니다.
 
----
+### 로비 상세
 
-## 🧩 로비 생성 시 맵 연결 흐름
+`canStart`는 snapshot 값입니다.  
+실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 최종 검증됩니다.
 
-```text
-클라이언트
-    │ POST /api/lobbies
-    │ Body: { title, maxPlayers, isPrivate, mapId?, roundCount?, timeLimitSeconds? }
-    ▼
-LobbyController.createLobby()
-    │ @AuthenticationPrincipal CustomPrincipal 주입
-    ▼
-LobbyService.createLobby()
-    │ 1. principal 검증
-    │ 2. host User 조회
-    │ 3. mapId가 있으면 QuizMap 조회 및 권한 검증
-    │ 4. LobbyMapMetadata 생성
-    ▼
-LobbyRepository.saveToRedis()
-    │ create_lobby.lua 실행
-    │ 초대 코드 선점 + Redis Hash 저장
-    ▼
-GameLobbyJpaRepository.save()
-    │ GAME_LOBBY 스냅샷 저장
-    ▼
-CreateLobbyResponse 반환
-```
+### STOMP ERROR
 
-### 맵 미선택 로비
-
-`mapId`가 없으면 맵 검증을 수행하지 않습니다.
+FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 
 ```json
 {
-  "mapId": null,
-  "mapTitle": null,
-  "mapCategory": null
+  "type": "STOMP_ERROR",
+  "code": "LOBBY_NOT_FOUND",
+  "message": "존재하지 않는 로비입니다.",
+  "action": "RETURN_TO_LOBBY_LIST",
+  "recoverable": false,
+  "timestamp": "2026-05-25T00:00:00Z"
 }
 ```
 
-Redis Hash에는 `map_id`, `map_title`, `map_category` 필드를 저장하지 않습니다.
+분기는 다음 기준으로 처리합니다.
 
-### 맵 선택 로비
-
-`mapId`가 있으면 검증 후 Redis Hash와 DB 스냅샷에 반영합니다.
-
-```json
-{
-  "mapId": 1,
-  "mapTitle": "K-POP 2세대",
-  "mapCategory": "K-POP"
-}
-```
-
-Redis Hash에는 아래 필드를 저장합니다.
-
-```text
-map_id
-map_title
-map_category
-```
-
----
-
-## 🧩 로비 ready 및 게임 시작 흐름
-
-### ready 상태 변경
-
-```text
-클라이언트
-    │ PATCH /api/lobbies/{code}/ready
-    │ Body: { ready: true }
-    ▼
-LobbyController.updateReadyStatus()
-    │ @AuthenticationPrincipal CustomPrincipal 주입
-    ▼
-LobbyService.updateReadyStatus()
-    │ 1. principal 검증
-    │ 2. Redis 로비 존재 여부 확인
-    │ 3. 로비 상태 WAITING 확인
-    │ 4. 참여자 여부 확인
-    │ 5. 방장 ready 요청 차단
-    ▼
-LobbyRepository.updateReadyStatus()
-    │ ready=true  → SADD lobby:{code}:ready userIdentifier
-    │ ready=false → SREM lobby:{code}:ready userIdentifier
-    ▼
-LobbyEventService.notifyLobbyInfoRefresh()
-    │ /topic/lobby/{code}/refresh 로 REFRESH_LOBBY_INFO 브로드캐스트
-```
-
-### canStart 계산
-
-`GET /api/lobbies/{code}` 응답의 `canStart`는 FE의 게임 시작 버튼 활성화 기준입니다.
-
-계산 조건:
-
-```text
-1. Redis 로비 상태가 WAITING
-2. Redis map_id 존재
-3. DB 기준 맵 문제 수가 roundCount 이상
-4. Redis participants 기준 방장 제외 참여자 1명 이상
-5. Redis ready Set 기준 방장 제외 모든 참여자가 ready
-```
-
-`canStart`는 조회 시점의 snapshot입니다.
-실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 `start_lobby.lua`가 최종 검증합니다.
-
----
-
-## 🧪 주요 검증 시나리오
-
-### 로비 생성
-
-| 시나리오                       | 기대 결과                      |
-| -------------------------- | -------------------------- |
-| `mapId` 없이 로비 생성           | `201 Created`, 맵 정보 `null` |
-| 공개 맵 `mapId`로 로비 생성        | `201 Created`, 맵 정보 포함     |
-| 본인 소유 비공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함     |
-| 타인 소유 비공개 맵 `mapId`로 로비 생성 | `403 Forbidden`            |
-| 삭제된 맵 `mapId`로 로비 생성       | `409 Conflict`             |
-| 존재하지 않는 `mapId`로 로비 생성     | `404 Not Found`            |
-| 음수 또는 0 `mapId`로 로비 생성     | `400 Bad Request`          |
-
-### Redis 저장
-
-| 시나리오     | 기대 결과                                       |
-| -------- | ------------------------------------------- |
-| 맵 미선택 로비 | `map_id`, `map_title`, `map_category` 필드 없음 |
-| 맵 선택 로비  | `map_id`, `map_title`, `map_category` 필드 있음 |
-| 맵 미선택 로비 | `"null"` 문자열 저장 없음                          |
-| ready 변경 | `lobby:{code}:ready` Set 추가/삭제              |
-| 퇴장/강퇴    | ready Set에서 해당 userIdentifier 제거            |
-
-### 로비 상세 / ready / start
-
-| 시나리오                                | 기대 결과                                                |
-| ----------------------------------- | ---------------------------------------------------- |
-| 로비 상세 조회                            | 참여자 목록, ready 상태, canStart 반환                        |
-| 방장이 ready 요청                        | `400 Bad Request`                                    |
-| 일반 참여자가 ready 요청                    | `204 No Content`, refresh 브로드캐스트                     |
-| canStart=true 상태에서 start 요청         | `204 No Content`, `GAME_STARTED` 브로드캐스트              |
-| ready 미완료 상태에서 start 요청             | `409 Conflict`                                       |
-| 맵 미선택 상태에서 start 요청                 | `409 Conflict`                                       |
-| 맵 문제 수 부족 상태에서 start 요청             | `409 Conflict`                                       |
-| stale participant가 있는 상태에서 start 요청 | `409 Conflict`, ready/participants/session 정합성 로그 기록 |
-| Redis Lua 성공 후 DB 동기화 실패            | Redis rollback 또는 reconciliation queue 적재            |
+| 필드 | 사용 목적 |
+| --- | --- |
+| `code` | 구체적인 실패 원인 분기 |
+| `action` | 화면 이동/재연결/재시도 정책 |
+| `recoverable` | 같은 화면에서 재시도 가능한지 판단 |
+| `message` | 사용자에게 표시할 문구 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,74 +67,71 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   ├── LobbyRepository.java                # 로비 Redis 데이터 접근 인터페이스
 │   │   │   ├── LobbyRepositoryImpl.java            # 로비 Repository Facade
 │   │   │   └── redis/
-│   │   │       ├── LobbyLuaScriptExecutor.java     # 로비 Lua 스크립트 실행 컴포넌트
-│   │   │       ├── LobbyLuaResultMapper.java       # Lua 반환 문자열 → 도메인 결과 매핑
-│   │   │       ├── LobbyRedisCommandRepository.java # Redis 로비 명령 처리
-│   │   │       ├── LobbyRedisQueryRepository.java  # Redis 로비 조회 처리
-│   │   │       └── LobbyStartReconciliationRepository.java # start 상태 불일치 재처리 큐 접근
+│   │   │       ├── LobbyLuaScriptExecutor.java
+│   │   │       ├── LobbyLuaResultMapper.java
+│   │   │       ├── LobbyRedisCommandRepository.java
+│   │   │       ├── LobbyRedisQueryRepository.java
+│   │   │       └── LobbyStartReconciliationRepository.java
 │   │   └── service/
-│   │       ├── LobbyCanStartPolicy.java            # 조회 시점 canStart 계산 정책
-│   │       ├── LobbyCreateService.java             # 로비 생성 유스케이스
-│   │       ├── LobbyJoinService.java               # 초대 코드 기반 입장 사전 검증 유스케이스
-│   │       ├── LobbyQueryService.java              # 로비 목록/상세 조회 유스케이스
-│   │       ├── LobbyReadyService.java              # ready 상태 변경 유스케이스
-│   │       ├── LobbyStartService.java              # 게임 시작 유스케이스
-│   │       ├── LobbyRealtimeNotifier.java          # 로비 refresh/STOMP 브로드캐스트
-│   │       └── LobbyStartReconciliationService.java # 게임 시작 Redis-DB 상태 불일치 재처리 스케줄러
+│   │       ├── LobbyCanStartPolicy.java
+│   │       ├── LobbyCreateService.java
+│   │       ├── LobbyJoinService.java
+│   │       ├── LobbyQueryService.java
+│   │       ├── LobbyReadyService.java
+│   │       ├── LobbyStartService.java
+│   │       ├── LobbyRealtimeNotifier.java
+│   │       └── LobbyStartReconciliationService.java
 │   │
 │   ├── map/                                        # 퀴즈 맵 도메인
 │   │   ├── controller/
-│   │   │   └── QuizMapController.java              # 맵 REST API
+│   │   │   └── QuizMapController.java
 │   │   ├── dto/
-│   │   │   └── ...                                 # 맵 생성/수정/조회 DTO
 │   │   ├── entity/
-│   │   │   ├── QuizMap.java                        # map 테이블 엔티티
-│   │   │   └── MapCategory.java                    # 맵 카테고리 enum (kpop, jpop, pop)
+│   │   │   ├── QuizMap.java
+│   │   │   └── MapCategory.java
 │   │   ├── repository/
-│   │   │   └── QuizMapJpaRepository.java           # 맵 JPA 리포지토리
+│   │   │   └── QuizMapJpaRepository.java
 │   │   └── service/
-│   │       └── QuizMapService.java                 # 맵 생성/수정/삭제/조회 비즈니스 로직
+│   │       └── QuizMapService.java
 │   │
-│   └── ...
+│   └── game/                                       # 인게임 도메인
+│       ├── controller/
+│       ├── dto/
+│       ├── entity/
+│       ├── repository/
+│       └── service/
 │
 └── global/                                         # 전역 인프라 레이어
-    ├── config/                                     # 애플리케이션 설정
-    │   ├── RedisConfig.java                        # Redis 연결, 직렬화, Pub/Sub 설정
-    │   ├── RedisScriptConfig.java                  # create/enter/leave/kick/start Lua 스크립트 Bean 등록
-    │   ├── SchedulingConfig.java                   # @Scheduled 기반 재처리 작업 활성화
-    │   ├── WebSocketConfig.java                    # STOMP 엔드포인트 및 브로커 설정
+    ├── config/
+    │   ├── RedisConfig.java
+    │   ├── RedisScriptConfig.java
+    │   ├── SchedulingConfig.java
+    │   ├── WebSocketConfig.java
     │   └── SecurityConfig/
-    │       ├── SecurityConfigDev.java              # 개발 환경 (인증 없이 전체 허용)
-    │       └── SecurityConfigProd.java             # 운영 환경 (전체 인증 필요)
-    │
-    ├── constant/                                   # 전역 상수 클래스
-    │   ├── RedisKeys.java                          # Redis 키 패턴 및 Hash 필드명 상수
-    │   ├── StompDestinations.java                  # STOMP 송신/구독 경로 상수
-    │   └── WebSocketHeaders.java                   # WebSocket 헤더 키 및 세션 속성 키 상수
-    │
-    ├── redis/                                      # Redis Pub/Sub 인프라
-    │   ├── RedisPublisher.java                     # Redis 채널 메시지 발행
-    │   └── RedisSubscriber.java                    # Redis 채널 메시지 수신 → WebSocket 브로드캐스트
-    │
-    ├── websocket/                                  # WebSocket 인프라
-    │   ├── CustomStompErrorHandler.java            # STOMP ERROR 프레임 핸들러
-    │   ├── StompChannelInterceptor.java            # CONNECT/SUBSCRIBE/SEND 인증 검증
-    │   ├── WebSocketEventListener.java             # WebSocket 연결 생명주기 이벤트 처리
-    │   ├── WebSocketMetric.java                    # 활성 세션 수 Prometheus 메트릭
-    │   ├── WebSocketSessionUtils.java              # 세션 식별자 추출 공통 유틸
-    │   ├── dto/
-    │   │   └── ChatMessageDto.java                 # WebSocket 채팅 메시지 DTO
+    ├── constant/
+    │   ├── RedisKeys.java
+    │   ├── StompDestinations.java
+    │   └── WebSocketHeaders.java
+    ├── redis/
+    │   ├── RedisPublisher.java
+    │   └── RedisSubscriber.java
+    ├── websocket/
+    │   ├── CustomStompErrorHandler.java
+    │   ├── StompChannelInterceptor.java
+    │   ├── WebSocketEventListener.java
+    │   ├── WebSocketMetric.java
+    │   ├── WebSocketSessionUtils.java
+    │   ├── error/
+    │   │   ├── StompErrorAction.java
+    │   │   ├── StompErrorCode.java
+    │   │   ├── StompErrorException.java
+    │   │   └── StompErrorPayload.java
     │   └── event/
-    │       └── PlayerLeaveEvent.java               # 플레이어 퇴장 Spring 이벤트 객체
+    │       └── PlayerLeaveEvent.java
     └── security/
-        ├── SecurityEndpoints.java                  # Security 경로 상수 중앙화
+        ├── SecurityEndpoints.java
         └── jwt/
-            ├── CustomPrincipal.java                # JWT 인증 주체 (userId + userIdentifier)
-            ├── JwtAuthenticationFilter.java        # Bearer 토큰 검증 및 SecurityContext 저장
-            ├── JwtClaims.java                      # JWT 클레임 키 상수 (발급/검증 공유)
-            ├── JwtTokenProvider.java               # JWT Access/Refresh 토큰 발급
-            └── TokenWithExpiry.java                # 토큰 + 만료시각 DTO
-````
+```
 
 ---
 
@@ -147,12 +144,12 @@ domain  →  global  (허용 ✅)
 global  →  domain  (금지 ❌)
 ```
 
-`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.
+`global` 패키지는 도메인에 종속되지 않는 순수 인프라 레이어입니다.  
 `global`이 `domain`을 직접 참조하면 의존 방향이 역전되어 순환 의존 및 결합도 증가 문제가 발생합니다.
 
-### 의존 방향 역전 해결 사례 — Spring ApplicationEventPublisher
+### 이벤트 기반 의존 역전 해소
 
-`WebSocketEventListener(global)`가 `LobbyEventService(domain)`를 직접 호출하던 문제를 아래와 같이 해결했습니다.
+`WebSocketEventListener(global)`가 로비 도메인을 직접 호출하지 않도록 `ApplicationEventPublisher`를 사용합니다.
 
 ```text
 [기존 — 의존 방향 역전]
@@ -164,26 +161,24 @@ global/WebSocketEventListener → ApplicationEventPublisher.publishEvent(PlayerL
                                domain/LobbyEventService @EventListener  ✅
 ```
 
-`PlayerLeaveEvent`는 `global/websocket/event`에 위치하여 `domain → global` 단방향 의존을 유지합니다.
+`PlayerLeaveEvent`는 `global/websocket/event`에 위치하고, 도메인 레이어가 이 이벤트를 구독합니다.
 
 ### 도메인 간 의존 규칙
 
 동일한 `domain` 하위 도메인 간 참조는 비즈니스 흐름상 허용하지만, 직접 엔티티 결합은 최소화합니다.
 
-예를 들어 로비 생성 시 맵을 연결할 때 `LobbyService`는 `QuizMapJpaRepository`로 맵 접근 권한을 검증합니다.
-하지만 Redis 저장 계층인 `LobbyRepositoryImpl`은 `QuizMap` 엔티티에 직접 의존하지 않고, `LobbyMapMetadata`라는 최소 DTO만 전달받습니다.
+예를 들어 로비 생성 시 맵을 연결할 때 `LobbyCreateService`는 맵 접근 권한을 검증합니다.  
+하지만 Redis 저장 계층은 `QuizMap` 엔티티에 직접 의존하지 않고 `LobbyMapMetadata`만 전달받습니다.
 
 ```text
-LobbyService
-    ├── QuizMapJpaRepository 조회
+LobbyCreateService
+    ├── QuizMap 조회
     ├── 맵 존재/삭제/권한 검증
     └── LobbyMapMetadata 생성
             ↓
 LobbyRepositoryImpl
     └── Redis 저장에 필요한 mapId, mapTitle, mapCategory만 사용
 ```
-
-이 구조를 통해 맵 도메인의 영속성 모델 변경이 Redis 저장 계층으로 직접 전파되는 것을 방지합니다.
 
 ---
 
@@ -200,19 +195,9 @@ Client
     ▼
 LobbyQueryController
     │ 요청 파라미터 수집
-    │ - keyword
-    │ - mapCategory
-    │ - sort
-    │ - page
-    │ - size
     ▼
 LobbySearchCondition
     │ 요청 조건 정규화
-    │ - keyword trim + lower-case
-    │ - mapCategory MapCategory.from()으로 검증
-    │ - sort LobbySortType으로 검증
-    │ - page 기본값/범위 검증
-    │ - size 기본값/최대값 검증
     ▼
 LobbyQueryService
     │ 로비 목록 노출 정책 적용
@@ -233,19 +218,18 @@ LobbyQueryService
 LobbyRepository
     ▼
 LobbyRedisQueryRepository
-    │ Redis Hash / Set / ZSET 조회
     ▼
 Redis
 ```
 
 ### 책임 분리
 
-| 계층                          | 책임                                                 |
-| --------------------------- | -------------------------------------------------- |
-| `LobbyQueryController`      | HTTP 요청 파라미터 수집                                    |
-| `LobbySearchCondition`      | 요청값 정규화 및 검증                                       |
-| `LobbyPageRequest`          | `page`, `size` 기본값/범위 검증                           |
-| `LobbyQueryService`         | 로비 목록 노출 정책, 검색, 필터링, 정렬, 페이징, 인덱스 사용 여부 결정        |
+| 계층 | 책임 |
+| --- | --- |
+| `LobbyQueryController` | HTTP 요청 파라미터 수집 |
+| `LobbySearchCondition` | 요청값 정규화 및 검증 |
+| `LobbyPageRequest` | `page`, `size` 기본값/범위 검증 |
+| `LobbyQueryService` | 로비 목록 노출 정책, 검색, 필터링, 정렬, 페이징, 인덱스 사용 여부 결정 |
 | `LobbyRedisQueryRepository` | Redis 원본 공개 로비 데이터 조회, ZSET 인덱스 조회, stale index 정리 |
 
 ### 노출 정책
@@ -258,125 +242,45 @@ Redis
 
 ### 페이징 정책
 
-| 항목         | 정책                                 |
-| ---------- | ---------------------------------- |
-| `page`     | 0-based 페이지 번호                     |
-| `page` 기본값 | `0`                                |
-| `size` 기본값 | `20`                               |
-| `size` 최소값 | `1`                                |
-| `size` 최대값 | `100`                              |
-| 응답 구조      | `items`, `page`, `size`, `hasNext` |
+| 항목 | 정책 |
+| --- | --- |
+| `page` | 0-based 페이지 번호 |
+| `page` 기본값 | `0` |
+| `size` 기본값 | `20` |
+| `size` 최소값 | `1` |
+| `size` 최대값 | `100` |
+| 응답 구조 | `items`, `page`, `size`, `hasNext` |
 
 ### 정렬 정책
 
-| 정렬 기준            | 설명                                           | Redis 인덱스                     |
-| ---------------- | -------------------------------------------- | ----------------------------- |
-| `latest`         | `createdAtEpochMillis` 내림차순                  | `lobby:public:latest`         |
-| `most_players`   | `currentPlayers` 내림차순, 동률이면 최신순              | `lobby:public:most_players`   |
-| `most_available` | `maxPlayers - currentPlayers` 내림차순, 동률이면 최신순 | `lobby:public:most_available` |
+| 정렬 기준 | 설명 | Redis 인덱스 |
+| --- | --- | --- |
+| `latest` | `createdAtEpochMillis` 내림차순 | `lobby:public:latest` |
+| `most_players` | `currentPlayers` 내림차순 | `lobby:public:most_players` |
+| `most_available` | `maxPlayers - currentPlayers` 내림차순 | `lobby:public:most_available` |
 
-`lobby:public`은 Redis Set이므로 삽입 순서가 보장되지 않습니다. 따라서 로비 생성 시 Redis Hash에 `created_at_epoch_millis`를 저장하고, 이 값을 기준으로 최신순 정렬을 수행합니다.
+`lobby:public`은 Redis Set이므로 삽입 순서가 보장되지 않습니다.  
+따라서 로비 생성 시 Redis Hash에 `created_at_epoch_millis`를 저장하고, 이 값을 기준으로 최신순 정렬을 수행합니다.
 
-**Redis 정렬 인덱스**
+### Redis 정렬 인덱스
 
-| Redis Key                     | Type | Member     | Score                           | 갱신 시점                                |
-| ----------------------------- | ---- | ---------- | ------------------------------- | ------------------------------------ |
-| `lobby:public:latest`         | ZSET | lobby code | `created_at_epoch_millis`       | 공개 로비 생성 시 `ZADD`, 로비 폭파/삭제 시 `ZREM` |
-| `lobby:public:most_players`   | ZSET | lobby code | `current_players`               | 공개 로비 생성/입장/퇴장/강퇴 시 갱신               |
-| `lobby:public:most_available` | ZSET | lobby code | `max_players - current_players` | 공개 로비 생성/입장/퇴장/강퇴 시 갱신               |
+| Redis Key | Type | Member | Score | 갱신 시점 |
+| --- | --- | --- | --- | --- |
+| `lobby:public:latest` | ZSET | lobby code | `created_at_epoch_millis` | 공개 로비 생성 시 `ZADD`, 로비 폭파/삭제 시 `ZREM` |
+| `lobby:public:most_players` | ZSET | lobby code | `current_players` | 공개 로비 생성/입장/퇴장/강퇴 시 갱신 |
+| `lobby:public:most_available` | ZSET | lobby code | `max_players - current_players` | 공개 로비 생성/입장/퇴장/강퇴 시 갱신 |
 
-**정렬 인덱스 사용 조건**
+### 정렬 인덱스 사용 조건
 
-| 조건                                          | 조회 방식                                 |
-| ------------------------------------------- | ------------------------------------- |
-| `keyword` 없음 + `mapCategory` 없음 + 정렬 인덱스 존재 | Redis ZSET에서 page 범위의 lobbyCode만 조회   |
-| `keyword` 있음                                | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
-| `mapCategory` 있음                            | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
-| 정렬 인덱스 없음                                   | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
+| 조건 | 조회 방식 |
+| --- | --- |
+| `keyword` 없음 + `mapCategory` 없음 + 정렬 인덱스 존재 | Redis ZSET에서 page 범위의 lobbyCode만 조회 |
+| `keyword` 있음 | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
+| `mapCategory` 있음 | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
+| 정렬 인덱스 없음 | `lobby:public` 전체 조회 후 Java 필터/정렬/페이징 |
 
-필터가 있는 경우 ZSET page 범위를 먼저 자르면 전체 필터링 결과 기준의 page가 깨질 수 있습니다.
-예를 들어 ZSET 상위 20개에는 `K-POP` 로비가 없지만 21번째 이후에 `K-POP` 로비가 있을 수 있습니다.
+필터가 있는 경우 ZSET page 범위를 먼저 자르면 전체 필터링 결과 기준의 page가 깨질 수 있습니다.  
 따라서 `keyword`, `mapCategory` 필터가 있는 경우는 안전하게 기존 전체 조회 경로로 폴백합니다.
-
-### 생성 시각 기준
-
-로비 생성 시각은 Java 애플리케이션 서버 시간이 아니라 Redis `TIME` 명령을 기준으로 생성합니다.
-
-```lua
-local redisTime = redis.call('TIME')
-local createdAtEpochMillis = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
-```
-
-멀티 인스턴스 운영 환경에서는 애플리케이션 서버 간 시간 편차가 발생할 수 있습니다.  
-따라서 Redis 서버 기준 단일 시간원을 사용해 최신순 정렬 기준을 일관되게 유지합니다.
-
-### 현재 인원 캐싱 정책
-
-`current_players`는 `lobby:{code}:participants` Set과 중복 상태입니다.
-따라서 Java 서비스에서 직접 증가/감소시키지 않고, participants 변경을 수행하는 Lua 스크립트 내부에서만 갱신합니다.
-
-| 이벤트       | 처리                                                          |
-| --------- | ----------------------------------------------------------- |
-| 로비 생성     | `current_players = 0`                                       |
-| 입장        | `SCARD lobby:{code}:participants` 결과를 `current_players`에 저장 |
-| 퇴장        | 남은 participants 수를 `current_players`에 저장                    |
-| 강퇴        | 남은 participants 수를 `current_players`에 저장                    |
-| 마지막 인원 퇴장 | 로비 Hash 삭제. 별도 `current_players = 0` 저장 불필요                 |
-
-조회 시에는 `lobby:{code}.current_players`를 우선 사용합니다.
-다만 배포 전 생성된 기존 Redis 데이터에는 해당 필드가 없을 수 있으므로, 누락 시 `SCARD lobby:{code}:participants` 결과로 fallback합니다.
-
-### Redis Hash 필드
-
-`lobby:{code}` Hash에는 공개 로비 목록 조회 및 정렬을 위해 다음 필드가 포함됩니다.
-
-| 필드                        | 설명                                           |
-| ------------------------- | -------------------------------------------- |
-| `created_at_epoch_millis` | Redis `TIME` 기준 로비 생성 시각. epoch milliseconds |
-| `current_players`         | 현재 참여 인원 캐시. participants Set 변경 Lua에서만 갱신   |
-| `map_category`            | 선택된 맵 카테고리. `K-POP`, `J-POP`, `POP`          |
-| `status`                  | 로비 상태. 목록에서는 `WAITING`, `PLAYING`만 노출        |
-| `is_private`              | 비공개 여부. 공개 로비 목록은 `false`만 노출                |
-| `max_players`             | 최대 참여 인원                                     |
-
-### Redis 정합성 방어
-
-공개 로비 인덱스에는 남아 있지만 `lobby:{code}` Hash가 TTL 만료, 수동 삭제, 과거 버전 로직 등으로 사라질 수 있습니다.
-
-이 경우 공개 로비 목록 조회 경로에서는 해당 code를 응답에서 제외만 합니다.  
-조회 요청 중 즉시 인덱스를 삭제하지 않습니다.
-
-인덱스 정리는 `LobbyPublicIndexCleanupScheduler`가 주기적으로 수행합니다.
-
-```text
-LobbyPublicIndexCleanupScheduler
-    │ fixedDelay 기반 주기 실행
-    ▼
-lobby:public Set에서 일부 code 샘플 조회
-    ▼
-각 code에 대해 lobby:{code} Hash 존재 여부 확인
-    ▼
-Hash가 없으면 아래 공개 인덱스에서 제거
-```
-정리 대상은 다음과 같습니다.
-
-```
-lobby:public
-lobby:public:latest
-lobby:public:most_players
-lobby:public:most_available
-```
-
-이 구조는 조회 경로와 정리 경로를 분리하기 위한 설계입니다.
-
-| 구분                                                    | 책임                                      |
-| ----------------------------------------------------- | --------------------------------------- |
-| `LobbyRedisQueryRepository#getPublicLobbiesByCodes()` | stale code를 응답에서 제외                     |
-| `LobbyPublicIndexCleanupScheduler`                    | stale code를 public Set/ZSET 인덱스에서 배치 정리 |
-| `removePublicLobbyIndexes()`                          | 보정/정리 경로에서 특정 lobbyCode를 공개 인덱스에서 제거    |
-
-정렬 인덱스 기반 조회 중 stale code가 섞이면 `LobbyQueryService`는 요청한 page size를 최대한 채우기 위해 추가 범위를 스캔합니다.
-스캔 상한은 `targetItemCount * 5` 기준으로 제한하여 stale index가 누적된 상황에서도 무한 조회를 방지합니다.
 
 ---
 
@@ -386,28 +290,23 @@ lobby:public:most_available
 
 ```text
 클라이언트
-    │ STOMP /app/chat/global (또는 /app/chat/lobby/{code})
+    │ STOMP /app/chat/global 또는 /app/chat/lobby/{code}
     ▼
 ChatController
-    │
     ▼
 ChatService
     │ sender 위변조 방지 — 클라이언트 sender 무시, 세션 식별자로 교체
-    │
     ▼
 RedisPublisher.publish()
-    │ Redis Pub/Sub 발행
     ▼
-Redis
-    │
+Redis Pub/Sub
     ▼
 RedisSubscriber.onMessage()
     │ JSON 문자열 그대로 WebSocket 브로드캐스트
     ▼
 SimpMessagingTemplate.convertAndSend()
-    │ STOMP /topic/chat/global (또는 /topic/lobby/{code})
     ▼
-클라이언트 (구독자 전체)
+클라이언트
 ```
 
 ### WebSocket 로비 입장 흐름
@@ -416,100 +315,186 @@ SimpMessagingTemplate.convertAndSend()
 클라이언트
     │ STOMP SUBSCRIBE /topic/lobby/{code}
     ▼
-WebSocketEventListener.handleSubscribeEvent()
-    │ 1. 로비 채팅 채널 구독 여부 확인
-    │    - /topic/lobby/{code}         → 입장 처리 대상
-    │    - /topic/lobby/{code}/refresh → 입장 처리 대상 아님
-    │ 2. 세션에서 userIdentifier 추출
-    │ 3. wsSessionId 추출
-    │
+StompChannelInterceptor.preSend()
+    │ enter_lobby.lua 실행
+    │ Redis 입장 상태가 확정된 경우에만 SUBSCRIBE 통과
     ▼
 enter_lobby.lua
-    │ Redis Lua 스크립트로 입장 상태를 원자적으로 저장
-    │
+    ├── lobby:{code} 존재 여부 확인
+    ├── WAITING 상태 확인
+    ├── kicked Set 확인
+    ├── sessionSequence 비교
+    ├── 최대 인원 검증
     ├── lobby:{code}:participants Set에 userIdentifier 저장
     ├── lobby:{code}:order List에 userIdentifier 저장
     ├── lobby:{code}:user_session:{userIdentifier}에 현재 wsSessionId 저장
     ├── lobby:{code}:user_session_seq:{userIdentifier}에 현재 세션 sequence 저장
     ├── ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
     └── 중복 구독 시 order List 중복 저장 방지
-    │
     ▼
-RedisPublisher.publish()
-    │ ENTER 시스템 메시지 발행
+SessionSubscribeEvent
     ▼
-Redis Pub/Sub
-    │
-    ▼
-RedisSubscriber.onMessage()
-    │ JSON 문자열 그대로 WebSocket 브로드캐스트
+WebSocketEventListener.handleSubscribeEvent()
+    │ 세션에 저장된 LOBBY_ENTER_RESULT 기반 후처리
+    ├── ENTERED → ENTER 메시지 발행 + 로비 refresh
+    ├── ALREADY_JOINED → ENTER 메시지 생략
+    └── SESSION_REPLACED → 최신 세션 유지
     ▼
 클라이언트
-    │ /topic/lobby/{code} 구독자로 ENTER 메시지 수신
-
-### 게임 세션 및 라운드 시작 흐름
-
-```text
-클라이언트 (방장)
-    │ POST /api/lobbies/{code}/start
-    ▼
-LobbyStartService
-    │ 1. start_lobby.lua 로 Redis 로비 상태 검증 및 PLAYING 변경
-    │ 2. DB 트랜잭션 시작 (@Transactional)
-    │ 3. DB 로비 상태 PLAYING 변경
-    │ 4. GameSessionCreateService 호출
-    ▼
-GameSessionCreateService
-    │ 1. MapItem 조회 및 셔플 (라운드 수만큼 선택)
-    │ 2. DB GameSession, GameSessionPlayer 스냅샷 생성 (Bulk Insert)
-    │ 3. init_game_session.lua 로 Redis 인게임 세션 데이터 초기화 (2시간 TTL 적용)
-    │ 4. 첫 라운드 정보(RoundStartDto) 반환
-    ▼
-LobbyStartService
-    │ TransactionSynchronizationManager.registerSynchronization (afterCommit)
-    │ DB 트랜잭션 정상 커밋 대기
-    ▼
-DB Commit 완료
-    │
-    ▼
-GameRealtimeNotifier / LobbyRealtimeNotifier
-    │ 1. /topic/lobby/{code}/game 으로 GAME_STARTED 브로드캐스트
-    │ 2. /topic/game/{code}/round 로 첫 번째 라운드 RoundStartDto 브로드캐스트
-    ▼
-클라이언트 (전체)
-    │ 게임 화면 전환 및 유튜브 플레이어 재생
 ```
 
-* **트랜잭션-웹소켓 동기화**: DB 커밋 전에 웹소켓 이벤트가 발송되어 클라이언트가 아직 DB에 반영되지 않은 상태를 조회하는 Race Condition을 방지하기 위해 `afterCommit` 훅을 사용합니다.
-* **보상 트랜잭션(Rollback)**: 게임 세션 생성이나 Redis 스크립트 실행 중 예외가 발생하면 DB 트랜잭션이 롤백되며, 로비 상태도 `WAITING`으로 안전하게 복구됩니다.
-```
-
-> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
+> 로비 입장 처리는 `/topic/lobby/{code}` 구독 시점에만 수행합니다.  
 > `/topic/lobby/{code}/refresh` 구독은 로비 정보 갱신 신호 수신용이며, 입장 처리 대상이 아닙니다.
 
-### WebSocket 연결 해제 흐름
+---
+
+## WebSocket 로비 입장 실패 처리 정책
+
+로비 입장은 REST와 WebSocket이 역할을 나누어 처리합니다.
+
+```text
+POST /api/lobbies/join
+    - 초대 코드 형식 검증
+    - 로비 존재 여부 사전 검증
+    - WAITING 상태 사전 검증
+    - 현재 인원 사전 검증
+    - 응답 성공 시 로비 기본 정보 반환
+
+SUBSCRIBE /topic/lobby/{code}
+    - 실제 participants 등록
+    - order List 등록
+    - ws:connection 역추적 정보 저장
+    - user_session / user_session_seq 저장
+    - ENTER 메시지 및 refresh 후처리
+```
+
+`POST /api/lobbies/join`은 UX용 사전 검증입니다.  
+실제 참여자 등록은 `SUBSCRIBE /topic/lobby/{code}` 시점에 `enter_lobby.lua`로 처리합니다.
+
+따라서 REST join 성공 후에도 아래 상황에서는 WebSocket SUBSCRIBE가 실패할 수 있습니다.
+
+| 상황 | Lua 반환값 | STOMP ERROR code | 처리 기준 |
+| --- | --- | --- | --- |
+| 로비가 삭제됨 | `LOBBY_NOT_FOUND` | `LOBBY_NOT_FOUND` | 로비 목록으로 복귀 |
+| REST join 이후 정원이 참 | `FULL` | `LOBBY_FULL` | 로비 목록으로 복귀 |
+| 방장이 게임을 시작함 | `LOBBY_NOT_WAITING` | `LOBBY_NOT_WAITING` | 로비 목록으로 복귀 |
+| 강퇴된 유저 재입장 | `KICKED_USER` | `LOBBY_KICKED_USER` | 로비 목록으로 복귀 |
+| 더 최신 세션이 존재함 | `STALE_SESSION:{wsSessionId}` | `LOBBY_STALE_SESSION` | 현재 세션 폐기 후 재연결 |
+| 세션 sequence 누락/비정상 | `INVALID_SEQUENCE` | `LOBBY_INVALID_SEQUENCE` | 새로고침 후 재시도 |
+| Redis 로비 정원 데이터 손상 | `INVALID_LOBBY_CAPACITY` | `LOBBY_INVALID_CAPACITY` | 로비 목록으로 복귀 |
+| Lua null/unknown/Redis 일시 장애 | `null` 또는 unknown | `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` | 새로고침 후 재시도 |
+
+### 실패 처리 흐름
+
+```text
+Client
+    │ SUBSCRIBE /topic/lobby/{code}
+    ▼
+StompChannelInterceptor.preSend()
+    │ enter_lobby.lua 실행
+    │
+    ├─ 성공
+    │   ├─ ENTERED
+    │   ├─ ALREADY_JOINED
+    │   └─ SESSION_REPLACED:{previousWsSessionId}
+    │
+    └─ 실패
+        ├─ Lua 반환값을 StompErrorCode로 변환
+        ├─ ws:connection 보상 삭제
+        └─ StompErrorException 발생
+                ▼
+CustomStompErrorHandler
+    │ STOMP ERROR JSON payload 생성
+    ▼
+Client
+    │ code/action/recoverable 기준으로 화면 처리
+```
+
+### STOMP ERROR payload 계약
+
+```json
+{
+  "type": "STOMP_ERROR",
+  "code": "LOBBY_NOT_FOUND",
+  "message": "존재하지 않는 로비입니다.",
+  "action": "RETURN_TO_LOBBY_LIST",
+  "recoverable": false,
+  "timestamp": "2026-05-25T00:00:00Z"
+}
+```
+
+FE는 `message` 문자열을 파싱하지 않습니다.  
+반드시 `code`, `action`, `recoverable` 기준으로 화면 복귀, 재연결, 새로고침 재시도를 결정합니다.
+
+### 성공 반환값 처리
+
+| Lua 반환값 | 의미 | 후처리 |
+| --- | --- | --- |
+| `ENTERED` | 신규 입장 성공 | ENTER 메시지 발행, 로비 refresh |
+| `ALREADY_JOINED` | 같은 세션의 중복 구독 | ENTER 메시지 생략 |
+| `SESSION_REPLACED:{previousWsSessionId}` | 같은 userIdentifier의 새 세션이 기존 세션을 대체 | 최신 세션 유지, 기존 세션 disconnect 시 stale 처리 |
+
+### 최신 세션 유지 정책
+
+동일한 userIdentifier가 같은 로비에 여러 WebSocket 세션으로 진입할 경우, `CONNECT` 시 Redis `INCR`로 발급한 `sessionSequence`가 더 큰 세션을 최신 세션으로 봅니다.
+
+```text
+lobby:{code}:user_session:{userIdentifier}
+lobby:{code}:user_session_seq:{userIdentifier}
+```
+
+이 정책으로 오래된 세션의 늦은 SUBSCRIBE 또는 늦은 DISCONNECT가 최신 세션 상태를 덮어쓰지 못하게 막습니다.
+
+### 보상 삭제 정책
+
+SUBSCRIBE 실패 시 현재 요청의 `ws:connection:{wsSessionId}`는 보상 삭제합니다.
+
+```text
+ws:connection:{wsSessionId}
+```
+
+다만 `participants`, `order`, `user_session`, `user_session_seq`는 Lua 성공 전 실패한 경우 생성되지 않았거나, stale 세션인 경우 최신 세션의 상태일 수 있으므로 Java에서 직접 삭제하지 않습니다.
+
+이 원칙을 지켜야 정상 사용자의 최신 세션을 실수로 제거하지 않습니다.
+
+---
+
+## WebSocket 연결 해제 흐름
 
 ```text
 클라이언트 연결 해제
-    │
     ▼
 WebSocketEventListener.handleDisconnectEvent()
     │ 1. Redis ws:connection:{wsSessionId} 에서 lobbyCode 역추적
-    │ 2. ApplicationEventPublisher.publishEvent(PlayerLeaveEvent)
-    │ 3. LEAVE 메시지 브로드캐스트
-    │ 4. Redis 키 정리 (user_status, ws:connection)
-    │
-    ▼ (이벤트 전달)
+    │ 2. stale 세션 여부 확인
+    │ 3. 최신 세션이면 PlayerLeaveEvent 발행
+    │ 4. LEAVE 메시지 브로드캐스트
+    │ 5. Redis 키 정리
+    ▼
 LobbyEventService.handlePlayerLeave(@EventListener)
-    │ Lua 스크립트로 원자적 퇴장 처리
     ▼
 leave_lobby.lua
     ├── DESTROYED → 전역 로비 리스트 새로고침
-    ├── DELEGATED → 로비 내부 새로고침 (새 방장 ID 포함)
+    ├── DELEGATED → 로비 내부 새로고침
     └── LEFT      → 로비 내부 새로고침
 ```
 
-### 로비 강퇴 흐름
+### stale DISCONNECT 정책
+
+동일 userIdentifier의 새 WebSocket 세션이 기존 세션을 대체한 후, 이전 세션의 DISCONNECT가 늦게 도착할 수 있습니다.
+
+이 경우 이전 세션은 최신 유효 세션이 아니므로 실제 퇴장 처리를 수행하지 않습니다.
+
+```text
+if lobby:{code}:user_session:{userIdentifier} != disconnectedWsSessionId
+    → stale 세션으로 판단
+    → PlayerLeaveEvent 발행 생략
+    → ws:connection:{oldWsSessionId}만 삭제
+```
+
+---
+
+## 로비 강퇴 흐름
 
 ```text
 방장 클라이언트
@@ -524,15 +509,14 @@ LobbyEventService.kickLobbyPlayer()
     │ 3. 강퇴 대상 식별자 검증
     ▼
 kick_lobby.lua
-    │ Redis Lua 스크립트로 강퇴 상태를 원자적으로 변경
-    │
-    ├── 방장 권한 검증
-    ├── 자기 자신 강퇴 방지
-    ├── 참여자 여부 검증
-    ├── participants/order에서 대상 제거
-    ├── kicked Set에 대상 추가
+    ├── 로비 존재 여부 확인
+    ├── 방장 정보 존재 여부 확인
+    ├── 요청자가 방장인지 검증
+    ├── 자기 자신 강퇴 요청인지 검증
+    ├── 강퇴 대상이 참여자인지 검증
+    ├── participants/order에서 강퇴 대상 제거
+    ├── kicked Set에 강퇴 대상 추가
     └── 대상의 현재 wsSessionId 반환
-    │
     ▼
 LobbyEventService.handleKickSuccess()
     │ 1. 대상 ws:connection 키 삭제
@@ -540,16 +524,17 @@ LobbyEventService.handleKickSuccess()
     │ 3. 로비 내부 refresh 브로드캐스트
 ```
 
-### 로비 게임 시작 흐름
+강퇴된 사용자는 `lobby:{code}:kicked` Set에 저장되며, 같은 로비에 다시 `SUBSCRIBE /topic/lobby/{code}`를 시도하면 `enter_lobby.lua`에서 `KICKED_USER`로 차단됩니다.
+
+---
+
+## 로비 게임 시작 흐름
 
 ```text
 방장 클라이언트
     │ REST POST /api/lobbies/{code}/start
     ▼
-LobbyController.startLobbyGame()
-    │ @AuthenticationPrincipal CustomPrincipal 전달
-    ▼
-LobbyService.startLobbyGame()
+LobbyStartService
     │ 1. 인증 정보 확인
     │ 2. Redis 로비 존재 여부 확인
     │ 3. DB GAME_LOBBY 스냅샷 조회
@@ -572,142 +557,114 @@ start_lobby.lua
     ├── lobby:{code}.status = PLAYING
     └── lobby:public에서 code 제거
     ▼
-LobbyService
-    │ DB GAME_LOBBY.status = PLAYING 저장
-    │ afterCommit에서 GAME_STARTED / REFRESH_LOBBY_INFO 브로드캐스트 등록
+DB GAME_LOBBY.status = PLAYING 저장
     ▼
-클라이언트
-    │ /topic/lobby/{code}/game에서 GAME_STARTED 수신
-    ▼
-인게임 화면 전환
+afterCommit
+    ├── /topic/lobby/{code}/game → GAME_STARTED
+    └── /topic/game/{code}/round → RoundStartDto
 ```
 
-`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.
+`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.  
 트랜잭션 동기화가 비활성인 경우 즉시 발행하지 않고 서버 오류로 처리하여 DB 커밋 전 이벤트 발행을 방지합니다.
+
+---
+
+## 게임 세션 및 라운드 시작 흐름
+
+```text
+클라이언트 (방장)
+    │ POST /api/lobbies/{code}/start
+    ▼
+LobbyStartService
+    │ Redis 로비 상태 검증 및 PLAYING 변경
+    │ DB 트랜잭션 시작
+    │ DB 로비 상태 PLAYING 변경
+    │ GameSessionCreateService 호출
+    ▼
+GameSessionCreateService
+    │ 1. MapItem 조회 및 셔플
+    │ 2. DB GameSession, GameSessionPlayer 스냅샷 생성
+    │ 3. init_game_session.lua 로 Redis 인게임 세션 데이터 초기화
+    │ 4. 첫 라운드 정보(RoundStartDto) 반환
+    ▼
+DB Commit 완료
+    ▼
+GameRealtimeNotifier / LobbyRealtimeNotifier
+    │ 1. /topic/lobby/{code}/game 으로 GAME_STARTED 브로드캐스트
+    │ 2. /topic/game/{code}/round 로 첫 번째 라운드 RoundStartDto 브로드캐스트
+    ▼
+클라이언트
+    │ 게임 화면 전환 및 YouTube IFrame API 재생
+```
+
+### 트랜잭션-웹소켓 동기화
+
+DB 커밋 전에 웹소켓 이벤트가 발송되면 클라이언트가 아직 DB에 반영되지 않은 상태를 조회할 수 있습니다.  
+이를 방지하기 위해 `afterCommit` 훅을 사용합니다.
+
+### 보상 트랜잭션
+
+게임 세션 생성이나 Redis 스크립트 실행 중 예외가 발생하면 DB 트랜잭션은 롤백되며, 로비 상태도 `WAITING`으로 복구합니다.  
+Redis 롤백까지 실패한 경우 재처리 큐에 적재합니다.
 
 ---
 
 ## 🗄️ Redis 데이터 구조
 
-| 키 패턴                                             | 타입     | 설명                                                                        |
-| ------------------------------------------------ | ------ | ------------------------------------------------------------------------- |
-| `lobby:{code}`                                   | Hash   | 로비 메타 정보 (title, status, host_user_id, map_id, map_title, map_category 등) |
-| `lobby:{code}:participants`                      | Set    | 로비 참여자 식별자 목록                                                             |
-| `lobby:{code}:ready`                             | Set    | ready 상태인 로비 참여자 userIdentifier 목록                                        |
-| `lobby:{code}:order`                             | List   | 입장 순서 (방장 위임 시 LINDEX 0 사용)                                               |
-| `lobby:{code}:kicked`                            | Set    | 강퇴된 사용자 식별자 목록                                                            |
-| `lobby:{code}:user_session:{userIdentifier}`     | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID                                        |
-| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence                                  |
-| `lobby:public`                                   | Set    | 공개 로비 코드 목록 (고속 필터링용)                                                     |
-| `lobby:start:reconciliation`                     | List   | 게임 시작 Redis-DB 상태 불일치 재처리 큐                                               |
-| `metric:lobby:start:reconciliation:enqueued`     | String | 게임 시작 상태 재처리 큐 적재 횟수                                                      |
-| `metric:lobby:start:reconciliation:success`      | String | 게임 시작 상태 재처리 성공 횟수                                                        |
-| `metric:lobby:start:reconciliation:failed`       | String | 게임 시작 상태 재처리 실패 횟수                                                        |
-| `metric:lobby:start:unknown-result`              | String | `start_lobby.lua` 알 수 없는 반환값 발생 횟수                                        |
-| `metric:lobby:ready:stale-cleanup`               | String | 게임 시작 전 stale ready 데이터 정리 횟수                                             |
-| `metric:lobby:ready:consistency-failure`         | String | 게임 시작 실패 시 ready/participants/session 정합성 진단 발생 횟수                        |
-| `auth:guest:session:{token}`                     | Hash   | 게스트 세션 정보 (userId, username, userType, TTL 30일)                           |
-| `auth:refresh:{sessionId}`                       | String | Refresh Token (TTL 30일)                                                   |
-| `user_status:{userIdentifier}`                   | String | 사용자 온라인 상태 (`ONLINE`, TTL 2시간)                                            |
-| `user_status:{userIdentifier}:sessions`          | Set    | 사용자별 활성 WebSocket 세션 목록                                                   |
-| `ws:connection:{wsSessionId}`                    | Hash   | WebSocket 세션 → userId, lobbyCode 매핑                                       |
-| `map:public:list:v:{version}:p:{page}:s:{size}`  | String | 공개 맵 목록 페이지 캐시                                                            |
-| `map:public:{mapId}`                             | String | 공개 맵 단건 캐시                                                                |
-| `map:public:list:version`                        | String | 공개 맵 목록 캐시 버전                                                             |
+| 키 패턴 | 타입 | 설명 |
+| --- | --- | --- |
+| `lobby:{code}` | Hash | 로비 메타 정보 |
+| `lobby:{code}:participants` | Set | 로비 참여자 식별자 목록 |
+| `lobby:{code}:ready` | Set | ready 상태인 로비 참여자 userIdentifier 목록 |
+| `lobby:{code}:order` | List | 입장 순서 |
+| `lobby:{code}:kicked` | Set | 강퇴된 사용자 식별자 목록 |
+| `lobby:{code}:user_session:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 ID |
+| `lobby:{code}:user_session_seq:{userIdentifier}` | String | 로비 내 특정 사용자의 현재 유효 WebSocket 세션 sequence |
+| `lobby:public` | Set | 공개 로비 코드 목록 |
+| `lobby:public:latest` | ZSET | 공개 로비 최신순 정렬 인덱스 |
+| `lobby:public:most_players` | ZSET | 공개 로비 현재 인원순 정렬 인덱스 |
+| `lobby:public:most_available` | ZSET | 공개 로비 빈자리순 정렬 인덱스 |
+| `lobby:start:reconciliation` | List | 게임 시작 Redis-DB 상태 불일치 재처리 큐 |
+| `auth:guest:session:{token}` | Hash | 게스트 세션 정보 |
+| `auth:refresh:{sessionId}` | String | Refresh Token |
+| `user_status:{userIdentifier}` | String | 사용자 온라인 상태 |
+| `user_status:{userIdentifier}:sessions` | Set | 사용자별 활성 WebSocket 세션 목록 |
+| `ws:connection:{wsSessionId}` | Hash | WebSocket 세션 → userId, lobbyCode 매핑 |
+| `map:public:list:v:{version}:p:{page}:s:{size}` | String | 공개 맵 목록 페이지 캐시 |
+| `map:public:{mapId}` | String | 공개 맵 단건 캐시 |
+| `map:public:list:version` | String | 공개 맵 목록 캐시 버전 |
 
-> ⚠️ `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`, `start_lobby.lua`와 맞춰 관리해야 합니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
+> `host_user_id` 필드명은 `leave_lobby.lua`, `kick_lobby.lua`, `start_lobby.lua`와 맞춰 관리해야 합니다. 변경 시 Lua 스크립트도 함께 수정해야 합니다.
 
 ### `lobby:{code}` Hash 구조
 
-로비 메타 정보는 Redis Hash로 저장합니다.
+| 필드 | 값 예시 | 설명 |
+| --- | --- | --- |
+| `code` | `ABC123` | 로비 초대 코드 |
+| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier |
+| `title` | `K-POP 퀴즈방` | 로비 제목 |
+| `max_players` | `8` | 최대 참여 인원 |
+| `current_players` | `3` | 현재 참여 인원 캐시 |
+| `is_private` | `false` | 비공개 여부 |
+| `status` | `WAITING` | 로비 상태 |
+| `map_id` | `1` | 선택된 맵 ID |
+| `map_title` | `K-POP 2세대` | 선택된 맵 제목 |
+| `map_category` | `kpop` | 선택된 맵 카테고리 원본 값 |
+| `created_at_epoch_millis` | `1778990123456` | Redis TIME 기준 생성 시각 |
 
-| 필드             | 값 예시                                   | 설명                                                          |
-| -------------- | -------------------------------------- | ----------------------------------------------------------- |
-| `code`         | `ABC123`                               | 로비 초대 코드                                                    |
-| `host_user_id` | `9746cc76-f8f2-4859-b602-df6e1032fea4` | 현재 방장 userIdentifier                                        |
-| `title`        | `K-POP 퀴즈방`                            | 로비 제목                                                       |
-| `max_players`  | `8`                                    | 최대 참여 인원                                                    |
-| `is_private`   | `false`                                | 비공개 여부. `true` = 비공개                                        |
-| `status`       | `WAITING`                              | 로비 상태                                                       |
-| `map_id`       | `1`                                    | 선택된 맵 ID                                                    |
-| `map_title`    | `K-POP 2세대`                            | 선택된 맵 제목                                                    |
-| `map_category` | `jpop`                                 | 선택된 맵 카테고리 원본 값. HTTP 응답 시 `K-POP`, `J-POP`, `POP` 형식으로 정규화 |
-
-`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.
+`map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.  
 맵이 선택되지 않은 로비는 위 세 필드를 저장하지 않습니다.
 
-Redis에 `"null"` 문자열을 저장하지 않고, 응답 DTO에서만 `null`로 표현합니다.
+---
 
-### Redis Hash 필드 상수 (`RedisKeys.FIELD_*`)
-
-로비 Hash(`lobby:{code}`) 내부 필드명은 `RedisKeys` 클래스의 `FIELD_*` 상수로 중앙 관리합니다.
-문자열 리터럴 직접 사용 시 오타가 런타임에서야 발견되는 문제를 컴파일 타임에 방지합니다.
-
-로비 맵 연결 기능에서 사용하는 주요 필드는 다음과 같습니다.
-
-| 필드 상수                | Redis Hash 필드명 | 설명                |
-| -------------------- | -------------- | ----------------- |
-| `FIELD_MAP_ID`       | `map_id`       | 선택된 맵 ID          |
-| `FIELD_MAP_TITLE`    | `map_title`    | 선택된 맵 제목          |
-| `FIELD_MAP_CATEGORY` | `map_category` | 선택된 맵 카테고리        |
-| `FIELD_STATUS`       | `status`       | 로비 상태             |
-| `FIELD_HOST_USER_ID` | `host_user_id` | 방장 userIdentifier |
-
-맵 미선택 로비에서는 맵 관련 필드를 저장하지 않습니다.
-
-### WebSocket 로비 입장 저장 구조
-
-로비 입장 상태는 `enter_lobby.lua`에서 원자적으로 저장합니다.
-
-| 키 패턴                                             | 타입     | 저장 시점                      | 설명                                                      |
-| ------------------------------------------------ | ------ | -------------------------- | ------------------------------------------------------- |
-| `lobby:{code}:participants`                      | Set    | `/topic/lobby/{code}` 구독 시 | 현재 로비에 참여 중인 userIdentifier 목록                          |
-| `lobby:{code}:order`                             | List   | `/topic/lobby/{code}` 구독 시 | 입장 순서. 방장 퇴장 시 다음 방장 위임 기준                              |
-| `lobby:{code}:user_session:{userIdentifier}`     | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 wsSessionId                                |
-| `lobby:{code}:user_session_seq:{userIdentifier}` | String | `/topic/lobby/{code}` 구독 시 | 해당 유저의 현재 유효 세션 sequence                                |
-| `ws:connection:{wsSessionId}`                    | Hash   | `/topic/lobby/{code}` 구독 시 | WebSocket 세션 ID로 userIdentifier와 lobbyCode를 역추적하기 위한 매핑 |
-
-`ws:connection:{wsSessionId}` Hash 필드:
-
-| 필드          | 값                | 설명                             |
-| ----------- | ---------------- | ------------------------------ |
-| `userId`    | `userIdentifier` | Redis/WebSocket에서 사용하는 사용자 식별자 |
-| `lobbyCode` | `{code}`         | 현재 WebSocket 세션이 참여 중인 로비 코드   |
-
-정상 저장 예시:
-
-```redis
-SMEMBERS lobby:R2VJW5:participants
-1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
-
-LRANGE lobby:R2VJW5:order 0 -1
-1) "9746cc76-f8f2-4859-b602-df6e1032fea4"
-
-GET lobby:R2VJW5:user_session:9746cc76-f8f2-4859-b602-df6e1032fea4
-"mhrg4it0"
-
-GET lobby:R2VJW5:user_session_seq:9746cc76-f8f2-4859-b602-df6e1032fea4
-"1"
-
-HGETALL ws:connection:mhrg4it0
-1) "userId"
-2) "9746cc76-f8f2-4859-b602-df6e1032fea4"
-3) "lobbyCode"
-4) "R2VJW5"
-```
-
-중복 구독 시 `participants`는 Set 구조로 중복 저장되지 않으며, `order` List도 `enter_lobby.lua`에서 신규 입장자일 때만 `RPUSH`하여 중복 저장을 방지합니다.
-
-### 로비 ready 상태 저장 구조
-
-로비 참여자의 ready 상태는 Redis Set으로 관리합니다.
+## 로비 ready 상태 저장 구조
 
 ```text
 lobby:{code}:ready
 ```
 
-| 키 패턴                 | 타입  | 설명                                  |
-| -------------------- | --- | ----------------------------------- |
+| 키 패턴 | 타입 | 설명 |
+| --- | --- | --- |
 | `lobby:{code}:ready` | Set | ready 상태인 일반 참여자의 userIdentifier 목록 |
 
 정책:
@@ -729,92 +686,31 @@ ready 상태는 `canStart` 계산과 `start_lobby.lua`의 최종 시작 조건 �
 
 ### Java 21 Virtual Thread + Lettuce
 
-가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 **Lettuce**를 사용합니다.
-Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝(Pinning)할 수 있으나,
-Lettuce는 Netty 기반 비동기 드라이버로 핀닝 없이 동작합니다.
+가상 스레드 환경에서 Redis 클라이언트로 Jedis 대신 Lettuce를 사용합니다.
 
-### 로비 생성 시 맵 연결 정책
+Jedis는 동기 블로킹 방식으로 가상 스레드를 캐리어 스레드에 핀닝할 수 있으나, Lettuce는 Netty 기반 비동기 드라이버로 핀닝 위험을 줄입니다.
 
-로비 생성 시 `mapId`는 선택 사항입니다.
+### Redis Pub/Sub + WebSocket 브로드캐스트
 
-```text
-로비 생성: mapId 선택 사항
-게임 시작: mapId 필수
-```
+멀티 인스턴스 환경에서는 특정 서버에 연결된 WebSocket 세션만 로컬 메모리에 존재합니다.
 
-이 구조를 선택한 이유는 로비가 게임 시작 전 대기실 역할을 하기 때문입니다.
-방장은 먼저 로비를 만들고 참여자를 모은 뒤, 로비 내부에서 맵을 선택하거나 변경할 수 있습니다.
-
-`mapId`가 전달된 경우 `LobbyService`에서 다음 순서로 검증합니다.
+따라서 로비 채팅, ENTER, LEAVE, KICK 등 실시간 메시지는 Redis Pub/Sub으로 발행한 뒤 각 서버의 `RedisSubscriber`가 자기 서버에 연결된 클라이언트에게 브로드캐스트합니다.
 
 ```text
-1. 맵 존재 여부 확인
-2. 삭제된 맵 여부 확인
-3. 공개 맵이면 허용
-4. 비공개 맵이면 소유자만 허용
+Server A
+    │ RedisPublisher.publish()
+    ▼
+Redis Pub/Sub
+    ├── Server A RedisSubscriber → local clients
+    ├── Server B RedisSubscriber → local clients
+    └── Server C RedisSubscriber → local clients
 ```
 
-검증 결과에 따른 HTTP 상태 코드는 다음과 같습니다.
+### Lua 스크립트 기반 원자 처리
 
-| 상황                  | 상태 코드           |
-| ------------------- | --------------- |
-| 존재하지 않는 맵           | `404 Not Found` |
-| 삭제된 맵               | `409 Conflict`  |
-| 타인 소유 비공개 맵         | `403 Forbidden` |
-| 공개 맵 또는 본인 소유 비공개 맵 | 로비 생성 허용        |
+로비 생성, 입장, 퇴장, 강퇴, 시작은 Redis Lua 스크립트로 원자 처리합니다.
 
-검증이 끝난 맵 정보는 `LobbyMapMetadata`로 변환하여 Redis 저장 계층에 전달합니다.
-이를 통해 `LobbyRepositoryImpl`이 `QuizMap` 엔티티에 직접 의존하지 않도록 분리합니다.
-
-### Lua 스크립트 기반 원자적 로비 생성
-
-`create_lobby.lua`는 초대 코드 선점과 로비 Hash 저장을 원자적으로 처리합니다.
-
-처리 대상:
-
-```text
-lobby:code:lock:{code}
-lobby:{code}
-lobby:public
-```
-
-로비 생성 시 아래 정보를 저장합니다.
-
-```text
-code
-host_user_id
-title
-max_players
-is_private
-status
-```
-
-이슈 #62 이후 선택된 맵이 있는 경우 아래 필드도 같은 Lua 스크립트 안에서 함께 저장합니다.
-
-```text
-map_id
-map_title
-map_category
-```
-
-맵 미선택 로비의 경우 Java에서 빈 문자열을 전달하고, Lua 스크립트는 `mapId`가 빈 문자열이면 맵 관련 필드를 저장하지 않습니다.
-이 방식으로 Redis Hash에 `"null"` 문자열이 저장되는 것을 방지합니다.
-
-### Lua 스크립트 기반 원자적 입장 처리
-
-`enter_lobby.lua`는 WebSocket 로비 입장 시 필요한 Redis 상태 변경을 단일 원자 연산으로 처리합니다.
-
-처리 대상:
-
-```text
-lobby:{code}:participants
-lobby:{code}:order
-lobby:{code}:user_session:{userIdentifier}
-lobby:{code}:user_session_seq:{userIdentifier}
-ws:connection:{wsSessionId}
-```
-
-Java 코드에서 위 Redis 명령을 개별적으로 실행하면 중간 실패 시 다음과 같은 상태 불일치가 발생할 수 있습니다.
+Java에서 Redis 명령을 여러 번 나누어 실행하면 중간 실패 시 상태 불일치가 발생할 수 있습니다.
 
 ```text
 participants에는 추가됐지만 order에는 없음
@@ -822,123 +718,11 @@ order에는 추가됐지만 ws:connection 매핑이 없음
 ws:connection은 있지만 participants에는 없음
 ```
 
-이를 방지하기 위해 `enter_lobby.lua`에서 아래 작업을 한 번에 수행합니다.
+이를 방지하기 위해 상태 변경을 Lua 내부에서 하나의 원자 연산으로 처리합니다.
 
-```text
-1. lobby:{code} 존재 여부 확인
-2. participants Set에 userIdentifier 추가
-3. 신규 입장자인 경우에만 order List에 userIdentifier 추가
-4. ws:connection:{wsSessionId} Hash에 userId/lobbyCode 저장
-5. 로비 내 유저별 현재 유효 wsSessionId 저장
-6. 로비 내 유저별 현재 유효 세션 sequence 저장
-7. 관련 키 TTL 설정
-```
+---
 
-반환값은 다음과 같습니다.
-
-| 반환값                         | 의미                                 |
-| --------------------------- | ---------------------------------- |
-| `ENTERED:{sequence}`        | 신규 입장 처리 완료                        |
-| `ALREADY_JOINED:{sequence}` | 이미 참여 중인 유저의 중복 구독. order 중복 저장 없음 |
-| `LOBBY_NOT_FOUND`           | 존재하지 않는 로비 코드로 구독 요청               |
-
-입장 처리는 반드시 `/topic/lobby/{code}` 구독 시점에만 수행합니다.
-`/topic/lobby/{code}/refresh`는 입장 처리를 트리거하지 않습니다.
-
-### Lua 스크립트 기반 원자적 퇴장 처리
-
-`leave_lobby.lua`는 참여자 제거 → 방장 위임 → 로비 폭파를 단일 트랜잭션으로 처리합니다.
-Redis는 싱글 스레드로 Lua 스크립트를 실행하므로 다수의 동시 퇴장 시에도 Race Condition이 발생하지 않습니다.
-
-반환값은 `DESTROYED`, `DELEGATED:{newHostId}`, `LEFT` 세 가지이며,
-`LobbyRepositoryImpl`에서 `LeaveLobbyResult` sealed interface로 파싱하여
-서비스 레이어가 Redis 반환 포맷을 알 필요 없도록 캡슐화합니다.
-
-### Lua 스크립트 기반 원자적 강퇴 처리
-
-`kick_lobby.lua`는 방장의 강퇴 요청을 원자적으로 처리합니다.
-
-처리 대상:
-
-```text
-lobby:{code}
-lobby:{code}:participants
-lobby:{code}:order
-lobby:{code}:kicked
-lobby:{code}:user_session:{targetUserIdentifier}
-lobby:{code}:user_session_seq:{targetUserIdentifier}
-```
-
-처리 순서:
-
-```text
-1. 로비 존재 여부 확인
-2. 방장 정보 존재 여부 확인
-3. 요청자가 방장인지 검증
-4. 자기 자신 강퇴 요청인지 검증
-5. 강퇴 대상이 참여자인지 검증
-6. participants/order에서 강퇴 대상 제거
-7. kicked Set에 강퇴 대상 추가
-8. 강퇴 대상의 현재 wsSessionId 반환
-9. 강퇴 대상의 user_session / user_session_seq 키 삭제
-```
-
-반환값은 다음과 같습니다.
-
-| 반환값                          | 의미                |
-| ---------------------------- | ----------------- |
-| `KICKED:{targetWsSessionId}` | 강퇴 성공             |
-| `LOBBY_NOT_FOUND`            | 존재하지 않는 로비        |
-| `HOST_NOT_FOUND`             | 로비 방장 정보 없음       |
-| `FORBIDDEN`                  | 요청자가 방장이 아님       |
-| `CANNOT_KICK_SELF`           | 자기 자신 강퇴 시도       |
-| `TARGET_NOT_PARTICIPANT`     | 강퇴 대상이 로비 참여자가 아님 |
-
-강퇴 성공 후 `LobbyEventService`는 `KICK` 메시지를 로비 채팅 채널로 브로드캐스트하고, 로비 내부 refresh 이벤트를 발행합니다.
-
-### Lua 스크립트 기반 원자적 게임 시작 처리
-
-`start_lobby.lua`는 게임 시작 조건 중 Redis 기준으로 원자 검증 가능한 조건을 처리합니다.
-
-처리 대상:
-
-```text
-lobby:{code}
-lobby:{code}:participants
-lobby:{code}:ready
-lobby:public
-```
-
-검증 조건:
-
-```text
-1. 로비가 존재해야 한다.
-2. 방장 정보가 존재해야 한다.
-3. 요청자가 방장이어야 한다.
-4. 로비 상태가 WAITING이어야 한다.
-5. map_id가 존재해야 한다.
-6. 방장 제외 참여자가 1명 이상이어야 한다.
-7. 방장 제외 참여자의 활성 로비 세션 키가 존재해야 한다.
-8. 방장 제외 모든 참여자가 ready 상태여야 한다.
-```
-
-반환값 계약은 `StartLobbyLuaResultCode` enum과 `StartLobbyLuaResultCodeContractTest`로 고정합니다.
-
-| 반환값                                  | 의미                                             |
-| ------------------------------------ | ---------------------------------------------- |
-| `STARTED`                            | 게임 시작 성공                                       |
-| `LOBBY_NOT_FOUND`                    | 로비 없음                                          |
-| `HOST_NOT_FOUND`                     | 방장 정보 없음                                       |
-| `FORBIDDEN`                          | 요청자가 방장이 아님                                    |
-| `LOBBY_NOT_WAITING`                  | 로비 상태가 WAITING이 아님                             |
-| `MAP_NOT_SELECTED`                   | 맵이 선택되지 않음                                     |
-| `NO_PLAYER`                          | 방장 제외 참여자 없음                                   |
-| `NOT_READY:{userIdentifier}`         | 준비하지 않은 참여자 존재                                 |
-| `STALE_PARTICIPANT:{userIdentifier}` | participants에는 있지만 활성 로비 세션 키가 없는 stale 참여자 존재 |
-
-알 수 없는 반환값 또는 `null` 반환값은 generic error로 처리하고, `[MONITORING_REQUIRED]` 로그와 metric을 남깁니다.
-
-### 게임 시작 Redis-DB 상태 불일치 재처리
+## 게임 시작 Redis-DB 상태 불일치 재처리
 
 게임 시작은 Redis Lua가 먼저 원자 검증 및 Redis 상태 전환을 수행하고, 이후 DB `GAME_LOBBY` 상태를 `PLAYING`으로 동기화합니다.
 
@@ -975,365 +759,92 @@ lobbyCode|reason|attempt|nextRetryAtEpochMillis
 
 재처리 사유:
 
-| reason                        | 보정 정책                       |
-| ----------------------------- | --------------------------- |
-| `START_DB_SYNC_FAILED`        | Redis 상태를 `WAITING`으로 롤백    |
-| `START_DB_SNAPSHOT_NOT_FOUND` | DB 스냅샷이 없으므로 Redis 잔존 로비 삭제 |
-
-운영 모니터링 대상:
-
-| 항목                                           | 설명               |
-| -------------------------------------------- | ---------------- |
-| `lobby:start:reconciliation`                 | 재처리 큐 길이         |
-| `[ALERT_REQUIRED]`                           | 즉시 운영 확인이 필요한 로그 |
-| `[MONITORING_REQUIRED]`                      | 모니터링 연계가 필요한 로그  |
-| `metric:lobby:start:reconciliation:enqueued` | 재처리 큐 적재 횟수      |
-| `metric:lobby:start:reconciliation:success`  | 재처리 성공 횟수        |
-| `metric:lobby:start:reconciliation:failed`   | 재처리 실패 횟수        |
-
-### ready / participants 정합성 보정 정책
-
-게임 시작 조건은 `participants`, `ready`, `user_session` 키의 정합성에 영향을 받습니다.
-
-정책:
-
-```text
-1. participants Set을 현재 로비 참여자의 source of truth로 사용한다.
-2. ready Set에는 있지만 participants Set에는 없는 값은 stale ready 데이터로 보고 게임 시작 직전에 제거한다.
-3. participants Set에는 있지만 user_session 키가 없는 값은 stale participant로 보고 게임 시작을 거부한다.
-4. participants Set에 있고 user_session 키도 있지만 ready가 아닌 값은 실제 미준비 유저로 보고 NOT_READY 처리한다.
-5. NOT_READY 또는 STALE_PARTICIPANT 발생 시 ready/participants/session 정합성 진단 로그를 남긴다.
-```
-
-이 정책은 정상 참여자를 임의 삭제하지 않기 위한 선택입니다.
-participants에 남아 있는 유저가 실제 미준비 유저인지 stale 유저인지 Lua 내부에서 완전히 판단하기 어렵기 때문에, user_session 키가 없는 경우만 `STALE_PARTICIPANT`로 분리합니다.
-
-### Redis 직렬화 JsonMapper와 HTTP 응답 JsonMapper 분리
-
-RedisTemplate은 타입 정보가 필요한 `GenericJacksonJsonRedisSerializer`를 사용합니다.
-기존처럼 타입 정보가 포함된 `JsonMapper`를 Spring Bean으로 노출하면 Spring MVC HTTP 응답 직렬화에 해당 Mapper가 개입할 수 있습니다.
-
-그 결과 REST 응답이 아래처럼 Jackson 타입 정보를 포함하는 형태로 내려갈 수 있습니다.
-
-```json
-[
-  "java.util.ArrayList",
-  [
-    [
-      "io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto",
-      {
-        "code": "ABC123",
-        "title": "K-POP 퀴즈방"
-      }
-    ]
-  ]
-]
-```
-
-이를 방지하기 위해 Redis 전용 JsonMapper는 `RedisConfig#createRedisJsonMapper()` private 메서드 내부에서만 생성합니다.
-
-정책:
-
-```text
-1. RedisTemplate 값 직렬화:
-   - 타입 정보 포함 JsonMapper 사용
-   - Spring Bean으로 노출하지 않음
-
-2. Pub/Sub 메시지 직렬화:
-   - 타입 정보 없는 pubSubJsonMapper Bean 사용
-
-3. HTTP 응답 직렬화:
-   - Redis 직렬화용 JsonMapper가 개입하지 않음
-   - 순수 DTO JSON 배열로 반환
-```
-
-기존 `jsonMapper` Bean 직접 주입 사용처는 없어야 하며, JsonMapper가 필요한 신규 코드에서는 목적에 맞는 Bean을 명시적으로 주입해야 합니다.
-
-### ChatMessageDto 위치
-
-`ChatMessageDto`는 채팅 도메인 전용 객체가 아닌 WebSocket 통신 전반에서 사용되는 메시지 포맷입니다.
-`domain/chat/dto`가 아닌 `global/websocket/dto`에 위치하여
-`global` 레이어의 `RedisPublisher`, `RedisSubscriber`, `WebSocketEventListener`가
-`domain`을 역참조하는 의존 방향 역전을 방지합니다.
-
-### Redis Pub/Sub 직렬화 분리
-
-Redis Pub/Sub 메시지는 WebSocket 클라이언트에게 그대로 전달될 수 있으므로, 일반 Redis 객체 저장용 `RedisTemplate<String, Object>`와 분리하여 처리합니다.
-
-#### 일반 Redis 데이터 저장
-
-`RedisTemplate<String, Object>`는 Redis Hash/Value에 객체 타입 정보를 보존하기 위해 `GenericJacksonJsonRedisSerializer`와 `activateDefaultTyping`을 사용합니다.
-
-사용 예:
-
-```text
-lobby:{code}
-auth:guest:session:{token}
-```
-
-#### Pub/Sub 메시지 발행
-
-Pub/Sub 메시지는 `StringRedisTemplate`과 Pub/Sub 전용 `JsonMapper`를 사용합니다.
-
-이유:
-
-```text
-RedisTemplate<String, Object>로 ChatMessageDto를 발행하면
-WebSocket 클라이언트가 ["클래스명", {...}] 형태의 메시지를 받게 됨
-```
-
-기존 문제 형태:
-
-```json
-["io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto",{"type":"ENTER","roomId":"R2VJW5"}]
-```
-
-수정 후 형태:
-
-```json
-{"type":"ENTER","roomId":"R2VJW5","sender":"...","content":"...","timestamp":"..."}
-```
-
-`RedisSubscriber`는 Pub/Sub 메시지를 DTO로 역직렬화하지 않고, JSON 문자열 그대로 `SimpMessagingTemplate.convertAndSend()`로 WebSocket 클라이언트에게 전달합니다.
-
-### 참여자 키 단일 진실의 원천
-
-기존에 `lobby:{code}:participants`(Lua 스크립트 관리)와 `user_room:{lobbyCode}`(Java 레벨 관리)로
-동일한 참여자 데이터를 이중 관리하던 문제를 해결했습니다.
-
-`lobby:{code}:participants`를 단일 진실의 원천으로 통일하여
-입장(Lua) → 퇴장(Lua) → 강퇴(Lua) → ready/start 검증 모두 동일한 키를 사용합니다.
-
-### SETNX 기반 초대 코드 중복 방지
-
-`LobbyRepositoryImpl`은 6자리 초대 코드를 생성할 때
-`lobby:code:lock:{code}` 키를 Redis SET NX 명령으로 원자적으로 선점합니다.
-선점 성공 시 해당 코드를 사용하고, 실패 시 최대 `LobbyDefaults.INVITE_CODE_MAX_RETRY`까지 재시도합니다.
-
-락 TTL은 `LobbyDefaults.INVITE_CODE_LOCK_TTL`을 따르며, 로비 생성 실패 시 자동 해제되어 코드 공간이 반환됩니다.
-
-### JWT 인증 구조
-
-`JwtAuthenticationFilter`가 모든 요청의 Authorization 헤더에서 Bearer 토큰을 파싱합니다.
-파싱 성공 시 `CustomPrincipal(userId, userIdentifier, userType)`을 생성하여 SecurityContext에 저장합니다.
-컨트롤러에서는 `@AuthenticationPrincipal CustomPrincipal`로 주입받아 사용합니다.
-
-[식별자 분리]
-
-* `userId` (Long) : DB users.id FK 참조용
-* `userIdentifier` (UUID String) : Redis/WebSocket 식별자
+| reason | 보정 정책 |
+| --- | --- |
+| `START_DB_SYNC_FAILED` | Redis 상태를 `WAITING`으로 롤백 |
 
 ---
 
-## 🌐 STOMP 채널 구조
+## 운영 및 관측성 기준
 
-| 방향         | 경로                            | 설명                          |
-| ---------- | ----------------------------- | --------------------------- |
-| 클라이언트 → 서버 | `/app/chat/global`            | 전체 채팅 메시지 송신                |
-| 클라이언트 → 서버 | `/app/chat/lobby/{code}`      | 로비 채팅 메시지 송신                |
-| 클라이언트 → 서버 | `/app/lobby/create`           | 로비 생성 이벤트 송신                |
-| 클라이언트 → 서버 | `/app/lobby/{code}/update`    | 로비 정보 변경 이벤트 송신             |
-| 클라이언트 → 서버 | `/app/lobby/{code}/kick`      | 방장의 로비 유저 강퇴 요청             |
-| 서버 → 클라이언트 | `/topic/chat/global`          | 전체 채팅 메시지 수신                |
-| 서버 → 클라이언트 | `/topic/lobby/{code}`         | 로비 채팅 메시지 수신 및 로비 입장 처리 트리거 |
-| 서버 → 클라이언트 | `/topic/lobby/{code}/refresh` | 로비 내부 정보 새로고침 신호            |
-| 서버 → 클라이언트 | `/topic/lobby/{code}/game`    | 게임 시작 이벤트 (`GAME_STARTED`)  |
-| 서버 → 클라이언트 | `/topic/lobby/refresh`        | 전역 로비 리스트 새로고침 신호           |
+### WebSocket Metric
 
-> `/topic/lobby/{code}`는 로비 채팅 메시지 수신 채널이면서 WebSocket 입장 처리 트리거입니다.
-> `/topic/lobby/{code}/refresh`는 로비 정보 새로고침 신호 수신 전용이며, 입장 처리 트리거가 아닙니다.
+`WebSocketMetric`은 활성 WebSocket 세션 수를 Prometheus에 노출합니다.
+
+```text
+CONNECT 성공 → increment
+DISCONNECT 처리 → decrement
+```
+
+### Redis 장애 처리
+
+Redis는 로비/세션/실시간 동기화의 핵심 저장소입니다.  
+Redis 장애는 대부분 실시간 기능 장애로 이어지므로 다음 기준을 따릅니다.
+
+| 영역 | 장애 처리 |
+| --- | --- |
+| 인증 refresh 저장소 | `503 Service Unavailable` |
+| WebSocket CONNECT 온라인 상태 저장 실패 | STOMP ERROR `CONNECT_ONLINE_STATUS_FAILED` |
+| 로비 입장 Lua 실패 | STOMP ERROR `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` |
+| Pub/Sub 발행 실패 | 로컬 WebSocket fallback 또는 로그/관측성 처리 |
+| 게임 시작 Redis-DB 불일치 | 보상 롤백 또는 reconciliation 큐 적재 |
+
+### 로그 기준
+
+로비 상태 정합성에 영향을 주는 오류는 단순 warn으로 묻지 않습니다.
+
+| 상황 | 로그 기준 |
+| --- | --- |
+| Lua 알 수 없는 반환값 | `error` + monitoring required |
+| Redis-DB 게임 시작 불일치 | `error` + reconciliation enqueue |
+| 최대 재시도 초과 | `error` + alert required |
+| stale 세션 disconnect | `info` |
+| 중복 구독 | `info` |
 
 ---
 
-## 🔐 인증 구조
+## FE 연동 핵심 계약
 
-### 정식 회원 (Member)
+### 로비 입장
 
-로그인 성공 시 JWT를 발급하고 `user_sessions`에 서버 세션 추적 정보를 저장합니다.
-맵 생성, 로비 호스팅 등 전체 기능에 접근할 수 있습니다.
-
-### 게스트 (Guest)
-
-닉네임 입력만으로 진입하며, 백엔드에서 UUID를 발급하여 `localStorage`에 저장합니다.
-재방문 시 UUID로 자동 복원됩니다. 퀴즈 플레이 참여만 가능합니다.
-
-### WebSocket 인증 흐름
+FE는 REST join 성공만으로 사용자를 로비 참여자로 확정하면 안 됩니다.
 
 ```text
-STOMP CONNECT 헤더: { userIdentifier: "UUID" }
-    │
-    ▼
-StompChannelInterceptor.handleConnect()
-    │ UUID 형식 검증 (8-4-4-4-12 포맷)
-    │ 세션에 userIdentifier 저장
-    ▼
-이후 모든 STOMP 명령에서 세션의 userIdentifier 검증
+1. POST /api/lobbies/join
+2. WebSocket CONNECT
+3. SUBSCRIBE /topic/lobby/{code}
+4. SUBSCRIBE 성공 후 GET /api/lobbies/{code}
 ```
 
-### REST API 인증 흐름
+### 로비 목록
 
-```text
-HTTP 요청 (Authorization: Bearer {accessToken})
-    │
-    ▼
-JwtAuthenticationFilter
-    │ 1. Authorization 헤더에서 Bearer 토큰 추출
-    │ 2. JWT 서명 검증 (secretKey)
-    │ 3. userId, userIdentifier, userType 클레임 추출 (JwtClaims 상수)
-    │ 4. CustomPrincipal 생성 → SecurityContext 저장
-    ▼
-Controller
-    │ @AuthenticationPrincipal CustomPrincipal로 주입
-    │ - principal.userId()          → DB Insert FK 용도
-    │ - principal.userIdentifier()  → Redis 저장 식별자 용도
-    ▼
-Service
-```
+`PLAYING` 로비는 목록에 노출될 수 있으나 입장 버튼은 비활성화해야 합니다.
 
----
+### 로비 상세
 
-## 🧩 로비 생성 시 맵 연결 흐름
+`canStart`는 snapshot 값입니다.  
+실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 최종 검증됩니다.
 
-```text
-클라이언트
-    │ POST /api/lobbies
-    │ Body: { title, maxPlayers, isPrivate, mapId?, roundCount?, timeLimitSeconds? }
-    ▼
-LobbyController.createLobby()
-    │ @AuthenticationPrincipal CustomPrincipal 주입
-    ▼
-LobbyService.createLobby()
-    │ 1. principal 검증
-    │ 2. host User 조회
-    │ 3. mapId가 있으면 QuizMap 조회 및 권한 검증
-    │ 4. LobbyMapMetadata 생성
-    ▼
-LobbyRepository.saveToRedis()
-    │ create_lobby.lua 실행
-    │ 초대 코드 선점 + Redis Hash 저장
-    ▼
-GameLobbyJpaRepository.save()
-    │ GAME_LOBBY 스냅샷 저장
-    ▼
-CreateLobbyResponse 반환
-```
+### STOMP ERROR
 
-### 맵 미선택 로비
-
-`mapId`가 없으면 맵 검증을 수행하지 않습니다.
+FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 
 ```json
 {
-  "mapId": null,
-  "mapTitle": null,
-  "mapCategory": null
+  "type": "STOMP_ERROR",
+  "code": "LOBBY_NOT_FOUND",
+  "message": "존재하지 않는 로비입니다.",
+  "action": "RETURN_TO_LOBBY_LIST",
+  "recoverable": false,
+  "timestamp": "2026-05-25T00:00:00Z"
 }
 ```
 
-Redis Hash에는 `map_id`, `map_title`, `map_category` 필드를 저장하지 않습니다.
+분기는 다음 기준으로 처리합니다.
 
-### 맵 선택 로비
-
-`mapId`가 있으면 검증 후 Redis Hash와 DB 스냅샷에 반영합니다.
-
-```json
-{
-  "mapId": 1,
-  "mapTitle": "K-POP 2세대",
-  "mapCategory": "K-POP"
-}
-```
-
-Redis Hash에는 아래 필드를 저장합니다.
-
-```text
-map_id
-map_title
-map_category
-```
-
----
-
-## 🧩 로비 ready 및 게임 시작 흐름
-
-### ready 상태 변경
-
-```text
-클라이언트
-    │ PATCH /api/lobbies/{code}/ready
-    │ Body: { ready: true }
-    ▼
-LobbyController.updateReadyStatus()
-    │ @AuthenticationPrincipal CustomPrincipal 주입
-    ▼
-LobbyService.updateReadyStatus()
-    │ 1. principal 검증
-    │ 2. Redis 로비 존재 여부 확인
-    │ 3. 로비 상태 WAITING 확인
-    │ 4. 참여자 여부 확인
-    │ 5. 방장 ready 요청 차단
-    ▼
-LobbyRepository.updateReadyStatus()
-    │ ready=true  → SADD lobby:{code}:ready userIdentifier
-    │ ready=false → SREM lobby:{code}:ready userIdentifier
-    ▼
-LobbyEventService.notifyLobbyInfoRefresh()
-    │ /topic/lobby/{code}/refresh 로 REFRESH_LOBBY_INFO 브로드캐스트
-```
-
-### canStart 계산
-
-`GET /api/lobbies/{code}` 응답의 `canStart`는 FE의 게임 시작 버튼 활성화 기준입니다.
-
-계산 조건:
-
-```text
-1. Redis 로비 상태가 WAITING
-2. Redis map_id 존재
-3. DB 기준 맵 문제 수가 roundCount 이상
-4. Redis participants 기준 방장 제외 참여자 1명 이상
-5. Redis ready Set 기준 방장 제외 모든 참여자가 ready
-```
-
-`canStart`는 조회 시점의 snapshot입니다.
-실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 `start_lobby.lua`가 최종 검증합니다.
-
----
-
-## 🧪 주요 검증 시나리오
-
-### 로비 생성
-
-| 시나리오                       | 기대 결과                      |
-| -------------------------- | -------------------------- |
-| `mapId` 없이 로비 생성           | `201 Created`, 맵 정보 `null` |
-| 공개 맵 `mapId`로 로비 생성        | `201 Created`, 맵 정보 포함     |
-| 본인 소유 비공개 맵 `mapId`로 로비 생성 | `201 Created`, 맵 정보 포함     |
-| 타인 소유 비공개 맵 `mapId`로 로비 생성 | `403 Forbidden`            |
-| 삭제된 맵 `mapId`로 로비 생성       | `409 Conflict`             |
-| 존재하지 않는 `mapId`로 로비 생성     | `404 Not Found`            |
-| 음수 또는 0 `mapId`로 로비 생성     | `400 Bad Request`          |
-
-### Redis 저장
-
-| 시나리오     | 기대 결과                                       |
-| -------- | ------------------------------------------- |
-| 맵 미선택 로비 | `map_id`, `map_title`, `map_category` 필드 없음 |
-| 맵 선택 로비  | `map_id`, `map_title`, `map_category` 필드 있음 |
-| 맵 미선택 로비 | `"null"` 문자열 저장 없음                          |
-| ready 변경 | `lobby:{code}:ready` Set 추가/삭제              |
-| 퇴장/강퇴    | ready Set에서 해당 userIdentifier 제거            |
-
-### 로비 상세 / ready / start
-
-| 시나리오                                | 기대 결과                                                |
-| ----------------------------------- | ---------------------------------------------------- |
-| 로비 상세 조회                            | 참여자 목록, ready 상태, canStart 반환                        |
-| 방장이 ready 요청                        | `400 Bad Request`                                    |
-| 일반 참여자가 ready 요청                    | `204 No Content`, refresh 브로드캐스트                     |
-| canStart=true 상태에서 start 요청         | `204 No Content`, `GAME_STARTED` 브로드캐스트              |
-| ready 미완료 상태에서 start 요청             | `409 Conflict`                                       |
-| 맵 미선택 상태에서 start 요청                 | `409 Conflict`                                       |
-| 맵 문제 수 부족 상태에서 start 요청             | `409 Conflict`                                       |
-| stale participant가 있는 상태에서 start 요청 | `409 Conflict`, ready/participants/session 정합성 로그 기록 |
-| Redis Lua 성공 후 DB 동기화 실패            | Redis rollback 또는 reconciliation queue 적재            |
+| 필드 | 사용 목적 |
+| --- | --- |
+| `code` | 구체적인 실패 원인 분기 |
+| `action` | 화면 이동/재연결/재시도 정책 |
+| `recoverable` | 같은 화면에서 재시도 가능한지 판단 |
+| `message` | 사용자에게 표시할 문구 |

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandler.java
@@ -68,15 +68,70 @@ public class CustomStompErrorHandler extends StompSubProtocolErrorHandler {
     }
 
     /**
-     * Spring WebSocket 내부에서 예외가 MessageDeliveryException 등으로 래핑될 수 있으므로,
-     * cause chain을 순회하면서 우리가 처리할 수 있는 예외를 찾는다.
+     * Spring WebSocket 내부에서 예외가 MessageDeliveryException 등으로 래핑될 수 있으므로
+     * cause chain을 순회하면서 처리 가능한 예외를 찾는다.
+     *
+     * [중요]
+     * StompErrorException은 FE 계약에 직접 연결되는 code/action/recoverable을 가진 예외다.
+     * 따라서 IllegalStateException / IllegalArgumentException보다 항상 우선해야 한다.
+     *
+     * 예:
+     * MessageDeliveryException
+     *   └── IllegalStateException
+     *       └── StompErrorException(LOBBY_FULL)
+     *
+     * 위 구조에서 중간의 IllegalStateException을 먼저 반환하면 LOBBY_FULL이 INTERNAL_STOMP_ERROR로 손실된다.
      */
     private Throwable findHandledException(Throwable throwable) {
+        StompErrorException stompErrorException = findCause(
+                throwable,
+                StompErrorException.class
+        );
+
+        if (stompErrorException != null) {
+            return stompErrorException;
+        }
+
+        Throwable legacyException = findLegacyClientException(throwable);
+
+        if (legacyException != null) {
+            return legacyException;
+        }
+
+        return throwable;
+    }
+
+    /**
+     * cause chain 전체에서 targetType에 해당하는 예외를 찾는다.
+     */
+    private <T extends Throwable> T findCause(
+            Throwable throwable,
+            Class<T> targetType
+    ) {
         Throwable current = throwable;
 
         while (current != null) {
-            if (current instanceof StompErrorException
-                    || current instanceof IllegalArgumentException
+            if (targetType.isInstance(current)) {
+                return targetType.cast(current);
+            }
+
+            current = current.getCause();
+        }
+
+        return null;
+    }
+
+    /**
+     * 기존 코드에서 사용하던 IllegalArgumentException / IllegalStateException 기반 STOMP 예외를 찾는다.
+     *
+     * 이 예외들은 구체적인 StompErrorCode를 갖고 있지 않으므로,
+     * INTERNAL_STOMP_ERROR로 fallback 처리한다.
+     */
+    private Throwable findLegacyClientException(Throwable throwable) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current instanceof IllegalArgumentException
                     || current instanceof IllegalStateException) {
                 return current;
             }
@@ -84,7 +139,7 @@ public class CustomStompErrorHandler extends StompSubProtocolErrorHandler {
             current = current.getCause();
         }
 
-        return throwable;
+        return null;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandler.java
@@ -1,50 +1,123 @@
 package io.github.ascrew.monomatbe.global.websocket;
 
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorCode;
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorException;
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorPayload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.nio.charset.StandardCharsets;
 
-
+/**
+ * STOMP ERROR 프레임을 표준 JSON payload로 변환하는 핸들러
+ *
+ * [기존 문제]
+ * 기존 구현은 ERROR body에 문자열만 내려주었기 때문에 FE가 메시지 문자열을 파싱해야 했음
+ *
+ * [변경 후]
+ * code/action/recoverable을 포함한 JSON payload를 내려주어
+ * FE가 안정적으로 화면 복귀, 재연결, 새로고침 재시도 여부를 판단할 수 있다.
+ */
+@Slf4j
 @Component
 public class CustomStompErrorHandler extends StompSubProtocolErrorHandler {
 
-    public CustomStompErrorHandler() {
-        super();
-    }
-    @Override
-    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
-        // 인터셉터에서 발생한 예외는 보통 MessageDeliveryException 등으로 래핑되어 전달됩니다.
-        // ex.getCause()를 통해 우리가 직접 던진 실제 예외(IllegalArgumentException 등)를 추출합니다.
-        Throwable cause = ex.getCause();
+    private static final String HEADER_ERROR_CODE = "error-code";
 
-        // 의도한 예외 (인증 실패, 권한 부족 등)인 경우
-        if (cause instanceof IllegalArgumentException || cause instanceof IllegalStateException) {
-            return handleCustomException(cause.getMessage());
+    private final JsonMapper jsonMapper;
+
+    public CustomStompErrorHandler(
+            @Qualifier("cacheJsonMapper") JsonMapper jsonMapper
+    ) {
+        super();
+        this.jsonMapper = jsonMapper;
+    }
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(
+            Message<byte[]> clientMessage,
+            Throwable ex
+    ) {
+        Throwable handledException = findHandledException(ex);
+
+        if (handledException instanceof StompErrorException stompErrorException) {
+            return buildErrorMessage(StompErrorPayload.from(stompErrorException));
         }
 
-        // 그 외의 예상치 못한 서버 에러인 경우 기본 처리
-        return super.handleClientMessageProcessingError(clientMessage, ex);
+        if (handledException instanceof IllegalArgumentException
+                || handledException instanceof IllegalStateException) {
+            log.warn("표준화되지 않은 STOMP 예외 감지 - message: {}", handledException.getMessage());
+
+            StompErrorException fallbackException = new StompErrorException(
+                    StompErrorCode.INTERNAL_STOMP_ERROR
+            );
+
+            return buildErrorMessage(StompErrorPayload.from(fallbackException));
+        }
+
+        log.error("예상하지 못한 STOMP 처리 오류", ex);
+
+        return buildErrorMessage(StompErrorPayload.from(StompErrorCode.INTERNAL_STOMP_ERROR));
     }
 
-    private Message<byte[]> handleCustomException(String errorMessage) {
-        // STOMP의 ERROR 프레임 생성
+    /**
+     * Spring WebSocket 내부에서 예외가 MessageDeliveryException 등으로 래핑될 수 있으므로,
+     * cause chain을 순회하면서 우리가 처리할 수 있는 예외를 찾는다.
+     */
+    private Throwable findHandledException(Throwable throwable) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current instanceof StompErrorException
+                    || current instanceof IllegalArgumentException
+                    || current instanceof IllegalStateException) {
+                return current;
+            }
+
+            current = current.getCause();
+        }
+
+        return throwable;
+    }
+
+    /**
+     * 표준 STOMP ERROR 메시지를 생성한다.
+     *
+     * message 헤더에는 error code를 넣고,
+     * body에는 JSON payload를 넣는다.
+     */
+    private Message<byte[]> buildErrorMessage(StompErrorPayload payload) {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
 
-        // 프론트엔드가 에러 원인을 파악할 수 있도록 메시지(message) 헤더 세팅
-        accessor.setMessage(errorMessage);
+        accessor.setMessage(payload.code());
+        accessor.setNativeHeader(HEADER_ERROR_CODE, payload.code());
         accessor.setLeaveMutable(true);
 
-        // 에러 상세 내용을 Body에 담아 전송
         return MessageBuilder.createMessage(
-                errorMessage.getBytes(StandardCharsets.UTF_8),
+                serializePayload(payload),
                 accessor.getMessageHeaders()
         );
+    }
 
+    private byte[] serializePayload(StompErrorPayload payload) {
+        try {
+            return jsonMapper.writeValueAsString(payload)
+                    .getBytes(StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.error("STOMP ERROR payload 직렬화 실패 - code: {}", payload.code(), e);
+
+            String fallbackJson = """
+                    {"type":"STOMP_ERROR","code":"INTERNAL_STOMP_ERROR","message":"WebSocket 처리 중 서버 오류가 발생했습니다.","action":"REFRESH_AND_RETRY","recoverable":true,"timestamp":"%s"}
+                    """.formatted(payload.timestamp());
+
+            return fallbackJson.getBytes(StandardCharsets.UTF_8);
+        }
     }
 }
-

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/LobbyEnterResultMapper.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/LobbyEnterResultMapper.java
@@ -1,0 +1,99 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorCode;
+
+/**
+ * enter_lobby.lua 반환값을 Java 내부 결과 타입으로 변환한다.
+ *
+ * Lua 반환 문자열과 STOMP ERROR code 매핑을 한 곳에서 관리해 반환값 추가/변경 시 누락 가능성을 줄인다.
+ */
+final class LobbyEnterResultMapper {
+
+    private static final String ENTER_RESULT_ENTERED = "ENTERED";
+    private static final String ENTER_RESULT_ALREADY_JOINED = "ALREADY_JOINED";
+    private static final String ENTER_RESULT_SESSION_REPLACED_PREFIX = "SESSION_REPLACED:";
+    private static final String ENTER_RESULT_STALE_SESSION_PREFIX = "STALE_SESSION:";
+    private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
+    private static final String ENTER_RESULT_INVALID_SEQUENCE = "INVALID_SEQUENCE";
+    private static final String ENTER_RESULT_FULL = "FULL";
+    private static final String ENTER_RESULT_LOBBY_NOT_WAITING = "LOBBY_NOT_WAITING";
+    private static final String ENTER_RESULT_INVALID_LOBBY_CAPACITY = "INVALID_LOBBY_CAPACITY";
+    private static final String ENTER_RESULT_KICKED_USER = "KICKED_USER";
+
+    LobbyEnterResultType parse(String result) {
+        if (ENTER_RESULT_ENTERED.equals(result)) {
+            return LobbyEnterResultType.ENTERED;
+        }
+
+        if (ENTER_RESULT_ALREADY_JOINED.equals(result)) {
+            return LobbyEnterResultType.ALREADY_JOINED;
+        }
+
+        if (result != null && result.startsWith(ENTER_RESULT_SESSION_REPLACED_PREFIX)) {
+            return LobbyEnterResultType.SESSION_REPLACED;
+        }
+
+        if (result != null && result.startsWith(ENTER_RESULT_STALE_SESSION_PREFIX)) {
+            return LobbyEnterResultType.STALE_SESSION;
+        }
+
+        if (ENTER_RESULT_LOBBY_NOT_FOUND.equals(result)) {
+            return LobbyEnterResultType.LOBBY_NOT_FOUND;
+        }
+
+        if (ENTER_RESULT_INVALID_SEQUENCE.equals(result)) {
+            return LobbyEnterResultType.INVALID_SEQUENCE;
+        }
+
+        if (ENTER_RESULT_FULL.equals(result)) {
+            return LobbyEnterResultType.FULL;
+        }
+
+        if (ENTER_RESULT_LOBBY_NOT_WAITING.equals(result)) {
+            return LobbyEnterResultType.LOBBY_NOT_WAITING;
+        }
+
+        if (ENTER_RESULT_INVALID_LOBBY_CAPACITY.equals(result)) {
+            return LobbyEnterResultType.INVALID_LOBBY_CAPACITY;
+        }
+
+        if (ENTER_RESULT_KICKED_USER.equals(result)) {
+            return LobbyEnterResultType.KICKED_USER;
+        }
+
+        return LobbyEnterResultType.UNKNOWN;
+    }
+
+    enum LobbyEnterResultType {
+        ENTERED(null),
+        ALREADY_JOINED(null),
+        SESSION_REPLACED(null),
+
+        STALE_SESSION(StompErrorCode.LOBBY_STALE_SESSION),
+        LOBBY_NOT_FOUND(StompErrorCode.LOBBY_NOT_FOUND),
+        INVALID_SEQUENCE(StompErrorCode.LOBBY_INVALID_SEQUENCE),
+        FULL(StompErrorCode.LOBBY_FULL),
+        LOBBY_NOT_WAITING(StompErrorCode.LOBBY_NOT_WAITING),
+        INVALID_LOBBY_CAPACITY(StompErrorCode.LOBBY_INVALID_CAPACITY),
+        KICKED_USER(StompErrorCode.LOBBY_KICKED_USER),
+        UNKNOWN(StompErrorCode.LOBBY_ENTER_UNKNOWN_RESULT);
+
+        private final StompErrorCode errorCode;
+
+        LobbyEnterResultType(StompErrorCode errorCode) {
+            this.errorCode = errorCode;
+        }
+
+        boolean isSuccess() {
+            return errorCode == null;
+        }
+
+        StompErrorCode resolveErrorCode() {
+            if (errorCode == null) {
+                throw new IllegalStateException("성공 로비 입장 결과에는 STOMP 에러 코드가 없습니다: " + this);
+            }
+
+            return errorCode;
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -31,15 +31,14 @@ import java.util.regex.Pattern;
  * - CONNECT 시 Redis INCR 기반 sessionSequence 발급
  * - CONNECT 시 사용자 온라인 상태 저장
  * - SUBSCRIBE/SEND/UNSUBSCRIBE 시 인증 세션 검증
- * - 로비 채팅 채널 SUBSCRIBE 시 enter_lobby.lua를 먼저 실행하여 입장 상태를 확정
+ * - 로비 채팅 채널 SUBSCRIBE 시 enter_lobby.lua를 먼저 실행하여 입장 상태 확정
  *
  * [중요]
  * SessionSubscribeEvent는 구독 요청이 처리된 이후 발생한다.
  * 따라서 해당 이벤트에서 Redis 입장 처리를 수행하면 Lua 실패 시에도 클라이언트는 이미 구독된 상태가 될 수 있다.
  *
  * 이를 방지하기 위해 /topic/lobby/{code} 구독은 preSend 단계에서
- * enter_lobby.lua를 먼저 실행하고, Redis 입장 상태가 확정된 경우에만
- * SUBSCRIBE를 통과시킨다.
+ * enter_lobby.lua를 먼저 실행하고, Redis 입장 상태가 확정된 경우에만 SUBSCRIBE를 통과시킨다.
  */
 @Slf4j
 @Component
@@ -78,12 +77,11 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
     /**
      * ws:connection:{wsSessionId}, lobby:{code}:user_session:{userIdentifier},
-     * lobby:{code}:user_session_seq:{userIdentifier} 매핑 TTL.
+     * lobby:{code}:user_session_seq:{userIdentifier} 매핑 TTL
      *
      * WebSocket DISCONNECT 이벤트 누락, 서버 비정상 종료에 대비한 안전장치다.
      *
-     * 기존 2시간은 장시간 로비 대기 또는 게임 진행 중 TTL 만료 타이밍 이슈가 생길 수 있어
-     * 6시간으로 늘린다.
+     * 기존 2시간은 장시간 로비 대기 또는 게임 진행 중 TTL 만료 타이밍 이슈가 생길 수 있어 6시간으로 늘린다.
      *
      * 사용자 온라인 상태 TTL은 userStatusTtl 설정값을 사용한다.
      */
@@ -98,7 +96,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final RedisScript<String> enterLobbyScript;
 
     /**
-     * 사용자 온라인 상태 TTL.
+     * 사용자 온라인 상태 TTL
      *
      * [기본값]
      * - PT2H: 2시간
@@ -113,10 +111,10 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final Duration userStatusTtl;
 
     /**
-     * 로비 입장 Lua 재시도 횟수.
+     * 로비 입장 Lua 재시도 횟수
      *
      * 기본값은 2입니다.
-     * 즉, 최초 실행 1회 + 재시도 1회를 의미
+     * 즉, 최초 실행 1회 + 재시도 1회를 의미한다.
      *
      * 설정 파일에 값을 추가하지 않아도 기본값 2로 동작합니다.
      * 운영 환경에서 조정이 필요하면 아래 키를 사용할 수 있습니다.
@@ -154,14 +152,16 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             case CONNECT -> handleConnect(accessor, sessionAttributes);
             case SUBSCRIBE, SEND, UNSUBSCRIBE -> validateSession(accessor, sessionAttributes);
             case DISCONNECT -> handleDisconnect(sessionAttributes);
-            default -> { /* 별도 처리 불필요 */ }
+            default -> {
+                // 별도 처리 불필요
+            }
         }
 
         return message;
     }
 
     /**
-     * CONNECT 명령 처리.
+     * CONNECT 명령 처리
      */
     private void handleConnect(
             StompHeaderAccessor accessor,
@@ -231,12 +231,14 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             case SEND -> log.info("[SEND] 메시지 발송 - 식별자: {}, 경로: {}",
                     userIdentifier, accessor.getDestination());
             case UNSUBSCRIBE -> log.info("[UNSUBSCRIBE] 구독 해제 - 식별자: {}", userIdentifier);
-            default -> { /* 별도 처리 불필요 */ }
+            default -> {
+                // 별도 처리 불필요
+            }
         }
     }
 
     /**
-     * SUBSCRIBE 명령 처리.
+     * SUBSCRIBE 명령 처리
      */
     private void handleSubscribe(
             StompHeaderAccessor accessor,
@@ -313,41 +315,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         return result;
                     }
 
-                    case FULL -> {
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_FULL);
-                    }
-
-                    case LOBBY_NOT_WAITING -> {
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_NOT_WAITING);
-                    }
-
-                    case INVALID_LOBBY_CAPACITY -> {
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_INVALID_CAPACITY);
-                    }
-
-                    case STALE_SESSION -> {
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_STALE_SESSION);
-                    }
-
-                    case KICKED_USER -> {
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_KICKED_USER);
-                    }
-
-                    case LOBBY_NOT_FOUND -> {
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_NOT_FOUND);
-                    }
-
-                    case INVALID_SEQUENCE -> {
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_INVALID_SEQUENCE);
-                    }
-
                     case UNKNOWN -> {
                         if (result == null) {
                             log.warn("로비 입장 Lua 결과 null - 재시도 여부 확인. attempt: {}/{}, 로비: {}, 식별자: {}, wsSessionId: {}",
@@ -358,9 +325,16 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         log.error("로비 입장 Lua 알 수 없는 반환값 - result: {}, 로비: {}, 식별자: {}, wsSessionId: {}",
                                 result, lobbyCode, userIdentifier, wsSessionId);
 
-                        cleanupWsConnection(wsSessionId);
-                        throw new StompErrorException(StompErrorCode.LOBBY_ENTER_UNKNOWN_RESULT);
+                        throwLobbyEnterFailure(
+                                wsSessionId,
+                                resultType.resolveErrorCode()
+                        );
                     }
+
+                    default -> throwLobbyEnterFailure(
+                            wsSessionId,
+                            resultType.resolveErrorCode()
+                    );
                 }
 
             } catch (StompErrorException e) {
@@ -497,6 +471,20 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     }
 
     /**
+     * 로비 입장 실패 결과를 STOMP 표준 예외로 변환한다.
+     *
+     * Lua 실패 결과는 대부분 현재 ws:connection을 유지할 이유가 없으므로
+     * 먼저 보상 삭제한 뒤, FE가 처리 가능한 StompErrorCode를 가진 예외를 던진다.
+     */
+    private void throwLobbyEnterFailure(
+            String wsSessionId,
+            StompErrorCode errorCode
+    ) {
+        cleanupWsConnection(wsSessionId);
+        throw new StompErrorException(errorCode);
+    }
+
+    /**
      * Lua 실패 시 현재 ws:connection 키를 보상 삭제한다.
      */
     private void cleanupWsConnection(String wsSessionId) {
@@ -559,17 +547,41 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         }
     }
 
+    /**
+     * enter_lobby.lua 반환값의 의미를 Java 내부 타입으로 변환한 값이다.
+     *
+     * 성공 타입은 errorCode가 null이다.
+     * 실패 타입은 FE에 내려줄 StompErrorCode를 직접 가진다.
+     *
+     * 이렇게 관리하면 Lua 반환값이 추가될 때 result type과 error code 매핑을
+     * 한 곳에서 함께 확인할 수 있다.
+     */
     private enum LobbyEnterResultType {
-        ENTERED,
-        ALREADY_JOINED,
-        SESSION_REPLACED,
-        STALE_SESSION,
-        LOBBY_NOT_FOUND,
-        INVALID_SEQUENCE,
-        FULL,
-        LOBBY_NOT_WAITING,
-        INVALID_LOBBY_CAPACITY,
-        KICKED_USER,
-        UNKNOWN
+        ENTERED(null),
+        ALREADY_JOINED(null),
+        SESSION_REPLACED(null),
+
+        STALE_SESSION(StompErrorCode.LOBBY_STALE_SESSION),
+        LOBBY_NOT_FOUND(StompErrorCode.LOBBY_NOT_FOUND),
+        INVALID_SEQUENCE(StompErrorCode.LOBBY_INVALID_SEQUENCE),
+        FULL(StompErrorCode.LOBBY_FULL),
+        LOBBY_NOT_WAITING(StompErrorCode.LOBBY_NOT_WAITING),
+        INVALID_LOBBY_CAPACITY(StompErrorCode.LOBBY_INVALID_CAPACITY),
+        KICKED_USER(StompErrorCode.LOBBY_KICKED_USER),
+        UNKNOWN(StompErrorCode.LOBBY_ENTER_UNKNOWN_RESULT);
+
+        private final StompErrorCode errorCode;
+
+        LobbyEnterResultType(StompErrorCode errorCode) {
+            this.errorCode = errorCode;
+        }
+
+        private StompErrorCode resolveErrorCode() {
+            if (errorCode == null) {
+                throw new IllegalStateException("성공 로비 입장 결과에는 STOMP 에러 코드가 없습니다: " + this);
+            }
+
+            return errorCode;
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -3,6 +3,8 @@ package io.github.ascrew.monomatbe.global.websocket;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorCode;
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +24,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
- * STOMP 채널 인터셉터.
+ * STOMP 채널 인터셉터
  *
  * [책임]
  * - CONNECT 시 userIdentifier 검증 및 세션 저장
@@ -169,24 +171,20 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
         if (userIdentifier == null || userIdentifier.isBlank()) {
             log.warn("STOMP CONNECT 거부: 사용자 식별자 없음");
-            throw new IllegalArgumentException(
-                    "STOMP CONNECT: 사용자 식별자가 없습니다. 연결이 거부되었습니다."
-            );
+            throw new StompErrorException(StompErrorCode.CONNECT_USER_IDENTIFIER_MISSING);
         }
 
         if (!UUID_PATTERN.matcher(userIdentifier).matches()) {
             log.warn("STOMP CONNECT 거부: 유효하지 않은 식별자 형식 = {}",
                     sanitizeForLog(userIdentifier));
-            throw new IllegalArgumentException(
-                    "STOMP CONNECT: 유효하지 않은 식별자 형식입니다. 연결이 거부되었습니다."
-            );
+            throw new StompErrorException(StompErrorCode.CONNECT_USER_IDENTIFIER_INVALID);
         }
 
         Long sessionSequence = stringRedisTemplate.opsForValue()
                 .increment(RedisKeys.WS_SESSION_SEQUENCE);
 
         if (sessionSequence == null) {
-            throw new IllegalStateException("STOMP CONNECT: WebSocket 세션 sequence 발급에 실패했습니다.");
+            throw new StompErrorException(StompErrorCode.CONNECT_SESSION_SEQUENCE_FAILED);
         }
 
         if (sessionAttributes != null) {
@@ -198,7 +196,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
         if (wsSessionId == null || wsSessionId.isBlank()) {
             log.warn("STOMP CONNECT 거부: WebSocket 세션 ID 없음 - userIdentifier: {}", userIdentifier);
-            throw new IllegalStateException("STOMP CONNECT: WebSocket 세션 ID가 없습니다.");
+            throw new StompErrorException(StompErrorCode.CONNECT_WS_SESSION_ID_MISSING);
         }
 
         log.debug("STOMP CONNECT 온라인 상태 저장 시작 - userIdentifier: {}, wsSessionId: {}, sessionSequence: {}",
@@ -225,7 +223,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
         if (userIdentifier == null) {
             log.warn("[{}] 인증되지 않은 세션 접근 차단", accessor.getCommand());
-            throw new IllegalStateException("인증 정보가 존재하지 않습니다.");
+            throw new StompErrorException(StompErrorCode.SESSION_UNAUTHENTICATED);
         }
 
         switch (accessor.getCommand()) {
@@ -291,7 +289,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             Map<String, Object> sessionAttributes
     ) {
         if (wsSessionId == null || wsSessionId.isBlank()) {
-            throw new IllegalStateException("로비 입장 실패: WebSocket 세션 ID가 없습니다.");
+            throw new StompErrorException(StompErrorCode.LOBBY_ENTER_WS_SESSION_MISSING);
         }
 
         long sessionSequence = extractSessionSequence(sessionAttributes);
@@ -317,37 +315,37 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
                     case FULL -> {
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패: 최대 인원에 도달했습니다.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_FULL);
                     }
 
                     case LOBBY_NOT_WAITING -> {
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패: 게임이 이미 시작된 로비입니다.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_NOT_WAITING);
                     }
 
                     case INVALID_LOBBY_CAPACITY -> {
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패: 로비 정원 정보가 유효하지 않습니다.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_INVALID_CAPACITY);
                     }
 
                     case STALE_SESSION -> {
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패: 더 최신 WebSocket 세션이 이미 존재합니다.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_STALE_SESSION);
                     }
 
                     case KICKED_USER -> {
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패 : 강퇴된 로비에는 재입장할 수 없습니다.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_KICKED_USER);
                     }
 
                     case LOBBY_NOT_FOUND -> {
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalArgumentException("로비 입장 실패: 존재하지 않는 로비입니다.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_NOT_FOUND);
                     }
 
                     case INVALID_SEQUENCE -> {
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패: 세션 상태가 유효하지 않습니다. 새로고침 후 다시 시도해주세요.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_INVALID_SEQUENCE);
                     }
 
                     case UNKNOWN -> {
@@ -361,11 +359,11 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                                 result, lobbyCode, userIdentifier, wsSessionId);
 
                         cleanupWsConnection(wsSessionId);
-                        throw new IllegalStateException("로비 입장 실패: 알 수 없는 서버 응답입니다.");
+                        throw new StompErrorException(StompErrorCode.LOBBY_ENTER_UNKNOWN_RESULT);
                     }
                 }
 
-            } catch (IllegalArgumentException | IllegalStateException e) {
+            } catch (StompErrorException e) {
                 throw e;
             } catch (RuntimeException e) {
                 lastException = e;
@@ -383,7 +381,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         }
 
         cleanupWsConnection(wsSessionId);
-        throw new IllegalStateException("일시적으로 로비 입장 상태를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.");
+        throw new StompErrorException(StompErrorCode.LOBBY_ENTER_TEMPORARILY_UNAVAILABLE);
     }
 
     /**
@@ -391,7 +389,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
      */
     private long extractSessionSequence(Map<String, Object> sessionAttributes) {
         if (sessionAttributes == null) {
-            throw new IllegalStateException("로비 입장 실패: STOMP 세션 속성이 없습니다.");
+            throw new StompErrorException(StompErrorCode.LOBBY_ENTER_SESSION_ATTRIBUTES_MISSING);
         }
 
         Object value = sessionAttributes.get(WebSocketHeaders.SESSION_SEQUENCE);
@@ -400,7 +398,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             return number.longValue();
         }
 
-        throw new IllegalStateException("로비 입장 실패: WebSocket 세션 sequence가 없습니다.");
+        throw new StompErrorException(StompErrorCode.LOBBY_ENTER_SEQUENCE_MISSING);
     }
 
     /**
@@ -557,7 +555,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         } catch (RuntimeException e) {
             log.error("STOMP CONNECT 온라인 상태 저장 실패 - userIdentifier: {}, wsSessionId: {}, userStatusKey: {}, userStatusSessionsKey: {}",
                     userIdentifier, wsSessionId, userStatusKey, userStatusSessionsKey, e);
-            throw new IllegalStateException("STOMP CONNECT: 사용자 온라인 상태 저장에 실패했습니다.", e);
+            throw new StompErrorException(StompErrorCode.CONNECT_ONLINE_STATUS_FAILED, e);
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -49,31 +49,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
             );
 
-    // =========================================================
-    // Redis Lua 반환값 상수
-    // =========================================================
-
-    private static final String ENTER_RESULT_ENTERED = "ENTERED";
-    private static final String ENTER_RESULT_ALREADY_JOINED = "ALREADY_JOINED";
-    private static final String ENTER_RESULT_SESSION_REPLACED_PREFIX = "SESSION_REPLACED:";
-    private static final String ENTER_RESULT_STALE_SESSION_PREFIX = "STALE_SESSION:";
-    private static final String ENTER_RESULT_LOBBY_NOT_FOUND = "LOBBY_NOT_FOUND";
-    private static final String ENTER_RESULT_INVALID_SEQUENCE = "INVALID_SEQUENCE";
-    private static final String ENTER_RESULT_FULL = "FULL";
-    private static final String ENTER_RESULT_LOBBY_NOT_WAITING = "LOBBY_NOT_WAITING";
-    private static final String ENTER_RESULT_INVALID_LOBBY_CAPACITY = "INVALID_LOBBY_CAPACITY";
-    private static final String ENTER_RESULT_KICKED_USER = "KICKED_USER";
-
-    // =========================================================
-    // 실패 사유 상수
-    // =========================================================
-
     private static final String ENTER_FAILURE_NULL_RESULT = "Lua result is null";
     private static final String ENTER_FAILURE_EXCEPTION = "Lua execution exception";
-
-    // =========================================================
-    // TTL 상수
-    // =========================================================
 
     /**
      * ws:connection:{wsSessionId}, lobby:{code}:user_session:{userIdentifier},
@@ -86,10 +63,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
      * 사용자 온라인 상태 TTL은 userStatusTtl 설정값을 사용한다.
      */
     private static final Duration WS_CONNECTION_TTL = Duration.ofHours(6);
-
-    // =========================================================
-    // 의존성
-    // =========================================================
 
     private final StringRedisTemplate stringRedisTemplate;
     private final WebSocketMetric webSocketMetric;
@@ -423,56 +396,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     }
 
     /**
-     * Lua 반환값을 enum으로 파싱한다.
-     *
-     * 반환 문자열 분기 처리를 이 메서드로 중앙화하여,
-     * Lua 반환값이 추가될 때 Java 수정 위치를 명확하게 한다.
-     */
-    private LobbyEnterResultType parseLobbyEnterResultType(String result) {
-        if (ENTER_RESULT_ENTERED.equals(result)) {
-            return LobbyEnterResultType.ENTERED;
-        }
-
-        if (ENTER_RESULT_ALREADY_JOINED.equals(result)) {
-            return LobbyEnterResultType.ALREADY_JOINED;
-        }
-
-        if (result != null && result.startsWith(ENTER_RESULT_SESSION_REPLACED_PREFIX)) {
-            return LobbyEnterResultType.SESSION_REPLACED;
-        }
-
-        if (result != null && result.startsWith(ENTER_RESULT_STALE_SESSION_PREFIX)) {
-            return LobbyEnterResultType.STALE_SESSION;
-        }
-
-        if (ENTER_RESULT_LOBBY_NOT_FOUND.equals(result)) {
-            return LobbyEnterResultType.LOBBY_NOT_FOUND;
-        }
-
-        if (ENTER_RESULT_INVALID_SEQUENCE.equals(result)) {
-            return LobbyEnterResultType.INVALID_SEQUENCE;
-        }
-
-        if (ENTER_RESULT_FULL.equals(result)) {
-            return LobbyEnterResultType.FULL;
-        }
-
-        if (ENTER_RESULT_LOBBY_NOT_WAITING.equals(result)) {
-            return LobbyEnterResultType.LOBBY_NOT_WAITING;
-        }
-
-        if (ENTER_RESULT_INVALID_LOBBY_CAPACITY.equals(result)) {
-            return LobbyEnterResultType.INVALID_LOBBY_CAPACITY;
-        }
-
-        if (ENTER_RESULT_KICKED_USER.equals(result)) {
-            return LobbyEnterResultType.KICKED_USER;
-        }
-
-        return LobbyEnterResultType.UNKNOWN;
-    }
-
-    /**
      * 로비 입장 실패 결과를 STOMP 표준 예외로 변환한다.
      *
      * Lua 실패 결과는 대부분 현재 ws:connection을 유지할 이유가 없으므로
@@ -546,44 +469,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             log.error("STOMP CONNECT 온라인 상태 저장 실패 - userIdentifier: {}, wsSessionId: {}, userStatusKey: {}, userStatusSessionsKey: {}",
                     userIdentifier, wsSessionId, userStatusKey, userStatusSessionsKey, e);
             throw new StompErrorException(StompErrorCode.CONNECT_ONLINE_STATUS_FAILED, e);
-        }
-    }
-
-    /**
-     * enter_lobby.lua 반환값의 의미를 Java 내부 타입으로 변환한 값이다.
-     *
-     * 성공 타입은 errorCode가 null이다.
-     * 실패 타입은 FE에 내려줄 StompErrorCode를 직접 가진다.
-     *
-     * 이렇게 관리하면 Lua 반환값이 추가될 때 result type과 error code 매핑을
-     * 한 곳에서 함께 확인할 수 있다.
-     */
-    private enum LobbyEnterResultType {
-        ENTERED(null),
-        ALREADY_JOINED(null),
-        SESSION_REPLACED(null),
-
-        STALE_SESSION(StompErrorCode.LOBBY_STALE_SESSION),
-        LOBBY_NOT_FOUND(StompErrorCode.LOBBY_NOT_FOUND),
-        INVALID_SEQUENCE(StompErrorCode.LOBBY_INVALID_SEQUENCE),
-        FULL(StompErrorCode.LOBBY_FULL),
-        LOBBY_NOT_WAITING(StompErrorCode.LOBBY_NOT_WAITING),
-        INVALID_LOBBY_CAPACITY(StompErrorCode.LOBBY_INVALID_CAPACITY),
-        KICKED_USER(StompErrorCode.LOBBY_KICKED_USER),
-        UNKNOWN(StompErrorCode.LOBBY_ENTER_UNKNOWN_RESULT);
-
-        private final StompErrorCode errorCode;
-
-        LobbyEnterResultType(StompErrorCode errorCode) {
-            this.errorCode = errorCode;
-        }
-
-        private StompErrorCode resolveErrorCode() {
-            if (errorCode == null) {
-                throw new IllegalStateException("성공 로비 입장 결과에는 STOMP 에러 코드가 없습니다: " + this);
-            }
-
-            return errorCode;
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/StompChannelInterceptor.java
@@ -94,6 +94,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final StringRedisTemplate stringRedisTemplate;
     private final WebSocketMetric webSocketMetric;
     private final RedisScript<String> enterLobbyScript;
+    private final LobbyEnterResultMapper lobbyEnterResultMapper = new LobbyEnterResultMapper();
 
     /**
      * 사용자 온라인 상태 TTL
@@ -308,7 +309,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                         sessionSequence
                 );
 
-                LobbyEnterResultType resultType = parseLobbyEnterResultType(result);
+                LobbyEnterResultMapper.LobbyEnterResultType resultType =
+                        lobbyEnterResultMapper.parse(result);
 
                 switch (resultType) {
                     case ENTERED, ALREADY_JOINED, SESSION_REPLACED -> {

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorAction.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorAction.java
@@ -1,0 +1,50 @@
+package io.github.ascrew.monomatbe.global.websocket.error;
+
+/**
+ * STOMP ERROR 수신 후 클라이언트가 수행해야 하는 후속 동작
+ *
+ * [설계 의도]
+ * FE가 에러 메시지 문자열을 파싱하지 않고,
+ * action 값만 보고 화면 전환/재시도/새로고침 정책을 결정할 수 있도록 한다.
+ */
+public enum StompErrorAction {
+
+    /**
+     * 현재 로비 입장을 중단하고 로비 목록 또는 이전 화면으로 복귀한다.
+     *
+     * 사용 예:
+     * - 존재하지 않는 로비
+     * - 만원 로비
+     * - 이미 시작된 로비
+     * - 강퇴된 로비
+     */
+    RETURN_TO_LOBBY_LIST,
+
+    /**
+     * WebSocket 연결 자체를 다시 시도한다.
+     *
+     * 사용 예:
+     * - CONNECT 단계에서 세션 ID가 없음
+     * - userIdentifier가 누락됨
+     */
+    RETRY_CONNECT,
+
+    /**
+     * 현재 화면 상태를 새로고침한 뒤 다시 시도한다.
+     *
+     * 사용 예:
+     * - sessionSequence 누락
+     * - 일시적 Redis/Lua 실패
+     */
+    REFRESH_AND_RETRY,
+
+    /**
+     * 더 최신 WebSocket 세션이 이미 있으므로 현재 세션은 폐기하고 재연결한다.
+     */
+    RECONNECT,
+
+    /**
+     * 별도 후속 동작 없이 현재 상태를 유지한다.
+     */
+    NONE
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorCode.java
@@ -1,0 +1,151 @@
+package io.github.ascrew.monomatbe.global.websocket.error;
+
+/**
+ * WebSocket / STOMP 실패 코드를 중앙 관리한다.
+ *
+ * [중요]
+ * FE는 message 문자열이 아니라 code/action/recoverable을 기준으로 분기해야 한다.
+ * 따라서 enum 이름은 API 계약으로 보고 함부로 변경하지 않는다.
+ */
+public enum StompErrorCode {
+
+    CONNECT_USER_IDENTIFIER_MISSING(
+            "사용자 식별자가 없습니다. 다시 로그인 후 접속해주세요.",
+            StompErrorAction.RETRY_CONNECT,
+            true
+    ),
+
+    CONNECT_USER_IDENTIFIER_INVALID(
+            "유효하지 않은 사용자 식별자입니다. 다시 로그인 후 접속해주세요.",
+            StompErrorAction.RETRY_CONNECT,
+            true
+    ),
+
+    CONNECT_SESSION_SEQUENCE_FAILED(
+            "WebSocket 세션 생성에 실패했습니다. 다시 접속해주세요.",
+            StompErrorAction.RETRY_CONNECT,
+            true
+    ),
+
+    CONNECT_WS_SESSION_ID_MISSING(
+            "WebSocket 세션 ID가 없습니다. 다시 접속해주세요.",
+            StompErrorAction.RETRY_CONNECT,
+            true
+    ),
+
+    CONNECT_ONLINE_STATUS_FAILED(
+            "사용자 온라인 상태 저장에 실패했습니다. 잠시 후 다시 접속해주세요.",
+            StompErrorAction.RETRY_CONNECT,
+            true
+    ),
+
+    SESSION_UNAUTHENTICATED(
+            "인증 정보가 존재하지 않습니다. 다시 접속해주세요.",
+            StompErrorAction.RETRY_CONNECT,
+            true
+    ),
+
+    LOBBY_ENTER_WS_SESSION_MISSING(
+            "로비 입장에 필요한 WebSocket 세션 ID가 없습니다. 다시 접속해주세요.",
+            StompErrorAction.RECONNECT,
+            true
+    ),
+
+    LOBBY_ENTER_SESSION_ATTRIBUTES_MISSING(
+            "로비 입장에 필요한 세션 정보가 없습니다. 새로고침 후 다시 시도해주세요.",
+            StompErrorAction.REFRESH_AND_RETRY,
+            true
+    ),
+
+    LOBBY_ENTER_SEQUENCE_MISSING(
+            "WebSocket 세션 순서 정보가 없습니다. 새로고침 후 다시 시도해주세요.",
+            StompErrorAction.REFRESH_AND_RETRY,
+            true
+    ),
+
+    LOBBY_NOT_FOUND(
+            "존재하지 않는 로비입니다.",
+            StompErrorAction.RETURN_TO_LOBBY_LIST,
+            false
+    ),
+
+    LOBBY_FULL(
+            "로비 최대 인원에 도달했습니다.",
+            StompErrorAction.RETURN_TO_LOBBY_LIST,
+            false
+    ),
+
+    LOBBY_NOT_WAITING(
+            "이미 시작되었거나 입장할 수 없는 로비입니다.",
+            StompErrorAction.RETURN_TO_LOBBY_LIST,
+            false
+    ),
+
+    LOBBY_INVALID_CAPACITY(
+            "로비 정원 정보가 유효하지 않습니다.",
+            StompErrorAction.RETURN_TO_LOBBY_LIST,
+            false
+    ),
+
+    LOBBY_STALE_SESSION(
+            "더 최신 WebSocket 세션이 이미 존재합니다. 다시 접속해주세요.",
+            StompErrorAction.RECONNECT,
+            true
+    ),
+
+    LOBBY_KICKED_USER(
+            "강퇴된 로비에는 재입장할 수 없습니다.",
+            StompErrorAction.RETURN_TO_LOBBY_LIST,
+            false
+    ),
+
+    LOBBY_INVALID_SEQUENCE(
+            "로비 입장 세션 상태가 유효하지 않습니다. 새로고침 후 다시 시도해주세요.",
+            StompErrorAction.REFRESH_AND_RETRY,
+            true
+    ),
+
+    LOBBY_ENTER_UNKNOWN_RESULT(
+            "로비 입장 중 알 수 없는 서버 응답이 발생했습니다. 새로고침 후 다시 시도해주세요.",
+            StompErrorAction.REFRESH_AND_RETRY,
+            true
+    ),
+
+    LOBBY_ENTER_TEMPORARILY_UNAVAILABLE(
+            "일시적으로 로비 입장 상태를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.",
+            StompErrorAction.REFRESH_AND_RETRY,
+            true
+    ),
+
+    INTERNAL_STOMP_ERROR(
+            "WebSocket 처리 중 서버 오류가 발생했습니다.",
+            StompErrorAction.REFRESH_AND_RETRY,
+            true
+    );
+
+    private final String defaultMessage;
+    private final StompErrorAction action;
+    private final boolean recoverable;
+
+    StompErrorCode(
+            String defaultMessage,
+            StompErrorAction action,
+            boolean recoverable
+    ) {
+        this.defaultMessage = defaultMessage;
+        this.action = action;
+        this.recoverable = recoverable;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+
+    public StompErrorAction getAction() {
+        return action;
+    }
+
+    public boolean isRecoverable() {
+        return recoverable;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorException.java
@@ -1,5 +1,7 @@
 package io.github.ascrew.monomatbe.global.websocket.error;
 
+import java.util.Objects;
+
 /**
  * STOMP 처리 중 의도적으로 클라이언트에게 표준 ERROR payload를 내려야 할 때 사용하는 예외이다.
  *
@@ -15,11 +17,11 @@ public class StompErrorException extends RuntimeException {
     private final String clientMessage;
 
     public StompErrorException(StompErrorCode errorCode) {
-        this(errorCode, errorCode.getDefaultMessage(), null);
+        this(errorCode, null, null);
     }
 
     public StompErrorException(StompErrorCode errorCode, Throwable cause) {
-        this(errorCode, errorCode.getDefaultMessage(), cause);
+        this(errorCode, null, cause);
     }
 
     public StompErrorException(
@@ -34,9 +36,9 @@ public class StompErrorException extends RuntimeException {
             String clientMessage,
             Throwable cause
     ) {
-        super(clientMessage, cause);
-        this.errorCode = errorCode;
-        this.clientMessage = clientMessage;
+        super(resolveClientMessage(errorCode, clientMessage), cause);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
+        this.clientMessage = resolveClientMessage(errorCode, clientMessage);
     }
 
     public StompErrorCode getErrorCode() {
@@ -44,6 +46,28 @@ public class StompErrorException extends RuntimeException {
     }
 
     public String getClientMessage() {
+        return clientMessage;
+    }
+
+    /**
+     * 클라이언트에게 내려줄 메시지를 결정한다.
+     *
+     * 명시 메시지가 있으면 해당 메시지를 사용하고,
+     * 없으면 StompErrorCode의 기본 메시지를 사용한다.
+     */
+    private static String resolveClientMessage(
+            StompErrorCode errorCode,
+            String clientMessage
+    ) {
+        StompErrorCode resolvedErrorCode = Objects.requireNonNull(
+                errorCode,
+                "errorCode must not be null"
+        );
+
+        if (clientMessage == null || clientMessage.isBlank()) {
+            return resolvedErrorCode.getDefaultMessage();
+        }
+
         return clientMessage;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorException.java
@@ -36,9 +36,23 @@ public class StompErrorException extends RuntimeException {
             String clientMessage,
             Throwable cause
     ) {
-        super(resolveClientMessage(errorCode, clientMessage), cause);
-        this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
-        this.clientMessage = resolveClientMessage(errorCode, clientMessage);
+        this(
+                Objects.requireNonNull(errorCode, "errorCode must not be null"),
+                resolveClientMessage(errorCode, clientMessage),
+                cause,
+                true
+        );
+    }
+
+    private StompErrorException(
+            StompErrorCode errorCode,
+            String resolvedClientMessage,
+            Throwable cause,
+            boolean ignored
+    ) {
+        super(resolvedClientMessage, cause);
+        this.errorCode = errorCode;
+        this.clientMessage = resolvedClientMessage;
     }
 
     public StompErrorCode getErrorCode() {
@@ -59,13 +73,8 @@ public class StompErrorException extends RuntimeException {
             StompErrorCode errorCode,
             String clientMessage
     ) {
-        StompErrorCode resolvedErrorCode = Objects.requireNonNull(
-                errorCode,
-                "errorCode must not be null"
-        );
-
         if (clientMessage == null || clientMessage.isBlank()) {
-            return resolvedErrorCode.getDefaultMessage();
+            return errorCode.getDefaultMessage();
         }
 
         return clientMessage;

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorException.java
@@ -1,0 +1,49 @@
+package io.github.ascrew.monomatbe.global.websocket.error;
+
+/**
+ * STOMP 처리 중 의도적으로 클라이언트에게 표준 ERROR payload를 내려야 할 때 사용하는 예외이다.
+ *
+ * [설계 의도]
+ * IllegalArgumentException / IllegalStateException의 문자열 메시지에 의존하면
+ * FE가 안정적으로 에러를 분기할 수 없다.
+ *
+ * 따라서 code/action/recoverable을 가진 StompErrorCode를 함께 전달한다.
+ */
+public class StompErrorException extends RuntimeException {
+
+    private final StompErrorCode errorCode;
+    private final String clientMessage;
+
+    public StompErrorException(StompErrorCode errorCode) {
+        this(errorCode, errorCode.getDefaultMessage(), null);
+    }
+
+    public StompErrorException(StompErrorCode errorCode, Throwable cause) {
+        this(errorCode, errorCode.getDefaultMessage(), cause);
+    }
+
+    public StompErrorException(
+            StompErrorCode errorCode,
+            String clientMessage
+    ) {
+        this(errorCode, clientMessage, null);
+    }
+
+    public StompErrorException(
+            StompErrorCode errorCode,
+            String clientMessage,
+            Throwable cause
+    ) {
+        super(clientMessage, cause);
+        this.errorCode = errorCode;
+        this.clientMessage = clientMessage;
+    }
+
+    public StompErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public String getClientMessage() {
+        return clientMessage;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorPayload.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorPayload.java
@@ -1,0 +1,52 @@
+package io.github.ascrew.monomatbe.global.websocket.error;
+
+import java.time.Instant;
+
+/**
+ * STOMP ERROR 프레임의 body에 담을 표준 payload
+ *
+ * [응답 예시]
+ * {
+ *   "type": "STOMP_ERROR",
+ *   "code": "LOBBY_NOT_FOUND",
+ *   "message": "존재하지 않는 로비입니다.",
+ *   "action": "RETURN_TO_LOBBY_LIST",
+ *   "recoverable": false,
+ *   "timestamp": "2026-05-25T00:00:00Z"
+ * }
+ */
+public record StompErrorPayload(
+        String type,
+        String code,
+        String message,
+        String action,
+        boolean recoverable,
+        String timestamp
+) {
+
+    private static final String TYPE = "STOMP_ERROR";
+
+    public static StompErrorPayload from(StompErrorException exception) {
+        StompErrorCode errorCode = exception.getErrorCode();
+
+        return new StompErrorPayload(
+                TYPE,
+                errorCode.name(),
+                exception.getClientMessage(),
+                errorCode.getAction().name(),
+                errorCode.isRecoverable(),
+                Instant.now().toString()
+        );
+    }
+
+    public static StompErrorPayload from(StompErrorCode errorCode) {
+        return new StompErrorPayload(
+                TYPE,
+                errorCode.name(),
+                errorCode.getDefaultMessage(),
+                errorCode.getAction().name(),
+                errorCode.isRecoverable(),
+                Instant.now().toString()
+        );
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandlerTest.java
@@ -174,6 +174,46 @@ class CustomStompErrorHandlerTest {
     }
 
     @Test
+    @DisplayName("중간 cause에 IllegalStateException이 있어도 더 깊은 StompErrorException을 우선한다")
+    void handleClientMessageProcessingError_withNestedStompErrorException_prioritizesStompErrorException() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        StompErrorException stompErrorException = new StompErrorException(
+                StompErrorCode.LOBBY_FULL
+        );
+
+        IllegalStateException intermediateException = new IllegalStateException(
+                "wrapped legacy exception",
+                stompErrorException
+        );
+
+        MessageDeliveryException wrappedException = new MessageDeliveryException(
+                clientMessage,
+                "STOMP message delivery failed",
+                intermediateException
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                wrappedException
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        String payload = payloadAsString(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("LOBBY_FULL");
+
+        assertThat(payload).contains("\"code\":\"LOBBY_FULL\"");
+        assertThat(payload).contains("\"message\":\"로비 최대 인원에 도달했습니다.\"");
+        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
+        assertThat(payload).contains("\"recoverable\":false");
+    }
+
+    @Test
     @DisplayName("예상하지 못한 RuntimeException도 INTERNAL_STOMP_ERROR로 변환된다")
     void handleClientMessageProcessingError_withUnexpectedRuntimeException_returnsInternalStompError() {
         // given

--- a/src/test/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandlerTest.java
@@ -1,0 +1,211 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorCode;
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomStompErrorHandlerTest {
+
+    private final CustomStompErrorHandler errorHandler =
+            new CustomStompErrorHandler(JsonMapper.builder().build());
+
+    @Test
+    @DisplayName("StompErrorException은 표준 STOMP ERROR JSON payload로 변환된다")
+    void handleClientMessageProcessingError_withStompErrorException_returnsStandardJsonPayload() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        StompErrorException exception = new StompErrorException(
+                StompErrorCode.LOBBY_NOT_FOUND
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                exception
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        String payload = payloadAsString(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("LOBBY_NOT_FOUND");
+
+        assertThat(payload).contains("\"type\":\"STOMP_ERROR\"");
+        assertThat(payload).contains("\"code\":\"LOBBY_NOT_FOUND\"");
+        assertThat(payload).contains("\"message\":\"존재하지 않는 로비입니다.\"");
+        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
+        assertThat(payload).contains("\"recoverable\":false");
+        assertThat(payload).contains("\"timestamp\"");
+    }
+
+    @Test
+    @DisplayName("강퇴된 유저 재입장 실패는 RETURN_TO_LOBBY_LIST 액션과 recoverable=false로 응답한다")
+    void handleClientMessageProcessingError_withKickedUser_returnsReturnToLobbyListPayload() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        StompErrorException exception = new StompErrorException(
+                StompErrorCode.LOBBY_KICKED_USER
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                exception
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        String payload = payloadAsString(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("LOBBY_KICKED_USER");
+
+        assertThat(payload).contains("\"code\":\"LOBBY_KICKED_USER\"");
+        assertThat(payload).contains("\"message\":\"강퇴된 로비에는 재입장할 수 없습니다.\"");
+        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
+        assertThat(payload).contains("\"recoverable\":false");
+    }
+
+    @Test
+    @DisplayName("stale 세션 실패는 RECONNECT 액션과 recoverable=true로 응답한다")
+    void handleClientMessageProcessingError_withStaleSession_returnsReconnectPayload() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        StompErrorException exception = new StompErrorException(
+                StompErrorCode.LOBBY_STALE_SESSION
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                exception
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        String payload = payloadAsString(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("LOBBY_STALE_SESSION");
+
+        assertThat(payload).contains("\"code\":\"LOBBY_STALE_SESSION\"");
+        assertThat(payload).contains("\"action\":\"RECONNECT\"");
+        assertThat(payload).contains("\"recoverable\":true");
+    }
+
+    @Test
+    @DisplayName("MessageDeliveryException으로 래핑된 StompErrorException도 원래 에러 코드로 변환된다")
+    void handleClientMessageProcessingError_withWrappedStompErrorException_returnsOriginalErrorCode() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        StompErrorException cause = new StompErrorException(
+                StompErrorCode.LOBBY_FULL
+        );
+
+        MessageDeliveryException wrappedException = new MessageDeliveryException(
+                clientMessage,
+                "STOMP message delivery failed",
+                cause
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                wrappedException
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        String payload = payloadAsString(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("LOBBY_FULL");
+
+        assertThat(payload).contains("\"code\":\"LOBBY_FULL\"");
+        assertThat(payload).contains("\"message\":\"로비 최대 인원에 도달했습니다.\"");
+        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
+        assertThat(payload).contains("\"recoverable\":false");
+    }
+
+    @Test
+    @DisplayName("표준화되지 않은 IllegalStateException은 INTERNAL_STOMP_ERROR로 변환된다")
+    void handleClientMessageProcessingError_withNonStandardIllegalStateException_returnsInternalStompError() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        IllegalStateException exception = new IllegalStateException(
+                "legacy stomp error"
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                exception
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        String payload = payloadAsString(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("INTERNAL_STOMP_ERROR");
+
+        assertThat(payload).contains("\"type\":\"STOMP_ERROR\"");
+        assertThat(payload).contains("\"code\":\"INTERNAL_STOMP_ERROR\"");
+        assertThat(payload).contains("\"message\":\"WebSocket 처리 중 서버 오류가 발생했습니다.\"");
+        assertThat(payload).contains("\"action\":\"REFRESH_AND_RETRY\"");
+        assertThat(payload).contains("\"recoverable\":true");
+    }
+
+    @Test
+    @DisplayName("예상하지 못한 RuntimeException도 INTERNAL_STOMP_ERROR로 변환된다")
+    void handleClientMessageProcessingError_withUnexpectedRuntimeException_returnsInternalStompError() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        RuntimeException exception = new RuntimeException(
+                "unexpected error"
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                exception
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        String payload = payloadAsString(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("INTERNAL_STOMP_ERROR");
+
+        assertThat(payload).contains("\"code\":\"INTERNAL_STOMP_ERROR\"");
+        assertThat(payload).contains("\"action\":\"REFRESH_AND_RETRY\"");
+        assertThat(payload).contains("\"recoverable\":true");
+    }
+
+    private Message<byte[]> emptyClientMessage() {
+        return MessageBuilder.withPayload(new byte[0]).build();
+    }
+
+    private String payloadAsString(Message<byte[]> message) {
+        return new String(message.getPayload(), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/websocket/CustomStompErrorHandlerTest.java
@@ -9,16 +9,20 @@ import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CustomStompErrorHandlerTest {
 
+    private final JsonMapper jsonMapper = JsonMapper.builder().build();
+
     private final CustomStompErrorHandler errorHandler =
-            new CustomStompErrorHandler(JsonMapper.builder().build());
+            new CustomStompErrorHandler(jsonMapper);
 
     @Test
     @DisplayName("StompErrorException은 표준 STOMP ERROR JSON payload로 변환된다")
@@ -38,17 +42,19 @@ class CustomStompErrorHandlerTest {
 
         // then
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
-        String payload = payloadAsString(result);
+        Map<String, Object> payload = payloadAsMap(result);
 
         assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
         assertThat(accessor.getMessage()).isEqualTo("LOBBY_NOT_FOUND");
 
-        assertThat(payload).contains("\"type\":\"STOMP_ERROR\"");
-        assertThat(payload).contains("\"code\":\"LOBBY_NOT_FOUND\"");
-        assertThat(payload).contains("\"message\":\"존재하지 않는 로비입니다.\"");
-        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
-        assertThat(payload).contains("\"recoverable\":false");
-        assertThat(payload).contains("\"timestamp\"");
+        assertThat(payload)
+                .containsEntry("type", "STOMP_ERROR")
+                .containsEntry("code", "LOBBY_NOT_FOUND")
+                .containsEntry("message", "존재하지 않는 로비입니다.")
+                .containsEntry("action", "RETURN_TO_LOBBY_LIST")
+                .containsEntry("recoverable", false);
+
+        assertTimestampExists(payload);
     }
 
     @Test
@@ -69,15 +75,19 @@ class CustomStompErrorHandlerTest {
 
         // then
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
-        String payload = payloadAsString(result);
+        Map<String, Object> payload = payloadAsMap(result);
 
         assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
         assertThat(accessor.getMessage()).isEqualTo("LOBBY_KICKED_USER");
 
-        assertThat(payload).contains("\"code\":\"LOBBY_KICKED_USER\"");
-        assertThat(payload).contains("\"message\":\"강퇴된 로비에는 재입장할 수 없습니다.\"");
-        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
-        assertThat(payload).contains("\"recoverable\":false");
+        assertThat(payload)
+                .containsEntry("type", "STOMP_ERROR")
+                .containsEntry("code", "LOBBY_KICKED_USER")
+                .containsEntry("message", "강퇴된 로비에는 재입장할 수 없습니다.")
+                .containsEntry("action", "RETURN_TO_LOBBY_LIST")
+                .containsEntry("recoverable", false);
+
+        assertTimestampExists(payload);
     }
 
     @Test
@@ -98,14 +108,19 @@ class CustomStompErrorHandlerTest {
 
         // then
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
-        String payload = payloadAsString(result);
+        Map<String, Object> payload = payloadAsMap(result);
 
         assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
         assertThat(accessor.getMessage()).isEqualTo("LOBBY_STALE_SESSION");
 
-        assertThat(payload).contains("\"code\":\"LOBBY_STALE_SESSION\"");
-        assertThat(payload).contains("\"action\":\"RECONNECT\"");
-        assertThat(payload).contains("\"recoverable\":true");
+        assertThat(payload)
+                .containsEntry("type", "STOMP_ERROR")
+                .containsEntry("code", "LOBBY_STALE_SESSION")
+                .containsEntry("message", "더 최신 WebSocket 세션이 이미 존재합니다. 다시 접속해주세요.")
+                .containsEntry("action", "RECONNECT")
+                .containsEntry("recoverable", true);
+
+        assertTimestampExists(payload);
     }
 
     @Test
@@ -132,45 +147,19 @@ class CustomStompErrorHandlerTest {
 
         // then
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
-        String payload = payloadAsString(result);
+        Map<String, Object> payload = payloadAsMap(result);
 
         assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
         assertThat(accessor.getMessage()).isEqualTo("LOBBY_FULL");
 
-        assertThat(payload).contains("\"code\":\"LOBBY_FULL\"");
-        assertThat(payload).contains("\"message\":\"로비 최대 인원에 도달했습니다.\"");
-        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
-        assertThat(payload).contains("\"recoverable\":false");
-    }
+        assertThat(payload)
+                .containsEntry("type", "STOMP_ERROR")
+                .containsEntry("code", "LOBBY_FULL")
+                .containsEntry("message", "로비 최대 인원에 도달했습니다.")
+                .containsEntry("action", "RETURN_TO_LOBBY_LIST")
+                .containsEntry("recoverable", false);
 
-    @Test
-    @DisplayName("표준화되지 않은 IllegalStateException은 INTERNAL_STOMP_ERROR로 변환된다")
-    void handleClientMessageProcessingError_withNonStandardIllegalStateException_returnsInternalStompError() {
-        // given
-        Message<byte[]> clientMessage = emptyClientMessage();
-
-        IllegalStateException exception = new IllegalStateException(
-                "legacy stomp error"
-        );
-
-        // when
-        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
-                clientMessage,
-                exception
-        );
-
-        // then
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
-        String payload = payloadAsString(result);
-
-        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
-        assertThat(accessor.getMessage()).isEqualTo("INTERNAL_STOMP_ERROR");
-
-        assertThat(payload).contains("\"type\":\"STOMP_ERROR\"");
-        assertThat(payload).contains("\"code\":\"INTERNAL_STOMP_ERROR\"");
-        assertThat(payload).contains("\"message\":\"WebSocket 처리 중 서버 오류가 발생했습니다.\"");
-        assertThat(payload).contains("\"action\":\"REFRESH_AND_RETRY\"");
-        assertThat(payload).contains("\"recoverable\":true");
+        assertTimestampExists(payload);
     }
 
     @Test
@@ -202,15 +191,52 @@ class CustomStompErrorHandlerTest {
 
         // then
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
-        String payload = payloadAsString(result);
+        Map<String, Object> payload = payloadAsMap(result);
 
         assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
         assertThat(accessor.getMessage()).isEqualTo("LOBBY_FULL");
 
-        assertThat(payload).contains("\"code\":\"LOBBY_FULL\"");
-        assertThat(payload).contains("\"message\":\"로비 최대 인원에 도달했습니다.\"");
-        assertThat(payload).contains("\"action\":\"RETURN_TO_LOBBY_LIST\"");
-        assertThat(payload).contains("\"recoverable\":false");
+        assertThat(payload)
+                .containsEntry("type", "STOMP_ERROR")
+                .containsEntry("code", "LOBBY_FULL")
+                .containsEntry("message", "로비 최대 인원에 도달했습니다.")
+                .containsEntry("action", "RETURN_TO_LOBBY_LIST")
+                .containsEntry("recoverable", false);
+
+        assertTimestampExists(payload);
+    }
+
+    @Test
+    @DisplayName("표준화되지 않은 IllegalStateException은 INTERNAL_STOMP_ERROR로 변환된다")
+    void handleClientMessageProcessingError_withNonStandardIllegalStateException_returnsInternalStompError() {
+        // given
+        Message<byte[]> clientMessage = emptyClientMessage();
+
+        IllegalStateException exception = new IllegalStateException(
+                "legacy stomp error"
+        );
+
+        // when
+        Message<byte[]> result = errorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                exception
+        );
+
+        // then
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
+        Map<String, Object> payload = payloadAsMap(result);
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getMessage()).isEqualTo("INTERNAL_STOMP_ERROR");
+
+        assertThat(payload)
+                .containsEntry("type", "STOMP_ERROR")
+                .containsEntry("code", "INTERNAL_STOMP_ERROR")
+                .containsEntry("message", "WebSocket 처리 중 서버 오류가 발생했습니다.")
+                .containsEntry("action", "REFRESH_AND_RETRY")
+                .containsEntry("recoverable", true);
+
+        assertTimestampExists(payload);
     }
 
     @Test
@@ -231,21 +257,47 @@ class CustomStompErrorHandlerTest {
 
         // then
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(result);
-        String payload = payloadAsString(result);
+        Map<String, Object> payload = payloadAsMap(result);
 
         assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
         assertThat(accessor.getMessage()).isEqualTo("INTERNAL_STOMP_ERROR");
 
-        assertThat(payload).contains("\"code\":\"INTERNAL_STOMP_ERROR\"");
-        assertThat(payload).contains("\"action\":\"REFRESH_AND_RETRY\"");
-        assertThat(payload).contains("\"recoverable\":true");
+        assertThat(payload)
+                .containsEntry("type", "STOMP_ERROR")
+                .containsEntry("code", "INTERNAL_STOMP_ERROR")
+                .containsEntry("message", "WebSocket 처리 중 서버 오류가 발생했습니다.")
+                .containsEntry("action", "REFRESH_AND_RETRY")
+                .containsEntry("recoverable", true);
+
+        assertTimestampExists(payload);
     }
 
     private Message<byte[]> emptyClientMessage() {
         return MessageBuilder.withPayload(new byte[0]).build();
     }
 
+    private Map<String, Object> payloadAsMap(Message<byte[]> message) {
+        try {
+            return jsonMapper.readValue(
+                    payloadAsString(message),
+                    new TypeReference<>() {}
+            );
+        } catch (Exception e) {
+            throw new AssertionError("STOMP ERROR payload JSON 파싱 실패", e);
+        }
+    }
+
     private String payloadAsString(Message<byte[]> message) {
         return new String(message.getPayload(), StandardCharsets.UTF_8);
+    }
+
+    private void assertTimestampExists(Map<String, Object> payload) {
+        assertThat(payload)
+                .containsKey("timestamp");
+
+        assertThat(payload.get("timestamp"))
+                .isInstanceOf(String.class)
+                .asString()
+                .isNotBlank();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/global/websocket/LobbyEnterResultMapperTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/websocket/LobbyEnterResultMapperTest.java
@@ -1,0 +1,120 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import io.github.ascrew.monomatbe.global.websocket.error.StompErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LobbyEnterResultMapperTest {
+
+    private final LobbyEnterResultMapper mapper = new LobbyEnterResultMapper();
+
+    @Test
+    @DisplayName("ENTERED는 성공 결과로 매핑된다")
+    void parse_entered_returnsSuccessType() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("ENTERED");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.ENTERED);
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("ALREADY_JOINED는 성공 결과로 매핑된다")
+    void parseAlreadyJoinedReturnsSuccessType() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("ALREADY_JOINED");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.ALREADY_JOINED);
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("SESSION_REPLACED prefix는 성공 결과로 매핑된다")
+    void parseSessionReplacedReturnsSuccessType() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("SESSION_REPLACED:old-session-id");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.SESSION_REPLACED);
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("STALE_SESSION prefix는 LOBBY_STALE_SESSION으로 매핑된다")
+    void parseStaleSessionReturnsLobbyStaleSession() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("STALE_SESSION:new-session-id");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.STALE_SESSION);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_STALE_SESSION);
+    }
+
+    @Test
+    @DisplayName("LOBBY_NOT_FOUND는 LOBBY_NOT_FOUND로 매핑된다")
+    void parseLobbyNotFoundReturnsLobbyNotFound() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("LOBBY_NOT_FOUND");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.LOBBY_NOT_FOUND);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("FULL은 LOBBY_FULL로 매핑된다")
+    void parseFullReturnsLobbyFull() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("FULL");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.FULL);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_FULL);
+    }
+
+    @Test
+    @DisplayName("LOBBY_NOT_WAITING은 LOBBY_NOT_WAITING으로 매핑된다")
+    void parseLobbyNotWaitingReturnsLobbyNotWaiting() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("LOBBY_NOT_WAITING");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.LOBBY_NOT_WAITING);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_NOT_WAITING);
+    }
+
+    @Test
+    @DisplayName("INVALID_LOBBY_CAPACITY는 LOBBY_INVALID_CAPACITY로 매핑된다")
+    void parseInvalidLobbyCapacityReturnsLobbyInvalidCapacity() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("INVALID_LOBBY_CAPACITY");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.INVALID_LOBBY_CAPACITY);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_INVALID_CAPACITY);
+    }
+
+    @Test
+    @DisplayName("KICKED_USER는 LOBBY_KICKED_USER로 매핑된다")
+    void parseKickedUserReturnsLobbyKickedUser() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("KICKED_USER");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.KICKED_USER);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_KICKED_USER);
+    }
+
+    @Test
+    @DisplayName("INVALID_SEQUENCE는 LOBBY_INVALID_SEQUENCE로 매핑된다")
+    void parseInvalidSequenceReturnsLobbyInvalidSequence() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("INVALID_SEQUENCE");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.INVALID_SEQUENCE);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_INVALID_SEQUENCE);
+    }
+
+    @Test
+    @DisplayName("null 결과는 UNKNOWN으로 매핑된다")
+    void parseNullReturnsUnknown() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse(null);
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.UNKNOWN);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_ENTER_UNKNOWN_RESULT);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 결과는 UNKNOWN으로 매핑된다")
+    void parseUnknownReturnsUnknown() {
+        LobbyEnterResultMapper.LobbyEnterResultType result = mapper.parse("SOMETHING_NEW");
+
+        assertThat(result).isEqualTo(LobbyEnterResultMapper.LobbyEnterResultType.UNKNOWN);
+        assertThat(result.resolveErrorCode()).isEqualTo(StompErrorCode.LOBBY_ENTER_UNKNOWN_RESULT);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorCodeContractTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorCodeContractTest.java
@@ -1,0 +1,105 @@
+package io.github.ascrew.monomatbe.global.websocket.error;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StompErrorCodeContractTest {
+
+    @Test
+    @DisplayName("로비 없음은 로비 목록 복귀 대상이며 복구 불가능 에러다")
+    void lobbyNotFound_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.LOBBY_NOT_FOUND;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.RETURN_TO_LOBBY_LIST);
+        assertThat(code.isRecoverable()).isFalse();
+        assertThat(code.getDefaultMessage()).isEqualTo("존재하지 않는 로비입니다.");
+    }
+
+    @Test
+    @DisplayName("로비 만원은 로비 목록 복귀 대상이며 복구 불가능 에러다")
+    void lobbyFull_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.LOBBY_FULL;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.RETURN_TO_LOBBY_LIST);
+        assertThat(code.isRecoverable()).isFalse();
+        assertThat(code.getDefaultMessage()).isEqualTo("로비 최대 인원에 도달했습니다.");
+    }
+
+    @Test
+    @DisplayName("이미 시작된 로비는 로비 목록 복귀 대상이며 복구 불가능 에러다")
+    void lobbyNotWaiting_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.LOBBY_NOT_WAITING;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.RETURN_TO_LOBBY_LIST);
+        assertThat(code.isRecoverable()).isFalse();
+        assertThat(code.getDefaultMessage()).isEqualTo("이미 시작되었거나 입장할 수 없는 로비입니다.");
+    }
+
+    @Test
+    @DisplayName("강퇴된 유저 재입장은 로비 목록 복귀 대상이며 복구 불가능 에러다")
+    void lobbyKickedUser_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.LOBBY_KICKED_USER;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.RETURN_TO_LOBBY_LIST);
+        assertThat(code.isRecoverable()).isFalse();
+        assertThat(code.getDefaultMessage()).isEqualTo("강퇴된 로비에는 재입장할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("stale 세션은 재연결 대상이며 복구 가능한 에러다")
+    void lobbyStaleSession_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.LOBBY_STALE_SESSION;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.RECONNECT);
+        assertThat(code.isRecoverable()).isTrue();
+        assertThat(code.getDefaultMessage()).isEqualTo("더 최신 WebSocket 세션이 이미 존재합니다. 다시 접속해주세요.");
+    }
+
+    @Test
+    @DisplayName("Redis 또는 Lua 일시 장애는 새로고침 후 재시도 대상이다")
+    void lobbyEnterTemporarilyUnavailable_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.LOBBY_ENTER_TEMPORARILY_UNAVAILABLE;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.REFRESH_AND_RETRY);
+        assertThat(code.isRecoverable()).isTrue();
+        assertThat(code.getDefaultMessage()).isEqualTo("일시적으로 로비 입장 상태를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.");
+    }
+
+    @Test
+    @DisplayName("CONNECT 사용자 식별자 누락은 WebSocket 연결 재시도 대상이다")
+    void connectUserIdentifierMissing_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.CONNECT_USER_IDENTIFIER_MISSING;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.RETRY_CONNECT);
+        assertThat(code.isRecoverable()).isTrue();
+        assertThat(code.getDefaultMessage()).isEqualTo("사용자 식별자가 없습니다. 다시 로그인 후 접속해주세요.");
+    }
+
+    @Test
+    @DisplayName("서버 내부 STOMP 오류는 새로고침 후 재시도 대상이다")
+    void internalStompError_contract() {
+        // given
+        StompErrorCode code = StompErrorCode.INTERNAL_STOMP_ERROR;
+
+        // then
+        assertThat(code.getAction()).isEqualTo(StompErrorAction.REFRESH_AND_RETRY);
+        assertThat(code.isRecoverable()).isTrue();
+        assertThat(code.getDefaultMessage()).isEqualTo("WebSocket 처리 중 서버 오류가 발생했습니다.");
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorExceptionTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/websocket/error/StompErrorExceptionTest.java
@@ -1,0 +1,82 @@
+package io.github.ascrew.monomatbe.global.websocket.error;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class StompErrorExceptionTest {
+
+    @Test
+    @DisplayName("errorCode가 null이면 예외 생성 시점에 차단한다")
+    void constructor_withNullErrorCode_throwsNullPointerException() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> new StompErrorException(null))
+                .withMessage("errorCode must not be null");
+    }
+
+    @Test
+    @DisplayName("clientMessage가 null이면 errorCode 기본 메시지를 사용한다")
+    void constructor_withNullClientMessage_usesDefaultMessage() {
+        // when
+        StompErrorException exception = new StompErrorException(
+                StompErrorCode.LOBBY_FULL,
+                (String) null
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(StompErrorCode.LOBBY_FULL);
+        assertThat(exception.getClientMessage()).isEqualTo("로비 최대 인원에 도달했습니다.");
+        assertThat(exception.getMessage()).isEqualTo("로비 최대 인원에 도달했습니다.");
+    }
+
+    @Test
+    @DisplayName("clientMessage가 blank이면 errorCode 기본 메시지를 사용한다")
+    void constructor_withBlankClientMessage_usesDefaultMessage() {
+        // when
+        StompErrorException exception = new StompErrorException(
+                StompErrorCode.LOBBY_NOT_FOUND,
+                "   "
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(StompErrorCode.LOBBY_NOT_FOUND);
+        assertThat(exception.getClientMessage()).isEqualTo("존재하지 않는 로비입니다.");
+        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 로비입니다.");
+    }
+
+    @Test
+    @DisplayName("clientMessage가 명시되면 명시 메시지를 사용한다")
+    void constructor_withCustomClientMessage_usesCustomMessage() {
+        // when
+        StompErrorException exception = new StompErrorException(
+                StompErrorCode.INTERNAL_STOMP_ERROR,
+                "커스텀 에러 메시지"
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(StompErrorCode.INTERNAL_STOMP_ERROR);
+        assertThat(exception.getClientMessage()).isEqualTo("커스텀 에러 메시지");
+        assertThat(exception.getMessage()).isEqualTo("커스텀 에러 메시지");
+    }
+
+    @Test
+    @DisplayName("cause를 전달하면 원인 예외를 유지한다")
+    void constructor_withCause_keepsCause() {
+        // given
+        RuntimeException cause = new RuntimeException("redis failed");
+
+        // when
+        StompErrorException exception = new StompErrorException(
+                StompErrorCode.CONNECT_ONLINE_STATUS_FAILED,
+                cause
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(StompErrorCode.CONNECT_ONLINE_STATUS_FAILED);
+        assertThat(exception.getClientMessage()).isEqualTo("사용자 온라인 상태 저장에 실패했습니다. 잠시 후 다시 접속해주세요.");
+        assertThat(exception.getMessage()).isEqualTo("사용자 온라인 상태 저장에 실패했습니다. 잠시 후 다시 접속해주세요.");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #93

## 📝 Summary

- REST join 성공 후 WebSocket SUBSCRIBE 단계에서 발생할 수 있는 로비 입장 실패 케이스를 표준화했습니다.
- STOMP ERROR 프레임 body를 문자열이 아닌 JSON payload 구조로 변경했습니다.
- 로비 없음, 만원, 이미 시작됨, 강퇴됨, stale 세션, Redis/Lua 일시 장애 등 주요 실패 상황을 `StompErrorCode`로 분리했습니다.
- FE가 `message` 문자열을 파싱하지 않고 `code`, `action`, `recoverable` 기준으로 처리할 수 있도록 응답 계약을 정리했습니다.
- `CustomStompErrorHandler`에서 `StompErrorException`을 표준 STOMP ERROR JSON payload로 변환하도록 수정했습니다.
- `docs/API.md`, `docs/ARCHITECTURE.md`에 REST join과 WebSocket SUBSCRIBE 실패 처리 기준을 문서화했습니다.
- `CustomStompErrorHandlerTest`, `StompErrorCodeContractTest`를 추가해 STOMP ERROR payload 및 에러 코드 계약을 검증했습니다.
- `ws-test.html`을 보강해 실제 WebSocket 연결 환경에서 STOMP ERROR payload를 수동 확인할 수 있도록 했습니다.

## 🙏PR point

- `POST /api/lobbies/join`은 입장 사전 검증만 수행하며, 실제 로비 참여 확정은 `SUBSCRIBE /topic/lobby/{code}` 성공 시점입니다.
- REST join이 성공했더라도 SUBSCRIBE 시점에 로비 상태가 바뀌면 STOMP ERROR가 발생할 수 있습니다.
  - 예: 로비 삭제, 정원 초과, 게임 시작, 강퇴 유저 재입장, stale 세션 등
- FE는 STOMP ERROR의 `message` 문자열을 파싱하지 말고, 반드시 아래 필드를 기준으로 분기해야 합니다.
  - `code`: 구체적인 실패 원인
  - `action`: 화면 복귀/재연결/새로고침 재시도 정책
  - `recoverable`: 같은 화면에서 재시도 가능한지 여부
- 주요 action 정책은 다음과 같습니다.
  - `RETURN_TO_LOBBY_LIST`: 로비 목록 또는 이전 화면으로 복귀
  - `RETRY_CONNECT`: WebSocket CONNECT 재시도
  - `REFRESH_AND_RETRY`: 화면 새로고침 후 재시도
  - `RECONNECT`: 현재 WebSocket 세션 폐기 후 재연결
- `/topic/lobby/{code}` 구독만 실제 입장 처리를 수행합니다.
- `/topic/lobby/{code}/refresh`, `/topic/lobby/{code}/game` 구독은 입장 처리를 트리거하지 않아야 합니다.
- stale 세션 처리 시 최신 세션의 `participants`, `user_session`, `user_session_seq`를 삭제하지 않도록 주의했습니다.

## 📬 Reference

- REST join은 사전 검증이고, 실제 참여자 등록은 WebSocket `/topic/lobby/{code}` 구독 시점에 처리됩니다.