### PR TITLE
[Feat/#94] 로비 퇴장 생명주기 테스트 강화

### DIFF
--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.KickLobbyResult;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -272,6 +273,104 @@ class LobbyLeaveLifecycleRepositoryTest {
             int availableSeats = Math.max(0, maxPlayers - currentPlayers);
             addPublicIndexes(lobbyCode, currentPlayers, availableSeats);
         }
+    }
+
+    @Test
+    @DisplayName("강퇴된 유저가 이후 퇴장 요청을 보내도 participants/order/current_players 상태가 깨지지 않는다")
+    void kickedUserLeaveDoesNotBreakLobbyState() {
+        // given
+        String targetWsSessionId = "ws-session-94-target";
+
+        givenLobby(
+                LOBBY_CODE,
+                HOST_ID,
+                false,
+                4,
+                HOST_ID,
+                SECOND_USER_ID,
+                THIRD_USER_ID
+        );
+
+        redisTemplate.opsForValue().set(
+                RedisKeys.lobbyUserSessionKey(LOBBY_CODE, SECOND_USER_ID),
+                targetWsSessionId
+        );
+
+        redisTemplate.opsForValue().set(
+                RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, SECOND_USER_ID),
+                "10"
+        );
+
+        redisTemplate.opsForSet().add(
+                RedisKeys.lobbyReadyKey(LOBBY_CODE),
+                SECOND_USER_ID,
+                THIRD_USER_ID
+        );
+
+        // when
+        KickLobbyResult kickResult = lobbyRepository.executeKickLobbyProcess(
+                LOBBY_CODE,
+                HOST_ID,
+                SECOND_USER_ID
+        );
+
+        // then
+        assertThat(kickResult).isInstanceOf(KickLobbyResult.Kicked.class);
+
+        KickLobbyResult.Kicked kicked = (KickLobbyResult.Kicked) kickResult;
+        assertThat(kicked.lobbyCode()).isEqualTo(LOBBY_CODE);
+        assertThat(kicked.targetUserIdentifier()).isEqualTo(SECOND_USER_ID);
+        assertThat(kicked.targetWsSessionId()).isEqualTo(targetWsSessionId);
+
+        assertThat(redisTemplate.opsForSet().members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE)))
+                .containsExactlyInAnyOrder(HOST_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForList().range(RedisKeys.lobbyOrderKey(LOBBY_CODE), 0, -1))
+                .containsExactly(HOST_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.lobbyKickedKey(LOBBY_CODE), SECOND_USER_ID))
+                .isTrue();
+
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, SECOND_USER_ID)))
+                .isFalse();
+
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, SECOND_USER_ID)))
+                .isFalse();
+
+        assertThat(redisTemplate.opsForHash()
+                .get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_CURRENT_PLAYERS))
+                .isEqualTo("2");
+
+        assertThat(redisTemplate.opsForSet().members(RedisKeys.lobbyReadyKey(LOBBY_CODE)))
+                .containsExactly(THIRD_USER_ID);
+
+        // when
+        LeaveLobbyResult leaveResult = lobbyRepository.executeLeaveLobbyProcess(
+                LOBBY_CODE,
+                SECOND_USER_ID
+        );
+
+        // then
+        assertThat(leaveResult).isInstanceOf(LeaveLobbyResult.Left.class);
+
+        assertThat(redisTemplate.opsForSet().members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE)))
+                .containsExactlyInAnyOrder(HOST_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForList().range(RedisKeys.lobbyOrderKey(LOBBY_CODE), 0, -1))
+                .containsExactly(HOST_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForHash()
+                .get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_CURRENT_PLAYERS))
+                .isEqualTo("2");
+
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.lobbyKickedKey(LOBBY_CODE), SECOND_USER_ID))
+                .isTrue();
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, LOBBY_CODE))
+                .isEqualTo(2.0);
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE, LOBBY_CODE))
+                .isEqualTo(2.0);
     }
 
     private void addPublicIndexes(String lobbyCode, int currentPlayers, int availableSeats) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
@@ -1,0 +1,233 @@
+package io.github.ascrew.monomatbe.domain.lobby.repository;
+
+import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=false"
+})
+class LobbyLeaveLifecycleRepositoryTest {
+    
+    private static final String LOBBY_CODE = "TEST94";
+
+    private static final String HOST_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String SECOND_USER_ID = "22222222-2222-2222-2222-222222222222";
+    private static final String THIRD_USER_ID = "33333333-3333-3333-3333-333333333333";
+
+    @Autowired
+    private LobbyRepository lobbyRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @AfterEach
+    void tearDown() {
+        deleteLobbyKeys(LOBBY_CODE);
+    }
+
+    @Test
+    @DisplayName("방장이 정상 퇴장하면 입장 순서상 다음 유저에게 방장이 위임된다")
+    void delegateHostToNextUserWhenHostLeaves() {
+        // given
+        givenLobby(
+                LOBBY_CODE,
+                HOST_ID,
+                false,
+                4,
+                HOST_ID,
+                SECOND_USER_ID,
+                THIRD_USER_ID
+        );
+
+        // when
+        LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, HOST_ID);
+
+        // then
+        assertThat(result).isInstanceOf(LeaveLobbyResult.Delegated.class);
+
+        LeaveLobbyResult.Delegated delegated = (LeaveLobbyResult.Delegated) result;
+        assertThat(delegated.lobbyCode()).isEqualTo(LOBBY_CODE);
+        assertThat(delegated.newHostId()).isEqualTo(SECOND_USER_ID);
+
+        Object storedHost = redisTemplate.opsForHash()
+                .get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_HOST_USER_ID);
+
+        assertThat(storedHost).isEqualTo(SECOND_USER_ID);
+
+        assertThat(redisTemplate.opsForSet().members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE)))
+                .containsExactlyInAnyOrder(SECOND_USER_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForList().range(RedisKeys.lobbyOrderKey(LOBBY_CODE), 0, -1))
+                .containsExactly(SECOND_USER_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForHash()
+                .get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_CURRENT_PLAYERS))
+                .isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("일반 참가자가 퇴장하면 participants, order, ready set에서 제거된다")
+    void removeParticipantStateWhenNormalUserLeaves() {
+        // given
+        givenLobby(
+                LOBBY_CODE,
+                HOST_ID,
+                false,
+                4,
+                HOST_ID,
+                SECOND_USER_ID,
+                THIRD_USER_ID
+        );
+
+        redisTemplate.opsForSet().add(
+                RedisKeys.lobbyReadyKey(LOBBY_CODE),
+                SECOND_USER_ID,
+                THIRD_USER_ID
+        );
+
+        // when
+        LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, SECOND_USER_ID);
+
+        // then
+        assertThat(result).isInstanceOf(LeaveLobbyResult.Left.class);
+
+        LeaveLobbyResult.Left left = (LeaveLobbyResult.Left) result;
+        assertThat(left.lobbyCode()).isEqualTo(LOBBY_CODE);
+        assertThat(left.userId()).isEqualTo(SECOND_USER_ID);
+
+        assertThat(redisTemplate.opsForSet().members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE)))
+                .containsExactlyInAnyOrder(HOST_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForList().range(RedisKeys.lobbyOrderKey(LOBBY_CODE), 0, -1))
+                .containsExactly(HOST_ID, THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForSet().members(RedisKeys.lobbyReadyKey(LOBBY_CODE)))
+                .containsExactly(THIRD_USER_ID);
+
+        assertThat(redisTemplate.opsForHash()
+                .get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_CURRENT_PLAYERS))
+                .isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("마지막 유저가 퇴장하면 Redis 로비 데이터가 삭제된다")
+    void destroyLobbyWhenLastUserLeaves() {
+        // given
+        givenLobby(
+                LOBBY_CODE,
+                HOST_ID,
+                false,
+                4,
+                HOST_ID
+        );
+
+        redisTemplate.opsForSet().add(RedisKeys.lobbyReadyKey(LOBBY_CODE), HOST_ID);
+        redisTemplate.opsForSet().add(RedisKeys.lobbyKickedKey(LOBBY_CODE), SECOND_USER_ID);
+        addPublicIndexes(LOBBY_CODE, 1, 3);
+
+        // when
+        LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, HOST_ID);
+
+        // then
+        assertThat(result).isInstanceOf(LeaveLobbyResult.Destroyed.class);
+
+        LeaveLobbyResult.Destroyed destroyed = (LeaveLobbyResult.Destroyed) result;
+        assertThat(destroyed.lobbyCode()).isEqualTo(LOBBY_CODE);
+
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyKey(LOBBY_CODE))).isFalse();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).isFalse();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyOrderKey(LOBBY_CODE))).isFalse();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyKickedKey(LOBBY_CODE))).isFalse();
+
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_PUBLIC, LOBBY_CODE)).isFalse();
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_LATEST, LOBBY_CODE)).isNull();
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, LOBBY_CODE)).isNull();
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE, LOBBY_CODE)).isNull();
+    }
+
+    private void givenLobby(
+            String lobbyCode,
+            String hostUserId,
+            boolean isPrivate,
+            int maxPlayers,
+            String... participantIds
+    ) {
+        deleteLobbyKeys(lobbyCode);
+
+        redisTemplate.opsForHash().putAll(
+                RedisKeys.lobbyKey(lobbyCode),
+                Map.of(
+                        RedisKeys.FIELD_CODE, lobbyCode,
+                        RedisKeys.FIELD_HOST_USER_ID, hostUserId,
+                        RedisKeys.FIELD_TITLE, "테스트 로비",
+                        RedisKeys.FIELD_MAX_PLAYERS, String.valueOf(maxPlayers),
+                        RedisKeys.FIELD_CURRENT_PLAYERS, String.valueOf(participantIds.length),
+                        RedisKeys.FIELD_IS_PRIVATE, String.valueOf(isPrivate),
+                        RedisKeys.FIELD_STATUS, "WAITING",
+                        RedisKeys.FIELD_CREATED_AT_EPOCH_MILLIS, String.valueOf(System.currentTimeMillis())
+                )
+        );
+
+        for (String participantId : participantIds) {
+            redisTemplate.opsForSet().add(RedisKeys.lobbyParticipantsKey(lobbyCode), participantId);
+            redisTemplate.opsForList().rightPush(RedisKeys.lobbyOrderKey(lobbyCode), participantId);
+        }
+
+        if (!isPrivate) {
+            int currentPlayers = participantIds.length;
+            int availableSeats = Math.max(0, maxPlayers - currentPlayers);
+            addPublicIndexes(lobbyCode, currentPlayers, availableSeats);
+        }
+    }
+
+    private void addPublicIndexes(String lobbyCode, int currentPlayers, int availableSeats) {
+        redisTemplate.opsForSet().add(RedisKeys.LOBBY_PUBLIC, lobbyCode);
+        redisTemplate.opsForZSet().add(
+                RedisKeys.LOBBY_PUBLIC_LATEST,
+                lobbyCode,
+                System.currentTimeMillis()
+        );
+        redisTemplate.opsForZSet().add(
+                RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS,
+                lobbyCode,
+                currentPlayers
+        );
+        redisTemplate.opsForZSet().add(
+                RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE,
+                lobbyCode,
+                availableSeats
+        );
+    }
+
+    private void deleteLobbyKeys(String lobbyCode) {
+        redisTemplate.delete(Set.of(
+                RedisKeys.lobbyKey(lobbyCode),
+                RedisKeys.lobbyParticipantsKey(lobbyCode),
+                RedisKeys.lobbyOrderKey(lobbyCode),
+                RedisKeys.lobbyKickedKey(lobbyCode),
+                RedisKeys.lobbyReadyKey(lobbyCode),
+                RedisKeys.lobbyUserSessionKey(lobbyCode, HOST_ID),
+                RedisKeys.lobbyUserSessionKey(lobbyCode, SECOND_USER_ID),
+                RedisKeys.lobbyUserSessionKey(lobbyCode, THIRD_USER_ID),
+                RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, HOST_ID),
+                RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, SECOND_USER_ID),
+                RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, THIRD_USER_ID)
+        ));
+
+        redisTemplate.opsForSet().remove(RedisKeys.LOBBY_PUBLIC, lobbyCode);
+        redisTemplate.opsForZSet().remove(RedisKeys.LOBBY_PUBLIC_LATEST, lobbyCode);
+        redisTemplate.opsForZSet().remove(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, lobbyCode);
+        redisTemplate.opsForZSet().remove(RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE, lobbyCode);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.flyway.enabled=false"
 })
 class LobbyLeaveLifecycleRepositoryTest {
-    
+
     private static final String LOBBY_CODE = "TEST94";
 
     private static final String HOST_ID = "11111111-1111-1111-1111-111111111111";
@@ -154,6 +154,89 @@ class LobbyLeaveLifecycleRepositoryTest {
         assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_LATEST, LOBBY_CODE)).isNull();
         assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, LOBBY_CODE)).isNull();
         assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE, LOBBY_CODE)).isNull();
+    }
+
+    @Test
+    @DisplayName("공개 로비에서 일반 참가자가 퇴장하면 public 인원 정렬 인덱스 score가 갱신된다")
+    void updatePublicCapacityIndexesWhenPublicLobbyParticipantLeaves() {
+        // given
+        givenLobby(
+                LOBBY_CODE,
+                HOST_ID,
+                false,
+                4,
+                HOST_ID,
+                SECOND_USER_ID,
+                THIRD_USER_ID
+        );
+
+        // when
+        LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, THIRD_USER_ID);
+
+        // then
+        assertThat(result).isInstanceOf(LeaveLobbyResult.Left.class);
+
+        assertThat(redisTemplate.opsForHash()
+                .get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_CURRENT_PLAYERS))
+                .isEqualTo("2");
+
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_PUBLIC, LOBBY_CODE))
+                .isTrue();
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, LOBBY_CODE))
+                .isEqualTo(2.0);
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE, LOBBY_CODE))
+                .isEqualTo(2.0);
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_LATEST, LOBBY_CODE))
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("비공개 로비에서 참가자가 퇴장해도 public index에 복구되지 않는다")
+    void doesNotRestorePrivateLobbyToPublicIndexesWhenParticipantLeaves() {
+        // given
+        givenLobby(
+                LOBBY_CODE,
+                HOST_ID,
+                true,
+                4,
+                HOST_ID,
+                SECOND_USER_ID,
+                THIRD_USER_ID
+        );
+
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_PUBLIC, LOBBY_CODE))
+                .isFalse();
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_LATEST, LOBBY_CODE))
+                .isNull();
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, LOBBY_CODE))
+                .isNull();
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE, LOBBY_CODE))
+                .isNull();
+
+        // when
+        LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, SECOND_USER_ID);
+
+        // then
+        assertThat(result).isInstanceOf(LeaveLobbyResult.Left.class);
+
+        assertThat(redisTemplate.opsForHash()
+                .get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_CURRENT_PLAYERS))
+                .isEqualTo("2");
+
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_PUBLIC, LOBBY_CODE))
+                .isFalse();
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_LATEST, LOBBY_CODE))
+                .isNull();
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, LOBBY_CODE))
+                .isNull();
+
+        assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_AVAILABLE, LOBBY_CODE))
+                .isNull();
     }
 
     private void givenLobby(

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicyTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicyTest.java
@@ -1,0 +1,204 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class LobbyCanStartPolicyTest {
+
+    private static final Long MAP_ID = 10L;
+    private static final String LOBBY_CODE = "TEST94";
+    private static final String HOST_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String PLAYER_ID = "22222222-2222-2222-2222-222222222222";
+
+    private final QuizMapJpaRepository quizMapJpaRepository =
+            Mockito.mock(QuizMapJpaRepository.class);
+
+    private final LobbyCanStartPolicy lobbyCanStartPolicy =
+            new LobbyCanStartPolicy(quizMapJpaRepository);
+
+    @Test
+    @DisplayName("퇴장 이후 방장을 제외한 참여자가 없으면 canStart는 false다")
+    void canStartFalseWhenOnlyHostRemainsAfterLeave() {
+        // given
+        JoinLobbyResponse lobbyInfo = waitingLobbyWithMap();
+
+        GameLobby gameLobby = gameLobbyWithRoundCount(3);
+        givenQuizMapSongCount(5);
+
+        List<LobbyPlayerResponse> players = List.of(
+                hostPlayer()
+        );
+
+        // when
+        boolean canStart = lobbyCanStartPolicy.calculateCanStart(
+                lobbyInfo,
+                players,
+                gameLobby
+        );
+
+        // then
+        assertThat(canStart).isFalse();
+    }
+
+    @Test
+    @DisplayName("퇴장 이후 남은 일반 참가자가 모두 ready 상태이면 canStart는 true다")
+    void canStartTrueWhenRemainingNonHostPlayersAreReadyAfterLeave() {
+        // given
+        JoinLobbyResponse lobbyInfo = waitingLobbyWithMap();
+
+        GameLobby gameLobby = gameLobbyWithRoundCount(3);
+        givenQuizMapSongCount(5);
+
+        List<LobbyPlayerResponse> players = List.of(
+                hostPlayer(),
+                readyPlayer(PLAYER_ID)
+        );
+
+        // when
+        boolean canStart = lobbyCanStartPolicy.calculateCanStart(
+                lobbyInfo,
+                players,
+                gameLobby
+        );
+
+        // then
+        assertThat(canStart).isTrue();
+    }
+
+    @Test
+    @DisplayName("퇴장 이후 남은 일반 참가자 중 ready가 아닌 유저가 있으면 canStart는 false다")
+    void canStartFalseWhenRemainingNonHostPlayerIsNotReadyAfterLeave() {
+        // given
+        JoinLobbyResponse lobbyInfo = waitingLobbyWithMap();
+
+        GameLobby gameLobby = gameLobbyWithRoundCount(3);
+        givenQuizMapSongCount(5);
+
+        List<LobbyPlayerResponse> players = List.of(
+                hostPlayer(),
+                notReadyPlayer(PLAYER_ID)
+        );
+
+        // when
+        boolean canStart = lobbyCanStartPolicy.calculateCanStart(
+                lobbyInfo,
+                players,
+                gameLobby
+        );
+
+        // then
+        assertThat(canStart).isFalse();
+    }
+
+    @Test
+    @DisplayName("맵 문제 수가 라운드 수보다 적으면 참여자가 ready여도 canStart는 false다")
+    void canStartFalseWhenMapSongCountIsLessThanRoundCount() {
+        // given
+        JoinLobbyResponse lobbyInfo = waitingLobbyWithMap();
+
+        GameLobby gameLobby = gameLobbyWithRoundCount(5);
+        givenQuizMapSongCount(3);
+
+        List<LobbyPlayerResponse> players = List.of(
+                hostPlayer(),
+                readyPlayer(PLAYER_ID)
+        );
+
+        // when
+        boolean canStart = lobbyCanStartPolicy.calculateCanStart(
+                lobbyInfo,
+                players,
+                gameLobby
+        );
+
+        // then
+        assertThat(canStart).isFalse();
+    }
+
+    private JoinLobbyResponse waitingLobbyWithMap() {
+        return new JoinLobbyResponse(
+                LOBBY_CODE,
+                "테스트 로비",
+                HOST_ID,
+                4,
+                2,
+                "WAITING",
+                MAP_ID,
+                "테스트 맵",
+                "K-POP"
+        );
+    }
+
+    private GameLobby gameLobbyWithRoundCount(int roundCount) {
+        return GameLobby.builder()
+                .id(1L)
+                .mapId(MAP_ID)
+                .inviteCode(LOBBY_CODE)
+                .title("테스트 로비")
+                .maxPlayers(4)
+                .roundCount(roundCount)
+                .timeLimitSeconds(30)
+                .isPrivate(false)
+                .status(LobbyStatus.WAITING)
+                .isDeleted(false)
+                .build();
+    }
+
+    private void givenQuizMapSongCount(int numOfSong) {
+        QuizMap quizMap = QuizMap.builder()
+                .id(MAP_ID)
+                .title("테스트 맵")
+                .description("테스트 맵 설명")
+                .category(MapCategory.KPOP)
+                .numOfSong(numOfSong)
+                .totalPlayTime(180)
+                .isPublic(true)
+                .pendingPublic(false)
+                .isDeleted(false)
+                .build();
+
+        when(quizMapJpaRepository.findById(MAP_ID))
+                .thenReturn(Optional.of(quizMap));
+    }
+
+    private LobbyPlayerResponse hostPlayer() {
+        return new LobbyPlayerResponse(
+                HOST_ID,
+                "host",
+                true,
+                false
+        );
+    }
+
+    private LobbyPlayerResponse readyPlayer(String userIdentifier) {
+        return new LobbyPlayerResponse(
+                userIdentifier,
+                "player",
+                false,
+                true
+        );
+    }
+
+    private LobbyPlayerResponse notReadyPlayer(String userIdentifier) {
+        return new LobbyPlayerResponse(
+                userIdentifier,
+                "player",
+                false,
+                false
+        );
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandlerTest.java
@@ -1,0 +1,139 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LobbyLeaveEventHandlerTest {
+
+    private static final String LOBBY_CODE = "TEST94";
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+    private static final String NEW_HOST_IDENTIFIER = "22222222-2222-2222-2222-222222222222";
+
+    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
+    private final LobbyRealtimeNotifier lobbyRealtimeNotifier = mock(LobbyRealtimeNotifier.class);
+
+    private final LobbyLeaveEventHandler handler = new LobbyLeaveEventHandler(
+            lobbyRepository,
+            lobbyRealtimeNotifier
+    );
+
+    @Test
+    @DisplayName("PlayerLeaveEvent 수신 시 로비 퇴장 처리를 실행한다")
+    void executeLeaveProcessWhenPlayerLeaveEventReceived() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
+
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(lobbyRepository).executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER);
+    }
+
+    @Test
+    @DisplayName("일반 참가자 퇴장 결과이면 로비 내부 refresh를 발행한다")
+    void notifyLobbyInfoRefreshWhenParticipantLeft() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
+
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+    }
+
+    @Test
+    @DisplayName("방장 위임 결과이면 로비 내부 refresh를 발행한다")
+    void notifyLobbyInfoRefreshWhenHostDelegated() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Delegated(LOBBY_CODE, NEW_HOST_IDENTIFIER));
+
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+    }
+
+    @Test
+    @DisplayName("마지막 유저 퇴장으로 로비가 삭제되면 로비 목록 refresh를 발행한다")
+    void notifyLobbyListRefreshWhenLobbyDestroyed() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Destroyed(LOBBY_CODE));
+
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(lobbyRealtimeNotifier).notifyLobbyListRefresh();
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
+    }
+
+    @Test
+    @DisplayName("퇴장 처리 실패 결과이면 refresh를 발행하지 않는다")
+    void doesNotNotifyWhenLeaveProcessFailed() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Error("Redis Lua execution failed"));
+
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
+    }
+
+    @Test
+    @DisplayName("로비 코드가 없으면 퇴장 처리를 실행하지 않는다")
+    void doesNotExecuteLeaveProcessWhenLobbyCodeIsBlank() {
+        // given
+        PlayerLeaveEvent event = new PlayerLeaveEvent(" ", USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(lobbyRepository, never()).executeLeaveLobbyProcess(" ", USER_IDENTIFIER);
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+    }
+
+    @Test
+    @DisplayName("사용자 식별자가 없으면 퇴장 처리를 실행하지 않는다")
+    void doesNotExecuteLeaveProcessWhenUserIdentifierIsBlank() {
+        // given
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, " ");
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(lobbyRepository, never()).executeLeaveLobbyProcess(LOBBY_CODE, " ");
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListenerDisconnectTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListenerDisconnectTest.java
@@ -1,0 +1,168 @@
+package io.github.ascrew.monomatbe.global.websocket;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.constant.StompDestinations;
+import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
+import io.github.ascrew.monomatbe.global.redis.RedisPublisher;
+import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class WebSocketEventListenerDisconnectTest {
+
+    private static final String LOBBY_CODE = "TEST94";
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+    private static final String WS_SESSION_ID = "ws-session-94";
+
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+    private final RedisPublisher redisPublisher = mock(RedisPublisher.class);
+    private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+    private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+    private final WebSocketMetric webSocketMetric = mock(WebSocketMetric.class);
+    private final JsonMapper pubSubJsonMapper = JsonMapper.builder().build();
+
+    private final HashOperations<String, Object, Object> hashOperations = mock(HashOperations.class);
+    private final SetOperations<String, String> setOperations = mock(SetOperations.class);
+    private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+    private final WebSocketEventListener listener = new WebSocketEventListener(
+            redisTemplate,
+            redisPublisher,
+            messagingTemplate,
+            eventPublisher,
+            webSocketMetric,
+            pubSubJsonMapper,
+            Duration.ofHours(2)
+    );
+
+    @Test
+    @DisplayName("DISCONNECT 시 wsSessionId로 로비를 역추적해 PlayerLeaveEvent를 발행한다")
+    void publishPlayerLeaveEventWhenValidLobbySessionDisconnects() {
+        // given
+        doReturn(hashOperations).when(redisTemplate).opsForHash();
+        doReturn(setOperations).when(redisTemplate).opsForSet();
+        doReturn(valueOperations).when(redisTemplate).opsForValue();
+
+        doReturn(Map.of(WebSocketHeaders.SESSION_LOBBY_CODE, LOBBY_CODE))
+                .when(hashOperations)
+                .entries(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+
+        doReturn(WS_SESSION_ID)
+                .when(valueOperations)
+                .get(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, USER_IDENTIFIER));
+
+        doReturn(0L)
+                .when(setOperations)
+                .size(RedisKeys.userStatusSessionsKey(USER_IDENTIFIER));
+
+        SessionDisconnectEvent event = disconnectEvent();
+
+        // when
+        listener.handleDisconnectEvent(event);
+
+        // then
+        verify(eventPublisher).publishEvent(
+                new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER)
+        );
+
+        verify(redisPublisher).publish(
+                eq(StompDestinations.subscribeLobbyChat(LOBBY_CODE)),
+                any()
+        );
+
+        verify(setOperations).remove(
+                RedisKeys.userStatusSessionsKey(USER_IDENTIFIER),
+                WS_SESSION_ID
+        );
+
+        verify(redisTemplate).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+        verify(redisTemplate).delete(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, USER_IDENTIFIER));
+        verify(redisTemplate).delete(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, USER_IDENTIFIER));
+        verify(redisTemplate).delete(RedisKeys.userStatusKey(USER_IDENTIFIER));
+        verify(redisTemplate).delete(RedisKeys.userStatusSessionsKey(USER_IDENTIFIER));
+        verify(webSocketMetric).decrement();
+    }
+
+    @Test
+    @DisplayName("stale WebSocket 세션 DISCONNECT는 실제 퇴장 이벤트를 발행하지 않는다")
+    void doesNotPublishLeaveEventWhenStaleLobbySessionDisconnects() {
+        // given
+        String latestWsSessionId = "ws-session-latest";
+
+        doReturn(hashOperations).when(redisTemplate).opsForHash();
+        doReturn(setOperations).when(redisTemplate).opsForSet();
+        doReturn(valueOperations).when(redisTemplate).opsForValue();
+
+        doReturn(Map.of(WebSocketHeaders.SESSION_LOBBY_CODE, LOBBY_CODE))
+                .when(hashOperations)
+                .entries(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+
+        doReturn(latestWsSessionId)
+                .when(valueOperations)
+                .get(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, USER_IDENTIFIER));
+
+        SessionDisconnectEvent event = disconnectEvent();
+
+        // when
+        listener.handleDisconnectEvent(event);
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any(PlayerLeaveEvent.class));
+        verify(redisPublisher, never()).publish(anyString(), any());
+
+        verify(setOperations).remove(
+                RedisKeys.userStatusSessionsKey(USER_IDENTIFIER),
+                WS_SESSION_ID
+        );
+
+        verify(redisTemplate).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+        verify(redisTemplate, never()).delete(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, USER_IDENTIFIER));
+        verify(redisTemplate, never()).delete(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, USER_IDENTIFIER));
+        verify(webSocketMetric).decrement();
+    }
+
+    private SessionDisconnectEvent disconnectEvent() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+        accessor.setSessionId(WS_SESSION_ID);
+        accessor.setSessionAttributes(Map.of(
+                WebSocketHeaders.USER_IDENTIFIER,
+                USER_IDENTIFIER
+        ));
+
+        Message<byte[]> message = MessageBuilder.createMessage(
+                new byte[0],
+                accessor.getMessageHeaders()
+        );
+
+        return new SessionDisconnectEvent(
+                this,
+                message,
+                WS_SESSION_ID,
+                CloseStatus.SESSION_NOT_RELIABLE
+        );
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #94

## 📝 Summary

- 로비 퇴장 생명주기 핵심 흐름에 대한 테스트를 추가했습니다.
- 방장 퇴장 시 다음 순번 유저에게 방장이 위임되는지 검증했습니다.
- 일반 참가자 퇴장 시 `participants`, `order`, `ready` 상태가 정리되는지 검증했습니다.
- 마지막 유저 퇴장 시 Redis 로비 데이터와 public index가 삭제되는지 검증했습니다.
- 공개/비공개 로비 퇴장 시 public index 정합성이 유지되는지 검증했습니다.
- 강퇴된 유저의 후속 퇴장 요청이 로비 상태를 깨지 않는지 검증했습니다.
- 퇴장 이후 `canStart` 계산 정책이 올바르게 동작하는지 검증했습니다.
- WebSocket `DISCONNECT` 발생 시 `PlayerLeaveEvent`가 발행되고, 해당 이벤트가 실제 로비 퇴장 처리로 연결되는지 검증했습니다.

## 🙏PR point

- 이번 PR은 기능 코드 변경 없이 테스트 코드 추가 중심입니다.
- Redis/Lua 기반 로비 퇴장 흐름을 실제 Redis 상태 기준으로 검증하도록 작성했습니다.
- `LobbyLeaveLifecycleRepositoryTest`는 테스트 목적과 무관한 Flyway 검증 실패를 피하기 위해 테스트 클래스에서 `spring.flyway.enabled=false`를 설정했습니다.
- `canStart`는 실제 게임 시작 가능 여부를 확정하는 값이 아니라, 로비 상세 조회 시점의 시작 버튼 활성화용 snapshot 값이므로 `LobbyCanStartPolicyTest`에서 정책 단위로 검증했습니다.
- WebSocket 비정상 종료 흐름은 E2E STOMP 테스트가 아니라 `WebSocketEventListener`와 `LobbyLeaveEventHandler` 단위 테스트로 검증했습니다.

## 📬 Reference

- `leave_lobby.lua`
- `kick_lobby.lua`
- `LobbyRepository`
- `LobbyCanStartPolicy`
- `WebSocketEventListener`
- `LobbyLeaveEventHandler`