### PR TITLE
[Feat/#74] 맵 목록 검색 및 내 맵 조회 API 구현

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
@@ -2,7 +2,7 @@ package io.github.ascrew.monomatbe.domain.map.controller;
 
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
-import io.github.ascrew.monomatbe.domain.map.dto.PublicMapPageResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.MapPageResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.MapSortType;
@@ -36,7 +36,7 @@ public class MapController {
 
     @Operation(summary = "공개 맵 목록 조회")
     @GetMapping
-    public ResponseEntity<PublicMapPageResponse> getPublicMaps(
+    public ResponseEntity<MapPageResponse> getPublicMaps(
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "20") Integer size,
             @RequestParam(required = false) String keyword,
@@ -49,7 +49,7 @@ public class MapController {
     @Operation(summary = "내 맵 목록 조회", description = "로그인한 사용자의 공개/비공개 맵을 모두 조회합니다.")
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<PublicMapPageResponse> getMyMaps(
+    public ResponseEntity<MapPageResponse> getMyMaps(
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "20") Integer size,
             @AuthenticationPrincipal CustomPrincipal principal

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
@@ -4,6 +4,8 @@ import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.PublicMapPageResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.MapSortType;
 import io.github.ascrew.monomatbe.domain.map.service.MapService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,9 +38,23 @@ public class MapController {
     @GetMapping
     public ResponseEntity<PublicMapPageResponse> getPublicMaps(
             @RequestParam(defaultValue = "0") Integer page,
-            @RequestParam(defaultValue = "20") Integer size
+            @RequestParam(defaultValue = "20") Integer size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) MapCategory category,
+            @RequestParam(required = false) MapSortType sort
     ) {
-        return ResponseEntity.ok(mapService.getPublicMaps(page, size));
+        return ResponseEntity.ok(mapService.getPublicMaps(page, size, keyword, category, sort));
+    }
+
+    @Operation(summary = "내 맵 목록 조회", description = "로그인한 사용자의 공개/비공개 맵을 모두 조회합니다.")
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<PublicMapPageResponse> getMyMaps(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        return ResponseEntity.ok(mapService.getMyMaps(page, size, principal));
     }
 
     @Operation(summary = "공개 맵 단건 조회")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapPageResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapPageResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record PublicMapPageResponse(
+public record MapPageResponse(
         List<MapSummaryResponse> content,
         int page,
         int size,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapSummaryResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapSummaryResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record MapSummaryResponse(
-        Long id,
+        Long mapId,
         String title,
         MapCategory category,
         int numOfSong,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapSortType.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapSortType.java
@@ -1,0 +1,16 @@
+package io.github.ascrew.monomatbe.domain.map.entity;
+
+public enum MapSortType {
+
+    /** 최신순 (updatedAt DESC, 기본값) */
+    NEWEST,
+
+    /** 오래된 순 (updatedAt ASC) */
+    OLDEST,
+
+    /** 곡 수 많은 순 (numOfSong DESC) */
+    MOST_SONGS,
+
+    /** 제목 오름차순 (title ASC) */
+    TITLE_ASC
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
@@ -4,10 +4,12 @@ import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 
-public interface QuizMapJpaRepository extends JpaRepository<QuizMap, Long> {
+public interface QuizMapJpaRepository
+        extends JpaRepository<QuizMap, Long>, JpaSpecificationExecutor<QuizMap> {
 
     Page<QuizMap> findAllByIsDeletedFalseAndIsPublicTrue(Pageable pageable);
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
@@ -29,7 +29,7 @@ public class QuizMapSpecification {
         if (keyword == null || keyword.isBlank()) {
             return null;
         }
-        String pattern = "%" + keyword.toLowerCase() + "%";
+        String pattern = "%" + keyword + "%";
         return (root, query, cb) ->
                 cb.like(cb.lower(root.get("title")), pattern);
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
@@ -1,0 +1,44 @@
+package io.github.ascrew.monomatbe.domain.map.repository;
+
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import org.springframework.data.jpa.domain.Specification;
+
+public class QuizMapSpecification {
+
+    private QuizMapSpecification() {}
+
+    /** is_public=true, is_deleted=false */
+    public static Specification<QuizMap> isPublicAndNotDeleted() {
+        return (root, query, cb) -> cb.and(
+                cb.isTrue(root.get("isPublic")),
+                cb.isFalse(root.get("isDeleted"))
+        );
+    }
+
+    /** owner_id=userId, is_deleted=false */
+    public static Specification<QuizMap> ownedByAndNotDeleted(Long userId) {
+        return (root, query, cb) -> cb.and(
+                cb.equal(root.get("owner").get("id"), userId),
+                cb.isFalse(root.get("isDeleted"))
+        );
+    }
+
+    /** title LIKE %keyword% (null/blank → null → no-op) */
+    public static Specification<QuizMap> withKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        String pattern = "%" + keyword.toLowerCase() + "%";
+        return (root, query, cb) ->
+                cb.like(cb.lower(root.get("title")), pattern);
+    }
+
+    /** category = ? (null → null → no-op) */
+    public static Specification<QuizMap> withCategory(MapCategory category) {
+        if (category == null) {
+            return null;
+        }
+        return (root, query, cb) -> cb.equal(root.get("category"), category);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -8,8 +8,12 @@ import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.PublicMapPageResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.MapSortType;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapSpecification;
+import org.springframework.data.jpa.domain.Specification;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.extern.slf4j.Slf4j;
@@ -67,18 +71,25 @@ public class MapService {
         this.jsonMapper = jsonMapper;
     }
 
-    // 공개된 맵 목록을 페이징하여 조회합니다. Redis 캐싱을 적용합니다.
+    // 공개된 맵 목록을 검색 조건과 함께 페이징하여 조회합니다. Redis 캐싱을 적용합니다.
     @Transactional(readOnly = true)
-    public PublicMapPageResponse getPublicMaps(Integer page, Integer size) {
-        // 파라미터 정규화 및 유효성 검사
+    public PublicMapPageResponse getPublicMaps(
+            Integer page, Integer size, String keyword, MapCategory category, MapSortType sort
+    ) {
         int normalizedPage = page == null || page < 0 ? DEFAULT_PAGE : page;
         int normalizedSize = size == null || size <= 0 ? DEFAULT_SIZE : Math.min(size, MAX_SIZE);
+        MapSortType normalizedSort = sort == null ? MapSortType.NEWEST : sort;
 
-        // 캐시 키 생성 및 조회
         String version = getPublicListCacheVersion();
-        String cacheKey = RedisKeys.mapPublicListKey(version, normalizedPage, normalizedSize);
+        String cacheKey = RedisKeys.mapPublicListKey(
+                version,
+                keyword,
+                category == null ? null : category.name(),
+                normalizedSort.name(),
+                normalizedPage,
+                normalizedSize
+        );
 
-        // 캐시 조회/역직렬화 실패는 DB fallback으로 처리합니다.
         try {
             String cachedValue = redisTemplate.opsForValue().get(cacheKey);
             if (cachedValue != null) {
@@ -97,14 +108,13 @@ public class MapService {
             log.warn("공개 맵 목록 캐시 조회 실패 - key: {}. DB fallback", cacheKey, e);
         }
 
-        // 캐시 미스 시 DB에서 데이터 조회
-        Pageable pageable = PageRequest.of(
-                normalizedPage,
-                normalizedSize,
-                Sort.by(Sort.Direction.DESC, "updatedAt")
-        );
+        Specification<QuizMap> spec = Specification
+                .where(QuizMapSpecification.isPublicAndNotDeleted())
+                .and(QuizMapSpecification.withKeyword(keyword))
+                .and(QuizMapSpecification.withCategory(category));
 
-        Page<QuizMap> pageResult = quizMapJpaRepository.findAllByIsDeletedFalseAndIsPublicTrue(pageable);
+        Pageable pageable = PageRequest.of(normalizedPage, normalizedSize, toSort(normalizedSort));
+        Page<QuizMap> pageResult = quizMapJpaRepository.findAll(spec, pageable);
 
         List<MapSummaryResponse> content = pageResult.getContent()
                 .stream()
@@ -123,6 +133,41 @@ public class MapService {
         safeWriteCache(cacheKey, response);
 
         return response;
+    }
+
+    // 로그인한 사용자의 맵 목록(공개/비공개 모두, 삭제 제외)을 페이징하여 조회합니다.
+    // 개인 데이터이므로 Redis 캐시를 적용하지 않습니다.
+    @Transactional(readOnly = true)
+    public PublicMapPageResponse getMyMaps(Integer page, Integer size, CustomPrincipal principal) {
+        validatePrincipal(principal);
+
+        int normalizedPage = page == null || page < 0 ? DEFAULT_PAGE : page;
+        int normalizedSize = size == null || size <= 0 ? DEFAULT_SIZE : Math.min(size, MAX_SIZE);
+
+        Specification<QuizMap> spec =
+                QuizMapSpecification.ownedByAndNotDeleted(principal.userId());
+
+        Pageable pageable = PageRequest.of(
+                normalizedPage,
+                normalizedSize,
+                Sort.by(Sort.Direction.DESC, "updatedAt")
+        );
+
+        Page<QuizMap> pageResult = quizMapJpaRepository.findAll(spec, pageable);
+
+        List<MapSummaryResponse> content = pageResult.getContent()
+                .stream()
+                .map(this::toSummaryResponse)
+                .toList();
+
+        return PublicMapPageResponse.builder()
+                .content(content)
+                .page(pageResult.getNumber())
+                .size(pageResult.getSize())
+                .totalElements(pageResult.getTotalElements())
+                .totalPages(pageResult.getTotalPages())
+                .hasNext(pageResult.hasNext())
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -311,6 +356,15 @@ public class MapService {
         } catch (Exception e) {
             log.warn("손상 캐시 삭제 실패 - key: {}", key, e);
         }
+    }
+
+    private Sort toSort(MapSortType sort) {
+        return switch (sort) {
+            case NEWEST     -> Sort.by(Sort.Direction.DESC, "updatedAt");
+            case OLDEST     -> Sort.by(Sort.Direction.ASC,  "updatedAt");
+            case MOST_SONGS -> Sort.by(Sort.Direction.DESC, "numOfSong");
+            case TITLE_ASC  -> Sort.by(Sort.Direction.ASC,  "title");
+        };
     }
 
     private MapSummaryResponse toSummaryResponse(QuizMap quizMap) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -71,7 +71,8 @@ public class MapService {
         this.jsonMapper = jsonMapper;
     }
 
-    // 공개된 맵 목록을 검색 조건과 함께 페이징하여 조회합니다. Redis 캐싱을 적용합니다.
+    // 공개된 맵 목록을 검색 조건과 함께 페이징하여 조회합니다.
+    // keyword 없는 경우에만 Redis 캐싱을 적용합니다 (keyword 검색은 무한 조합으로 캐시 효율이 낮음).
     @Transactional(readOnly = true)
     public PublicMapPageResponse getPublicMaps(
             Integer page, Integer size, String keyword, MapCategory category, MapSortType sort
@@ -80,10 +81,18 @@ public class MapService {
         int normalizedSize = size == null || size <= 0 ? DEFAULT_SIZE : Math.min(size, MAX_SIZE);
         MapSortType normalizedSort = sort == null ? MapSortType.NEWEST : sort;
 
+        String normalizedKeyword = (keyword == null || keyword.isBlank())
+                ? null
+                : keyword.trim().toLowerCase();
+
+        if (normalizedKeyword != null) {
+            return queryPublicMaps(normalizedKeyword, category, normalizedPage, normalizedSize, normalizedSort);
+        }
+
         String version = getPublicListCacheVersion();
         String cacheKey = RedisKeys.mapPublicListKey(
                 version,
-                keyword,
+                null,
                 category == null ? null : category.name(),
                 normalizedSort.name(),
                 normalizedPage,
@@ -108,12 +117,23 @@ public class MapService {
             log.warn("공개 맵 목록 캐시 조회 실패 - key: {}. DB fallback", cacheKey, e);
         }
 
+        PublicMapPageResponse response =
+                queryPublicMaps(null, category, normalizedPage, normalizedSize, normalizedSort);
+
+        safeWriteCache(cacheKey, response);
+
+        return response;
+    }
+
+    private PublicMapPageResponse queryPublicMaps(
+            String keyword, MapCategory category, int page, int size, MapSortType sort
+    ) {
         Specification<QuizMap> spec = Specification
                 .where(QuizMapSpecification.isPublicAndNotDeleted())
                 .and(QuizMapSpecification.withKeyword(keyword))
                 .and(QuizMapSpecification.withCategory(category));
 
-        Pageable pageable = PageRequest.of(normalizedPage, normalizedSize, toSort(normalizedSort));
+        Pageable pageable = PageRequest.of(page, size, toSort(sort));
         Page<QuizMap> pageResult = quizMapJpaRepository.findAll(spec, pageable);
 
         List<MapSummaryResponse> content = pageResult.getContent()
@@ -121,7 +141,7 @@ public class MapService {
                 .map(this::toSummaryResponse)
                 .toList();
 
-        PublicMapPageResponse response = PublicMapPageResponse.builder()
+        return PublicMapPageResponse.builder()
                 .content(content)
                 .page(pageResult.getNumber())
                 .size(pageResult.getSize())
@@ -129,10 +149,6 @@ public class MapService {
                 .totalPages(pageResult.getTotalPages())
                 .hasNext(pageResult.hasNext())
                 .build();
-
-        safeWriteCache(cacheKey, response);
-
-        return response;
     }
 
     // 로그인한 사용자의 맵 목록(공개/비공개 모두, 삭제 제외)을 페이징하여 조회합니다.
@@ -369,7 +385,7 @@ public class MapService {
 
     private MapSummaryResponse toSummaryResponse(QuizMap quizMap) {
         return MapSummaryResponse.builder()
-                .id(quizMap.getId())
+                .mapId(quizMap.getId())
                 .title(quizMap.getTitle())
                 .category(quizMap.getCategory())
                 .numOfSong(quizMap.getNumOfSong())

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -6,7 +6,7 @@ import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
-import io.github.ascrew.monomatbe.domain.map.dto.PublicMapPageResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.MapPageResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.MapSortType;
@@ -74,7 +74,7 @@ public class MapService {
     // 공개된 맵 목록을 검색 조건과 함께 페이징하여 조회합니다.
     // keyword 없는 경우에만 Redis 캐싱을 적용합니다 (keyword 검색은 무한 조합으로 캐시 효율이 낮음).
     @Transactional(readOnly = true)
-    public PublicMapPageResponse getPublicMaps(
+    public MapPageResponse getPublicMaps(
             Integer page, Integer size, String keyword, MapCategory category, MapSortType sort
     ) {
         int normalizedPage = page == null || page < 0 ? DEFAULT_PAGE : page;
@@ -105,7 +105,7 @@ public class MapService {
                 try {
                     return jsonMapper.readValue(
                             cachedValue,
-                            new TypeReference<PublicMapPageResponse>() {
+                            new TypeReference<MapPageResponse>() {
                             }
                     );
                 } catch (Exception e) {
@@ -117,7 +117,7 @@ public class MapService {
             log.warn("공개 맵 목록 캐시 조회 실패 - key: {}. DB fallback", cacheKey, e);
         }
 
-        PublicMapPageResponse response =
+        MapPageResponse response =
                 queryPublicMaps(null, category, normalizedPage, normalizedSize, normalizedSort);
 
         safeWriteCache(cacheKey, response);
@@ -125,7 +125,7 @@ public class MapService {
         return response;
     }
 
-    private PublicMapPageResponse queryPublicMaps(
+    private MapPageResponse queryPublicMaps(
             String keyword, MapCategory category, int page, int size, MapSortType sort
     ) {
         Specification<QuizMap> spec = Specification
@@ -141,7 +141,7 @@ public class MapService {
                 .map(this::toSummaryResponse)
                 .toList();
 
-        return PublicMapPageResponse.builder()
+        return MapPageResponse.builder()
                 .content(content)
                 .page(pageResult.getNumber())
                 .size(pageResult.getSize())
@@ -154,7 +154,7 @@ public class MapService {
     // 로그인한 사용자의 맵 목록(공개/비공개 모두, 삭제 제외)을 페이징하여 조회합니다.
     // 개인 데이터이므로 Redis 캐시를 적용하지 않습니다.
     @Transactional(readOnly = true)
-    public PublicMapPageResponse getMyMaps(Integer page, Integer size, CustomPrincipal principal) {
+    public MapPageResponse getMyMaps(Integer page, Integer size, CustomPrincipal principal) {
         validatePrincipal(principal);
 
         int normalizedPage = page == null || page < 0 ? DEFAULT_PAGE : page;
@@ -176,7 +176,7 @@ public class MapService {
                 .map(this::toSummaryResponse)
                 .toList();
 
-        return PublicMapPageResponse.builder()
+        return MapPageResponse.builder()
                 .content(content)
                 .page(pageResult.getNumber())
                 .size(pageResult.getSize())

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -488,6 +488,31 @@ public final class RedisKeys {
     }
 
     /**
+     * 검색 조건이 포함된 공개 맵 목록 캐시 키를 반환합니다.
+     *
+     * <p>버전 기반 무효화 정책이 유지되므로 {@link #mapPublicListVersionKey()} 버전 증가 시
+     * 이 키로 저장된 모든 캐시도 함께 무효화됩니다.
+     *
+     * @param version  캐시 버전
+     * @param keyword  제목 검색어 (null 또는 빈 문자열 허용)
+     * @param category 카테고리 이름 (null 허용)
+     * @param sort     정렬 기준 이름 (null 허용)
+     * @param page     페이지 번호
+     * @param size     페이지 크기
+     * @return "map:public:list:v:{version}:k:{keyword}:c:{category}:sort:{sort}:p:{page}:s:{size}"
+     */
+    public static String mapPublicListKey(
+            String version, String keyword, String category, String sort, int page, int size) {
+        return MAP_PUBLIC_LIST_PREFIX
+                + ":v:" + version
+                + ":k:" + (keyword == null ? "" : keyword)
+                + ":c:" + (category == null ? "" : category)
+                + ":sort:" + (sort == null ? "" : sort)
+                + ":p:" + page
+                + ":s:" + size;
+    }
+
+    /**
      * 공개 맵 단건 캐시 키를 반환합니다.
      *
      * @param mapId 맵 ID


### PR DESCRIPTION
## 📣 Related Issue
- #74

## 📝 Summary
- `GET /api/maps`에 `keyword`(제목 검색), `category`(카테고리 필터), `sort`(정렬 기준) 파라미터 추가
- `GET /api/maps/me` 신규 엔드포인트 구현 — 로그인 사용자의 공개/비공개 맵 전체 조회
- JPA Specification 도입(`QuizMapSpecification`)으로 동적 조건 조합 처리
- `MapSortType` enum 추가 (NEWEST / OLDEST / MOST_SONGS / TITLE_ASC)
- 검색 조건이 포함된 Redis 캐시 키 확장, 기존 버전 기반 무효화 정책과 충돌 없음
- `/api/maps/me`는 개인 데이터이므로 Redis 캐시 미적용

## 🙏PR point
- 공개 맵 검색 결과도 Redis에 캐싱합니다. keyword × category × sort 조합만큼 캐시 키가 늘어날 수 있으나, TTL 5분 + 버전 기반 일괄 무효화로 관리 가능하다고 판단했습니다. 다른 전략이 있으면 의견 주세요.
- `QuizMapJpaRepository`가 `JpaSpecificationExecutor`를 새로 상속합니다. 기존 메서드명 기반 쿼리는 그대로 유지됩니다.
- `GET /api/maps/me`는 `@PreAuthorize("isAuthenticated()")` 적용, 미인증 시 401 반환합니다.

## 📬 Reference
- Closes #74