### PR TITLE
[Feat/#102] 게임 세션 생성 및 라운드 시작을 위한 핵심 구조 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -776,6 +776,7 @@ JWT Access Token이 필요하며, 방장만 호출할 수 있습니다.
 * 로비 상태가 이미 변경된 경우
 * participants Set에 stale 유저가 남아 있는 경우
 * Redis participants/ready/session 정합성이 깨진 경우
+* 이미 진행 중인 게임 세션이 존재하는 경우
 
 ---
 
@@ -1052,11 +1053,14 @@ SUBSCRIBE /topic/game/{code}/round
 
 ```json
 {
+  "type": "ROUND_READY",
   "videoId": "dQw4w9WgXcQ",
+  "youtubeUrl": "https://youtube.com/watch?v=dQw4w9WgXcQ",
   "startTime": 10,
   "endTime": 30,
+  "timeLimitSeconds": 30,
   "roundNo": 1,
-  "serverTime": 1716500000000
+  "serverStartedAt": 1716500000000
 }
 ```
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundStartDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundStartDto.java
@@ -8,10 +8,18 @@ import lombok.Builder;
  */
 @Builder
 public record RoundStartDto(
+        String type,
         String videoId,
+        String youtubeUrl,
         int startTime,
         int endTime,
+        int timeLimitSeconds,
         int roundNo,
-        long serverTime
+        long serverStartedAt
 ) {
+    public RoundStartDto {
+        if (type == null) {
+            type = "ROUND_STARTED";
+        }
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundStartDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundStartDto.java
@@ -19,7 +19,7 @@ public record RoundStartDto(
 ) {
     public RoundStartDto {
         if (type == null) {
-            type = "ROUND_STARTED";
+            type = "ROUND_READY";
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
@@ -22,6 +22,10 @@ public class GameSession {
     @JoinColumn(name = "lobby_id", nullable = false)
     private GameLobby lobby;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "map_id", nullable = false)
+    private io.github.ascrew.monomatbe.domain.map.entity.QuizMap map;
+
     @Column(name = "current_round_no", nullable = false)
     private Integer currentRoundNo;
 
@@ -31,6 +35,12 @@ public class GameSession {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private GameSessionStatus status;
+
+    @Column(name = "started_at", nullable = false, updatable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
@@ -41,7 +41,7 @@ public class GameSession {
             this.currentRoundNo = 1;
         }
         if (this.status == null) {
-            this.status = GameSessionStatus.PLAYING;
+            this.status = GameSessionStatus.READY;
         }
         if (this.createdAt == null) {
             this.createdAt = LocalDateTime.now();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSessionStatus.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSessionStatus.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.game.entity;
 
 public enum GameSessionStatus {
+    READY,
     PLAYING,
     FINISHED
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/exception/GameSessionAlreadyExistsException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/exception/GameSessionAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package io.github.ascrew.monomatbe.domain.game.exception;
+
+public class GameSessionAlreadyExistsException extends RuntimeException {
+    public GameSessionAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/exception/NotEnoughMapItemsException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/exception/NotEnoughMapItemsException.java
@@ -1,0 +1,7 @@
+package io.github.ascrew.monomatbe.domain.game.exception;
+
+public class NotEnoughMapItemsException extends RuntimeException {
+    public NotEnoughMapItemsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameParticipantResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameParticipantResolver.java
@@ -19,20 +19,14 @@ public class GameParticipantResolver {
     private final GuestSessionRepository guestSessionRepository;
 
     public List<User> resolveUsers(List<String> participantIdentifiers) {
-        List<User> users = new ArrayList<>();
+        java.util.Map<Long, User> userMap = new java.util.HashMap<>();
 
-        List<User> sessionUsers = userSessionRepository.findBySessionIdIn(participantIdentifiers)
-                .stream()
-                .map(UserSession::getUser)
-                .toList();
-        users.addAll(sessionUsers);
+        userSessionRepository.findBySessionIdIn(participantIdentifiers)
+                .forEach(session -> userMap.put(session.getUser().getId(), session.getUser()));
 
-        List<User> guestUsers = guestSessionRepository.findByGuestTokenIn(participantIdentifiers)
-                .stream()
-                .map(GuestSession::getUser)
-                .toList();
-        users.addAll(guestUsers);
+        guestSessionRepository.findByGuestTokenIn(participantIdentifiers)
+                .forEach(session -> userMap.put(session.getUser().getId(), session.getUser()));
 
-        return users;
+        return new ArrayList<>(userMap.values());
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameParticipantResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameParticipantResolver.java
@@ -19,14 +19,17 @@ public class GameParticipantResolver {
     private final GuestSessionRepository guestSessionRepository;
 
     public List<User> resolveUsers(List<String> participantIdentifiers) {
-        java.util.Map<Long, User> userMap = new java.util.HashMap<>();
+        java.util.Map<String, User> resolvedByIdentifier = new java.util.HashMap<>();
 
         userSessionRepository.findBySessionIdIn(participantIdentifiers)
-                .forEach(session -> userMap.put(session.getUser().getId(), session.getUser()));
+                .forEach(session -> resolvedByIdentifier.put(session.getSessionId(), session.getUser()));
 
         guestSessionRepository.findByGuestTokenIn(participantIdentifiers)
-                .forEach(session -> userMap.put(session.getUser().getId(), session.getUser()));
+                .forEach(session -> resolvedByIdentifier.put(session.getGuestToken(), session.getUser()));
 
-        return new ArrayList<>(userMap.values());
+        return participantIdentifiers.stream()
+                .map(resolvedByIdentifier::get)
+                .filter(java.util.Objects::nonNull)
+                .toList();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -96,12 +96,16 @@ public class GameSessionCreateService {
                 .collect(Collectors.joining(","));
         String participantsStr = String.join(",", participantIdentifiers);
 
+        long serverStartedAt = System.currentTimeMillis();
+
         String result = redisTemplate.execute(
                 initGameSessionScript,
                 List.of(sessionKey, roundsKey, playersKey),
                 String.valueOf(lobby.getRoundCount()),
                 mapItemIdsStr,
-                participantsStr
+                participantsStr,
+                String.valueOf(lobby.getTimeLimitSeconds()),
+                String.valueOf(serverStartedAt)
         );
 
         if (!"OK".equals(result)) {
@@ -113,11 +117,14 @@ public class GameSessionCreateService {
 
         MapItem firstItem = selectedItems.get(0);
         return RoundStartDto.builder()
+                .type("ROUND_STARTED")
                 .videoId(firstItem.getVideoId())
+                .youtubeUrl(firstItem.getYoutubeUrl())
                 .startTime(firstItem.getStartTime())
                 .endTime(firstItem.getEndTime())
+                .timeLimitSeconds(lobby.getTimeLimitSeconds())
                 .roundNo(1)
-                .serverTime(System.currentTimeMillis())
+                .serverStartedAt(serverStartedAt)
                 .build();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -7,6 +7,7 @@ import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.exception.GameSessionAlreadyExistsException;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
@@ -18,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.Collections;
 import java.util.List;
@@ -114,7 +117,7 @@ public class GameSessionCreateService {
         );
 
         if ("ERROR_ALREADY_EXISTS".equals(result)) {
-            throw new IllegalStateException("게임 세션이 이미 존재합니다.");
+            throw new GameSessionAlreadyExistsException("게임 세션이 이미 존재합니다.");
         }
         if (!"OK".equals(result)) {
             throw new IllegalStateException("게임 세션 Redis 초기화 실패: " + result);
@@ -122,6 +125,16 @@ public class GameSessionCreateService {
 
         log.info("게임 세션 생성 완료 - 로비 코드: {}, 라운드 수: {}, 참여자 수: {}", 
                  code, lobby.getRoundCount(), participantIdentifiers.size());
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_ROLLED_BACK) {
+                    log.warn("DB 트랜잭션 롤백 감지 - Redis 세션 잔여 데이터 정리. code: {}", code);
+                    redisTemplate.delete(List.of(sessionKey, roundsKey, playersKey));
+                }
+            }
+        });
 
         MapItem firstItem = selectedItems.get(0);
         return RoundStartDto.builder()

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -10,6 +10,7 @@ import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRep
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
@@ -47,25 +48,30 @@ public class GameSessionCreateService {
      * 로비 게임 시작 시 호출되어 게임 세션을 초기화한다.
      * 트랜잭션 내에서 실행되므로, 이 과정 중 예외가 발생하면 로비 상태 변경도 롤백된다.
      */
-    public RoundStartDto createGameSession(GameLobby lobby) {
+    public RoundStartDto createGameSession(GameLobby lobby, QuizMap map) {
         String code = lobby.getInviteCode();
 
         // 1. 문제 데이터 로드 및 셔플링
-        List<MapItem> mapItems = mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(lobby.getMapId());
+        List<MapItem> mapItems = mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(map.getId());
         Collections.shuffle(mapItems);
         List<MapItem> selectedItems = mapItems.stream()
                 .limit(lobby.getRoundCount())
                 .toList();
 
         if (selectedItems.size() < lobby.getRoundCount()) {
-            throw new IllegalStateException("출제 가능한 문제 수가 라운드 수보다 적습니다.");
+            throw new io.github.ascrew.monomatbe.domain.game.exception.NotEnoughMapItemsException("출제 가능한 문제 수가 라운드 수보다 적습니다.");
         }
+
+        long serverStartedAt = System.currentTimeMillis();
+        java.time.LocalDateTime startedAt = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(serverStartedAt), java.time.ZoneId.systemDefault());
 
         // 2. DB 세션 생성
         GameSession gameSession = GameSession.builder()
                 .lobby(lobby)
+                .map(map)
                 .currentRoundNo(1)
                 .totalRoundCount(lobby.getRoundCount())
+                .startedAt(startedAt)
                 .build();
         gameSessionJpaRepository.save(gameSession);
 
@@ -96,8 +102,6 @@ public class GameSessionCreateService {
                 .collect(Collectors.joining(","));
         String participantsStr = String.join(",", participantIdentifiers);
 
-        long serverStartedAt = System.currentTimeMillis();
-
         String result = redisTemplate.execute(
                 initGameSessionScript,
                 List.of(sessionKey, roundsKey, playersKey),
@@ -105,9 +109,13 @@ public class GameSessionCreateService {
                 mapItemIdsStr,
                 participantsStr,
                 String.valueOf(lobby.getTimeLimitSeconds()),
-                String.valueOf(serverStartedAt)
+                String.valueOf(serverStartedAt),
+                String.valueOf(7200)
         );
 
+        if ("ERROR_ALREADY_EXISTS".equals(result)) {
+            throw new IllegalStateException("게임 세션이 이미 존재합니다.");
+        }
         if (!"OK".equals(result)) {
             throw new IllegalStateException("게임 세션 Redis 초기화 실패: " + result);
         }
@@ -117,7 +125,7 @@ public class GameSessionCreateService {
 
         MapItem firstItem = selectedItems.get(0);
         return RoundStartDto.builder()
-                .type("ROUND_STARTED")
+                .type("ROUND_READY")
                 .videoId(firstItem.getVideoId())
                 .youtubeUrl(firstItem.getYoutubeUrl())
                 .startTime(firstItem.getStartTime())

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
@@ -125,7 +125,11 @@ public class LobbyStartService {
         try {
             gameLobby.changeStatus(LobbyStatus.PLAYING);
             gameLobbyJpaRepository.saveAndFlush(gameLobby);
-            firstRound = gameSessionCreateService.createGameSession(gameLobby);
+            firstRound = gameSessionCreateService.createGameSession(gameLobby, quizMap);
+        } catch (io.github.ascrew.monomatbe.domain.game.exception.NotEnoughMapItemsException e) {
+            log.warn("게임 시작 요청 거부 - 문제 수 부족. code: {}, requester: {}", code, requesterIdentifier);
+            lobbyRepository.rollbackStartedLobbyStatus(code);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "출제 가능한 문제 수가 라운드 수보다 적습니다.");
         } catch (Exception e) {
             log.error(
                     "게임 시작 DB 상태 변경 실패 - Redis 상태 보상 롤백 시도. code: {}, requester: {}",

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
@@ -130,6 +130,10 @@ public class LobbyStartService {
             log.warn("게임 시작 요청 거부 - 문제 수 부족. code: {}, requester: {}", code, requesterIdentifier);
             lobbyRepository.rollbackStartedLobbyStatus(code);
             throw new ResponseStatusException(HttpStatus.CONFLICT, "출제 가능한 문제 수가 라운드 수보다 적습니다.");
+        } catch (io.github.ascrew.monomatbe.domain.game.exception.GameSessionAlreadyExistsException e) {
+            log.warn("게임 시작 요청 거부 - 이미 진행 중인 게임 세션 존재. code: {}, requester: {}", code, requesterIdentifier);
+            lobbyRepository.rollbackStartedLobbyStatus(code);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 진행 중인 게임 세션이 있습니다.");
         } catch (Exception e) {
             log.error(
                     "게임 시작 DB 상태 변경 실패 - Redis 상태 보상 롤백 시도. code: {}, requester: {}",

--- a/src/main/resources/db/migration/V5__create_game_session_tables.sql
+++ b/src/main/resources/db/migration/V5__create_game_session_tables.sql
@@ -1,11 +1,15 @@
 CREATE TABLE game_session (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     lobby_id BIGINT NOT NULL,
+    map_id BIGINT NOT NULL,
     current_round_no INT NOT NULL DEFAULT 1,
     total_round_count INT NOT NULL,
     status VARCHAR(20) NOT NULL,
+    started_at DATETIME(6) NOT NULL,
+    ended_at DATETIME(6) NULL,
     created_at TIMESTAMP NOT NULL,
-    CONSTRAINT fk_game_session_lobby FOREIGN KEY (lobby_id) REFERENCES game_lobby(id) ON DELETE CASCADE
+    CONSTRAINT fk_game_session_lobby FOREIGN KEY (lobby_id) REFERENCES game_lobby(id) ON DELETE CASCADE,
+    CONSTRAINT fk_game_session_map FOREIGN KEY (map_id) REFERENCES quiz_map(id)
 );
 
 CREATE TABLE game_session_player (

--- a/src/main/resources/db/migration/V5__create_game_session_tables.sql
+++ b/src/main/resources/db/migration/V5__create_game_session_tables.sql
@@ -9,7 +9,7 @@ CREATE TABLE game_session (
     ended_at DATETIME(6) NULL,
     created_at TIMESTAMP NOT NULL,
     CONSTRAINT fk_game_session_lobby FOREIGN KEY (lobby_id) REFERENCES game_lobby(id) ON DELETE CASCADE,
-    CONSTRAINT fk_game_session_map FOREIGN KEY (map_id) REFERENCES quiz_map(id)
+    CONSTRAINT fk_game_session_map FOREIGN KEY (map_id) REFERENCES map(id)
 );
 
 CREATE TABLE game_session_player (

--- a/src/main/resources/scripts/init_game_session.lua
+++ b/src/main/resources/scripts/init_game_session.lua
@@ -14,6 +14,8 @@ local playersKey = KEYS[3]
 local totalRounds = ARGV[1]
 local mapItemIds  = ARGV[2] -- 쉼표로 구분된 문자열 (예: "1,4,5,2,3")
 local participants = ARGV[3] -- 쉼표로 구분된 문자열 (예: "uuid1,uuid2")
+local timeLimitSeconds = ARGV[4]
+local roundStartedAt = ARGV[5]
 
 -- 1. 기존 게임 세션 데이터 초기화 (재시도 대응)
 redis.call('DEL', sessionKey, roundsKey, playersKey)
@@ -22,7 +24,9 @@ redis.call('DEL', sessionKey, roundsKey, playersKey)
 redis.call('HSET', sessionKey, 
     'current_round_no', '1',
     'total_round_count', totalRounds,
-    'status', 'PLAYING'
+    'status', 'READY',
+    'time_limit_seconds', timeLimitSeconds,
+    'round_started_at', roundStartedAt
 )
 redis.call('EXPIRE', sessionKey, 7200)
 

--- a/src/main/resources/scripts/init_game_session.lua
+++ b/src/main/resources/scripts/init_game_session.lua
@@ -16,8 +16,14 @@ local mapItemIds  = ARGV[2] -- 쉼표로 구분된 문자열 (예: "1,4,5,2,3")
 local participants = ARGV[3] -- 쉼표로 구분된 문자열 (예: "uuid1,uuid2")
 local timeLimitSeconds = ARGV[4]
 local roundStartedAt = ARGV[5]
+local ttl = ARGV[6]
 
--- 1. 기존 게임 세션 데이터 초기화 (재시도 대응)
+-- 0. 게임 세션이 이미 존재하는지 검사 (멱등성 보장)
+if redis.call('EXISTS', sessionKey) == 1 then
+    return "ERROR_ALREADY_EXISTS"
+end
+
+-- 1. 기존 잔여 데이터 초기화 (혹시 모를 가비지 데이터 정리)
 redis.call('DEL', sessionKey, roundsKey, playersKey)
 
 -- 2. 세션 메타데이터 저장
@@ -28,19 +34,19 @@ redis.call('HSET', sessionKey,
     'time_limit_seconds', timeLimitSeconds,
     'round_started_at', roundStartedAt
 )
-redis.call('EXPIRE', sessionKey, 7200)
+redis.call('EXPIRE', sessionKey, ttl)
 
--- 2. 라운드별 MapItem ID 저장
+-- 3. 라운드별 MapItem ID 저장
 -- mapItemIds를 분리하여 RPUSH
 for id in string.gmatch(mapItemIds, '([^,]+)') do
     redis.call('RPUSH', roundsKey, id)
 end
-redis.call('EXPIRE', roundsKey, 7200)
+redis.call('EXPIRE', roundsKey, ttl)
 
--- 3. 참가자 초기 점수 저장
+-- 4. 참가자 초기 점수 저장
 for uuid in string.gmatch(participants, '([^,]+)') do
     redis.call('HSET', playersKey, uuid, '0')
 end
-redis.call('EXPIRE', playersKey, 7200)
+redis.call('EXPIRE', playersKey, ttl)
 
 return "OK"

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
@@ -97,11 +97,12 @@ class GameSessionCreateServiceTest {
                 anyString(),
                 anyString(),
                 anyString(),
+                anyString(),
                 anyString()
         )).thenReturn("OK");
 
         // when
-        RoundStartDto result = gameSessionCreateService.createGameSession(lobby);
+        RoundStartDto result = gameSessionCreateService.createGameSession(lobby, quizMap);
 
         // then
         // 1. DB Session 생성 확인
@@ -119,7 +120,7 @@ class GameSessionCreateServiceTest {
         assertThat(savedPlayers.get(0).getUser()).isEqualTo(user);
 
         // 3. Payload 필드 검증 (정답 및 민감정보 미포함, 신규 필드 포함)
-        assertThat(result.type()).isEqualTo("ROUND_STARTED");
+        assertThat(result.type()).isEqualTo("ROUND_READY");
         assertThat(result.videoId()).isEqualTo("vId");
         assertThat(result.youtubeUrl()).isEqualTo("https://youtube.com/vId");
         assertThat(result.startTime()).isEqualTo(10);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
@@ -6,6 +6,7 @@ import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
+import io.github.ascrew.monomatbe.domain.game.exception.GameSessionAlreadyExistsException;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
@@ -23,6 +24,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.List;
 
@@ -53,6 +57,16 @@ class GameSessionCreateServiceTest {
 
     @InjectMocks
     private GameSessionCreateService gameSessionCreateService;
+
+    @BeforeEach
+    void setUp() {
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TransactionSynchronizationManager.clearSynchronization();
+    }
 
     @Test
     @DisplayName("정상적으로 게임 세션이 생성되고 라운드 시작 이벤트 payload에 정답이 포함되지 않는지 검증")
@@ -130,5 +144,40 @@ class GameSessionCreateServiceTest {
         assertThat(result.serverStartedAt()).isGreaterThan(0L);
 
         // title, artist, answer 같은 필드가 DTO에 아예 존재하지 않음을 코드 구조상(record 정의) 보장됨.
+    }
+
+    @Test
+    @DisplayName("Redis 세션 키가 이미 존재하여 ERROR_ALREADY_EXISTS가 반환될 때 GameSessionAlreadyExistsException 발생")
+    void createGameSession_alreadyExistsThrowsException() {
+        // given
+        GameLobby lobby = GameLobby.builder()
+                .inviteCode("ABC1234")
+                .mapId(1L)
+                .roundCount(1)
+                .timeLimitSeconds(30)
+                .status(LobbyStatus.PLAYING)
+                .build();
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(1).build();
+        MapItem mapItem = MapItem.builder().map(quizMap).orderNum(1).videoId("vId").build();
+
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L)).thenReturn(List.of(mapItem));
+        when(lobbyRepository.getParticipantIdentifiers("ABC1234")).thenReturn(List.of("uId"));
+        when(gameParticipantResolver.resolveUsers(List.of("uId"))).thenReturn(List.of(User.builder().id(1L).build()));
+
+        when(redisTemplate.execute(
+                eq(initGameSessionScript),
+                any(List.class),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString()
+        )).thenReturn("ERROR_ALREADY_EXISTS");
+
+        // when & then
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> gameSessionCreateService.createGameSession(lobby, quizMap))
+                .isInstanceOf(GameSessionAlreadyExistsException.class)
+                .hasMessage("게임 세션이 이미 존재합니다.");
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
@@ -1,0 +1,133 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GameSessionCreateServiceTest {
+
+    @Mock
+    private GameSessionJpaRepository gameSessionJpaRepository;
+    @Mock
+    private GameSessionPlayerJpaRepository gameSessionPlayerJpaRepository;
+    @Mock
+    private MapItemJpaRepository mapItemJpaRepository;
+    @Mock
+    private LobbyRepository lobbyRepository;
+    @Mock
+    private GameParticipantResolver gameParticipantResolver;
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private RedisScript<String> initGameSessionScript;
+
+    @InjectMocks
+    private GameSessionCreateService gameSessionCreateService;
+
+    @Test
+    @DisplayName("정상적으로 게임 세션이 생성되고 라운드 시작 이벤트 payload에 정답이 포함되지 않는지 검증")
+    void createGameSession_successAndValidatesPayload() {
+        // given
+        GameLobby lobby = GameLobby.builder()
+                .inviteCode("ABC1234")
+                .mapId(1L)
+                .roundCount(1)
+                .timeLimitSeconds(30)
+                .status(LobbyStatus.PLAYING)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(1).build();
+
+        MapItem mapItem = MapItem.builder()
+                .map(quizMap)
+                .orderNum(1)
+                .videoId("vId")
+                .youtubeUrl("https://youtube.com/vId")
+                .startTime(10)
+                .endTime(20)
+                .title("Secret Title")
+                .artist("Secret Artist")
+                .answer("정답")
+                .hint("힌트")
+                .build();
+
+        User user = User.builder().id(1L).username("uId").userType(UserType.REGISTERED).build();
+
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(mapItem));
+        when(lobbyRepository.getParticipantIdentifiers("ABC1234"))
+                .thenReturn(List.of("uId"));
+        when(gameParticipantResolver.resolveUsers(List.of("uId")))
+                .thenReturn(List.of(user));
+        
+        when(redisTemplate.execute(
+                eq(initGameSessionScript),
+                any(List.class),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString()
+        )).thenReturn("OK");
+
+        // when
+        RoundStartDto result = gameSessionCreateService.createGameSession(lobby);
+
+        // then
+        // 1. DB Session 생성 확인
+        ArgumentCaptor<GameSession> sessionCaptor = ArgumentCaptor.forClass(GameSession.class);
+        verify(gameSessionJpaRepository).save(sessionCaptor.capture());
+        GameSession savedSession = sessionCaptor.getValue();
+        assertThat(savedSession.getCurrentRoundNo()).isEqualTo(1);
+        assertThat(savedSession.getTotalRoundCount()).isEqualTo(1);
+
+        // 2. DB Player 생성 확인
+        ArgumentCaptor<List<GameSessionPlayer>> playersCaptor = ArgumentCaptor.forClass(List.class);
+        verify(gameSessionPlayerJpaRepository).saveAll(playersCaptor.capture());
+        List<GameSessionPlayer> savedPlayers = playersCaptor.getValue();
+        assertThat(savedPlayers).hasSize(1);
+        assertThat(savedPlayers.get(0).getUser()).isEqualTo(user);
+
+        // 3. Payload 필드 검증 (정답 및 민감정보 미포함, 신규 필드 포함)
+        assertThat(result.type()).isEqualTo("ROUND_STARTED");
+        assertThat(result.videoId()).isEqualTo("vId");
+        assertThat(result.youtubeUrl()).isEqualTo("https://youtube.com/vId");
+        assertThat(result.startTime()).isEqualTo(10);
+        assertThat(result.endTime()).isEqualTo(20);
+        assertThat(result.timeLimitSeconds()).isEqualTo(30);
+        assertThat(result.roundNo()).isEqualTo(1);
+        assertThat(result.serverStartedAt()).isGreaterThan(0L);
+
+        // title, artist, answer 같은 필드가 DTO에 아예 존재하지 않음을 코드 구조상(record 정의) 보장됨.
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
@@ -1,0 +1,159 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
+import io.github.ascrew.monomatbe.domain.game.service.GameRealtimeNotifier;
+import io.github.ascrew.monomatbe.domain.game.service.GameSessionCreateService;
+import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LobbyStartServiceTest {
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+    @Mock
+    private LobbyRealtimeNotifier lobbyRealtimeNotifier;
+    @Mock
+    private GameLobbyJpaRepository gameLobbyJpaRepository;
+    @Mock
+    private GameSessionCreateService gameSessionCreateService;
+    @Mock
+    private GameRealtimeNotifier gameRealtimeNotifier;
+    @Mock
+    private QuizMapJpaRepository quizMapJpaRepository;
+
+    private LobbyStartService lobbyStartService;
+    private LobbyStartPolicy lobbyStartPolicy;
+
+    @BeforeEach
+    void setUp() {
+        TransactionSynchronizationManager.initSynchronization();
+        
+        lobbyStartPolicy = new LobbyStartPolicy(quizMapJpaRepository);
+        
+        lobbyStartService = new LobbyStartService(
+                lobbyRepository,
+                lobbyRealtimeNotifier,
+                gameLobbyJpaRepository,
+                lobbyStartPolicy,
+                gameSessionCreateService,
+                gameRealtimeNotifier
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    @Test
+    @DisplayName("정상적으로 게임 세션 생성을 요청하고 성공한다")
+    void startLobbyGame_success() {
+        // given
+        String code = "ABC1234";
+        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
+        
+        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).isDeleted(false).build();
+        
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.Started(code));
+        when(gameSessionCreateService.createGameSession(gameLobby)).thenReturn(mock(RoundStartDto.class));
+
+        // when
+        lobbyStartService.startLobbyGame(code, principal);
+
+        // then
+        verify(gameLobbyJpaRepository).saveAndFlush(gameLobby);
+        verify(gameSessionCreateService).createGameSession(gameLobby);
+    }
+
+    @Test
+    @DisplayName("맵이 없는 로비에서 시작 시 예외 발생")
+    void startLobbyGame_failsWhenNoMap() {
+        // given
+        String code = "ABC1234";
+        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
+        
+        // mapId가 없는 경우
+        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(null).roundCount(5).build();
+        
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
+
+        // when & then
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409 CONFLICT");
+    }
+
+    @Test
+    @DisplayName("문제가 없는 맵(또는 요구 라운드 수보다 적은 맵)으로 시작 시 예외 발생")
+    void startLobbyGame_failsWhenNotEnoughSongs() {
+        // given
+        String code = "ABC1234";
+        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
+        
+        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
+        // 맵에 곡 수가 부족한 경우
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(3).isDeleted(false).build();
+        
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+
+        // when & then
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409 CONFLICT");
+    }
+
+    @Test
+    @DisplayName("중복 게임 시작 요청 시 차단")
+    void startLobbyGame_failsWhenDuplicateStart() {
+        // given
+        String code = "ABC1234";
+        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
+        
+        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).isDeleted(false).build();
+        
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        // 이미 진행 중인 로비이므로 LobbyNotWaiting 반환
+        when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.LobbyNotWaiting(code));
+
+        // when & then
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409 CONFLICT");
+        
+        verify(gameSessionCreateService, never()).createGameSession(any());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
+import io.github.ascrew.monomatbe.domain.game.exception.GameSessionAlreadyExistsException;
 import io.github.ascrew.monomatbe.domain.game.service.GameRealtimeNotifier;
 import io.github.ascrew.monomatbe.domain.game.service.GameSessionCreateService;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
@@ -155,5 +156,30 @@ class LobbyStartServiceTest {
                 .hasMessageContaining("409 CONFLICT");
         
         verify(gameSessionCreateService, never()).createGameSession(any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 게임 세션이 존재하는 경우 예외(409) 발생 및 롤백 확인")
+    void startLobbyGame_alreadyExistsSession() {
+        // given
+        String code = "ABC1234";
+        CustomPrincipal principal = new CustomPrincipal(1L, "uId", io.github.ascrew.monomatbe.domain.auth.entity.UserType.REGISTERED);
+        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).build();
+
+        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(org.mockito.Mockito.mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.Started(code));
+
+        when(gameSessionCreateService.createGameSession(gameLobby, quizMap))
+                .thenThrow(new GameSessionAlreadyExistsException("게임 세션이 이미 존재합니다."));
+
+        // when & then
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409 CONFLICT");
+
+        verify(lobbyRepository).rollbackStartedLobbyStatus(code);
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
@@ -83,14 +83,14 @@ class LobbyStartServiceTest {
         when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
         when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
         when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.Started(code));
-        when(gameSessionCreateService.createGameSession(gameLobby)).thenReturn(mock(RoundStartDto.class));
+        when(gameSessionCreateService.createGameSession(gameLobby, quizMap)).thenReturn(mock(RoundStartDto.class));
 
         // when
         lobbyStartService.startLobbyGame(code, principal);
 
         // then
         verify(gameLobbyJpaRepository).saveAndFlush(gameLobby);
-        verify(gameSessionCreateService).createGameSession(gameLobby);
+        verify(gameSessionCreateService).createGameSession(gameLobby, quizMap);
     }
 
     @Test
@@ -154,6 +154,6 @@ class LobbyStartServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("409 CONFLICT");
         
-        verify(gameSessionCreateService, never()).createGameSession(any());
+        verify(gameSessionCreateService, never()).createGameSession(any(), any());
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #101 
- #102

## 📝 Summary

- 로비에서 게임 시작 시 선택된 맵을 기반으로 게임 세션을 생성하고 라운드를 시작하는 인게임 기반 구조를 구현했습니다.
- `domain/game` 패키지에 `GameSession` 및 `GameSessionPlayer` 엔티티를 추가하고, `GameSessionStatus`에 `READY` 상태를 추가했습니다.
- `LobbyStartPolicy`를 통해 로비에 맵이 정상 선택되었고, 문제 수가 라운드 수 이상인지 사전 검증하도록 했습니다.
- `GameSessionCreateService`에서 시작 시점의 참여자 스냅샷을 DB(`GameSessionPlayer`)와 Redis에 저장하도록 구현했습니다.
- `GameParticipantResolver`에서 게스트 유저가 두 테이블(`user_sessions`, `guest_sessions`) 모두에 존재하여 중복 조회되던 500 에러 버그를 `id` 기준 중복 제거(`Map` 활용)로 해결했습니다.
- `init_game_session.lua`를 수정하여 세션 초기 상태를 `READY`로 지정하고, `round_started_at`, `time_limit_seconds`를 메타데이터로 추가 저장하도록 했습니다.
- 라운드 시작 이벤트로 전달할 `RoundStartDto`를 구현하고, 정답 정보(`title`, `answer`)를 완전히 제외한 채 `youtubeUrl`, `timeLimitSeconds`, `serverStartedAt`, `type="ROUND_STARTED"` 필드를 추가했습니다.
- `GameSessionEventPublisher`를 통해 `/topic/game/{code}/round` 경로로 STOMP 라운드 시작 이벤트를 전파하도록 구현했습니다.
- `LobbyStartServiceTest`에 정상 생성, 맵 없음 에러, 문제 수 부족 에러, 중복(동시) 시작 차단, 이벤트 정답 미포함 등을 검증하는 통합 테스트 코드를 추가했습니다.
- `src/main/resources/static/test_game.html`을 추가하여 프론트엔드 연동 전 백엔드 단독으로 원클릭 E2E 테스트(로그인~로비생성~준비~시작)를 수행할 수 있도록 환경을 마련했습니다.

## 🙏PR point

- `GameSessionStatus` 초기 상태는 `PLAYING`이 아닌 `READY`로 설정되며, 세션 생성 직후 라운드가 준비 상태에 놓임을 명시합니다.
- 정답 관련 데이터(title, artist, answer 등)는 클라이언트로 절대 유출되지 않도록 서버에서 캡슐화하였으며, 클라이언트는 `RoundStartDto`만 수신합니다.
- 동시 게임 시작 등 동시성 제어는 `start_lobby.lua` 스크립트를 통해 원자적으로 차단되도록 설계되었습니다.
- **[주의]** 게스트 사용자의 식별자(UUID)는 `user_sessions`와 `guest_sessions` 양쪽에 저장되는 이중 저장 정책이므로, 참가자 조회 시 `id` 기준 중복 방지 처리가 필수적입니다. 이로 인한 500 에러를 이번 PR에서 해결했습니다.
- 이슈 요구사항에 따라 YouTube 단일 재생 로직을 위해 서버에서 직접 API를 다루지 않으며, 클라이언트가 IFrame API를 통해 런타임에서 영상 상태를 직접 핸들링하도록 설계되었습니다.

## 📬 Reference
