### PR TITLE
main 브랜치 OCI 백엔드 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-backend-main.yml
+++ b/.github/workflows/deploy-backend-main.yml
@@ -1,0 +1,56 @@
+name: Deploy Backend Main to OCI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy backend main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to OCI via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          username: ${{ secrets.OCI_USER }}
+          key: ${{ secrets.OCI_SSH_KEY }}
+          port: ${{ secrets.OCI_SSH_PORT || 22 }}
+          script_stop: true
+          script: |
+            set -e
+
+            APP_DIR="${{ secrets.OCI_APP_DIR }}"
+            IMAGE_NAME="monomat-be:latest"
+            CONTAINER_NAME="monomat-be"
+
+            cd "$APP_DIR"
+
+            git fetch origin
+            git checkout main
+            git pull origin main
+
+            sudo docker build -t "$IMAGE_NAME" .
+
+            sudo docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+            sudo docker run -d \
+              --name "$CONTAINER_NAME" \
+              --network monomat-network \
+              --add-host=host.docker.internal:host-gateway \
+              --env-file .env \
+              -p 8080:8080 \
+              --restart unless-stopped \
+              "$IMAGE_NAME"
+
+            sleep 40
+
+            sudo docker ps | grep "$CONTAINER_NAME"
+            curl -f http://localhost:8080/actuator/health


### PR DESCRIPTION
## 📣 Related Issue

- close 없음

## 📝 Summary

- main 브랜치 push 시 OCI 백엔드 서버에 자동 배포되는 GitHub Actions 워크플로우를 추가했습니다.
- Actions는 SSH로 OCI 서버에 접속한 뒤 main 브랜치를 pull하고 Docker 이미지를 재빌드합니다.
- 기존 monomat-be 컨테이너를 재생성한 뒤 `/actuator/health`로 배포 상태를 검증합니다.

## 🙏PR point

- OCI 서버의 `.env` 파일은 GitHub에 올리지 않고 서버 로컬 파일을 그대로 사용합니다.
- main 브랜치에 merge되는 순간 OCI 서버가 자동 갱신됩니다.
- 현재 OCI 서버는 dev 프로필로 동작 중이므로 `/actuator/health` health check가 가능합니다.
- 추후 prod 전환 시 `/actuator/health`만 permitAll 처리하지 않으면 health check가 실패할 수 있습니다.

## 📬 Reference

- OCI 서버 수동 배포 검증 완료
- Docker build / run / Swagger / Actuator health 확인 완료