### PR TITLE
[Feat/#92] 로비 설정 변경 

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
@@ -29,8 +29,8 @@ public class GameSession {
     @Column(name = "current_round_no", nullable = false)
     private Integer currentRoundNo;
 
-    @Column(name = "total_round_count", nullable = false)
-    private Integer totalRoundCount;
+    @Column(name = "total_question_count", nullable = false)
+    private Integer totalQuestionCount;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -58,11 +58,11 @@ public class GameSessionCreateService {
         List<MapItem> mapItems = mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(map.getId());
         Collections.shuffle(mapItems);
         List<MapItem> selectedItems = mapItems.stream()
-                .limit(lobby.getRoundCount())
+                .limit(lobby.getQuestionCount())
                 .toList();
 
-        if (selectedItems.size() < lobby.getRoundCount()) {
-            throw new io.github.ascrew.monomatbe.domain.game.exception.NotEnoughMapItemsException("출제 가능한 문제 수가 라운드 수보다 적습니다.");
+        if (selectedItems.size() < lobby.getQuestionCount()) {
+            throw new io.github.ascrew.monomatbe.domain.game.exception.NotEnoughMapItemsException("출제 가능한 문제 수가 설정된 문제 갯수보다 적습니다.");
         }
 
         long serverStartedAt = System.currentTimeMillis();
@@ -73,7 +73,7 @@ public class GameSessionCreateService {
                 .lobby(lobby)
                 .map(map)
                 .currentRoundNo(1)
-                .totalRoundCount(lobby.getRoundCount())
+                .totalQuestionCount(lobby.getQuestionCount())
                 .startedAt(startedAt)
                 .build();
         gameSessionJpaRepository.save(gameSession);
@@ -108,7 +108,7 @@ public class GameSessionCreateService {
         String result = redisTemplate.execute(
                 initGameSessionScript,
                 List.of(sessionKey, roundsKey, playersKey),
-                String.valueOf(lobby.getRoundCount()),
+                String.valueOf(lobby.getQuestionCount()),
                 mapItemIdsStr,
                 participantsStr,
                 String.valueOf(lobby.getTimeLimitSeconds()),
@@ -123,8 +123,8 @@ public class GameSessionCreateService {
             throw new IllegalStateException("게임 세션 Redis 초기화 실패: " + result);
         }
 
-        log.info("게임 세션 생성 완료 - 로비 코드: {}, 라운드 수: {}, 참여자 수: {}", 
-                 code, lobby.getRoundCount(), participantIdentifiers.size());
+        log.info("게임 세션 생성 완료 - 로비 코드: {}, 문제 갯수: {}, 참여자 수: {}",
+                 code, lobby.getQuestionCount(), participantIdentifiers.size());
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
@@ -137,12 +137,13 @@ public class GameSessionCreateService {
         });
 
         MapItem firstItem = selectedItems.get(0);
+        int effectiveEndTime = firstItem.getStartTime() + lobby.getTimeLimitSeconds();
         return RoundStartDto.builder()
                 .type("ROUND_READY")
                 .videoId(firstItem.getVideoId())
                 .youtubeUrl(firstItem.getYoutubeUrl())
                 .startTime(firstItem.getStartTime())
-                .endTime(firstItem.getEndTime())
+                .endTime(effectiveEndTime)
                 .timeLimitSeconds(lobby.getTimeLimitSeconds())
                 .roundNo(1)
                 .serverStartedAt(serverStartedAt)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/CreateLobbyRequest.java
@@ -1,6 +1,5 @@
 package io.github.ascrew.monomatbe.domain.lobby.dto;
 
-import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import jakarta.validation.constraints.*;
 
 /**
@@ -10,14 +9,16 @@ import jakarta.validation.constraints.*;
  * mapId는 선택 사항이다.
  * 로비는 맵 없이 먼저 생성될 수 있으며, 게임 시작 시점에 맵 선택 여부를 검증한다.
  *
- * [기본값 처리]
- * roundCount, timeLimitSeconds는 클라이언트가 null로 생략하면 LobbyDefaults 상수값으로 자동 적용된다.
+ * [questionCount 기본값 처리]
+ * questionCount가 null인 경우 LobbyCreateService에서 맥락에 따라 처리한다.
+ * - mapId가 있으면: 맵의 numOfSong을 상한으로 자동 설정
+ * - mapId가 없으면: LobbyDefaults.DEFAULT_QUESTION_COUNT 적용
  *
  * [검증 규칙 — 기능명세서 기준]
  * - title      : 필수, 최대 255자
  * - maxPlayers : 2~8명
  * - mapId      : 선택 사항 (맵 없는 로비 허용), 전달 시 양수
- * - roundCount : 1~20 (생략 시 기본값 5)
+ * - questionCount : 최솟값 1 (상한은 맵의 numOfSong으로 동적 검증)
  * - timeLimitSeconds : 10~120초 (생략 시 기본값 30)
  */
 public record CreateLobbyRequest(
@@ -41,25 +42,26 @@ public record CreateLobbyRequest(
         @Positive(message = "맵 ID는 양수여야 합니다.")
         Long mapId,
 
-        @Min(value = 1, message = "라운드 수는 1 이상이어야 합니다.")
-        @Max(value = 20, message = "라운드 수는 20 이하이어야 합니다.")
-        Integer roundCount,
+        /**
+         * 문제 갯수 (라운드 수).
+         *
+         * null이면 LobbyCreateService에서 맥락에 따라 기본값을 결정한다.
+         * 맵이 선택된 경우 맵의 문제 수(numOfSong)를 상한으로 자동 설정한다.
+         */
+        @Min(value = 1, message = "문제 갯수는 1 이상이어야 합니다.")
+        Integer questionCount,
 
         @Min(value = 10, message = "제한 시간은 10초 이상이어야 합니다.")
         @Max(value = 120, message = "제한 시간은 120초 이하이어야 합니다.")
         Integer timeLimitSeconds
 ) {
     /**
-     * 기본값 적용 compact constructor.
-     * roundCount, timeLimitSeconds가 null이면 LobbyDefaults 상수값으로 대체한다.
-     * Integer(nullable) 선언으로 @Min 검증과 충돌 없이 기본값을 적용한다.
+     * timeLimitSeconds 기본값 적용 compact constructor.
+     * questionCount의 기본값은 LobbyCreateService에서 맵 정보를 기반으로 결정한다.
      */
     public CreateLobbyRequest {
-        if (roundCount == null) {
-            roundCount = LobbyDefaults.DEFAULT_ROUND_COUNT;
-        }
         if (timeLimitSeconds == null) {
-            timeLimitSeconds = LobbyDefaults.DEFAULT_TIME_LIMIT_SECONDS;
+            timeLimitSeconds = io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults.DEFAULT_TIME_LIMIT_SECONDS;
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/JoinLobbyResponse.java
@@ -31,6 +31,10 @@ public record JoinLobbyResponse(
         // 선택된 맵 제목 (미선택 시 null)
         String mapTitle,
         // 선택된 맵의 카테고리 (미선택 시 null)
-        String mapCategory
+        String mapCategory,
+        // 문제 수 (Redis에 저장된 값, 없으면 null)
+        Integer questionCount,
+        // 제한 시간(초) (Redis에 저장된 값, 없으면 null)
+        Integer timeLimitSeconds
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
@@ -27,7 +27,7 @@ public record LobbyDetailResponse(
         Long mapId,
         String mapTitle,
         String mapCategory,
-        Integer roundCount,
+        Integer questionCount,
         Integer timeLimitSeconds,
         List<LobbyPlayerResponse> players,
         boolean canStart

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
  * [포함 정보]
  * - 로비 기본 정보
  * - 선택된 맵 정보
- * - 룰 정보 (roundCount, timeLimitSeconds)
+ * - 룰 정보 (questionCount, timeLimitSeconds)
  * - 참여자별 ready 상태
  * - 현재 게임 시작 버튼 활성화 가능 여부 (canStart)
  */

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyRedisDto.java
@@ -27,6 +27,8 @@ public class LobbyRedisDto {
     private Integer currentPlayers; // 현재 참여 인원 수
     private Boolean isPrivate;    // 공개(false) / 비공개(true) 여부
     private String status;        // 로비 상태 (WAITING, PLAYING)
+    private Integer questionCount;     // 문제 수
+    private Integer timeLimitSeconds;  // 제한 시간(초)
 
     /*
      * 로비 생성 시각

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
@@ -147,4 +147,13 @@ public class GameLobby {
     public void updateMap(Long mapId) {
         this.mapId = mapId;
     }
+
+    /**
+     * 로비 맵과 문제 수를 함께 변경한다.
+     * 맵 변경 시 새 맵의 numOfSong으로 questionCount를 재설정할 때 사용한다.
+     */
+    public void updateMapAndQuestionCount(Long mapId, Integer questionCount) {
+        this.mapId = mapId;
+        this.questionCount = questionCount;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/GameLobby.java
@@ -80,8 +80,8 @@ public class GameLobby {
     @Column(name = "max_players", nullable = false)
     private Integer maxPlayers;
 
-    @Column(name = "round_count", nullable = false)
-    private Integer roundCount;
+    @Column(name = "question_count", nullable = false)
+    private Integer questionCount;
 
     @Column(name = "time_limit_seconds", nullable = false)
     private Integer timeLimitSeconds;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/LobbyDefaults.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/entity/LobbyDefaults.java
@@ -16,8 +16,8 @@ public final class LobbyDefaults {
 
     private LobbyDefaults() {}
 
-    /** 기본 라운드 수 */
-    public static final int DEFAULT_ROUND_COUNT = 5;
+    /** 기본 문제 갯수 (맵 미선택 시 적용) */
+    public static final int DEFAULT_QUESTION_COUNT = 5;
 
     /** 기본 문제당 제한 시간 (초) */
     public static final int DEFAULT_TIME_LIMIT_SECONDS = 30;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
@@ -1,12 +1,10 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
-import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
@@ -64,48 +62,4 @@ public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
      */
     boolean existsByInviteCode(String inviteCode);
 
-    /**
-     * status가 지정한 값인 경우에만 map_id를 갱신한다.
-     *
-     * [정책]
-     * 맵 변경 시 status == WAITING 원자 검증으로 동시 게임 시작 레이스를 방지한다.
-     * status 값은 호출자가 LobbyStatus.WAITING을 전달한다.
-     * JPQL 문자열에 enum 풀네임을 박지 않기 위해 파라미터로 받는다 (패키지 리네임 안전).
-     *
-     * [0행 반환 의미]
-     * 반환값이 0이면 다음 두 경우 중 하나다.
-     *   1) 해당 초대 코드의 row가 더 이상 존재하지 않음 (DB 스냅샷 누락)
-     *   2) row는 있지만 status가 전달한 값과 다름 (이미 PLAYING으로 전환됨)
-     * 호출자는 existsByInviteCode 등으로 두 경우를 구분하여 분기 처리해야 한다.
-     *
-     * @param code   로비 초대 코드
-     * @param mapId  새 맵 ID (null이면 맵 미선택 상태로 복원)
-     * @param status 갱신을 허용할 현재 상태 (호출 측에서 LobbyStatus.WAITING 전달)
-     * @return 갱신된 행 수 (0 또는 1)
-     */
-    @Modifying
-    @Query("UPDATE GameLobby g SET g.mapId = :mapId WHERE g.inviteCode = :code AND g.status = :status")
-    int updateMapIdIfWaiting(
-            @Param("code") String code,
-            @Param("mapId") Long mapId,
-            @Param("status") LobbyStatus status);
-
-    /**
-     * status가 지정한 값인 경우에만 map_id와 question_count를 함께 갱신한다.
-     *
-     * 맵 변경 시 새 맵의 numOfSong으로 questionCount를 재설정할 때 사용한다.
-     *
-     * @param code          로비 초대 코드
-     * @param mapId         새 맵 ID (null이면 맵 미선택 상태로 복원)
-     * @param questionCount 새 문제 갯수 (새 맵의 numOfSong)
-     * @param status        갱신을 허용할 현재 상태 (호출 측에서 LobbyStatus.WAITING 전달)
-     * @return 갱신된 행 수 (0 또는 1)
-     */
-    @Modifying
-    @Query("UPDATE GameLobby g SET g.mapId = :mapId, g.questionCount = :questionCount WHERE g.inviteCode = :code AND g.status = :status")
-    int updateMapAndQuestionCountIfWaiting(
-            @Param("code") String code,
-            @Param("mapId") Long mapId,
-            @Param("questionCount") Integer questionCount,
-            @Param("status") LobbyStatus status);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/GameLobbyJpaRepository.java
@@ -89,4 +89,23 @@ public interface GameLobbyJpaRepository extends JpaRepository<GameLobby, Long> {
             @Param("code") String code,
             @Param("mapId") Long mapId,
             @Param("status") LobbyStatus status);
+
+    /**
+     * status가 지정한 값인 경우에만 map_id와 question_count를 함께 갱신한다.
+     *
+     * 맵 변경 시 새 맵의 numOfSong으로 questionCount를 재설정할 때 사용한다.
+     *
+     * @param code          로비 초대 코드
+     * @param mapId         새 맵 ID (null이면 맵 미선택 상태로 복원)
+     * @param questionCount 새 문제 갯수 (새 맵의 numOfSong)
+     * @param status        갱신을 허용할 현재 상태 (호출 측에서 LobbyStatus.WAITING 전달)
+     * @return 갱신된 행 수 (0 또는 1)
+     */
+    @Modifying
+    @Query("UPDATE GameLobby g SET g.mapId = :mapId, g.questionCount = :questionCount WHERE g.inviteCode = :code AND g.status = :status")
+    int updateMapAndQuestionCountIfWaiting(
+            @Param("code") String code,
+            @Param("mapId") Long mapId,
+            @Param("questionCount") Integer questionCount,
+            @Param("status") LobbyStatus status);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -59,11 +59,15 @@ public interface LobbyRepository {
    * @param request 로비 생성 요청
    * @param userIdentifier 방장 사용자 식별자
    * @param mapMetadata 선택된 맵 메타데이터 (맵 미선택 시 null)
+   * @param effectiveQuestionCount 실제 적용할 문제 수
+   * @param timeLimitSeconds 제한 시간(초)
    */
   String saveToRedis(
           CreateLobbyRequest request,
           String userIdentifier,
-          LobbyMapMetadata mapMetadata
+          LobbyMapMetadata mapMetadata,
+          int effectiveQuestionCount,
+          int timeLimitSeconds
   );
 
   /**
@@ -250,12 +254,13 @@ public interface LobbyRepository {
   int getCurrentPlayerCount(String inviteCode);
 
   /**
-   * Redis 로비 Hash의 맵 메타데이터 3개 필드(map_id, map_title, map_category)를 갱신한다.
+   * Redis 로비 Hash의 맵 메타데이터와 문제 수를 갱신한다.
    *
-   * @param code     로비 초대 코드
-   * @param metadata 새 맵 메타데이터 (null이면 맵 필드를 제거한다)
+   * @param code          로비 초대 코드
+   * @param metadata      새 맵 메타데이터 (null이면 맵 필드를 제거한다)
+   * @param questionCount 새 문제 수
    */
-  void updateMapMetadata(String code, LobbyMapMetadata metadata);
+  void updateMapMetadata(String code, LobbyMapMetadata metadata, int questionCount);
 
   /**
    * 로비 맵 변경 트랜잭션 보상 복구를 status==WAITING 원자 검증과 함께 수행한다.
@@ -268,13 +273,15 @@ public interface LobbyRepository {
    * Redis 연결 단절·타임아웃·Lua 스크립트 로딩 실패 등 인프라 예외는 호출자에게 그대로 전파한다.
    * 호출자(LobbyMapUpdateService)가 도메인 결과(LOBBY_NOT_FOUND)와 인프라 장애를 분리 처리한다.
    *
-   * @param code        로비 초대 코드
-   * @param oldMetadata 복구할 이전 맵 메타데이터 (null 또는 필드가 null이면 HDEL 처리)
+   * @param code             로비 초대 코드
+   * @param oldMetadata      복구할 이전 맵 메타데이터 (null 또는 필드가 null이면 HDEL 처리)
+   * @param oldQuestionCount 복구할 이전 문제 수
    * @return 보상 처리 결과 (COMPENSATED / SKIPPED_NOT_WAITING / LOBBY_NOT_FOUND)
    * @throws RuntimeException Redis 인프라 오류 발생 시
    */
   LobbyMapCompensationResult compensateMapMetadataIfWaiting(
           String code,
-          LobbyMapMetadata oldMetadata
+          LobbyMapMetadata oldMetadata,
+          int oldQuestionCount
   );
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -168,16 +168,17 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   @Override
-  public void updateMapMetadata(String code, LobbyMapMetadata metadata) {
-    lobbyRedisCommandRepository.updateMapMetadata(code, metadata);
+  public void updateMapMetadata(String code, LobbyMapMetadata metadata, int questionCount) {
+    lobbyRedisCommandRepository.updateMapMetadata(code, metadata, questionCount);
   }
 
   @Override
   public LobbyMapCompensationResult compensateMapMetadataIfWaiting(
           String code,
-          LobbyMapMetadata oldMetadata
+          LobbyMapMetadata oldMetadata,
+          int oldQuestionCount
   ) {
-    String result = lobbyLuaScriptExecutor.executeCompensateLobbyMap(code, oldMetadata);
+    String result = lobbyLuaScriptExecutor.executeCompensateLobbyMap(code, oldMetadata, oldQuestionCount);
     return lobbyLuaResultMapper.toLobbyMapCompensationResult(result, code);
   }
 
@@ -189,7 +190,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   public String saveToRedis(
           CreateLobbyRequest request,
           String userIdentifier,
-          LobbyMapMetadata mapMetadata
+          LobbyMapMetadata mapMetadata,
+          int effectiveQuestionCount,
+          int timeLimitSeconds
   ) {
     for (int attempt = 0; attempt < LobbyDefaults.INVITE_CODE_MAX_RETRY; attempt++) {
       String candidate = lobbyInviteCodeGenerator.generate();
@@ -198,7 +201,9 @@ public class LobbyRepositoryImpl implements LobbyRepository {
               candidate,
               request,
               userIdentifier,
-              mapMetadata
+              mapMetadata,
+              effectiveQuestionCount,
+              timeLimitSeconds
       );
 
       if (result == null) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -77,6 +77,8 @@ public class LobbyLuaScriptExecutor {
      * ARGV[8]  = mapId or ""
      * ARGV[9]  = mapTitle or ""
      * ARGV[10] = mapCategory or ""
+     * ARGV[11] = questionCount
+     * ARGV[12] = timeLimitSeconds
      *
      * @return "OK" | "LOCK_FAILED" | null
      */
@@ -84,7 +86,9 @@ public class LobbyLuaScriptExecutor {
             String inviteCode,
             CreateLobbyRequest request,
             String userIdentifier,
-            LobbyMapMetadata mapMetadata
+            LobbyMapMetadata mapMetadata,
+            int questionCount,
+            int timeLimitSeconds
     ) {
         List<String> keys = List.of(
                 RedisKeys.lobbyCodeLockKey(inviteCode),
@@ -112,7 +116,9 @@ public class LobbyLuaScriptExecutor {
                 // 맵 미선택 시 빈 문자열을 전달하여 Redis에 "null" 문자열이 저장되지 않게 한다.
                 mapMetadata != null ? String.valueOf(mapMetadata.mapId()) : EMPTY_REDIS_VALUE,
                 mapMetadata != null ? mapMetadata.mapTitle() : EMPTY_REDIS_VALUE,
-                mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE
+                mapMetadata != null ? mapMetadata.mapCategory() : EMPTY_REDIS_VALUE,
+                String.valueOf(questionCount),
+                String.valueOf(timeLimitSeconds)
         );
     }
 
@@ -260,14 +266,16 @@ public class LobbyLuaScriptExecutor {
      * KEYS[1] = lobby:{code}
      *
      * [ARGV 계약]
-     * ARGV[1] = status field name
-     * ARGV[2] = mapId field name
-     * ARGV[3] = mapTitle field name
-     * ARGV[4] = mapCategory field name
-     * ARGV[5] = WAITING status
-     * ARGV[6] = oldMapId (없으면 "")
-     * ARGV[7] = oldMapTitle (없으면 "")
-     * ARGV[8] = oldMapCategory (없으면 "")
+     * ARGV[1]  = status field name
+     * ARGV[2]  = mapId field name
+     * ARGV[3]  = mapTitle field name
+     * ARGV[4]  = mapCategory field name
+     * ARGV[5]  = WAITING status
+     * ARGV[6]  = oldMapId (없으면 "")
+     * ARGV[7]  = oldMapTitle (없으면 "")
+     * ARGV[8]  = oldMapCategory (없으면 "")
+     * ARGV[9]  = questionCount field name
+     * ARGV[10] = oldQuestionCount
      *
      * [null oldMetadata 처리]
      * oldMetadata가 null이거나 필드가 일부 null이면 빈 문자열로 전달하여
@@ -275,7 +283,7 @@ public class LobbyLuaScriptExecutor {
      *
      * @return "COMPENSATED" | "SKIPPED_NOT_WAITING" | "LOBBY_NOT_FOUND"
      */
-    public String executeCompensateLobbyMap(String code, LobbyMapMetadata oldMetadata) {
+    public String executeCompensateLobbyMap(String code, LobbyMapMetadata oldMetadata, int oldQuestionCount) {
         List<String> keys = List.of(RedisKeys.lobbyKey(code));
 
         boolean restoreMap = oldMetadata != null
@@ -293,7 +301,9 @@ public class LobbyLuaScriptExecutor {
                 LobbyStatus.WAITING.name(),
                 restoreMap ? String.valueOf(oldMetadata.mapId()) : EMPTY_REDIS_VALUE,
                 restoreMap ? oldMetadata.mapTitle() : EMPTY_REDIS_VALUE,
-                restoreMap ? oldMetadata.mapCategory() : EMPTY_REDIS_VALUE
+                restoreMap ? oldMetadata.mapCategory() : EMPTY_REDIS_VALUE,
+                RedisKeys.FIELD_QUESTION_COUNT,
+                String.valueOf(oldQuestionCount)
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisCommandRepository.java
@@ -384,15 +384,17 @@ public class LobbyRedisCommandRepository {
      * [정책]
      * - metadata != null이고 모든 필드가 non-null → map_id, map_title, map_category를 단일 HSET으로 원자 갱신
      * - metadata == null 또는 필드 중 하나라도 null → 3개 필드를 HDEL (맵 미선택 상태로 복원)
+     * question_count는 항상 갱신된다.
      *
      * [null 필드 처리]
      * 보상 복구 경로에서 기존에 맵이 없던 로비의 oldMetadata는 필드가 모두 null일 수 있다.
      * 이 경우 metadata == null과 동일하게 HDEL로 처리하여 "null" 문자열 오염을 방지한다.
      *
-     * @param code     로비 초대 코드
-     * @param metadata 새 맵 메타데이터 (null 또는 필드가 하나라도 null이면 맵 필드를 제거한다)
+     * @param code          로비 초대 코드
+     * @param metadata      새 맵 메타데이터 (null 또는 필드가 하나라도 null이면 맵 필드를 제거한다)
+     * @param questionCount 새 문제 수
      */
-    public void updateMapMetadata(String code, LobbyMapMetadata metadata) {
+    public void updateMapMetadata(String code, LobbyMapMetadata metadata, int questionCount) {
         String lobbyKey = RedisKeys.lobbyKey(code);
 
         if (metadata != null
@@ -402,7 +404,8 @@ public class LobbyRedisCommandRepository {
             redisTemplate.opsForHash().putAll(lobbyKey, Map.of(
                     RedisKeys.FIELD_MAP_ID, String.valueOf(metadata.mapId()),
                     RedisKeys.FIELD_MAP_TITLE, metadata.mapTitle(),
-                    RedisKeys.FIELD_MAP_CATEGORY, metadata.mapCategory()
+                    RedisKeys.FIELD_MAP_CATEGORY, metadata.mapCategory(),
+                    RedisKeys.FIELD_QUESTION_COUNT, String.valueOf(questionCount)
             ));
         } else {
             redisTemplate.opsForHash().delete(
@@ -411,6 +414,7 @@ public class LobbyRedisCommandRepository {
                     RedisKeys.FIELD_MAP_TITLE,
                     RedisKeys.FIELD_MAP_CATEGORY
             );
+            redisTemplate.opsForHash().put(lobbyKey, RedisKeys.FIELD_QUESTION_COUNT, String.valueOf(questionCount));
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -656,6 +656,8 @@ public class LobbyRedisQueryRepository {
                         inviteCode,
                         (String) data.get(RedisKeys.FIELD_MAP_CATEGORY)
                 ))
+                .questionCount(parseNullableInt(data.get(RedisKeys.FIELD_QUESTION_COUNT)))
+                .timeLimitSeconds(parseNullableInt(data.get(RedisKeys.FIELD_TIME_LIMIT_SECONDS)))
                 .build());
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicy.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicy.java
@@ -109,7 +109,7 @@ public class LobbyCanStartPolicy {
      * @return 맵 문제 수가 라운드 수 이상이면 true
      */
     private boolean hasEnoughSongsForRound(GameLobby gameLobby) {
-        if (gameLobby == null || gameLobby.getMapId() == null || gameLobby.getRoundCount() == null) {
+        if (gameLobby == null || gameLobby.getMapId() == null || gameLobby.getQuestionCount() == null) {
             return false;
         }
 
@@ -117,7 +117,7 @@ public class LobbyCanStartPolicy {
                 .filter(quizMap -> !Boolean.TRUE.equals(quizMap.getIsDeleted()))
                 .map(quizMap -> {
                     Integer numOfSong = quizMap.getNumOfSong();
-                    return numOfSong != null && numOfSong >= gameLobby.getRoundCount();
+                    return numOfSong != null && numOfSong >= gameLobby.getQuestionCount();
                 })
                 .orElse(false);
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateService.java
@@ -125,7 +125,9 @@ public class LobbyCreateService {
         String inviteCode = lobbyRepository.saveToRedis(
                 request,
                 principal.userIdentifier(),
-                mapMetadata
+                mapMetadata,
+                effectiveQuestionCount,
+                request.timeLimitSeconds()
         );
 
         try {
@@ -187,22 +189,35 @@ public class LobbyCreateService {
      * 유효한 questionCount를 결정한다.
      *
      * [결정 규칙]
-     * - mapId 있음: min(request.questionCount ?: numOfSong, numOfSong)
-     *   → 맵 선택 시 기본값은 맵의 전체 문제 수, 명시 시에는 numOfSong 초과 불가
      * - mapId 없음: request.questionCount ?: DEFAULT_QUESTION_COUNT
+     * - mapId 있음:
+     *   - request.questionCount == null → numOfSong (맵 전체 문제 수로 자동 설정)
+     *   - request.questionCount > numOfSong → 400 BAD_REQUEST
+     *   - request.questionCount <= numOfSong → request.questionCount 그대로 사용
      *
      * LobbyMapPolicy가 이미 맵 존재·삭제·권한을 검증했으므로 findById는 항상 성공한다.
      */
     private int resolveQuestionCount(CreateLobbyRequest request, LobbyMapMetadata mapMetadata) {
-        if (mapMetadata != null && mapMetadata.mapId() != null) {
-            QuizMap map = quizMapJpaRepository.findById(mapMetadata.mapId()).orElseThrow();
-            int numOfSong = map.getNumOfSong();
+        if (mapMetadata == null || mapMetadata.mapId() == null) {
             return (request.questionCount() == null)
-                    ? numOfSong
-                    : Math.min(request.questionCount(), numOfSong);
+                    ? LobbyDefaults.DEFAULT_QUESTION_COUNT
+                    : request.questionCount();
         }
-        return (request.questionCount() == null)
-                ? LobbyDefaults.DEFAULT_QUESTION_COUNT
-                : request.questionCount();
+
+        QuizMap map = quizMapJpaRepository.findById(mapMetadata.mapId()).orElseThrow();
+        int numOfSong = map.getNumOfSong();
+
+        if (request.questionCount() == null) {
+            return numOfSong;
+        }
+
+        if (request.questionCount() > numOfSong) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "설정한 문제 수(" + request.questionCount() + ")가 맵의 등록 곡 수(" + numOfSong + ")보다 많습니다."
+            );
+        }
+
+        return request.questionCount();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateService.java
@@ -5,6 +5,7 @@
  * - 인증 주체 검증
  * - 방장 User 조회
  * - 선택된 맵 접근 가능 여부 검증 위임
+ * - questionCount 자동 설정 (맵 선택 시 numOfSong 기준)
  * - Redis 로비 상태 생성
  * - DB GAME_LOBBY 스냅샷 저장
  * - DB 저장 실패 시 Redis 보상 삭제
@@ -20,8 +21,11 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.CreateLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,6 +68,7 @@ public class LobbyCreateService {
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final UserRepository userRepository;
     private final LobbyMapPolicy lobbyMapPolicy;
+    private final QuizMapJpaRepository quizMapJpaRepository;
 
     /**
      * 로비를 생성한다.
@@ -72,9 +77,12 @@ public class LobbyCreateService {
      * 1. principal null 및 userId null 검증
      * 2. JWT에서 추출한 userId로 User 엔티티 조회
      * 3. 선택된 mapId가 있으면 LobbyMapPolicy로 맵 존재/삭제/권한 검증
-     * 4. Lua 스크립트로 초대 코드 선점 및 Redis 로비 데이터 원자 저장
-     * 5. DB에 GAME_LOBBY 스냅샷 저장
-     * 6. DB 저장 실패 시 Redis 보상 삭제
+     * 4. questionCount 자동 설정:
+     *    - mapId 있음: min(request.questionCount ?: numOfSong, numOfSong)
+     *    - mapId 없음: request.questionCount ?: DEFAULT_QUESTION_COUNT
+     * 5. Lua 스크립트로 초대 코드 선점 및 Redis 로비 데이터 원자 저장
+     * 6. DB에 GAME_LOBBY 스냅샷 저장
+     * 7. DB 저장 실패 시 Redis 보상 삭제
      *
      * [트랜잭션 경계]
      * 로비 생성은 Redis와 DB를 함께 다룬다.
@@ -106,13 +114,13 @@ public class LobbyCreateService {
          * - mapId가 없으면 맵 미선택 로비로 생성한다.
          * - mapId가 있으면 LobbyMapPolicy에서 존재 여부, 삭제 여부, 접근 권한을 검증한다.
          * - 검증된 최소 맵 정보만 Redis 저장 계층으로 전달한다.
-         *
-         * 이 정책은 향후 "방장 로비 설정 변경 API"에서도 동일하게 재사용할 수 있다.
          */
         LobbyMapMetadata mapMetadata = lobbyMapPolicy.resolveLobbyMapMetadata(
                 request.mapId(),
                 principal.userId()
         );
+
+        int effectiveQuestionCount = resolveQuestionCount(request, mapMetadata);
 
         String inviteCode = lobbyRepository.saveToRedis(
                 request,
@@ -127,16 +135,17 @@ public class LobbyCreateService {
                     .inviteCode(inviteCode)
                     .title(request.title())
                     .maxPlayers(request.maxPlayers())
-                    .roundCount(request.roundCount())
+                    .questionCount(effectiveQuestionCount)
                     .timeLimitSeconds(request.timeLimitSeconds())
                     .isPrivate(request.isPrivate())
                     .build());
 
             log.info(
-                    "로비 생성 완료 - 코드: {}, 방장: {}, mapId: {}",
+                    "로비 생성 완료 - 코드: {}, 방장: {}, mapId: {}, questionCount: {}",
                     inviteCode,
                     principal.userIdentifier(),
-                    mapMetadata != null ? mapMetadata.mapId() : null
+                    mapMetadata != null ? mapMetadata.mapId() : null,
+                    effectiveQuestionCount
             );
 
             return CreateLobbyResponse.builder()
@@ -172,5 +181,28 @@ public class LobbyCreateService {
                     ERROR_CREATE_LOBBY_FAILED
             );
         }
+    }
+
+    /**
+     * 유효한 questionCount를 결정한다.
+     *
+     * [결정 규칙]
+     * - mapId 있음: min(request.questionCount ?: numOfSong, numOfSong)
+     *   → 맵 선택 시 기본값은 맵의 전체 문제 수, 명시 시에는 numOfSong 초과 불가
+     * - mapId 없음: request.questionCount ?: DEFAULT_QUESTION_COUNT
+     *
+     * LobbyMapPolicy가 이미 맵 존재·삭제·권한을 검증했으므로 findById는 항상 성공한다.
+     */
+    private int resolveQuestionCount(CreateLobbyRequest request, LobbyMapMetadata mapMetadata) {
+        if (mapMetadata != null && mapMetadata.mapId() != null) {
+            QuizMap map = quizMapJpaRepository.findById(mapMetadata.mapId()).orElseThrow();
+            int numOfSong = map.getNumOfSong();
+            return (request.questionCount() == null)
+                    ? numOfSong
+                    : Math.min(request.questionCount(), numOfSong);
+        }
+        return (request.questionCount() == null)
+                ? LobbyDefaults.DEFAULT_QUESTION_COUNT
+                : request.questionCount();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -43,6 +43,8 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -98,6 +100,7 @@ public class LobbyMapUpdateService {
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final LobbyMapPolicy lobbyMapPolicy;
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
+    private final QuizMapJpaRepository quizMapJpaRepository;
 
     /**
      * 로비 대기실에서 방장의 맵 변경 요청을 처리한다.
@@ -164,9 +167,12 @@ public class LobbyMapUpdateService {
         lobbyRepository.updateMapMetadata(code, newMetadata);
 
         Long newMapId = newMetadata != null ? newMetadata.mapId() : null;
+        int newQuestionCount = resolveNewQuestionCount(gameLobby, newMetadata);
+
         int updated;
         try {
-            updated = gameLobbyJpaRepository.updateMapIdIfWaiting(code, newMapId, LobbyStatus.WAITING);
+            updated = gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
+                    code, newMapId, newQuestionCount, LobbyStatus.WAITING);
         } catch (Exception e) {
             log.error(LOG_DB_UPDATE_FAILED, code, e);
             compensateRedisMapMetadata(code, oldMetadata);
@@ -175,7 +181,7 @@ public class LobbyMapUpdateService {
 
         if (updated == 0) {
             log.error(
-                    "{} 락 보유 중에 updateMapIdIfWaiting이 0행 반환 - 정합성 이상. code: {}",
+                    "{} 락 보유 중에 updateMapAndQuestionCountIfWaiting이 0행 반환 - 정합성 이상. code: {}",
                     LOG_MONITORING_REQUIRED,
                     code
             );
@@ -184,11 +190,12 @@ public class LobbyMapUpdateService {
         }
 
         log.info(
-                "로비 맵 변경 완료 - code: {}, host: {}, oldMapId: {}, newMapId: {}",
+                "로비 맵 변경 완료 - code: {}, host: {}, oldMapId: {}, newMapId: {}, newQuestionCount: {}",
                 code,
                 principal.userIdentifier(),
                 oldMetadata != null ? oldMetadata.mapId() : null,
-                newMapId
+                newMapId,
+                newQuestionCount
         );
 
         registerMapChangedEventAfterCommit(code);
@@ -289,6 +296,22 @@ public class LobbyMapUpdateService {
                     e
             );
         }
+    }
+
+    /**
+     * 맵 변경 후 새 questionCount를 결정한다.
+     *
+     * 새 맵이 선택된 경우 해당 맵의 numOfSong으로 재설정한다.
+     * 맵이 해제된 경우(newMetadata == null) 기존 questionCount를 유지한다.
+     *
+     * LobbyMapPolicy가 이미 맵 존재·삭제·권한을 검증했으므로 findById는 항상 성공한다.
+     */
+    private int resolveNewQuestionCount(GameLobby gameLobby, LobbyMapMetadata newMetadata) {
+        if (newMetadata != null && newMetadata.mapId() != null) {
+            QuizMap newMap = quizMapJpaRepository.findById(newMetadata.mapId()).orElseThrow();
+            return newMap.getNumOfSong();
+        }
+        return gameLobby.getQuestionCount();
     }
 
     private void registerMapChangedEventAfterCommit(String code) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -164,29 +164,19 @@ public class LobbyMapUpdateService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
         }
 
-        lobbyRepository.updateMapMetadata(code, newMetadata);
-
+        int oldQuestionCount = gameLobby.getQuestionCount();
         Long newMapId = newMetadata != null ? newMetadata.mapId() : null;
         int newQuestionCount = resolveNewQuestionCount(gameLobby, newMetadata);
 
-        int updated;
+        lobbyRepository.updateMapMetadata(code, newMetadata, newQuestionCount);
+
         try {
-            updated = gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
-                    code, newMapId, newQuestionCount, LobbyStatus.WAITING);
+            gameLobby.updateMapAndQuestionCount(newMapId, newQuestionCount);
+            gameLobbyJpaRepository.saveAndFlush(gameLobby);
         } catch (Exception e) {
             log.error(LOG_DB_UPDATE_FAILED, code, e);
-            compensateRedisMapMetadata(code, oldMetadata);
+            compensateRedisMapMetadata(code, oldMetadata, oldQuestionCount);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ERROR_UPDATE_MAP_FAILED);
-        }
-
-        if (updated == 0) {
-            log.error(
-                    "{} 락 보유 중에 updateMapAndQuestionCountIfWaiting이 0행 반환 - 정합성 이상. code: {}",
-                    LOG_MONITORING_REQUIRED,
-                    code
-            );
-            compensateRedisMapMetadata(code, oldMetadata);
-            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_LOBBY_NOT_WAITING);
         }
 
         log.info(
@@ -262,7 +252,7 @@ public class LobbyMapUpdateService {
     }
 
     /**
-     * Redis 맵 메타데이터를 status==WAITING 원자 조건으로 보상 복구한다.
+     * Redis 맵 메타데이터와 문제 수를 status==WAITING 원자 조건으로 보상 복구한다.
      *
      * [안전 정책]
      * 보상 시점에 다른 트랜잭션이 status를 PLAYING으로 바꿨다면 oldMetadata로 되돌리면 안 된다.
@@ -273,10 +263,10 @@ public class LobbyMapUpdateService {
      * Redis 연결 단절·타임아웃·스크립트 로딩 실패 등 인프라 예외는 catch 블록에서 별도 처리하여
      * 원인 분류와 운영 대응이 가능하도록 한다.
      */
-    private void compensateRedisMapMetadata(String code, LobbyMapMetadata oldMetadata) {
+    private void compensateRedisMapMetadata(String code, LobbyMapMetadata oldMetadata, int oldQuestionCount) {
         try {
             LobbyMapCompensationResult result =
-                    lobbyRepository.compensateMapMetadataIfWaiting(code, oldMetadata);
+                    lobbyRepository.compensateMapMetadataIfWaiting(code, oldMetadata, oldQuestionCount);
 
             switch (result) {
                 case COMPENSATED -> log.info("Redis 맵 보상 복구 완료 - code: {}", code);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -624,7 +624,7 @@ public class LobbyQueryService {
      *
      * [조회 대상]
      * - 로비 기본 정보
-     * - DB에 저장된 룰 정보(roundCount, timeLimitSeconds)
+     * - Redis에 저장된 룰 정보(questionCount, timeLimitSeconds)
      * - Redis 참여자 목록
      * - Redis ready 상태
      * - 현재 시작 가능 여부(canStart)
@@ -704,8 +704,8 @@ public class LobbyQueryService {
                 .mapId(lobbyInfo.mapId())
                 .mapTitle(lobbyInfo.mapTitle())
                 .mapCategory(lobbyInfo.mapCategory())
-                .questionCount(gameLobby != null ? gameLobby.getQuestionCount() : null)
-                .timeLimitSeconds(gameLobby != null ? gameLobby.getTimeLimitSeconds() : null)
+                .questionCount(lobbyInfo.questionCount())
+                .timeLimitSeconds(lobbyInfo.timeLimitSeconds())
                 .players(players)
                 .canStart(canStart)
                 .build();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -704,7 +704,7 @@ public class LobbyQueryService {
                 .mapId(lobbyInfo.mapId())
                 .mapTitle(lobbyInfo.mapTitle())
                 .mapCategory(lobbyInfo.mapCategory())
-                .roundCount(gameLobby != null ? gameLobby.getRoundCount() : null)
+                .questionCount(gameLobby != null ? gameLobby.getQuestionCount() : null)
                 .timeLimitSeconds(gameLobby != null ? gameLobby.getTimeLimitSeconds() : null)
                 .players(players)
                 .canStart(canStart)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartPolicy.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartPolicy.java
@@ -99,9 +99,9 @@ public class LobbyStartPolicy {
      */
     private void validateMapSongCount(QuizMap quizMap, GameLobby gameLobby) {
         Integer numOfSong = quizMap.getNumOfSong();
-        Integer roundCount = gameLobby.getRoundCount();
+        Integer questionCount = gameLobby.getQuestionCount();
 
-        if (numOfSong == null || roundCount == null || numOfSong < roundCount) {
+        if (numOfSong == null || questionCount == null || numOfSong < questionCount) {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,
                     ERROR_START_MAP_SONG_COUNT_NOT_ENOUGH

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
@@ -162,11 +162,11 @@ public class LobbyStartService {
         registerGameStartedEventAfterCommit(code, requesterIdentifier, firstRound);
 
         log.info(
-                "게임 시작 처리 완료 - code: {}, requester: {}, mapId: {}, roundCount: {}",
+                "게임 시작 처리 완료 - code: {}, requester: {}, mapId: {}, questionCount: {}",
                 code,
                 requesterIdentifier,
                 quizMap.getId(),
-                gameLobby.getRoundCount()
+                gameLobby.getQuestionCount()
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
@@ -24,20 +24,20 @@ public class QuizMapSpecification {
         );
     }
 
-    /** title LIKE %keyword% (null/blank → null → no-op) */
+    /** title LIKE %keyword% (null/blank → no-op) */
     public static Specification<QuizMap> withKeyword(String keyword) {
         if (keyword == null || keyword.isBlank()) {
-            return null;
+            return (root, query, cb) -> null;
         }
-        String pattern = "%" + keyword + "%";
+        String pattern = "%" + keyword.toLowerCase() + "%";
         return (root, query, cb) ->
                 cb.like(cb.lower(root.get("title")), pattern);
     }
 
-    /** category = ? (null → null → no-op) */
+    /** category = ? (null → no-op) */
     public static Specification<QuizMap> withCategory(MapCategory category) {
         if (category == null) {
-            return null;
+            return (root, query, cb) -> null;
         }
         return (root, query, cb) -> cb.equal(root.get("category"), category);
     }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/FlywayRepairConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/FlywayRepairConfig.java
@@ -1,0 +1,26 @@
+package io.github.ascrew.monomatbe.global.config;
+
+import org.springframework.boot.flyway.autoconfigure.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * dev 환경에서 부분 적용된 Flyway 마이그레이션(failed 상태)을 자동으로 복구한다.
+ *
+ * repair()는 flyway_schema_history의 실패 항목을 제거하므로,
+ * 이후 migrate()가 해당 버전을 idempotent 버전으로 재실행할 수 있다.
+ * prod에는 적용하지 않는다 — repair는 의도적인 판단 하에 수행해야 한다.
+ */
+@Configuration
+@Profile("dev")
+public class FlywayRepairConfig {
+
+    @Bean
+    public FlywayMigrationStrategy repairAndMigrate() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -231,6 +231,12 @@ public final class RedisKeys {
     /** 로비 Hash의 상태 필드. 저장 값: "WAITING" / "PLAYING" */
     public static final String FIELD_STATUS = "status";
 
+    /** 로비 Hash의 문제 수 필드 */
+    public static final String FIELD_QUESTION_COUNT = "question_count";
+
+    /** 로비 Hash의 제한 시간(초) 필드 */
+    public static final String FIELD_TIME_LIMIT_SECONDS = "time_limit_seconds";
+
     /**
      * 로비 Hash의 생성 시각 필드
      * 저장 값 : System.currentTimeMillis() 기준 epoch milliseconds 문자열

--- a/src/main/resources/db/migration/V6__rename_round_count_to_question_count.sql
+++ b/src/main/resources/db/migration/V6__rename_round_count_to_question_count.sql
@@ -1,0 +1,25 @@
+-- game_lobby: round_count → question_count (idempotent)
+SET @sql1 = (SELECT IF(COUNT(*) > 0,
+    'ALTER TABLE game_lobby RENAME COLUMN round_count TO question_count',
+    'SELECT 1')
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME = 'game_lobby'
+  AND COLUMN_NAME = 'round_count');
+
+PREPARE v6_stmt1 FROM @sql1;
+EXECUTE v6_stmt1;
+DEALLOCATE PREPARE v6_stmt1;
+
+-- game_session: total_round_count → total_question_count (idempotent)
+SET @sql2 = (SELECT IF(COUNT(*) > 0,
+    'ALTER TABLE game_session RENAME COLUMN total_round_count TO total_question_count',
+    'SELECT 1')
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME = 'game_session'
+  AND COLUMN_NAME = 'total_round_count');
+
+PREPARE v6_stmt2 FROM @sql2;
+EXECUTE v6_stmt2;
+DEALLOCATE PREPARE v6_stmt2;

--- a/src/main/resources/scripts/compensate_lobby_map.lua
+++ b/src/main/resources/scripts/compensate_lobby_map.lua
@@ -23,6 +23,8 @@
 -- ARGV[6] = oldMapId or ""
 -- ARGV[7] = oldMapTitle or ""
 -- ARGV[8] = oldMapCategory or ""
+-- ARGV[9] = fieldQuestionCount
+-- ARGV[10] = oldQuestionCount
 
 local lobbyKey = KEYS[1]
 
@@ -34,6 +36,8 @@ local waitingStatus = ARGV[5]
 local oldMapId = ARGV[6]
 local oldMapTitle = ARGV[7]
 local oldMapCategory = ARGV[8]
+local fieldQuestionCount = ARGV[9]
+local oldQuestionCount = ARGV[10]
 
 if redis.call('EXISTS', lobbyKey) == 0 then
     return 'LOBBY_NOT_FOUND'
@@ -50,5 +54,7 @@ if oldMapId == nil or oldMapId == '' then
 else
     redis.call('HSET', lobbyKey, fieldMapId, oldMapId, fieldMapTitle, oldMapTitle, fieldMapCategory, oldMapCategory)
 end
+
+redis.call('HSET', lobbyKey, fieldQuestionCount, oldQuestionCount)
 
 return 'COMPENSATED'

--- a/src/main/resources/scripts/create_lobby.lua
+++ b/src/main/resources/scripts/create_lobby.lua
@@ -31,6 +31,8 @@ local status          = ARGV[7]   -- "WAITING"
 local mapId           = ARGV[8]   -- 선택된 맵 ID. 미선택 시 ""
 local mapTitle        = ARGV[9]   -- 선택된 맵 제목. 미선택 시 ""
 local mapCategory     = ARGV[10]  -- 선택된 맵 카테고리. 미선택 시 ""
+local questionCount   = ARGV[11]  -- 문제 수
+local timeLimitSeconds = ARGV[12] -- 제한 시간(초)
 
 -- Redis Hash 필드명은 스크립트 상단에서 중앙 관리합니다.
 local FIELD_CODE                    = 'code'
@@ -44,6 +46,8 @@ local FIELD_MAP_ID                  = 'map_id'
 local FIELD_MAP_TITLE               = 'map_title'
 local FIELD_MAP_CATEGORY            = 'map_category'
 local FIELD_CREATED_AT_EPOCH_MILLIS = 'created_at_epoch_millis'
+local FIELD_QUESTION_COUNT          = 'question_count'
+local FIELD_TIME_LIMIT_SECONDS      = 'time_limit_seconds'
 
 -- Redis 서버 기준 현재 시각을 epoch milliseconds로 계산한다.
 --
@@ -78,7 +82,9 @@ redis.call('HSET', lobbyKey,
     FIELD_CURRENT_PLAYERS,         '0',
     FIELD_IS_PRIVATE,              isPrivate,
     FIELD_STATUS,                  status,
-    FIELD_CREATED_AT_EPOCH_MILLIS, tostring(createdAtEpochMillis)
+    FIELD_CREATED_AT_EPOCH_MILLIS, tostring(createdAtEpochMillis),
+    FIELD_QUESTION_COUNT,          questionCount,
+    FIELD_TIME_LIMIT_SECONDS,      timeLimitSeconds
 )
 
 -- 3. 맵이 선택된 경우에만 맵 메타 정보 저장

--- a/src/main/resources/scripts/init_game_session.lua
+++ b/src/main/resources/scripts/init_game_session.lua
@@ -27,9 +27,9 @@ end
 redis.call('DEL', sessionKey, roundsKey, playersKey)
 
 -- 2. 세션 메타데이터 저장
-redis.call('HSET', sessionKey, 
+redis.call('HSET', sessionKey,
     'current_round_no', '1',
-    'total_round_count', totalRounds,
+    'total_question_count', totalRounds,
     'status', 'READY',
     'time_limit_seconds', timeLimitSeconds,
     'round_started_at', roundStartedAt

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
@@ -75,7 +75,7 @@ class GameSessionCreateServiceTest {
         GameLobby lobby = GameLobby.builder()
                 .inviteCode("ABC1234")
                 .mapId(1L)
-                .roundCount(1)
+                .questionCount(1)
                 .timeLimitSeconds(30)
                 .status(LobbyStatus.PLAYING)
                 .build();
@@ -124,7 +124,7 @@ class GameSessionCreateServiceTest {
         verify(gameSessionJpaRepository).save(sessionCaptor.capture());
         GameSession savedSession = sessionCaptor.getValue();
         assertThat(savedSession.getCurrentRoundNo()).isEqualTo(1);
-        assertThat(savedSession.getTotalRoundCount()).isEqualTo(1);
+        assertThat(savedSession.getTotalQuestionCount()).isEqualTo(1);
 
         // 2. DB Player 생성 확인
         ArgumentCaptor<List<GameSessionPlayer>> playersCaptor = ArgumentCaptor.forClass(List.class);
@@ -138,7 +138,7 @@ class GameSessionCreateServiceTest {
         assertThat(result.videoId()).isEqualTo("vId");
         assertThat(result.youtubeUrl()).isEqualTo("https://youtube.com/vId");
         assertThat(result.startTime()).isEqualTo(10);
-        assertThat(result.endTime()).isEqualTo(20);
+        assertThat(result.endTime()).isEqualTo(40); // startTime(10) + timeLimitSeconds(30)
         assertThat(result.timeLimitSeconds()).isEqualTo(30);
         assertThat(result.roundNo()).isEqualTo(1);
         assertThat(result.serverStartedAt()).isGreaterThan(0L);
@@ -153,7 +153,7 @@ class GameSessionCreateServiceTest {
         GameLobby lobby = GameLobby.builder()
                 .inviteCode("ABC1234")
                 .mapId(1L)
-                .roundCount(1)
+                .questionCount(1)
                 .timeLimitSeconds(30)
                 .status(LobbyStatus.PLAYING)
                 .build();

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
@@ -16,7 +16,8 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(properties = {
-        "spring.flyway.enabled=false"
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=none"
 })
 class LobbyLeaveLifecycleRepositoryTest {
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicyTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicyTest.java
@@ -139,7 +139,9 @@ class LobbyCanStartPolicyTest {
                 "WAITING",
                 MAP_ID,
                 "테스트 맵",
-                "K-POP"
+                "K-POP",
+                10,
+                30
         );
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicyTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCanStartPolicyTest.java
@@ -143,14 +143,14 @@ class LobbyCanStartPolicyTest {
         );
     }
 
-    private GameLobby gameLobbyWithRoundCount(int roundCount) {
+    private GameLobby gameLobbyWithRoundCount(int questionCount) {
         return GameLobby.builder()
                 .id(1L)
                 .mapId(MAP_ID)
                 .inviteCode(LOBBY_CODE)
                 .title("테스트 로비")
                 .maxPlayers(4)
-                .roundCount(roundCount)
+                .questionCount(questionCount)
                 .timeLimitSeconds(30)
                 .isPrivate(false)
                 .status(LobbyStatus.WAITING)

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
@@ -41,7 +42,6 @@ import static org.mockito.Mockito.*;
  * - 정상 변경 시 Redis/DB 갱신 및 realtime 이벤트 등록
  * - 맵 변경 시 questionCount가 새 맵의 numOfSong으로 재설정됨
  * - DB 갱신 실패 시 compensateMapMetadataIfWaiting 호출
- * - DB 조건부 갱신 0행 시 보상 + 409
  * - 기존 맵 미선택 로비에서 DB 실패 시 보상이 null oldMetadata로 호출됨
  * - DB GAME_LOBBY 스냅샷 누락 시 reconciliation 패턴 적용
  */
@@ -64,6 +64,7 @@ class LobbyMapUpdateServiceTest {
     private static final String CODE = "ABC123";
     private static final String HOST_ID = "host-uuid";
     private static final Long USER_ID = 1L;
+    private static final int OLD_QUESTION_COUNT = 5;
     private static final int NEW_MAP_NUM_OF_SONG = 10;
 
     private CustomPrincipal hostPrincipal() {
@@ -81,6 +82,8 @@ class LobbyMapUpdateServiceTest {
                 .mapId(10L)
                 .mapTitle("K-POP 구곡")
                 .mapCategory("K-POP")
+                .questionCount(OLD_QUESTION_COUNT)
+                .timeLimitSeconds(30)
                 .build();
     }
 
@@ -95,6 +98,8 @@ class LobbyMapUpdateServiceTest {
                 .mapId(null)
                 .mapTitle(null)
                 .mapCategory(null)
+                .questionCount(OLD_QUESTION_COUNT)
+                .timeLimitSeconds(30)
                 .build();
     }
 
@@ -106,7 +111,7 @@ class LobbyMapUpdateServiceTest {
                 .inviteCode(CODE)
                 .title("테스트 로비")
                 .maxPlayers(6)
-                .questionCount(5)
+                .questionCount(OLD_QUESTION_COUNT)
                 .timeLimitSeconds(30)
                 .isPrivate(false)
                 .status(status)
@@ -211,7 +216,7 @@ class LobbyMapUpdateServiceTest {
                 .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
                         .isEqualTo(HttpStatus.CONFLICT));
 
-        verify(lobbyRepository, never()).updateMapMetadata(any(), any());
+        verify(lobbyRepository, never()).updateMapMetadata(any(), any(), anyInt());
     }
 
     // ─── 방장 검증 ────────────────────────────────────────
@@ -248,8 +253,8 @@ class LobbyMapUpdateServiceTest {
                     assertThat(rse.getReason()).contains("진행 중");
                 });
 
-        verify(lobbyRepository, never()).updateMapMetadata(any(), any());
-        verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any());
+        verify(lobbyRepository, never()).updateMapMetadata(any(), any(), anyInt());
+        verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any(), anyInt());
     }
 
     // ─── DB 스냅샷 누락 ─────────────────────────────────
@@ -270,7 +275,7 @@ class LobbyMapUpdateServiceTest {
 
         verify(lobbyRepository).deleteFromRedis(CODE);
         verify(lobbyRepository, never()).enqueueStartReconciliation(any(), any());
-        verify(lobbyRepository, never()).updateMapMetadata(any(), any());
+        verify(lobbyRepository, never()).updateMapMetadata(any(), any(), anyInt());
     }
 
     @Test
@@ -300,18 +305,17 @@ class LobbyMapUpdateServiceTest {
             when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
             LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
             when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+            GameLobby gameLobby = gameLobbyWith(LobbyStatus.WAITING, 10L);
             when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
-                    .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
+                    .thenReturn(Optional.of(gameLobby));
             givenNewMapExists(2L);
-            when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
-                    CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING)).thenReturn(1);
+            when(gameLobbyJpaRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
             sut.updateMap(CODE, request(2L), hostPrincipal());
 
-            verify(lobbyRepository).updateMapMetadata(CODE, newMetadata);
-            verify(gameLobbyJpaRepository).updateMapAndQuestionCountIfWaiting(
-                    CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING);
-            verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any());
+            verify(lobbyRepository).updateMapMetadata(CODE, newMetadata, NEW_MAP_NUM_OF_SONG);
+            verify(gameLobbyJpaRepository).saveAndFlush(gameLobby);
+            verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any(), anyInt());
 
             TransactionSynchronizationManager.getSynchronizations()
                     .forEach(TransactionSynchronization::afterCommit);
@@ -332,10 +336,9 @@ class LobbyMapUpdateServiceTest {
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
         givenNewMapExists(2L);
-        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
-                eq(CODE), eq(2L), eq(NEW_MAP_NUM_OF_SONG), eq(LobbyStatus.WAITING)))
+        when(gameLobbyJpaRepository.saveAndFlush(any()))
                 .thenThrow(new RuntimeException("DB 장애"));
-        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
+        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any(), anyInt()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
 
         assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
@@ -344,8 +347,8 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
         LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
-        verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
-        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), eq(oldMetadata));
+        verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata), eq(NEW_MAP_NUM_OF_SONG));
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), eq(oldMetadata), eq(OLD_QUESTION_COUNT));
         verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
     }
 
@@ -358,10 +361,9 @@ class LobbyMapUpdateServiceTest {
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, null)));
         givenNewMapExists(1L);
-        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
-                eq(CODE), eq(1L), eq(NEW_MAP_NUM_OF_SONG), eq(LobbyStatus.WAITING)))
+        when(gameLobbyJpaRepository.saveAndFlush(any()))
                 .thenThrow(new RuntimeException("DB 장애"));
-        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
+        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any(), anyInt()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
 
         assertThatThrownBy(() -> sut.updateMap(CODE, request(1L), hostPrincipal()))
@@ -369,31 +371,8 @@ class LobbyMapUpdateServiceTest {
                 .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
                         .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
-        verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata));
-        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), (LobbyMapMetadata) isNull());
-    }
-
-    @Test
-    @DisplayName("DB 조건부 갱신이 0행 반환이면 Redis를 보상 복구하고 409를 던진다")
-    void updateMap_rollbacksRedisAndThrowsConflict_whenDbUpdatedZeroRows() {
-        when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
-        when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
-        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
-                .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        givenNewMapExists(2L);
-        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
-                CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING)).thenReturn(0);
-        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
-                .thenReturn(LobbyMapCompensationResult.COMPENSATED);
-
-        assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
-                .isInstanceOf(ResponseStatusException.class)
-                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
-                        .isEqualTo(HttpStatus.CONFLICT));
-
-        LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
-        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), eq(oldMetadata));
+        verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata), eq(NEW_MAP_NUM_OF_SONG));
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), (LobbyMapMetadata) isNull(), eq(OLD_QUESTION_COUNT));
     }
 
     @Test
@@ -405,16 +384,16 @@ class LobbyMapUpdateServiceTest {
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
         givenNewMapExists(2L);
-        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
-                CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING)).thenReturn(0);
-        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
+        when(gameLobbyJpaRepository.saveAndFlush(any()))
+                .thenThrow(new RuntimeException("DB 장애"));
+        when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any(), anyInt()))
                 .thenReturn(LobbyMapCompensationResult.SKIPPED_NOT_WAITING);
 
         assertThatThrownBy(() -> sut.updateMap(CODE, request(2L), hostPrincipal()))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
-                        .isEqualTo(HttpStatus.CONFLICT));
+                        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
-        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), any());
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), any(), anyInt());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
@@ -10,6 +10,8 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -36,6 +39,7 @@ import static org.mockito.Mockito.*;
  * - WAITING 상태 제한 (Redis 1차 / DB 락 후 재검증)
  * - 방장 권한 제한
  * - 정상 변경 시 Redis/DB 갱신 및 realtime 이벤트 등록
+ * - 맵 변경 시 questionCount가 새 맵의 numOfSong으로 재설정됨
  * - DB 갱신 실패 시 compensateMapMetadataIfWaiting 호출
  * - DB 조건부 갱신 0행 시 보상 + 409
  * - 기존 맵 미선택 로비에서 DB 실패 시 보상이 null oldMetadata로 호출됨
@@ -47,17 +51,20 @@ class LobbyMapUpdateServiceTest {
     private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
     private final LobbyMapPolicy lobbyMapPolicy = mock(LobbyMapPolicy.class);
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier = mock(LobbyRealtimeNotifier.class);
+    private final QuizMapJpaRepository quizMapJpaRepository = mock(QuizMapJpaRepository.class);
 
     private final LobbyMapUpdateService sut = new LobbyMapUpdateService(
             lobbyRepository,
             gameLobbyJpaRepository,
             lobbyMapPolicy,
-            lobbyRealtimeNotifier
+            lobbyRealtimeNotifier,
+            quizMapJpaRepository
     );
 
     private static final String CODE = "ABC123";
     private static final String HOST_ID = "host-uuid";
     private static final Long USER_ID = 1L;
+    private static final int NEW_MAP_NUM_OF_SONG = 10;
 
     private CustomPrincipal hostPrincipal() {
         return new CustomPrincipal(USER_ID, HOST_ID, UserType.REGISTERED);
@@ -99,12 +106,21 @@ class LobbyMapUpdateServiceTest {
                 .inviteCode(CODE)
                 .title("테스트 로비")
                 .maxPlayers(6)
-                .roundCount(5)
+                .questionCount(5)
                 .timeLimitSeconds(30)
                 .isPrivate(false)
                 .status(status)
                 .isDeleted(false)
                 .build();
+    }
+
+    /** 주어진 mapId의 맵 조회 시 numOfSong=NEW_MAP_NUM_OF_SONG(10)인 QuizMap을 반환하도록 설정 */
+    private void givenNewMapExists(Long mapId) {
+        QuizMap quizMap = QuizMap.builder()
+                .id(mapId)
+                .numOfSong(NEW_MAP_NUM_OF_SONG)
+                .build();
+        when(quizMapJpaRepository.findById(mapId)).thenReturn(Optional.of(quizMap));
     }
 
     private UpdateLobbyMapRequest request(long mapId) {
@@ -277,7 +293,7 @@ class LobbyMapUpdateServiceTest {
     // ─── 정상 변경 ───────────────────────────────────────
 
     @Test
-    @DisplayName("정상 요청 시 Redis/DB를 갱신하고 afterCommit 이벤트를 등록한다")
+    @DisplayName("정상 요청 시 Redis/DB를 갱신하고 questionCount를 새 맵의 numOfSong으로 재설정한다")
     void updateMap_updatesRedisAndDb_andRegistersAfterCommitEvent() {
         TransactionSynchronizationManager.initSynchronization();
         try {
@@ -286,12 +302,15 @@ class LobbyMapUpdateServiceTest {
             when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
             when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                     .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-            when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(1);
+            givenNewMapExists(2L);
+            when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
+                    CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING)).thenReturn(1);
 
             sut.updateMap(CODE, request(2L), hostPrincipal());
 
             verify(lobbyRepository).updateMapMetadata(CODE, newMetadata);
-            verify(gameLobbyJpaRepository).updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING);
+            verify(gameLobbyJpaRepository).updateMapAndQuestionCountIfWaiting(
+                    CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING);
             verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any());
 
             TransactionSynchronizationManager.getSynchronizations()
@@ -312,7 +331,9 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(2L), eq(LobbyStatus.WAITING)))
+        givenNewMapExists(2L);
+        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
+                eq(CODE), eq(2L), eq(NEW_MAP_NUM_OF_SONG), eq(LobbyStatus.WAITING)))
                 .thenThrow(new RuntimeException("DB 장애"));
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
@@ -336,7 +357,9 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(1L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, null)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(eq(CODE), eq(1L), eq(LobbyStatus.WAITING)))
+        givenNewMapExists(1L);
+        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
+                eq(CODE), eq(1L), eq(NEW_MAP_NUM_OF_SONG), eq(LobbyStatus.WAITING)))
                 .thenThrow(new RuntimeException("DB 장애"));
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
@@ -358,7 +381,9 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(0);
+        givenNewMapExists(2L);
+        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
+                CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING)).thenReturn(0);
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.COMPENSATED);
 
@@ -379,7 +404,9 @@ class LobbyMapUpdateServiceTest {
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        when(gameLobbyJpaRepository.updateMapIdIfWaiting(CODE, 2L, LobbyStatus.WAITING)).thenReturn(0);
+        givenNewMapExists(2L);
+        when(gameLobbyJpaRepository.updateMapAndQuestionCountIfWaiting(
+                CODE, 2L, NEW_MAP_NUM_OF_SONG, LobbyStatus.WAITING)).thenReturn(0);
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any()))
                 .thenReturn(LobbyMapCompensationResult.SKIPPED_NOT_WAITING);
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
@@ -155,7 +155,7 @@ class LobbyQueryServiceCanStartTest {
                 .mapId(2L)
                 .title("테스트 로비")
                 .maxPlayers(4)
-                .roundCount(5)
+                .questionCount(5)
                 .timeLimitSeconds(30)
                 .isPrivate(false)
                 .build();

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -442,7 +442,9 @@ class LobbyQueryServiceTest {
                 LobbyStatus.WAITING.name(),
                 1L,
                 "테스트 맵",
-                "K-POP"
+                "K-POP",
+                10,
+                30
         );
 
         when(lobbyRepository.findByInviteCode(code))
@@ -508,6 +510,8 @@ class LobbyQueryServiceTest {
                 8,
                 2,
                 LobbyStatus.WAITING.name(),
+                null,
+                null,
                 null,
                 null,
                 null

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
@@ -118,7 +118,7 @@ class LobbyStartServiceTest {
         GameLobby gameLobby = GameLobby.builder()
                 .inviteCode(LOBBY_CODE)
                 .mapId(null)
-                .roundCount(ROUND_COUNT)
+                .questionCount(ROUND_COUNT)
                 .build();
 
         when(lobbyRepository.findByInviteCode(LOBBY_CODE))
@@ -221,7 +221,7 @@ class LobbyStartServiceTest {
         return GameLobby.builder()
                 .inviteCode(LOBBY_CODE)
                 .mapId(MAP_ID)
-                .roundCount(ROUND_COUNT)
+                .questionCount(ROUND_COUNT)
                 .build();
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/service/ReportServiceTest.java
@@ -341,7 +341,7 @@ class ReportServiceTest {
                 .inviteCode(inviteCode)
                 .title("테스트 로비")
                 .maxPlayers(8)
-                .roundCount(5)
+                .questionCount(5)
                 .timeLimitSeconds(30)
                 .isPrivate(false)
                 .isDeleted(isDeleted)


### PR DESCRIPTION
## 📣 Related Issue
- #92 

## 📝 Summary
- `roundCount` → `questionCount` 변수명 일괄 변경 (DB 컬럼 포함, Flyway V6 마이그레이션)
- 로비 생성 시 `questionCount` 자동 상한 설정: 선택된 맵의 `numOfSong`을 초과할 수 없음
- 맵 변경 시 `questionCount`를 새 맵의 `numOfSong`으로 자동 재설정
- 게임 시작 시 `RoundStartDto.endTime`을 맵 제작자 설정값 대신 `startTime` + `timeLimitSeconds`로 오버라이드
- Spring Data JPA 4.0 breaking change 대응: `Specification.and(null)` → `no-op Predicate` 반환으로 수정 (`queryPublicMaps` 크래시 수정)

## 🙏PR point
- Flyway V6 마이그레이션 주의: 기존에 V6 실행에 실패한 이력이 있는 dev DB는 서버 기동 시 `FlywayRepairConfig`가 자동으로 `repair()` 후 `migrate()`를 수행합니다. 별도 수동 작업 불필요합니다.
- Spring Data JPA 4.0 breaking change: 3.x에서는 Specification.and(null)이 no-op이었으나, 4.0부터 IllegalArgumentException을 던집니다. QuizMapSpecification의 withKeyword / withCategory에서 null 대신 (root, query, cb) -> null을 반환하도록 수정했습니다.
- questionCount 상한 로직은 LobbyCreateService와 LobbyMapUpdateService에 각각 위치하며, LobbyMapPolicy가 이미 맵 존재/권한을 검증한 이후에 실행되므로 findById는 항상 성공합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
