### PR TITLE
[Feat/#95] 로비 채팅 제한 및 메시지 타입 계약 정리

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,8 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   ├── controller/
 │   │   │   └── ChatController.java
 │   │   └── service/
-│   │       └── ChatService.java
+│   │       ├── ChatService.java
+│   │       └── LobbyChatRateLimitService.java       # Redis 기반 로비 채팅 제한 정책
 │   │
 │   ├── lobby/                                      # 로비 도메인
 │   │   ├── KickLobbyResult.java
@@ -57,6 +58,7 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   ├── LobbyRedisDto.java
 │   │   │   ├── LobbySearchCondition.java
 │   │   │   ├── LobbySortType.java
+│   │   │   ├── UpdateLobbyMapRequest.java
 │   │   │   └── UpdateLobbyReadyRequest.java
 │   │   ├── entity/
 │   │   │   ├── GameLobby.java
@@ -67,6 +69,7 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   ├── LobbyRepository.java
 │   │   │   ├── LobbyRepositoryImpl.java
 │   │   │   └── redis/
+│   │   │       ├── LobbyInviteCodeGenerator.java
 │   │   │       ├── LobbyLuaScriptExecutor.java
 │   │   │       ├── LobbyLuaResultMapper.java
 │   │   │       ├── LobbyRedisCommandRepository.java
@@ -76,10 +79,15 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │       ├── LobbyCanStartPolicy.java
 │   │       ├── LobbyCreateService.java
 │   │       ├── LobbyJoinService.java
+│   │       ├── LobbyLeaveEventHandler.java
+│   │       ├── LobbyMapPolicy.java
+│   │       ├── LobbyMapUpdateService.java
+│   │       ├── LobbyPlayerNicknameResolver.java
 │   │       ├── LobbyQueryService.java
 │   │       ├── LobbyReadyService.java
-│   │       ├── LobbyStartService.java
 │   │       ├── LobbyRealtimeNotifier.java
+│   │       ├── LobbyStartPolicy.java
+│   │       ├── LobbyStartService.java
 │   │       └── LobbyStartReconciliationService.java
 │   │
 │   ├── map/                                        # 퀴즈 맵 도메인
@@ -89,11 +97,31 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   │   └── ...
 │   │   ├── entity/
 │   │   │   ├── QuizMap.java
+│   │   │   ├── MapItem.java
 │   │   │   └── MapCategory.java
 │   │   ├── repository/
-│   │   │   └── QuizMapJpaRepository.java
+│   │   │   ├── QuizMapJpaRepository.java
+│   │   │   └── MapItemJpaRepository.java
 │   │   └── service/
-│   │       └── MapService.java
+│   │       ├── MapService.java
+│   │       ├── MapCacheEvictor.java
+│   │       ├── MapItemPersistenceService.java
+│   │       └── MapPublicationValidator.java
+│   │
+│   ├── youtube/                                    # YouTube oEmbed 검증 도메인
+│   │   ├── client/
+│   │   │   └── YoutubeOEmbedClient.java
+│   │   ├── model/
+│   │   │   └── YoutubeMetadata.java
+│   │   └── service/
+│   │       └── YoutubeValidationService.java
+│   │
+│   ├── report/                                     # 신고 도메인
+│   │   ├── controller/
+│   │   ├── dto/
+│   │   ├── entity/
+│   │   ├── repository/
+│   │   └── service/
 │   │
 │   └── game/                                       # 인게임 도메인
 │       ├── controller/
@@ -168,7 +196,7 @@ global  →  domain  (금지)
 global/WebSocketEventListener
     │ publishEvent(PlayerLeaveEvent)
     ▼
-domain/LobbyEventService @EventListener
+domain/LobbyLeaveEventHandler @EventListener
 ```
 
 ### 도메인 간 의존 규칙
@@ -255,10 +283,21 @@ Redis
 ChatController
     ▼
 ChatService
-    │ sender 위변조 방지
-    │ 클라이언트 sender 무시, 세션 식별자로 교체
-    ▼
-RedisPublisher.publish()
+    │ 1. STOMP 세션에서 userIdentifier 추출
+    │ 2. 클라이언트 sender / roomId / timestamp 무시
+    │ 3. content null / blank / length 검증
+    │ 4. 일반 사용자 메시지는 CHAT 타입만 허용
+    │
+    ├─ [global chat]
+    │      RedisPublisher.publish(/topic/chat/global)
+    │
+    └─ [lobby chat]
+           1. 로비 존재 여부 검증
+           2. 강퇴 유저 차단
+           3. 로비 참여자 여부 검증
+           4. Redis 기반 쿨타임 검증
+           5. Redis 기반 반복 메시지 검증
+           6. RedisPublisher.publish(/topic/lobby/{code})
     ▼
 Redis Pub/Sub
     ▼
@@ -267,6 +306,142 @@ RedisSubscriber.onMessage()
 SimpMessagingTemplate.convertAndSend()
     ▼
 클라이언트
+```
+
+#### 로비 채팅 송신 destination
+
+| 구분 | STOMP destination | 설명 |
+| --- | --- | --- |
+| 전체 채팅 송신 | `/app/chat/global` | 전체 채팅 메시지 송신 |
+| 로비 채팅 송신 | `/app/chat/lobby/{code}` | 특정 로비 채팅 메시지 송신 |
+
+#### 로비 채팅 수신 destination
+
+| 구분 | STOMP destination | 설명 |
+| --- | --- | --- |
+| 전체 채팅 수신 | `/topic/chat/global` | 전체 채팅 메시지 수신 |
+| 로비 채팅 수신 | `/topic/lobby/{code}` | 로비 채팅 및 로비 시스템 메시지 수신 |
+| 로비 정보 refresh | `/topic/lobby/{code}/refresh` | 로비 상세 정보 재조회 신호 |
+| 게임 시작 이벤트 | `/topic/lobby/{code}/game` | 대기실 → 인게임 전환 신호 |
+
+#### 클라이언트 송신 payload
+
+클라이언트는 일반 채팅만 보낼 수 있습니다.
+
+```json
+{
+  "type": "CHAT",
+  "content": "안녕하세요"
+}
+```
+
+서버는 클라이언트가 보낸 `sender`, `roomId`, `timestamp`를 신뢰하지 않습니다.  
+해당 값들은 서버에서 다음 기준으로 다시 구성합니다.
+
+| 필드 | 서버 처리 |
+| --- | --- |
+| `type` | 일반 사용자 송신은 `CHAT`만 허용 |
+| `roomId` | STOMP destination의 `{code}` 또는 `"global"` 값으로 덮어씀 |
+| `sender` | STOMP 세션의 `userIdentifier`로 덮어씀 |
+| `content` | trim 후 blank / length 검증 |
+| `timestamp` | 서버 시각으로 생성 |
+
+#### 서버 송신 payload 공통 구조
+
+```json
+{
+  "type": "CHAT",
+  "roomId": "ABC123",
+  "sender": "user-identifier",
+  "content": "안녕하세요",
+  "timestamp": "2026-05-26T12:00:00"
+}
+```
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `type` | string | 메시지 타입 |
+| `roomId` | string | `"global"` 또는 로비 코드 |
+| `sender` | string | 메시지 주체 userIdentifier |
+| `content` | string | 표시할 메시지 본문 |
+| `timestamp` | string | 서버 발행 시각 |
+
+#### 메시지 타입 계약
+
+| type | 발행 주체 | destination | 설명 | FE 처리 기준 |
+| --- | --- | --- | --- | --- |
+| `CHAT` | 사용자 | `/topic/chat/global`, `/topic/lobby/{code}` | 일반 채팅 | 일반 말풍선 |
+| `SYSTEM` | 서버 | `/topic/lobby/{code}` | 범용 시스템 안내 | 시스템 안내 스타일 |
+| `ENTER` | 서버 | `/topic/lobby/{code}` | 로비 입장 알림 | 입장 안내 |
+| `LEAVE` | 서버 | `/topic/lobby/{code}` | 로비 퇴장 알림 | 퇴장 안내 |
+| `KICK` | 서버 | `/topic/lobby/{code}` | 강퇴 알림 | 강퇴 안내 또는 모달 |
+| `READY_CHANGED` | 서버 | `/topic/lobby/{code}` | ready 상태 변경 알림 | ready 변경 안내 |
+| `HOST_CHANGED` | 서버 | `/topic/lobby/{code}` | 방장 위임 알림 | 방장 변경 안내 |
+
+FE는 `content` 문자열을 파싱하지 않습니다.  
+화면 분기는 반드시 `type` 기준으로 처리합니다.
+
+#### 로비 채팅 검증 정책
+
+로비 채팅은 다음 조건을 모두 만족해야 전송됩니다.
+
+| 검증 | 실패 시 처리 |
+| --- | --- |
+| 로비가 Redis에 존재해야 함 | 404 |
+| 송신자가 `lobby:{code}:kicked`에 없어야 함 | 403 |
+| 송신자가 `lobby:{code}:participants`에 있어야 함 | 403 |
+| `content`가 null 또는 blank가 아니어야 함 | 400 |
+| `content`가 500자 이하여야 함 | 400 |
+| 사용자 송신 타입은 `CHAT`이어야 함 | 400 |
+| 1초 쿨타임을 통과해야 함 | 429 |
+| 5초 이내 동일 메시지 반복이 아니어야 함 | 429 |
+
+#### 로비 채팅 제한 Redis Key
+
+| Redis Key | Type | Value | TTL | 설명 |
+| --- | --- | --- | --- | --- |
+| `chat:lobby:{code}:cooldown:{userIdentifier}` | String | `"1"` | 1초 | 같은 사용자의 로비 채팅 연속 전송 제한 |
+| `chat:lobby:{code}:recent:{userIdentifier}` | String | SHA-256(content) | 5초 | 같은 메시지 단기 반복 전송 제한 |
+
+반복 메시지 제한은 원문이 아니라 SHA-256 해시를 저장합니다.  
+채팅 본문에 개인정보가 포함될 수 있으므로 제한 검증 목적에는 해시만 저장합니다.
+
+#### 서버 시스템 메시지 예시
+
+READY_CHANGED:
+
+```json
+{
+  "type": "READY_CHANGED",
+  "roomId": "ABC123",
+  "sender": "user-identifier",
+  "content": "user-identifier님이 준비 완료 상태로 변경했습니다.",
+  "timestamp": "2026-05-26T12:00:00"
+}
+```
+
+HOST_CHANGED:
+
+```json
+{
+  "type": "HOST_CHANGED",
+  "roomId": "ABC123",
+  "sender": "new-host-identifier",
+  "content": "new-host-identifier님이 새로운 방장이 되었습니다.",
+  "timestamp": "2026-05-26T12:00:00"
+}
+```
+
+KICK:
+
+```json
+{
+  "type": "KICK",
+  "roomId": "ABC123",
+  "sender": "target-user-identifier",
+  "content": "target-user-identifier님이 강퇴되었습니다.",
+  "timestamp": "2026-05-26T12:00:00"
+}
 ```
 
 ---
@@ -398,11 +573,11 @@ WebSocketEventListener.handleDisconnectEvent()
     │ 4. LEAVE 메시지 브로드캐스트
     │ 5. Redis 키 정리
     ▼
-LobbyEventService.handlePlayerLeave(@EventListener)
+LobbyLeaveEventHandler.handlePlayerLeave(@EventListener)
     ▼
 leave_lobby.lua
     ├── DESTROYED → 전역 로비 리스트 새로고침
-    ├── DELEGATED → 로비 내부 새로고침
+    ├── DELEGATED → HOST_CHANGED 메시지 브로드캐스트 + 로비 내부 새로고침
     └── LEFT      → 로비 내부 새로고침
 ```
 
@@ -458,9 +633,10 @@ LobbyEventService.handleKickSuccess()
 LobbyStartService
     │ 1. 인증 정보 확인
     │ 2. Redis 로비 존재 여부 확인
-    │ 3. DB GAME_LOBBY 스냅샷 조회
+    │ 3. DB GAME_LOBBY 스냅샷 조회 및 PESSIMISTIC_WRITE 락 획득
     │ 4. 선택된 맵 존재/삭제 여부 확인
     │ 5. 맵 문제 수 >= roundCount 검증
+    │ 6. 트랜잭션 동기화 활성 여부 확인
     ▼
 LobbyRepositoryImpl.executeStartLobbyProcess()
     │ 1. start_lobby.lua 실행 전 stale ready 데이터 정리
@@ -480,12 +656,18 @@ start_lobby.lua
     ▼
 DB GAME_LOBBY.status = PLAYING 저장
     ▼
+GameSessionCreateService.createGameSession()
+    ├── MapItem 조회 및 셔플
+    ├── DB GameSession, GameSessionPlayer 스냅샷 생성
+    └── init_game_session.lua 로 Redis 인게임 세션 초기화
+    ▼
 afterCommit
     ├── /topic/lobby/{code}/game → GAME_STARTED
+    ├── /topic/lobby/{code}/refresh → REFRESH_LOBBY_INFO
     └── /topic/game/{code}/round → RoundStartDto
 ```
 
-`GAME_STARTED` 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.  
+`GAME_STARTED` 이벤트와 첫 라운드 이벤트는 DB 트랜잭션 커밋 이후에만 발행합니다.  
 트랜잭션 동기화가 비활성인 경우 즉시 발행하지 않고 서버 오류로 처리하여 DB 커밋 전 이벤트 발행을 방지합니다.
 
 ---
@@ -533,14 +715,23 @@ GameRealtimeNotifier / LobbyRealtimeNotifier
 | `lobby:public:most_players` | ZSET | 공개 로비 현재 인원순 정렬 인덱스 |
 | `lobby:public:most_available` | ZSET | 공개 로비 빈자리순 정렬 인덱스 |
 | `lobby:start:reconciliation` | List | 게임 시작 Redis-DB 상태 불일치 재처리 큐 |
+| `chat:lobby:{code}:cooldown:{userIdentifier}` | String | 로비 채팅 쿨타임 제한 |
+| `chat:lobby:{code}:recent:{userIdentifier}` | String | 로비 채팅 동일 메시지 반복 제한 |
 | `auth:guest:session:{token}` | Hash | 게스트 세션 정보 |
 | `auth:refresh:{sessionId}` | String | Refresh Token |
+| `auth:session:active:{sessionId}` | String | 활성 세션 |
+| `auth:blacklist:access:{accessTokenHash}` | String | Access Token 블랙리스트 |
 | `user_status:{userIdentifier}` | String | 사용자 온라인 상태 |
 | `user_status:{userIdentifier}:sessions` | Set | 사용자별 활성 WebSocket 세션 목록 |
 | `ws:connection:{wsSessionId}` | Hash | WebSocket 세션 → userId, lobbyCode 매핑 |
 | `map:public:list:v:{version}:p:{page}:s:{size}` | String | 공개 맵 목록 페이지 캐시 |
 | `map:public:{mapId}` | String | 공개 맵 단건 캐시 |
 | `map:public:list:version` | String | 공개 맵 목록 캐시 버전 |
+| `youtube:oembed:success:{videoId}` | String | YouTube oEmbed 성공 캐시 |
+| `youtube:oembed:failure:{videoId}` | String | YouTube oEmbed 실패 negative cache |
+| `game:session:{lobbyCode}` | Hash | 인게임 세션 메타데이터 |
+| `game:session:{lobbyCode}:rounds` | List | 출제된 라운드 목록 |
+| `game:session:{lobbyCode}:players` | Hash | 인게임 플레이어 점수 |
 
 ### `lobby:{code}` Hash 구조
 
@@ -575,9 +766,10 @@ lobby:{code}:ready
 1. 방장은 ready 대상에서 제외한다.
 2. 일반 참여자만 ready 상태를 변경할 수 있다.
 3. ready 변경은 PATCH /api/lobbies/{code}/ready에서 처리한다.
-4. ready 변경 성공 시 /topic/lobby/{code}/refresh로 REFRESH_LOBBY_INFO를 브로드캐스트한다.
-5. 퇴장/강퇴 시 ready Set에서 해당 userIdentifier를 제거한다.
-6. 게임 시작 직전 ready Set에는 있지만 participants Set에는 없는 stale ready 데이터를 정리한다.
+4. ready 변경 성공 시 /topic/lobby/{code}로 READY_CHANGED 시스템 메시지를 브로드캐스트한다.
+5. ready 변경 성공 시 /topic/lobby/{code}/refresh로 REFRESH_LOBBY_INFO를 브로드캐스트한다.
+6. 퇴장/강퇴 시 ready Set에서 해당 userIdentifier를 제거한다.
+7. 게임 시작 직전 ready Set에는 있지만 participants Set에는 없는 stale ready 데이터를 정리한다.
 ```
 
 ---
@@ -617,6 +809,17 @@ ws:connection은 있지만 participants에는 없음
 ```
 
 이를 방지하기 위해 상태 변경을 Lua 내부에서 하나의 원자 연산으로 처리합니다.
+
+### Redis 기반 로비 채팅 제한
+
+로비 채팅 제한은 서버 메모리가 아니라 Redis에 저장합니다.
+
+```text
+chat:lobby:{code}:cooldown:{userIdentifier}
+chat:lobby:{code}:recent:{userIdentifier}
+```
+
+이 구조는 WebSocket 서버가 여러 인스턴스로 늘어나도 동일 사용자에 대한 제한을 일관되게 적용할 수 있습니다.
 
 ---
 
@@ -665,6 +868,7 @@ DISCONNECT 처리 → decrement
 | 인증 refresh 저장소 | `503 Service Unavailable` |
 | WebSocket CONNECT 온라인 상태 저장 실패 | STOMP ERROR `CONNECT_ONLINE_STATUS_FAILED` |
 | 로비 입장 Lua 실패 | STOMP ERROR `LOBBY_ENTER_TEMPORARILY_UNAVAILABLE` |
+| 로비 채팅 제한 Redis 처리 실패 | `503 Service Unavailable` |
 | Pub/Sub 발행 실패 | 로컬 WebSocket fallback 또는 로그/관측성 처리 |
 | 게임 시작 Redis-DB 불일치 | 보상 롤백 또는 reconciliation 큐 적재 |
 
@@ -675,6 +879,7 @@ DISCONNECT 처리 → decrement
 | Lua 알 수 없는 반환값 | `error` + monitoring required |
 | Redis-DB 게임 시작 불일치 | `error` + reconciliation enqueue |
 | 최대 재시도 초과 | `error` + alert required |
+| READY_CHANGED / HOST_CHANGED / KICK 메시지 발행 실패 | `error` + alert required |
 | stale 세션 disconnect | `info` |
 | 중복 구독 | `info` |
 
@@ -701,6 +906,23 @@ FE는 REST join 성공만으로 사용자를 로비 참여자로 확정하면 �
 
 `canStart`는 snapshot 값입니다.  
 실제 시작 가능 여부는 `POST /api/lobbies/{code}/start`에서 최종 검증됩니다.
+
+### 로비 채팅
+
+FE는 로비 채팅 수신 시 `type` 기준으로 UI를 분기해야 합니다.
+
+```text
+CHAT          → 일반 채팅 말풍선
+SYSTEM        → 시스템 안내
+ENTER         → 입장 안내
+LEAVE         → 퇴장 안내
+KICK          → 강퇴 안내
+READY_CHANGED → ready 상태 변경 안내
+HOST_CHANGED  → 방장 변경 안내
+```
+
+FE는 `content` 문자열을 파싱하지 않습니다.  
+서버가 내려준 `type`을 기준으로 스타일과 동작을 결정합니다.
 
 ### STOMP ERROR
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatService.java
@@ -7,6 +7,7 @@
  * - 클라이언트 sender / timestamp 위변조 방지
  * - 채팅 메시지 본문 검증
  * - 로비 채팅 전송 권한 검증
+ * - Redis 기반 로비 채팅 쿨타임/반복 전송 제한
  * - Redis Pub/Sub 채널로 메시지 발행
  *
  * [주의]
@@ -55,6 +56,7 @@ public class ChatService {
 
     private final RedisPublisher redisPublisher;
     private final LobbyRepository lobbyRepository;
+    private final LobbyChatRateLimitService lobbyChatRateLimitService;
 
     /**
      * 전체 채팅 메시지를 처리하고 Redis 전체 채팅 채널로 발행한다.
@@ -65,6 +67,7 @@ public class ChatService {
      *
      * [정책]
      * 전체 채팅은 특정 로비 참여 상태와 무관하므로 로비 참여자 검증을 수행하지 않는다.
+     * 이번 이슈 범위는 로비 채팅 제한이므로, Redis 쿨타임도 로비 채팅에만 적용한다.
      *
      * @param message  클라이언트로부터 수신한 메시지
      * @param accessor STOMP 헤더 접근자
@@ -88,6 +91,10 @@ public class ChatService {
      * - 강퇴된 사용자는 전송할 수 없다.
      * - 현재 로비 참여자만 전송할 수 있다.
      *
+     * [도배 방지]
+     * - Redis 기반 쿨타임을 적용한다.
+     * - 짧은 시간 내 동일 메시지 반복 전송을 차단한다.
+     *
      * @param code     로비 초대 코드
      * @param message  클라이언트로부터 수신한 메시지
      * @param accessor STOMP 헤더 접근자
@@ -103,6 +110,12 @@ public class ChatService {
 
         ChatMessageDto secureMessage = buildUserChatMessage(message, code, userIdentifier);
 
+        lobbyChatRateLimitService.validateAndRecord(
+                code,
+                userIdentifier,
+                secureMessage.getContent()
+        );
+
         redisPublisher.publish(StompDestinations.subscribeLobbyChat(code), secureMessage);
     }
 
@@ -116,7 +129,8 @@ public class ChatService {
      *
      * [강퇴 여부를 참여자 여부보다 먼저 확인하는 이유]
      * 강퇴 처리 후에는 participants Set에서 제거되고 kicked Set에 추가될 수 있다.
-     * 이때 참여자 검증을 먼저 수행하면 강퇴 유저도 단순 미참여자로만 처리되어 클라이언트가 정확한 사유를 알기 어렵다.
+     * 이때 참여자 검증을 먼저 수행하면 강퇴 유저도 단순 미참여자로만 처리되어
+     * 클라이언트가 정확한 사유를 알기 어렵다.
      */
     private void validateLobbyChatPermission(String code, String userIdentifier) {
         if (!lobbyRepository.existsByCode(code)) {
@@ -170,7 +184,7 @@ public class ChatService {
     }
 
     /**
-     * 채팅 본문을 검증하고 trim된 문자열을 반환합니다.
+     * 채팅 본문을 검증하고 trim된 문자열을 반환한다.
      */
     private String normalizeContent(ChatMessageDto message) {
         if (message == null || message.getContent() == null) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatService.java
@@ -6,6 +6,7 @@
  * - 클라이언트 메시지를 서버 신뢰 데이터로 재구성
  * - 클라이언트 sender / timestamp 위변조 방지
  * - 채팅 메시지 본문 검증
+ * - 로비 채팅 전송 권한 검증
  * - Redis Pub/Sub 채널로 메시지 발행
  *
  * [주의]
@@ -14,15 +15,16 @@
  */
 package io.github.ascrew.monomatbe.domain.chat.service;
 
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import io.github.ascrew.monomatbe.global.redis.RedisPublisher;
 import io.github.ascrew.monomatbe.global.websocket.WebSocketSessionUtils;
 import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
@@ -44,8 +46,15 @@ public class ChatService {
             "채팅 메시지는 500자 이하로 입력해주세요.";
     private static final String ERROR_INVALID_MESSAGE_TYPE =
             "일반 채팅으로 전송할 수 없는 메시지 타입입니다.";
+    private static final String ERROR_LOBBY_NOT_FOUND =
+            "존재하지 않는 로비입니다.";
+    private static final String ERROR_LOBBY_CHAT_FORBIDDEN =
+            "로비 참여자만 로비 채팅을 보낼 수 있습니다.";
+    private static final String ERROR_LOBBY_CHAT_KICKED =
+            "강퇴된 로비에는 채팅을 보낼 수 없습니다.";
 
     private final RedisPublisher redisPublisher;
+    private final LobbyRepository lobbyRepository;
 
     /**
      * 전체 채팅 메시지를 처리하고 Redis 전체 채팅 채널로 발행한다.
@@ -53,6 +62,9 @@ public class ChatService {
      * [보안]
      * 클라이언트가 전송한 sender, roomId, timestamp를 신뢰하지 않고,
      * 서버에서 신뢰 가능한 값으로 재구성한다.
+     *
+     * [정책]
+     * 전체 채팅은 특정 로비 참여 상태와 무관하므로 로비 참여자 검증을 수행하지 않는다.
      *
      * @param message  클라이언트로부터 수신한 메시지
      * @param accessor STOMP 헤더 접근자
@@ -71,9 +83,10 @@ public class ChatService {
      * 클라이언트가 전송한 sender, roomId, timestamp를 신뢰하지 않고,
      * 서버에서 신뢰 가능한 값으로 재구성한다.
      *
-     * [후속 단계]
-     * 로비 참여자 검증, 강퇴 유저 차단, Redis 기반 쿨타임/반복 전송 제한은
-     * 다음 단계에서 이 메서드에 추가합니다.
+     * [권한]
+     * - 존재하는 로비에 대해서만 전송할 수 있다.
+     * - 강퇴된 사용자는 전송할 수 없다.
+     * - 현재 로비 참여자만 전송할 수 있다.
      *
      * @param code     로비 초대 코드
      * @param message  클라이언트로부터 수신한 메시지
@@ -85,9 +98,38 @@ public class ChatService {
             SimpMessageHeaderAccessor accessor
     ) {
         String userIdentifier = WebSocketSessionUtils.extractUserIdentifier(accessor);
+
+        validateLobbyChatPermission(code, userIdentifier);
+
         ChatMessageDto secureMessage = buildUserChatMessage(message, code, userIdentifier);
 
         redisPublisher.publish(StompDestinations.subscribeLobbyChat(code), secureMessage);
+    }
+
+    /**
+     * 로비 채팅 전송 권한을 검증한다.
+     *
+     * [검증 순서]
+     * 1. 로비 존재 여부 확인
+     * 2. 강퇴 여부 확인
+     * 3. 현재 참여자 여부 확인
+     *
+     * [강퇴 여부를 참여자 여부보다 먼저 확인하는 이유]
+     * 강퇴 처리 후에는 participants Set에서 제거되고 kicked Set에 추가될 수 있다.
+     * 이때 참여자 검증을 먼저 수행하면 강퇴 유저도 단순 미참여자로만 처리되어 클라이언트가 정확한 사유를 알기 어렵다.
+     */
+    private void validateLobbyChatPermission(String code, String userIdentifier) {
+        if (!lobbyRepository.existsByCode(code)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_LOBBY_NOT_FOUND);
+        }
+
+        if (lobbyRepository.isKicked(code, userIdentifier)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_LOBBY_CHAT_KICKED);
+        }
+
+        if (!lobbyRepository.isParticipant(code, userIdentifier)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_LOBBY_CHAT_FORBIDDEN);
+        }
     }
 
     /**
@@ -128,7 +170,7 @@ public class ChatService {
     }
 
     /**
-     * 채팅 본문을 검증하고 trim된 문자열을 반환한다.
+     * 채팅 본문을 검증하고 trim된 문자열을 반환합니다.
      */
     private String normalizeContent(ChatMessageDto message) {
         if (message == null || message.getContent() == null) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatService.java
@@ -1,98 +1,167 @@
 /*
- * 채팅 메시지 처리 비즈니스 로직을 담당하는 서비스.
+ * 채팅 메시지 처리 비즈니스 로직을 담당하는 서비스
  *
- * [ChatController에서 이전된 책임]
+ * [책임]
  * - 세션에서 사용자 식별자 추출
- * - 클라이언트 메시지를 서버 신뢰 데이터로 재구성 (발신자 위변조 방지)
+ * - 클라이언트 메시지를 서버 신뢰 데이터로 재구성
+ * - 클라이언트 sender / timestamp 위변조 방지
+ * - 채팅 메시지 본문 검증
  * - Redis Pub/Sub 채널로 메시지 발행
  *
- * [리팩토링 변경 사항]
- * - extractUserIdentifier() private 메서드 제거
- *   → WebSocketSessionUtils.extractUserIdentifier()로 위임
- *   → 동일 로직이 WebSocketEventListener에도 존재하던 중복을 제거
+ * [주의]
+ * 클라이언트가 전송한 sender, roomId, timestamp는 신뢰하지 않는다.
+ * 서버에서 STOMP 세션과 MessageMapping 경로를 기준으로 신뢰 가능한 값으로 재구성한다.
  */
 package io.github.ascrew.monomatbe.domain.chat.service;
 
-import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import io.github.ascrew.monomatbe.global.redis.RedisPublisher;
 import io.github.ascrew.monomatbe.global.websocket.WebSocketSessionUtils;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class ChatService {
 
+    /*
+     * 채팅 메시지 최대 길이
+     *
+     * MAIN_CHAT.content가 VARCHAR(500) 기준이므로,
+     * 향후 채팅 저장 정책이 추가되어도 payload와 DB 제약이 충돌하지 않도록 500자로 제한한다.
+     */
+    private static final int MAX_CHAT_CONTENT_LENGTH = 500;
+
+    private static final String ERROR_MESSAGE_REQUIRED =
+            "채팅 메시지를 입력해주세요.";
+    private static final String ERROR_MESSAGE_TOO_LONG =
+            "채팅 메시지는 500자 이하로 입력해주세요.";
+    private static final String ERROR_INVALID_MESSAGE_TYPE =
+            "일반 채팅으로 전송할 수 없는 메시지 타입입니다.";
+
     private final RedisPublisher redisPublisher;
 
     /**
-     * 전체 채팅 메시지를 처리하고 Redis 전체 채팅 채널로 발행합니다.
+     * 전체 채팅 메시지를 처리하고 Redis 전체 채팅 채널로 발행한다.
      *
      * [보안]
-     * 클라이언트가 전송한 sender 필드를 신뢰하지 않고,
-     * 서버 세션에서 추출한 식별자로 덮어씁니다.
+     * 클라이언트가 전송한 sender, roomId, timestamp를 신뢰하지 않고,
+     * 서버에서 신뢰 가능한 값으로 재구성한다.
      *
-     * @param message  클라이언트로부터 수신한 메시지 (sender 필드는 신뢰하지 않음)
-     * @param accessor STOMP 헤더 접근자 (세션에서 사용자 식별자 추출용)
+     * @param message  클라이언트로부터 수신한 메시지
+     * @param accessor STOMP 헤더 접근자
      */
     public void publishGlobalMessage(ChatMessageDto message, SimpMessageHeaderAccessor accessor) {
-        // [수정] private extractUserIdentifier() 제거
-        //        → WebSocketSessionUtils 정적 메서드로 위임하여 중복 로직 제거
         String userIdentifier = WebSocketSessionUtils.extractUserIdentifier(accessor);
-        ChatMessageDto secureMessage = buildSecureMessage(message, "global", userIdentifier);
+        ChatMessageDto secureMessage = buildUserChatMessage(message, "global", userIdentifier);
+
         redisPublisher.publish(StompDestinations.SUBSCRIBE_GLOBAL_CHAT, secureMessage);
     }
 
     /**
-     * 로비 채팅 메시지를 처리하고 해당 로비 채널로 발행합니다.
+     * 로비 채팅 메시지를 처리하고 해당 로비 채널로 발행한다.
      *
      * [보안]
-     * 클라이언트가 전송한 sender 필드를 신뢰하지 않고,
-     * 서버 세션에서 추출한 식별자로 덮어씁니다.
+     * 클라이언트가 전송한 sender, roomId, timestamp를 신뢰하지 않고,
+     * 서버에서 신뢰 가능한 값으로 재구성한다.
+     *
+     * [후속 단계]
+     * 로비 참여자 검증, 강퇴 유저 차단, Redis 기반 쿨타임/반복 전송 제한은
+     * 다음 단계에서 이 메서드에 추가합니다.
      *
      * @param code     로비 초대 코드
-     * @param message  클라이언트로부터 수신한 메시지 (sender 필드는 신뢰하지 않음)
-     * @param accessor STOMP 헤더 접근자 (세션에서 사용자 식별자 추출용)
+     * @param message  클라이언트로부터 수신한 메시지
+     * @param accessor STOMP 헤더 접근자
      */
     public void publishLobbyMessage(
             String code,
             ChatMessageDto message,
             SimpMessageHeaderAccessor accessor
     ) {
-        // [수정] private extractUserIdentifier() 제거
-        //        → WebSocketSessionUtils 정적 메서드로 위임하여 중복 로직 제거
         String userIdentifier = WebSocketSessionUtils.extractUserIdentifier(accessor);
-        ChatMessageDto secureMessage = buildSecureMessage(message, code, userIdentifier);
+        ChatMessageDto secureMessage = buildUserChatMessage(message, code, userIdentifier);
+
         redisPublisher.publish(StompDestinations.subscribeLobbyChat(code), secureMessage);
     }
 
     /**
-     * 클라이언트 메시지를 서버 신뢰 데이터로 재구성합니다.
+     * 사용자가 직접 입력한 일반 채팅 메시지를 서버 신뢰 데이터로 재구성한다.
      *
-     * [보안 — 발신자 위변조 방지]
-     * 클라이언트가 전송한 sender 필드를 그대로 사용하지 않고,
-     * 서버 세션에서 추출한 userIdentifier로 반드시 덮어씁니다.
-     * 이를 통해 다른 사용자를 사칭하는 발신자 위변조를 원천 차단합니다.
+     * [검증 정책]
+     * - message null 차단
+     * - content null 차단
+     * - trim 후 빈 문자열 차단
+     * - 최대 길이 초과 차단
+     * - 일반 사용자 전송 타입은 CHAT만 허용
      *
-     * @param message        원본 클라이언트 메시지
-     * @param roomId         수신 대상 방 코드 ("global" 또는 로비 코드)
-     * @param userIdentifier 세션에서 추출한 신뢰할 수 있는 사용자 식별자
-     * @return 서버 신뢰 데이터로 재구성된 메시지
+     * [보안 정책]
+     * - sender는 STOMP 세션의 userIdentifier로 덮어쓴다.
+     * - roomId는 MessageMapping 경로 또는 서버 정책 값으로 덮어쓴다.
+     * - timestamp는 서버 시각으로 생성한다.
+     *
+     * @param message        클라이언트 원본 메시지
+     * @param roomId         서버가 확정한 수신 대상
+     * @param userIdentifier 서버 세션에서 추출한 사용자 식별자
+     * @return 서버 신뢰 데이터로 재구성된 일반 채팅 메시지
      */
-    private ChatMessageDto buildSecureMessage(
+    private ChatMessageDto buildUserChatMessage(
             ChatMessageDto message,
             String roomId,
             String userIdentifier
     ) {
+        String normalizedContent = normalizeContent(message);
+        validateUserMessageType(message);
+
         return ChatMessageDto.builder()
-                .type(message.getType())
+                .type(ChatMessageDto.MessageType.CHAT)
                 .roomId(roomId)
-                // 클라이언트 sender 무시, 서버 세션 식별자로 교체
                 .sender(userIdentifier)
-                .content(message.getContent())
-                .timestamp(message.getTimestamp())
+                .content(normalizedContent)
+                .timestamp(LocalDateTime.now().toString())
                 .build();
+    }
+
+    /**
+     * 채팅 본문을 검증하고 trim된 문자열을 반환한다.
+     */
+    private String normalizeContent(ChatMessageDto message) {
+        if (message == null || message.getContent() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_MESSAGE_REQUIRED);
+        }
+
+        String content = message.getContent().trim();
+
+        if (content.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_MESSAGE_REQUIRED);
+        }
+
+        if (content.length() > MAX_CHAT_CONTENT_LENGTH) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_MESSAGE_TOO_LONG);
+        }
+
+        return content;
+    }
+
+    /**
+     * 클라이언트가 일반 채팅 경로로 시스템 메시지를 위조하지 못하도록 타입을 제한한다.
+     *
+     * null 타입은 기존 FE 호환성을 위해 CHAT으로 간주한다.
+     * 단, ENTER / LEAVE / KICK / SYSTEM / READY_CHANGED / HOST_CHANGED 같은 시스템 타입은
+     * 서버 내부 로직에서만 생성되어야 하므로 일반 채팅 경로에서는 차단한다.
+     */
+    private void validateUserMessageType(ChatMessageDto message) {
+        if (message.getType() == null) {
+            return;
+        }
+
+        if (message.getType() != ChatMessageDto.MessageType.CHAT) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_MESSAGE_TYPE);
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/LobbyChatRateLimitService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/LobbyChatRateLimitService.java
@@ -1,0 +1,170 @@
+/*
+ * 로비 채팅 전송 제한 정책을 담당하는 서비스
+ *
+ * [책임]
+ * - Redis 기반 로비 채팅 쿨타임 적용
+ * - 같은 메시지 단기 반복 전송 방지
+ *
+ * [Redis를 사용하는 이유]
+ * WebSocket 서버가 여러 인스턴스로 확장되더라도 동일 사용자의 도배 제한이
+ * 모든 서버에서 일관되게 적용되어야 한다.
+ * 따라서 서버 메모리가 아니라 Redis를 기준으로 제한 상태를 관리한다.
+ */
+package io.github.ascrew.monomatbe.domain.chat.service;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LobbyChatRateLimitService {
+
+    /*
+     * 같은 사용자가 같은 로비에 채팅을 연속 전송할 수 없는 최소 간격
+     *
+     * 1초는 일반 채팅 UX를 크게 해치지 않으면서,
+     * 매크로나 Enter 연타성 도배를 차단하기에 적절한 기본값이다.
+     */
+    private static final Duration CHAT_COOLDOWN_TTL = Duration.ofSeconds(1);
+
+    /*
+     * 같은 사용자가 같은 로비에 동일 메시지를 반복 전송할 수 없는 기간
+     *
+     * 5초는 일반적인 실수성 재전송은 어느 정도 허용하면서,
+     * 짧은 시간 내 같은 문구 도배를 막는 현실적인 값이다.
+     */
+    private static final Duration REPEATED_MESSAGE_TTL = Duration.ofSeconds(5);
+
+    private static final String REDIS_LOCK_VALUE = "1";
+
+    private static final String ERROR_CHAT_TOO_FAST =
+            "채팅을 너무 빠르게 전송하고 있습니다. 잠시 후 다시 시도해주세요.";
+    private static final String ERROR_CHAT_REPEATED =
+            "같은 메시지를 짧은 시간 안에 반복해서 보낼 수 없습니다.";
+    private static final String ERROR_CHAT_LIMIT_UNAVAILABLE =
+            "채팅 제한 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 로비 채팅 전송 제한을 검증하고, 통과 시 현재 메시지 전송 상태를 Redis에 기록한다.
+     *
+     * [처리 순서]
+     * 1. 쿨타임 SET NX 시도
+     * 2. 실패하면 429 TOO_MANY_REQUESTS
+     * 3. 최근 메시지 해시 조회
+     * 4. 동일 메시지가 반복되면 429 TOO_MANY_REQUESTS
+     * 5. 현재 메시지 해시를 TTL과 함께 저장
+     *
+     * [주의]
+     * 이 메서드는 실제 채팅 발행 직전에 호출되어야 한다.
+     * 그래야 제한을 통과한 메시지만 Redis Pub/Sub으로 발행된다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param userIdentifier 사용자 식별자
+     * @param content 정규화된 채팅 본문
+     */
+    public void validateAndRecord(
+            String lobbyCode,
+            String userIdentifier,
+            String content
+    ) {
+        try {
+            validateCooldown(lobbyCode, userIdentifier);
+            validateRepeatedMessage(lobbyCode, userIdentifier, content);
+        } catch (ResponseStatusException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            log.error(
+                    "로비 채팅 제한 Redis 처리 실패 - lobbyCode: {}, userIdentifier: {}",
+                    lobbyCode,
+                    userIdentifier,
+                    e
+            );
+
+            throw new ResponseStatusException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    ERROR_CHAT_LIMIT_UNAVAILABLE,
+                    e
+            );
+        }
+    }
+
+    /**
+     * 채팅 쿨타임을 검증
+     *
+     * SET NX를 사용하여 동일 사용자의 동시 요청이 들어와도
+     * Redis에서 원자적으로 1개 요청만 통과시킨다.
+     */
+    private void validateCooldown(String lobbyCode, String userIdentifier) {
+        String cooldownKey = RedisKeys.lobbyChatCooldownKey(lobbyCode, userIdentifier);
+
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(
+                cooldownKey,
+                REDIS_LOCK_VALUE,
+                CHAT_COOLDOWN_TTL
+        );
+
+        if (!Boolean.TRUE.equals(acquired)) {
+            throw new ResponseStatusException(
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    ERROR_CHAT_TOO_FAST
+            );
+        }
+    }
+
+    /**
+     * 같은 메시지의 단기 반복 전송을 검증
+     *
+     * 메시지 원문을 Redis에 그대로 저장하지 않고 SHA-256 해시만 저장한다.
+     * 채팅 본문이 개인정보를 포함할 수 있으므로, 제한 검증 목적에는 해시 저장이 더 안전하다.
+     */
+    private void validateRepeatedMessage(
+            String lobbyCode,
+            String userIdentifier,
+            String content
+    ) {
+        String recentMessageKey = RedisKeys.lobbyChatRecentMessageKey(lobbyCode, userIdentifier);
+        String currentMessageHash = hashContent(content);
+
+        String previousMessageHash = redisTemplate.opsForValue().get(recentMessageKey);
+
+        if (currentMessageHash.equals(previousMessageHash)) {
+            throw new ResponseStatusException(
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    ERROR_CHAT_REPEATED
+            );
+        }
+
+        redisTemplate.opsForValue().set(
+                recentMessageKey,
+                currentMessageHash,
+                REPEATED_MESSAGE_TTL
+        );
+    }
+
+    /**
+     * 채팅 본문을 SHA-256 해시 문자열로 변환한다.
+     */
+    private String hashContent(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 해시 알고리즘을 사용할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -25,6 +25,9 @@ public interface LobbyRepository {
   /** 해당 유저가 해당 로비의 참여자인지 확인합니다. */
   boolean isParticipant(String code, String userId);
 
+  /** 해당 유저가 해당 로비에서 강퇴된 유저인지 확인합니다. */
+  boolean isKicked(String code, String userIdentifier);
+
   /**
    * 로비 참여자의 준비 상태를 변경한다.
    *

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -79,6 +79,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   @Override
+  public boolean isKicked(String code, String userIdentifier) {
+    return lobbyRedisQueryRepository.isKicked(code, userIdentifier);
+  }
+
+  @Override
   public List<String> getParticipantIdentifiers(String code) {
     return lobbyRedisQueryRepository.getParticipantIdentifiers(code);
   }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -76,6 +76,23 @@ public class LobbyRedisQueryRepository {
     }
 
     /**
+     * 해당 유저가 로비에서 강퇴된 유저인지 확인한다.
+     *
+     * [조회 기준]
+     * kick_lobby.lua는 강퇴된 사용자를 lobby:{code}:kicked Set에 저장한다.
+     * 로비 채팅 전송 시 이 Set을 확인하여 강퇴된 사용자의 메시지 전송을 차단한다.
+     *
+     * @param code 로비 초대 코드
+     * @param userIdentifier 사용자 식별자
+     * @return kicked Set 포함 여부
+     */
+    public boolean isKicked(String code, String userIdentifier) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForSet().isMember(RedisKeys.lobbyKickedKey(code), userIdentifier)
+        );
+    }
+
+    /**
      * 로비 참여자 목록을 입장 순서 기준으로 조회한다.
      *
      * [조회 전략]

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
@@ -5,6 +5,7 @@
  * - PlayerLeaveEvent 수신
  * - leave_lobby.lua 실행 위임
  * - 퇴장 결과에 따른 실시간 알림 발행
+ * - 방장 위임 시 HOST_CHANGED 시스템 메시지 발행
  *
  * [설계 의도]
  * WebSocket DISCONNECT 자체는 global.websocket 계층에서 감지한다.
@@ -38,7 +39,7 @@ public class LobbyLeaveEventHandler {
      *
      * [처리 분기]
      * - Destroyed : 마지막 유저 퇴장으로 로비 폭파 -> 전역 로비 목록 refresh
-     * - Delegated : 방장 퇴장으로 방장 위임 -> 로비 내부 refresh
+     * - Delegated : 방장 퇴장으로 방장 위임 -> HOST_CHANGED 메시지 + 로비 내부 refresh
      * - Left      : 일반 퇴장 -> 로비 내부 refresh
      * - Error     : 처리 실패 -> 브로드캐스트 없이 로그만 기록
      */
@@ -65,6 +66,20 @@ public class LobbyLeaveEventHandler {
                         delegated.lobbyCode(),
                         delegated.newHostId()
                 );
+
+                boolean messagePublished = lobbyRealtimeNotifier.notifyHostChangedMessage(
+                        delegated.lobbyCode(),
+                        delegated.newHostId()
+                );
+
+                if (!messagePublished) {
+                    log.error(
+                            "[ALERT_REQUIRED] HOST_CHANGED 메시지 발행 실패 - code: {}, newHostId: {}",
+                            delegated.lobbyCode(),
+                            delegated.newHostId()
+                    );
+                }
+
                 lobbyRealtimeNotifier.notifyLobbyInfoRefresh(delegated.lobbyCode());
             }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyReadyService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyReadyService.java
@@ -8,6 +8,7 @@
  * - 로비 참여자 여부 검증
  * - 방장 ready 변경 차단
  * - Redis ready Set 갱신
+ * - READY_CHANGED 시스템 메시지 발행
  * - 로비 정보 refresh 이벤트 발행
  *
  * [주의]
@@ -57,6 +58,7 @@ public class LobbyReadyService {
      * - WAITING 상태의 로비에서만 준비 상태를 변경할 수 있다.
      * - 로비 참여자만 준비 상태를 변경할 수 있다.
      * - 방장은 ready 대상에서 제외한다.
+     * - 변경 완료 후 READY_CHANGED 시스템 메시지를 발행한다.
      * - 변경 완료 후 로비 내부 refresh 신호를 전송한다.
      */
     public void updateReadyStatus(
@@ -97,11 +99,28 @@ public class LobbyReadyService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_HOST_READY_NOT_ALLOWED);
         }
 
+        boolean ready = Boolean.TRUE.equals(request.ready());
+
         lobbyRepository.updateReadyStatus(
                 code,
                 userIdentifier,
-                Boolean.TRUE.equals(request.ready())
+                ready
         );
+
+        boolean messagePublished = lobbyRealtimeNotifier.notifyReadyChangedMessage(
+                code,
+                userIdentifier,
+                ready
+        );
+
+        if (!messagePublished) {
+            log.error(
+                    "[ALERT_REQUIRED] READY_CHANGED 메시지 발행 실패 - code: {}, userIdentifier: {}, ready: {}",
+                    code,
+                    userIdentifier,
+                    ready
+            );
+        }
 
         lobbyRealtimeNotifier.notifyLobbyInfoRefresh(code, userIdentifier);
 
@@ -109,7 +128,7 @@ public class LobbyReadyService {
                 "로비 준비 상태 변경 완료 - code: {}, userIdentifier: {}, ready: {}",
                 code,
                 userIdentifier,
-                request.ready()
+                ready
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyRealtimeNotifier.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyRealtimeNotifier.java
@@ -6,11 +6,13 @@
  * - 로비 내부 정보 refresh 브로드캐스트
  * - 게임 시작 이벤트 브로드캐스트
  * - KICK 시스템 메시지 생성 및 브로드캐스트
+ * - READY_CHANGED 시스템 메시지 생성 및 브로드캐스트
+ * - HOST_CHANGED 시스템 메시지 생성 및 브로드캐스트
  *
  * [설계 의도]
  * 기존 단일 로비 이벤트 서비스는 강퇴 유스케이스, 퇴장 이벤트 처리, STOMP 브로드캐스트를 함께 담당했다.
- * 이 클래스는 STOMP 알림 책임만 분리하여, 강퇴/퇴장/시작 서비스가 "무엇을 알릴지"만 결정하고
- * "어떻게 보낼지"는 이 컴포넌트에 위임하도록 만든다.
+ * 이 클래스는 STOMP 알림 책임만 분리하여, 강퇴/퇴장/시작/ready 변경 서비스가
+ * "무엇을 알릴지"만 결정하고 "어떻게 보낼지"는 이 컴포넌트에 위임하도록 만든다.
  *
  * [주의]
  * 기존 STOMP destination 계약은 변경하지 않는다.
@@ -38,12 +40,17 @@ import java.util.regex.Pattern;
 public class LobbyRealtimeNotifier {
 
     /*
-     * 로비 코드 검증 패턴
+     * 로비 코드 검증 패턴.
      * 기존 로비 이벤트 처리 흐름에서 사용하던 검증 규칙을 그대로 유지한다.
      */
     private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
 
     private static final String KICK_MESSAGE_FORMAT = "%s님이 강퇴되었습니다.";
+    private static final String READY_CHANGED_MESSAGE_FORMAT = "%s님이 %s 상태로 변경했습니다.";
+    private static final String HOST_CHANGED_MESSAGE_FORMAT = "%s님이 새로운 방장이 되었습니다.";
+
+    private static final String READY_STATUS_READY = "준비 완료";
+    private static final String READY_STATUS_NOT_READY = "준비 해제";
 
     private final SimpMessagingTemplate messagingTemplate;
     private final LobbyRepository lobbyRepository;
@@ -158,11 +165,85 @@ public class LobbyRealtimeNotifier {
      * 따라서 실패 여부만 반환하고, 호출자가 관측 로그를 남긴다.
      */
     public boolean notifyKickMessage(String lobbyCode, String targetUserIdentifier) {
+        return notifySystemChatMessage(
+                lobbyCode,
+                ChatMessageDto.MessageType.KICK,
+                targetUserIdentifier,
+                String.format(KICK_MESSAGE_FORMAT, targetUserIdentifier),
+                "KICK"
+        );
+    }
+
+    /**
+     * READY_CHANGED 시스템 메시지를 로비 채팅 채널로 발행한다.
+     *
+     * [사용 시점]
+     * 참여자가 ready 상태를 변경한 직후 호출한다.
+     *
+     * [주의]
+     * ready 상태 변경은 Redis ready Set에 이미 반영된 상태다.
+     * 메시지 발행 실패가 ready 상태 변경을 롤백해서는 안 되므로 boolean 결과만 반환한다.
+     */
+    public boolean notifyReadyChangedMessage(
+            String lobbyCode,
+            String userIdentifier,
+            boolean ready
+    ) {
+        String readyStatus = ready ? READY_STATUS_READY : READY_STATUS_NOT_READY;
+
+        return notifySystemChatMessage(
+                lobbyCode,
+                ChatMessageDto.MessageType.READY_CHANGED,
+                userIdentifier,
+                String.format(READY_CHANGED_MESSAGE_FORMAT, userIdentifier, readyStatus),
+                "READY_CHANGED"
+        );
+    }
+
+    /**
+     * HOST_CHANGED 시스템 메시지를 로비 채팅 채널로 발행한다.
+     *
+     * [사용 시점]
+     * 방장 퇴장으로 새 방장이 위임된 직후 호출한다.
+     */
+    public boolean notifyHostChangedMessage(
+            String lobbyCode,
+            String newHostIdentifier
+    ) {
+        return notifySystemChatMessage(
+                lobbyCode,
+                ChatMessageDto.MessageType.HOST_CHANGED,
+                newHostIdentifier,
+                String.format(HOST_CHANGED_MESSAGE_FORMAT, newHostIdentifier),
+                "HOST_CHANGED"
+        );
+    }
+
+    /**
+     * 로비 채팅 채널로 시스템 메시지를 전송한다.
+     *
+     * [공통 계약]
+     * - roomId: lobbyCode
+     * - sender: 이벤트 주체 userIdentifier
+     * - timestamp: 서버 시각
+     *
+     * [전송 방식]
+     * 기존 KICK 메시지와 동일하게 SimpMessagingTemplate으로 직접 전송한다.
+     * Redis Pub/Sub을 거치는 구조로 바꾸면 멀티 인스턴스 전파 일관성은 좋아지지만,
+     * 이번 단계에서는 기존 destination/payload 계약을 유지하는 것을 우선한다.
+     */
+    private boolean notifySystemChatMessage(
+            String lobbyCode,
+            ChatMessageDto.MessageType type,
+            String sender,
+            String content,
+            String context
+    ) {
         ChatMessageDto message = ChatMessageDto.builder()
-                .type(ChatMessageDto.MessageType.KICK)
+                .type(type)
                 .roomId(lobbyCode)
-                .sender(targetUserIdentifier)
-                .content(String.format(KICK_MESSAGE_FORMAT, targetUserIdentifier))
+                .sender(sender)
+                .content(content)
                 .timestamp(LocalDateTime.now().toString())
                 .build();
 
@@ -177,9 +258,10 @@ public class LobbyRealtimeNotifier {
             return true;
         } catch (Exception e) {
             log.error(
-                    "KICK 메시지 직렬화 또는 전송 실패 - lobbyCode: {}, targetUserIdentifier: {}",
+                    "{} 메시지 직렬화 또는 전송 실패 - lobbyCode: {}, sender: {}",
+                    context,
                     lobbyCode,
-                    targetUserIdentifier,
+                    sender,
                     e
             );
             return false;

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -79,6 +79,12 @@ public final class RedisKeys {
     /** YouTube oEmbed 실패 캐시 키 접두사 */
     private static final String YOUTUBE_OEMBED_FAILURE_PREFIX = "youtube:oembed:failure:";
 
+    /** 로비 채팅 쿨타임 키 접두사 */
+    private static final String LOBBY_CHAT_COOLDOWN_PREFIX = "chat:lobby:";
+
+    /** 로비 채팅 최근 메시지 키 접두사 */
+    private static final String LOBBY_CHAT_RECENT_MESSAGE_PREFIX = "chat:lobby:";
+
     // =========================================================
     // Redis Hash 필드 키 상수 (auth:guest:session:{token} Hash 내부 필드명)
     // =========================================================
@@ -516,6 +522,38 @@ public final class RedisKeys {
      */
     public static String youtubeOembedFailureKey(String videoId) {
         return YOUTUBE_OEMBED_FAILURE_PREFIX + videoId;
+    }
+
+    /**
+     * 로비 채팅 쿨타임 키를 반환한다.
+     *
+     * 저장 구조:
+     * - Key   : chat:lobby:{code}:cooldown:{userIdentifier}
+     * - Value : "1"
+     * - TTL   : 채팅 쿨타임
+     *
+     * @param code 로비 초대 코드
+     * @param userIdentifier 사용자 식별자
+     * @return 로비 채팅 쿨타임 Redis key
+     */
+    public static String lobbyChatCooldownKey(String code, String userIdentifier) {
+        return LOBBY_CHAT_COOLDOWN_PREFIX + code + ":cooldown:" + userIdentifier;
+    }
+
+    /**
+     * 로비 채팅 최근 메시지 키를 반환한다.
+     *
+     * 저장 구조:
+     * - Key   : chat:lobby:{code}:recent:{userIdentifier}
+     * - Value : 최근 전송한 메시지 본문 해시
+     * - TTL   : 반복 메시지 감지 기간
+     *
+     * @param code 로비 초대 코드
+     * @param userIdentifier 사용자 식별자
+     * @return 로비 채팅 최근 메시지 Redis key
+     */
+    public static String lobbyChatRecentMessageKey(String code, String userIdentifier) {
+        return LOBBY_CHAT_RECENT_MESSAGE_PREFIX + code + ":recent:" + userIdentifier;
     }
 
     // =========================================================

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/dto/ChatMessageDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/dto/ChatMessageDto.java
@@ -1,5 +1,5 @@
 /*
- * WebSocket 채팅 메시지 전송에 사용되는 DTO.
+ * WebSocket 채팅 메시지 전송에 사용되는 DTO
  * Redis Pub/Sub을 통해 직렬화/역직렬화되므로 @NoArgsConstructor가 필수적이다.
  *
  * [global/websocket/dto에 위치하는 이유]
@@ -20,27 +20,64 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChatMessageDto {
 
-    private MessageType type;     // 메시지 유형 (CHAT, ANSWER, ENTER, LEAVE)
-    private String roomId;        // 수신 대상 방 코드 (전체 채팅은 "global")
-    private String sender;        // 발신자 식별자 (세션에서 추출한 서버 신뢰 값)
-    private String content;       // 메시지 본문
-    private String timestamp;     // 메시지 발신 시각
+    /*
+     * 메시지 유형
+     *
+     * FE는 이 값을 기준으로 일반 채팅, 시스템 메시지, 입장/퇴장/강퇴,
+     * ready 변경, 방장 변경 UI를 분기 처리한다.
+     */
+    private MessageType type;
+
+    /*
+     * 수신 대상 방 코드
+     *
+     * - 전체 채팅: "global"
+     * - 로비 채팅: lobby inviteCode
+     */
+    private String roomId;
+
+    /*
+     * 발신자 식별자
+     *
+     * 클라이언트가 보낸 sender 값은 신뢰하지 않는다.
+     * ChatService에서 STOMP 세션에 저장된 userIdentifier로 덮어쓴다.
+     */
+    private String sender;
+
+    /*
+     * 메시지 본문
+     *
+     * 일반 채팅에서는 사용자가 입력한 메시지이고,
+     * 시스템 메시지에서는 서버가 생성한 안내 문구다.
+     */
+    private String content;
+
+    /*
+     * 메시지 발신 시각
+     *
+     * 클라이언트 timestamp는 신뢰하지 않고,
+     * 서버에서 생성한 시각으로 덮어쓰는 방향으로 후속 단계에서 정리한다.
+     */
+    private String timestamp;
 
     /**
-     * 메시지 유형 열거형.
-     * - CHAT         : 일반 채팅 메시지
-     * - ANSWER       : 정답 제출 메시지 (인게임 전용)
-     * - ENTER        : 입장 알림 시스템 메시지
-     * - LEAVE        : 퇴장 알림 시스템 메시지
-     * - KICK         : 강퇴 알림 시스템 메시지
-     * - ENTER_FAILED : 입장 실패 알림 메시지
+     * 로비 채팅 메시지 타입 표준
+     *
+     * - CHAT          : 사용자가 직접 입력한 일반 채팅 메시지
+     * - SYSTEM        : 범용 시스템 안내 메시지
+     * - ENTER         : 로비 입장 알림
+     * - LEAVE         : 로비 퇴장 알림
+     * - KICK          : 강퇴 알림
+     * - READY_CHANGED : 준비 상태 변경 알림
+     * - HOST_CHANGED  : 방장 변경 알림
      */
     public enum MessageType {
         CHAT,
-        ANSWER,
+        SYSTEM,
         ENTER,
         LEAVE,
         KICK,
-        ENTER_FAILED
+        READY_CHANGED,
+        HOST_CHANGED
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/chat/service/ChatServiceTest.java
@@ -1,0 +1,281 @@
+package io.github.ascrew.monomatbe.domain.chat.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.StompDestinations;
+import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
+import io.github.ascrew.monomatbe.global.redis.RedisPublisher;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+    private static final String LOBBY_CODE = "ABC123";
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+
+    @Mock
+    private RedisPublisher redisPublisher;
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+
+    @Mock
+    private LobbyChatRateLimitService lobbyChatRateLimitService;
+
+    private ChatService chatService;
+
+    @BeforeEach
+    void setUp() {
+        chatService = new ChatService(
+                redisPublisher,
+                lobbyRepository,
+                lobbyChatRateLimitService
+        );
+    }
+
+    @Test
+    @DisplayName("로비 참여자는 정상 채팅을 전송할 수 있고 서버 신뢰 값으로 payload가 재구성된다")
+    void publishLobbyMessage_success() {
+        // given
+        ChatMessageDto request = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.CHAT)
+                .roomId("FAKE_ROOM")
+                .sender("spoofed-user")
+                .content("  안녕하세요  ")
+                .timestamp("2000-01-01T00:00:00")
+                .build();
+
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        when(lobbyRepository.isKicked(LOBBY_CODE, USER_IDENTIFIER)).thenReturn(false);
+        when(lobbyRepository.isParticipant(LOBBY_CODE, USER_IDENTIFIER)).thenReturn(true);
+
+        SimpMessageHeaderAccessor accessor = accessorWithUserIdentifier();
+
+        // when
+        chatService.publishLobbyMessage(LOBBY_CODE, request, accessor);
+
+        // then
+        verify(lobbyChatRateLimitService).validateAndRecord(
+                LOBBY_CODE,
+                USER_IDENTIFIER,
+                "안녕하세요"
+        );
+
+        ArgumentCaptor<ChatMessageDto> captor = ArgumentCaptor.forClass(ChatMessageDto.class);
+
+        verify(redisPublisher).publish(
+                eq(StompDestinations.subscribeLobbyChat(LOBBY_CODE)),
+                captor.capture()
+        );
+
+        ChatMessageDto published = captor.getValue();
+
+        assertThat(published.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(published.getRoomId()).isEqualTo(LOBBY_CODE);
+        assertThat(published.getSender()).isEqualTo(USER_IDENTIFIER);
+        assertThat(published.getContent()).isEqualTo("안녕하세요");
+        assertThat(published.getTimestamp()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 로비에는 채팅을 보낼 수 없다")
+    void publishLobbyMessage_failsWhenLobbyNotFound() {
+        // given
+        ChatMessageDto request = chatMessage("안녕하세요");
+
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() ->
+                chatService.publishLobbyMessage(LOBBY_CODE, request, accessorWithUserIdentifier())
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+                );
+
+        verify(lobbyChatRateLimitService, never()).validateAndRecord(any(), any(), any());
+        verify(redisPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("강퇴된 유저는 로비 채팅을 보낼 수 없다")
+    void publishLobbyMessage_failsWhenUserKicked() {
+        // given
+        ChatMessageDto request = chatMessage("안녕하세요");
+
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        when(lobbyRepository.isKicked(LOBBY_CODE, USER_IDENTIFIER)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() ->
+                chatService.publishLobbyMessage(LOBBY_CODE, request, accessorWithUserIdentifier())
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN)
+                );
+
+        verify(lobbyRepository, never()).isParticipant(LOBBY_CODE, USER_IDENTIFIER);
+        verify(lobbyChatRateLimitService, never()).validateAndRecord(any(), any(), any());
+        verify(redisPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("로비 참여자가 아니면 로비 채팅을 보낼 수 없다")
+    void publishLobbyMessage_failsWhenNotParticipant() {
+        // given
+        ChatMessageDto request = chatMessage("안녕하세요");
+
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        when(lobbyRepository.isKicked(LOBBY_CODE, USER_IDENTIFIER)).thenReturn(false);
+        when(lobbyRepository.isParticipant(LOBBY_CODE, USER_IDENTIFIER)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() ->
+                chatService.publishLobbyMessage(LOBBY_CODE, request, accessorWithUserIdentifier())
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN)
+                );
+
+        verify(lobbyChatRateLimitService, never()).validateAndRecord(any(), any(), any());
+        verify(redisPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("공백 메시지는 전송할 수 없다")
+    void publishLobbyMessage_failsWhenBlankContent() {
+        // given
+        ChatMessageDto request = chatMessage("     ");
+
+        givenValidLobbyPermission();
+
+        // when & then
+        assertThatThrownBy(() ->
+                chatService.publishLobbyMessage(LOBBY_CODE, request, accessorWithUserIdentifier())
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
+                );
+
+        verify(lobbyChatRateLimitService, never()).validateAndRecord(any(), any(), any());
+        verify(redisPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("500자를 초과한 메시지는 전송할 수 없다")
+    void publishLobbyMessage_failsWhenContentTooLong() {
+        // given
+        ChatMessageDto request = chatMessage("가".repeat(501));
+
+        givenValidLobbyPermission();
+
+        // when & then
+        assertThatThrownBy(() ->
+                chatService.publishLobbyMessage(LOBBY_CODE, request, accessorWithUserIdentifier())
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
+                );
+
+        verify(lobbyChatRateLimitService, never()).validateAndRecord(any(), any(), any());
+        verify(redisPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("일반 채팅 경로로 시스템 메시지 타입을 위조할 수 없다")
+    void publishLobbyMessage_failsWhenMessageTypeSpoofed() {
+        // given
+        ChatMessageDto request = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.KICK)
+                .content("강퇴 메시지 위조")
+                .build();
+
+        givenValidLobbyPermission();
+
+        // when & then
+        assertThatThrownBy(() ->
+                chatService.publishLobbyMessage(LOBBY_CODE, request, accessorWithUserIdentifier())
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
+                );
+
+        verify(lobbyChatRateLimitService, never()).validateAndRecord(any(), any(), any());
+        verify(redisPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("전체 채팅은 로비 참여자 검증 없이 CHAT 메시지를 발행한다")
+    void publishGlobalMessage_success() {
+        // given
+        ChatMessageDto request = chatMessage("  전체 채팅  ");
+
+        SimpMessageHeaderAccessor accessor = accessorWithUserIdentifier();
+
+        // when
+        chatService.publishGlobalMessage(request, accessor);
+
+        // then
+        verify(lobbyRepository, never()).existsByCode(any());
+        verify(lobbyChatRateLimitService, never()).validateAndRecord(any(), any(), any());
+
+        ArgumentCaptor<ChatMessageDto> captor = ArgumentCaptor.forClass(ChatMessageDto.class);
+
+        verify(redisPublisher).publish(
+                eq(StompDestinations.SUBSCRIBE_GLOBAL_CHAT),
+                captor.capture()
+        );
+
+        ChatMessageDto published = captor.getValue();
+
+        assertThat(published.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(published.getRoomId()).isEqualTo("global");
+        assertThat(published.getSender()).isEqualTo(USER_IDENTIFIER);
+        assertThat(published.getContent()).isEqualTo("전체 채팅");
+        assertThat(published.getTimestamp()).isNotBlank();
+    }
+
+    private void givenValidLobbyPermission() {
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        when(lobbyRepository.isKicked(LOBBY_CODE, USER_IDENTIFIER)).thenReturn(false);
+        when(lobbyRepository.isParticipant(LOBBY_CODE, USER_IDENTIFIER)).thenReturn(true);
+    }
+
+    private ChatMessageDto chatMessage(String content) {
+        return ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.CHAT)
+                .content(content)
+                .build();
+    }
+
+    private SimpMessageHeaderAccessor accessorWithUserIdentifier() {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+
+        Map<String, Object> sessionAttributes = new HashMap<>();
+        sessionAttributes.put(WebSocketHeaders.USER_IDENTIFIER, USER_IDENTIFIER);
+
+        accessor.setSessionAttributes(sessionAttributes);
+
+        return accessor;
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/chat/service/LobbyChatRateLimitServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/chat/service/LobbyChatRateLimitServiceTest.java
@@ -1,0 +1,165 @@
+package io.github.ascrew.monomatbe.domain.chat.service;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.HexFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LobbyChatRateLimitServiceTest {
+
+    private static final String LOBBY_CODE = "ABC123";
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+    private static final String CONTENT = "안녕하세요";
+
+    private static final Duration COOLDOWN_TTL = Duration.ofSeconds(1);
+    private static final Duration REPEATED_MESSAGE_TTL = Duration.ofSeconds(5);
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private LobbyChatRateLimitService lobbyChatRateLimitService;
+
+    @BeforeEach
+    void setUp() {
+        lobbyChatRateLimitService = new LobbyChatRateLimitService(redisTemplate);
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("쿨타임과 반복 메시지 검증을 통과하면 최근 메시지 해시를 저장한다")
+    void validateAndRecord_success() {
+        // given
+        String cooldownKey = RedisKeys.lobbyChatCooldownKey(LOBBY_CODE, USER_IDENTIFIER);
+        String recentMessageKey = RedisKeys.lobbyChatRecentMessageKey(LOBBY_CODE, USER_IDENTIFIER);
+
+        when(valueOperations.setIfAbsent(cooldownKey, "1", COOLDOWN_TTL))
+                .thenReturn(true);
+        when(valueOperations.get(recentMessageKey))
+                .thenReturn(null);
+
+        // when
+        lobbyChatRateLimitService.validateAndRecord(
+                LOBBY_CODE,
+                USER_IDENTIFIER,
+                CONTENT
+        );
+
+        // then
+        verify(valueOperations).setIfAbsent(cooldownKey, "1", COOLDOWN_TTL);
+        verify(valueOperations).get(recentMessageKey);
+        verify(valueOperations).set(
+                eq(recentMessageKey),
+                eq(sha256(CONTENT)),
+                eq(REPEATED_MESSAGE_TTL)
+        );
+    }
+
+    @Test
+    @DisplayName("쿨타임 key 획득에 실패하면 429로 차단한다")
+    void validateAndRecord_failsWhenCooldownActive() {
+        // given
+        String cooldownKey = RedisKeys.lobbyChatCooldownKey(LOBBY_CODE, USER_IDENTIFIER);
+        String recentMessageKey = RedisKeys.lobbyChatRecentMessageKey(LOBBY_CODE, USER_IDENTIFIER);
+
+        when(valueOperations.setIfAbsent(cooldownKey, "1", COOLDOWN_TTL))
+                .thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() ->
+                lobbyChatRateLimitService.validateAndRecord(
+                        LOBBY_CODE,
+                        USER_IDENTIFIER,
+                        CONTENT
+                )
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+                );
+
+        verify(valueOperations, never()).get(recentMessageKey);
+        verify(valueOperations, never()).set(eq(recentMessageKey), eq(sha256(CONTENT)), eq(REPEATED_MESSAGE_TTL));
+    }
+
+    @Test
+    @DisplayName("같은 메시지를 5초 이내 반복 전송하면 429로 차단한다")
+    void validateAndRecord_failsWhenRepeatedMessage() {
+        // given
+        String cooldownKey = RedisKeys.lobbyChatCooldownKey(LOBBY_CODE, USER_IDENTIFIER);
+        String recentMessageKey = RedisKeys.lobbyChatRecentMessageKey(LOBBY_CODE, USER_IDENTIFIER);
+
+        when(valueOperations.setIfAbsent(cooldownKey, "1", COOLDOWN_TTL))
+                .thenReturn(true);
+        when(valueOperations.get(recentMessageKey))
+                .thenReturn(sha256(CONTENT));
+
+        // when & then
+        assertThatThrownBy(() ->
+                lobbyChatRateLimitService.validateAndRecord(
+                        LOBBY_CODE,
+                        USER_IDENTIFIER,
+                        CONTENT
+                )
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+                );
+
+        verify(valueOperations, never()).set(eq(recentMessageKey), eq(sha256(CONTENT)), eq(REPEATED_MESSAGE_TTL));
+    }
+
+    @Test
+    @DisplayName("Redis 처리 중 예외가 발생하면 503으로 차단한다")
+    void validateAndRecord_failsWhenRedisUnavailable() {
+        // given
+        String cooldownKey = RedisKeys.lobbyChatCooldownKey(LOBBY_CODE, USER_IDENTIFIER);
+
+        when(valueOperations.setIfAbsent(cooldownKey, "1", COOLDOWN_TTL))
+                .thenThrow(new RuntimeException("Redis unavailable"));
+
+        // when & then
+        assertThatThrownBy(() ->
+                lobbyChatRateLimitService.validateAndRecord(
+                        LOBBY_CODE,
+                        USER_IDENTIFIER,
+                        CONTENT
+                )
+        )
+                .isInstanceOfSatisfying(ResponseStatusException.class, e ->
+                        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+                );
+    }
+
+    private String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyRealtimeNotifierTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyRealtimeNotifierTest.java
@@ -1,0 +1,165 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.StompDestinations;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LobbyRealtimeNotifierTest {
+
+    private static final String LOBBY_CODE = "ABC123";
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+    private static final String NEW_HOST_IDENTIFIER = "22222222-2222-2222-2222-222222222222";
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+
+    @Mock
+    private JsonMapper pubSubJsonMapper;
+
+    private LobbyRealtimeNotifier lobbyRealtimeNotifier;
+
+    @BeforeEach
+    void setUp() {
+        lobbyRealtimeNotifier = new LobbyRealtimeNotifier(
+                messagingTemplate,
+                lobbyRepository,
+                pubSubJsonMapper
+        );
+    }
+
+    @Test
+    @DisplayName("READY_CHANGED 시스템 메시지를 로비 채팅 채널로 발행한다")
+    void notifyReadyChangedMessage_success() {
+        // given
+        when(pubSubJsonMapper.writeValueAsString(org.mockito.ArgumentMatchers.any(ChatMessageDto.class)))
+                .thenReturn("{\"type\":\"READY_CHANGED\"}");
+
+        // when
+        boolean result = lobbyRealtimeNotifier.notifyReadyChangedMessage(
+                LOBBY_CODE,
+                USER_IDENTIFIER,
+                true
+        );
+
+        // then
+        assertThat(result).isTrue();
+
+        ArgumentCaptor<ChatMessageDto> messageCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+
+        verify(pubSubJsonMapper).writeValueAsString(messageCaptor.capture());
+        verify(messagingTemplate).convertAndSend(
+                eq(StompDestinations.subscribeLobbyChat(LOBBY_CODE)),
+                eq("{\"type\":\"READY_CHANGED\"}")
+        );
+
+        ChatMessageDto message = messageCaptor.getValue();
+
+        assertThat(message.getType()).isEqualTo(ChatMessageDto.MessageType.READY_CHANGED);
+        assertThat(message.getRoomId()).isEqualTo(LOBBY_CODE);
+        assertThat(message.getSender()).isEqualTo(USER_IDENTIFIER);
+        assertThat(message.getContent()).contains("준비 완료");
+        assertThat(message.getTimestamp()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("HOST_CHANGED 시스템 메시지를 로비 채팅 채널로 발행한다")
+    void notifyHostChangedMessage_success() {
+        // given
+        when(pubSubJsonMapper.writeValueAsString(org.mockito.ArgumentMatchers.any(ChatMessageDto.class)))
+                .thenReturn("{\"type\":\"HOST_CHANGED\"}");
+
+        // when
+        boolean result = lobbyRealtimeNotifier.notifyHostChangedMessage(
+                LOBBY_CODE,
+                NEW_HOST_IDENTIFIER
+        );
+
+        // then
+        assertThat(result).isTrue();
+
+        ArgumentCaptor<ChatMessageDto> messageCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+
+        verify(pubSubJsonMapper).writeValueAsString(messageCaptor.capture());
+        verify(messagingTemplate).convertAndSend(
+                eq(StompDestinations.subscribeLobbyChat(LOBBY_CODE)),
+                eq("{\"type\":\"HOST_CHANGED\"}")
+        );
+
+        ChatMessageDto message = messageCaptor.getValue();
+
+        assertThat(message.getType()).isEqualTo(ChatMessageDto.MessageType.HOST_CHANGED);
+        assertThat(message.getRoomId()).isEqualTo(LOBBY_CODE);
+        assertThat(message.getSender()).isEqualTo(NEW_HOST_IDENTIFIER);
+        assertThat(message.getContent()).contains("새로운 방장");
+        assertThat(message.getTimestamp()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("KICK 시스템 메시지를 로비 채팅 채널로 발행한다")
+    void notifyKickMessage_success() {
+        // given
+        when(pubSubJsonMapper.writeValueAsString(org.mockito.ArgumentMatchers.any(ChatMessageDto.class)))
+                .thenReturn("{\"type\":\"KICK\"}");
+
+        // when
+        boolean result = lobbyRealtimeNotifier.notifyKickMessage(
+                LOBBY_CODE,
+                USER_IDENTIFIER
+        );
+
+        // then
+        assertThat(result).isTrue();
+
+        ArgumentCaptor<ChatMessageDto> messageCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+
+        verify(pubSubJsonMapper).writeValueAsString(messageCaptor.capture());
+        verify(messagingTemplate).convertAndSend(
+                eq(StompDestinations.subscribeLobbyChat(LOBBY_CODE)),
+                eq("{\"type\":\"KICK\"}")
+        );
+
+        ChatMessageDto message = messageCaptor.getValue();
+
+        assertThat(message.getType()).isEqualTo(ChatMessageDto.MessageType.KICK);
+        assertThat(message.getRoomId()).isEqualTo(LOBBY_CODE);
+        assertThat(message.getSender()).isEqualTo(USER_IDENTIFIER);
+        assertThat(message.getContent()).contains("강퇴");
+        assertThat(message.getTimestamp()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("시스템 메시지 직렬화 실패 시 false를 반환한다")
+    void notifySystemMessage_returnsFalseWhenSerializeFails() {
+        // given
+        when(pubSubJsonMapper.writeValueAsString(org.mockito.ArgumentMatchers.any(ChatMessageDto.class)))
+                .thenThrow(new RuntimeException("serialize failed"));
+
+        // when
+        boolean result = lobbyRealtimeNotifier.notifyReadyChangedMessage(
+                LOBBY_CODE,
+                USER_IDENTIFIER,
+                true
+        );
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
@@ -1,17 +1,18 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
 import io.github.ascrew.monomatbe.domain.game.exception.GameSessionAlreadyExistsException;
 import io.github.ascrew.monomatbe.domain.game.service.GameRealtimeNotifier;
 import io.github.ascrew.monomatbe.domain.game.service.GameSessionCreateService;
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
-import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,30 +20,42 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LobbyStartServiceTest {
 
+    private static final String LOBBY_CODE = "ABC1234";
+    private static final String REQUESTER_IDENTIFIER = "uId";
+    private static final Long REQUESTER_USER_ID = 1L;
+    private static final Long MAP_ID = 1L;
+    private static final int ROUND_COUNT = 5;
+
     @Mock
     private LobbyRepository lobbyRepository;
+
     @Mock
     private LobbyRealtimeNotifier lobbyRealtimeNotifier;
+
     @Mock
     private GameLobbyJpaRepository gameLobbyJpaRepository;
+
     @Mock
     private GameSessionCreateService gameSessionCreateService;
+
     @Mock
     private GameRealtimeNotifier gameRealtimeNotifier;
+
     @Mock
     private QuizMapJpaRepository quizMapJpaRepository;
 
@@ -52,9 +65,9 @@ class LobbyStartServiceTest {
     @BeforeEach
     void setUp() {
         TransactionSynchronizationManager.initSynchronization();
-        
+
         lobbyStartPolicy = new LobbyStartPolicy(quizMapJpaRepository);
-        
+
         lobbyStartService = new LobbyStartService(
                 lobbyRepository,
                 lobbyRealtimeNotifier,
@@ -74,20 +87,23 @@ class LobbyStartServiceTest {
     @DisplayName("정상적으로 게임 세션 생성을 요청하고 성공한다")
     void startLobbyGame_success() {
         // given
-        String code = "ABC1234";
-        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
-        
-        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
-        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).isDeleted(false).build();
-        
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
-        when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.Started(code));
-        when(gameSessionCreateService.createGameSession(gameLobby, quizMap)).thenReturn(mock(RoundStartDto.class));
+        CustomPrincipal principal = registeredPrincipal();
+        GameLobby gameLobby = startableLobby();
+        QuizMap quizMap = startableMap();
+
+        when(lobbyRepository.findByInviteCode(LOBBY_CODE))
+                .thenReturn(Optional.of(mock(JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(LOBBY_CODE))
+                .thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(MAP_ID))
+                .thenReturn(Optional.of(quizMap));
+        when(lobbyRepository.executeStartLobbyProcess(LOBBY_CODE, REQUESTER_IDENTIFIER))
+                .thenReturn(new StartLobbyResult.Started(LOBBY_CODE));
+        when(gameSessionCreateService.createGameSession(gameLobby, quizMap))
+                .thenReturn(mock(RoundStartDto.class));
 
         // when
-        lobbyStartService.startLobbyGame(code, principal);
+        lobbyStartService.startLobbyGame(LOBBY_CODE, principal);
 
         // then
         verify(gameLobbyJpaRepository).saveAndFlush(gameLobby);
@@ -98,38 +114,45 @@ class LobbyStartServiceTest {
     @DisplayName("맵이 없는 로비에서 시작 시 예외 발생")
     void startLobbyGame_failsWhenNoMap() {
         // given
-        String code = "ABC1234";
-        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
-        
-        // mapId가 없는 경우
-        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(null).roundCount(5).build();
-        
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
+        CustomPrincipal principal = registeredPrincipal();
+        GameLobby gameLobby = GameLobby.builder()
+                .inviteCode(LOBBY_CODE)
+                .mapId(null)
+                .roundCount(ROUND_COUNT)
+                .build();
+
+        when(lobbyRepository.findByInviteCode(LOBBY_CODE))
+                .thenReturn(Optional.of(mock(JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(LOBBY_CODE))
+                .thenReturn(Optional.of(gameLobby));
 
         // when & then
-        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(LOBBY_CODE, principal))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("409 CONFLICT");
     }
 
     @Test
-    @DisplayName("문제가 없는 맵(또는 요구 라운드 수보다 적은 맵)으로 시작 시 예외 발생")
+    @DisplayName("문제가 없는 맵 또는 요구 라운드 수보다 적은 맵으로 시작 시 예외 발생")
     void startLobbyGame_failsWhenNotEnoughSongs() {
         // given
-        String code = "ABC1234";
-        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
-        
-        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
-        // 맵에 곡 수가 부족한 경우
-        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(3).isDeleted(false).build();
-        
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        CustomPrincipal principal = registeredPrincipal();
+        GameLobby gameLobby = startableLobby();
+        QuizMap quizMap = QuizMap.builder()
+                .id(MAP_ID)
+                .numOfSong(ROUND_COUNT - 1)
+                .isDeleted(false)
+                .build();
+
+        when(lobbyRepository.findByInviteCode(LOBBY_CODE))
+                .thenReturn(Optional.of(mock(JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(LOBBY_CODE))
+                .thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(MAP_ID))
+                .thenReturn(Optional.of(quizMap));
 
         // when & then
-        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(LOBBY_CODE, principal))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("409 CONFLICT");
     }
@@ -138,23 +161,24 @@ class LobbyStartServiceTest {
     @DisplayName("중복 게임 시작 요청 시 차단")
     void startLobbyGame_failsWhenDuplicateStart() {
         // given
-        String code = "ABC1234";
-        CustomPrincipal principal = new CustomPrincipal(1L, "uId", UserType.REGISTERED);
-        
-        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
-        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).isDeleted(false).build();
-        
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
-        // 이미 진행 중인 로비이므로 LobbyNotWaiting 반환
-        when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.LobbyNotWaiting(code));
+        CustomPrincipal principal = registeredPrincipal();
+        GameLobby gameLobby = startableLobby();
+        QuizMap quizMap = startableMap();
+
+        when(lobbyRepository.findByInviteCode(LOBBY_CODE))
+                .thenReturn(Optional.of(mock(JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(LOBBY_CODE))
+                .thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(MAP_ID))
+                .thenReturn(Optional.of(quizMap));
+        when(lobbyRepository.executeStartLobbyProcess(LOBBY_CODE, REQUESTER_IDENTIFIER))
+                .thenReturn(new StartLobbyResult.LobbyNotWaiting(LOBBY_CODE));
 
         // when & then
-        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(LOBBY_CODE, principal))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("409 CONFLICT");
-        
+
         verify(gameSessionCreateService, never()).createGameSession(any(), any());
     }
 
@@ -162,24 +186,50 @@ class LobbyStartServiceTest {
     @DisplayName("이미 게임 세션이 존재하는 경우 예외(409) 발생 및 롤백 확인")
     void startLobbyGame_alreadyExistsSession() {
         // given
-        String code = "ABC1234";
-        CustomPrincipal principal = new CustomPrincipal(1L, "uId", io.github.ascrew.monomatbe.domain.auth.entity.UserType.REGISTERED);
-        GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(1L).roundCount(5).build();
-        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).build();
+        CustomPrincipal principal = registeredPrincipal();
+        GameLobby gameLobby = startableLobby();
+        QuizMap quizMap = startableMap();
 
-        when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(org.mockito.Mockito.mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
-        when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.Started(code));
-
+        when(lobbyRepository.findByInviteCode(LOBBY_CODE))
+                .thenReturn(Optional.of(mock(JoinLobbyResponse.class)));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(LOBBY_CODE))
+                .thenReturn(Optional.of(gameLobby));
+        when(quizMapJpaRepository.findById(MAP_ID))
+                .thenReturn(Optional.of(quizMap));
+        when(lobbyRepository.executeStartLobbyProcess(LOBBY_CODE, REQUESTER_IDENTIFIER))
+                .thenReturn(new StartLobbyResult.Started(LOBBY_CODE));
         when(gameSessionCreateService.createGameSession(gameLobby, quizMap))
                 .thenThrow(new GameSessionAlreadyExistsException("게임 세션이 이미 존재합니다."));
 
         // when & then
-        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
+        assertThatThrownBy(() -> lobbyStartService.startLobbyGame(LOBBY_CODE, principal))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("409 CONFLICT");
 
-        verify(lobbyRepository).rollbackStartedLobbyStatus(code);
+        verify(lobbyRepository).rollbackStartedLobbyStatus(LOBBY_CODE);
+    }
+
+    private CustomPrincipal registeredPrincipal() {
+        return new CustomPrincipal(
+                REQUESTER_USER_ID,
+                REQUESTER_IDENTIFIER,
+                UserType.REGISTERED
+        );
+    }
+
+    private GameLobby startableLobby() {
+        return GameLobby.builder()
+                .inviteCode(LOBBY_CODE)
+                .mapId(MAP_ID)
+                .roundCount(ROUND_COUNT)
+                .build();
+    }
+
+    private QuizMap startableMap() {
+        return QuizMap.builder()
+                .id(MAP_ID)
+                .numOfSong(ROUND_COUNT * 2)
+                .isDeleted(false)
+                .build();
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #95

## 📝 Summary

- 로비 채팅 메시지 타입을 표준화했습니다.
  - `CHAT`
  - `SYSTEM`
  - `ENTER`
  - `LEAVE`
  - `KICK`
  - `READY_CHANGED`
  - `HOST_CHANGED`
- 일반 사용자가 로비 채팅 경로로 시스템 메시지 타입을 위조할 수 없도록 제한했습니다.
- 로비 채팅 본문 검증을 추가했습니다.
  - `null` 메시지 차단
  - 빈 메시지 차단
  - 공백 메시지 차단
  - 500자 초과 메시지 차단
  - 서버 기준 `trim` 적용
- 로비 채팅 전송 권한 검증을 추가했습니다.
  - 존재하지 않는 로비 차단
  - 로비 참여자가 아닌 사용자 차단
  - 강퇴된 사용자 차단
- Redis 기반 로비 채팅 제한 정책을 추가했습니다.
  - 1초 이내 연속 전송 차단
  - 5초 이내 동일 메시지 반복 전송 차단
  - 반복 메시지 검증 시 원문이 아닌 SHA-256 해시 저장
- 로비 상태 변경 시스템 메시지 발행을 추가했습니다.
  - ready 변경 시 `READY_CHANGED` 메시지 발행
  - 방장 위임 시 `HOST_CHANGED` 메시지 발행
  - 기존 `KICK` 메시지도 공통 시스템 메시지 발행 로직으로 정리
- `ws-test.html`을 확장하여 로비 채팅 제한 정책을 수동 검증할 수 있도록 했습니다.
  - 타입 위조 테스트
  - 공백 메시지 테스트
  - 500자 초과 메시지 테스트
  - 즉시 2회 전송 테스트
  - Raw Payload 송신 테스트
- `ARCHITECTURE.md`에 로비 채팅 payload 계약과 FE 처리 기준을 문서화했습니다.
- 로비 채팅 제한 및 시스템 메시지 발행 관련 단위 테스트를 추가했습니다.

## 🙏PR point

- 클라이언트가 보낸 `sender`, `roomId`, `timestamp`는 신뢰하지 않고 서버에서 재구성합니다.
- 일반 사용자가 `/app/chat/lobby/{code}`로 보낼 수 있는 타입은 `CHAT`만 허용됩니다.
- `SYSTEM`, `ENTER`, `LEAVE`, `KICK`, `READY_CHANGED`, `HOST_CHANGED`는 서버 내부 로직에서만 발행되는 타입입니다.
- FE는 채팅 메시지의 `content` 문자열을 파싱하지 말고, 반드시 `type` 기준으로 UI를 분기해야 합니다.
- 로비 채팅 제한 Redis key는 다음과 같습니다.
  - `chat:lobby:{code}:cooldown:{userIdentifier}`
  - `chat:lobby:{code}:recent:{userIdentifier}`
- 반복 메시지 검증은 개인정보 노출 방지를 위해 메시지 원문이 아니라 SHA-256 해시를 Redis에 저장합니다.
- Redis 채팅 제한 처리 중 장애가 발생하면 채팅 전송을 `503 Service Unavailable`로 차단하도록 했습니다.
- `READY_CHANGED`, `HOST_CHANGED`, `KICK` 메시지는 상태 변경 자체를 롤백하지 않고, 메시지 발행 실패 시 로그로 관측 가능하게 처리했습니다.

## 📬 Reference

- Redis Lua 기반 로비 참여자 / 강퇴자 상태
  - `lobby:{code}:participants`
  - `lobby:{code}:kicked`
- WebSocket 로비 채팅 destination
  - 송신: `/app/chat/lobby/{code}`
  - 수신: `/topic/lobby/{code}`
- 로비 정보 refresh destination
  - `/topic/lobby/{code}/refresh`
- 게임 시작 이벤트 destination
  - `/topic/lobby/{code}/game`