### PR TITLE
[Feat/#128] 인증 API 에러 응답 코드 표준화

### DIFF
--- a/docs/AUTH_ERROR_CODES.md
+++ b/docs/AUTH_ERROR_CODES.md
@@ -104,12 +104,9 @@ if (error.message === '이미 사용 중인 로그인 ID입니다.') {
 | 상황 | code |
 |---|---|
 | 로그인 ID 누락 | `AUTH_LOGIN_ID_REQUIRED` |
-| 로그인 ID 길이 오류 | `AUTH_LOGIN_ID_INVALID_LENGTH` |
-| 로그인 ID 형식 오류 | `AUTH_LOGIN_ID_INVALID_FORMAT` |
 | 로그인 ID 공백 포함 | `AUTH_LOGIN_ID_CONTAINS_WHITESPACE` |
 | 로그인 ID 중복 | `AUTH_LOGIN_ID_DUPLICATED` |
 | 비밀번호 누락 | `AUTH_PASSWORD_REQUIRED` |
-| 비밀번호 길이 오류 | `AUTH_PASSWORD_INVALID_LENGTH` |
 | 비밀번호 공백 포함 | `AUTH_PASSWORD_CONTAINS_WHITESPACE` |
 | 닉네임 누락 | `AUTH_NICKNAME_REQUIRED` |
 | 닉네임 길이 오류 | `AUTH_NICKNAME_INVALID_LENGTH` |

--- a/docs/AUTH_ERROR_CODES.md
+++ b/docs/AUTH_ERROR_CODES.md
@@ -94,6 +94,7 @@ if (error.message === '이미 사용 중인 로그인 ID입니다.') {
 | `AUTH_INVALID_REFRESH_TOKEN` | Refresh Token이 유효하지 않습니다. | `null` | 401 |
 | `AUTH_SESSION_EXPIRED` | 세션이 만료되었습니다. | `null` | 401 |
 | `AUTH_TEMPORARY_UNAVAILABLE` | 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요. | `null` | 503 |
+| `AUTH_INVALID_REQUEST_BODY` | 요청 본문 형식이 올바르지 않습니다. | `null` | 400 |
 
 ---
 
@@ -159,6 +160,14 @@ if (error.message === '이미 사용 중인 로그인 ID입니다.') {
 | Authorization 헤더 누락 | `AUTH_INVALID_AUTHORIZATION` |
 | Authorization 헤더 형식 오류 | `AUTH_INVALID_AUTHORIZATION` |
 | Access Token 파싱 실패 | `AUTH_INVALID_AUTHORIZATION` |
+
+---
+
+### 공통 요청 오류
+
+| 상황 | code |
+|---|---|
+| JSON body 형식 오류 | `AUTH_INVALID_REQUEST_BODY` |
 
 ---
 

--- a/docs/AUTH_ERROR_CODES.md
+++ b/docs/AUTH_ERROR_CODES.md
@@ -91,6 +91,7 @@ if (error.message === '이미 사용 중인 로그인 ID입니다.') {
 | `AUTH_ACCOUNT_LOCKED` | 로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요. | `null` | 423 |
 | `AUTH_UNAUTHENTICATED` | 인증 정보가 없습니다. | `null` | 401 |
 | `AUTH_INVALID_AUTHORIZATION` | Authorization 헤더가 유효하지 않습니다. | `null` | 401 |
+| `AUTH_REFRESH_TOKEN_REQUIRED` | Refresh Token은 비어 있을 수 없습니다. | `refreshToken` | 400 |
 | `AUTH_INVALID_REFRESH_TOKEN` | Refresh Token이 유효하지 않습니다. | `null` | 401 |
 | `AUTH_SESSION_EXPIRED` | 세션이 만료되었습니다. | `null` | 401 |
 | `AUTH_TEMPORARY_UNAVAILABLE` | 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요. | `null` | 503 |
@@ -144,7 +145,8 @@ if (error.message === '이미 사용 중인 로그인 ID입니다.') {
 
 | 상황 | code |
 |---|---|
-| Refresh Token 누락 | `AUTH_INVALID_REFRESH_TOKEN` |
+| Refresh Token 누락 | `AUTH_REFRESH_TOKEN_REQUIRED` |
+| Refresh Token 빈 값 | `AUTH_REFRESH_TOKEN_REQUIRED` |
 | Refresh Token 형식 오류 | `AUTH_INVALID_REFRESH_TOKEN` |
 | Refresh Token 불일치 | `AUTH_INVALID_REFRESH_TOKEN` |
 | 세션 만료 | `AUTH_SESSION_EXPIRED` |

--- a/docs/AUTH_ERROR_CODES.md
+++ b/docs/AUTH_ERROR_CODES.md
@@ -1,0 +1,220 @@
+# 인증 API 에러 코드
+
+## 목적
+
+인증 API는 프론트엔드가 사용자 표시 메시지 문자열에 의존하지 않도록 `code`, `message`, `field` 기반 에러 응답을 반환합니다.
+
+프론트엔드는 `message`가 아니라 `code`와 `field`를 기준으로 에러 UI를 제어해야 합니다.
+
+---
+
+## 에러 응답 포맷
+
+```json
+{
+  "code": "AUTH_INVALID_CREDENTIALS",
+  "message": "로그인 ID 또는 비밀번호가 올바르지 않습니다.",
+  "field": null
+}
+```
+
+| 필드 | 설명 |
+|---|---|
+| `code` | 프론트엔드 분기 기준이 되는 안정적인 에러 코드 |
+| `message` | 사용자에게 표시할 수 있는 기본 메시지 |
+| `field` | 특정 입력 필드와 연결되는 경우 필드명, 전역 에러면 `null` |
+
+---
+
+## 프론트엔드 처리 원칙
+
+프론트엔드는 아래처럼 `message` 문자열이 아니라 `code`를 기준으로 분기합니다.
+
+```ts
+if (error.code === 'AUTH_LOGIN_ID_DUPLICATED') {
+  setLoginIdError(error.message);
+}
+```
+
+다음 방식은 사용하지 않습니다.
+
+```ts
+if (error.message === '이미 사용 중인 로그인 ID입니다.') {
+  setLoginIdError(error.message);
+}
+```
+
+사용자 표시 문구는 백엔드에서 변경될 수 있지만, `code`는 API 계약이므로 안정적으로 유지합니다.
+
+---
+
+## 로그인 ID 에러 코드
+
+| code | message | field | HTTP Status |
+|---|---|---|---:|
+| `AUTH_LOGIN_ID_REQUIRED` | 로그인 ID는 비어 있을 수 없습니다. | `loginId` | 400 |
+| `AUTH_LOGIN_ID_INVALID_LENGTH` | 로그인 ID는 4자 이상 50자 이하여야 합니다. | `loginId` | 400 |
+| `AUTH_LOGIN_ID_INVALID_FORMAT` | 로그인 ID는 영문과 숫자만 사용할 수 있습니다. | `loginId` | 400 |
+| `AUTH_LOGIN_ID_CONTAINS_WHITESPACE` | 로그인 ID에는 공백을 포함할 수 없습니다. | `loginId` | 400 |
+| `AUTH_LOGIN_ID_DUPLICATED` | 이미 사용 중인 로그인 ID입니다. | `loginId` | 409 |
+
+---
+
+## 비밀번호 에러 코드
+
+| code | message | field | HTTP Status |
+|---|---|---|---:|
+| `AUTH_PASSWORD_REQUIRED` | 비밀번호는 비어 있을 수 없습니다. | `password` | 400 |
+| `AUTH_PASSWORD_INVALID_LENGTH` | 비밀번호는 8자 이상 100자 이하여야 합니다. | `password` | 400 |
+| `AUTH_PASSWORD_CONTAINS_WHITESPACE` | 비밀번호에는 공백을 포함할 수 없습니다. | `password` | 400 |
+
+---
+
+## 닉네임 에러 코드
+
+| code | message | field | HTTP Status |
+|---|---|---|---:|
+| `AUTH_NICKNAME_REQUIRED` | 닉네임은 비어 있을 수 없습니다. | `nickname` | 400 |
+| `AUTH_NICKNAME_INVALID_LENGTH` | 닉네임은 2자 이상 12자 이하여야 합니다. | `nickname` | 400 |
+| `AUTH_NICKNAME_DUPLICATED` | 이미 사용 중인 닉네임입니다. | `nickname` | 409 |
+| `AUTH_NICKNAME_FORBIDDEN_WORD` | 사용할 수 없는 닉네임입니다. | `nickname` | 400 |
+
+> `AUTH_NICKNAME_FORBIDDEN_WORD`는 금칙어 검증 정책 추가 시 사용합니다.
+
+---
+
+## 로그인/세션 에러 코드
+
+| code | message | field | HTTP Status |
+|---|---|---|---:|
+| `AUTH_INVALID_CREDENTIALS` | 로그인 ID 또는 비밀번호가 올바르지 않습니다. | `null` | 401 |
+| `AUTH_ACCOUNT_LOCKED` | 로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요. | `null` | 423 |
+| `AUTH_UNAUTHENTICATED` | 인증 정보가 없습니다. | `null` | 401 |
+| `AUTH_INVALID_AUTHORIZATION` | Authorization 헤더가 유효하지 않습니다. | `null` | 401 |
+| `AUTH_INVALID_REFRESH_TOKEN` | Refresh Token이 유효하지 않습니다. | `null` | 401 |
+| `AUTH_SESSION_EXPIRED` | 세션이 만료되었습니다. | `null` | 401 |
+| `AUTH_TEMPORARY_UNAVAILABLE` | 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요. | `null` | 503 |
+
+---
+
+## API별 주요 에러
+
+### `POST /api/auth/register`
+
+| 상황 | code |
+|---|---|
+| 로그인 ID 누락 | `AUTH_LOGIN_ID_REQUIRED` |
+| 로그인 ID 길이 오류 | `AUTH_LOGIN_ID_INVALID_LENGTH` |
+| 로그인 ID 형식 오류 | `AUTH_LOGIN_ID_INVALID_FORMAT` |
+| 로그인 ID 공백 포함 | `AUTH_LOGIN_ID_CONTAINS_WHITESPACE` |
+| 로그인 ID 중복 | `AUTH_LOGIN_ID_DUPLICATED` |
+| 비밀번호 누락 | `AUTH_PASSWORD_REQUIRED` |
+| 비밀번호 길이 오류 | `AUTH_PASSWORD_INVALID_LENGTH` |
+| 비밀번호 공백 포함 | `AUTH_PASSWORD_CONTAINS_WHITESPACE` |
+| 닉네임 누락 | `AUTH_NICKNAME_REQUIRED` |
+| 닉네임 길이 오류 | `AUTH_NICKNAME_INVALID_LENGTH` |
+| 닉네임 중복 | `AUTH_NICKNAME_DUPLICATED` |
+
+---
+
+### `POST /api/auth/login`
+
+| 상황 | code |
+|---|---|
+| 로그인 ID 누락 | `AUTH_LOGIN_ID_REQUIRED` |
+| 로그인 ID 길이 오류 | `AUTH_LOGIN_ID_INVALID_LENGTH` |
+| 로그인 ID 형식 오류 | `AUTH_LOGIN_ID_INVALID_FORMAT` |
+| 비밀번호 누락 | `AUTH_PASSWORD_REQUIRED` |
+| 비밀번호 길이 오류 | `AUTH_PASSWORD_INVALID_LENGTH` |
+| 로그인 ID 또는 비밀번호 불일치 | `AUTH_INVALID_CREDENTIALS` |
+| 계정 잠금 | `AUTH_ACCOUNT_LOCKED` |
+
+---
+
+### `POST /api/auth/guest`
+
+| 상황 | code |
+|---|---|
+| 닉네임 누락 | `AUTH_NICKNAME_REQUIRED` |
+| 닉네임 길이 오류 | `AUTH_NICKNAME_INVALID_LENGTH` |
+| 닉네임 중복 | `AUTH_NICKNAME_DUPLICATED` |
+| 닉네임 금칙어 포함 | `AUTH_NICKNAME_FORBIDDEN_WORD` |
+
+---
+
+### `POST /api/auth/refresh`
+
+| 상황 | code |
+|---|---|
+| Refresh Token 누락 | `AUTH_INVALID_REFRESH_TOKEN` |
+| Refresh Token 형식 오류 | `AUTH_INVALID_REFRESH_TOKEN` |
+| Refresh Token 불일치 | `AUTH_INVALID_REFRESH_TOKEN` |
+| 세션 만료 | `AUTH_SESSION_EXPIRED` |
+| 세션 저장소 일시 오류 | `AUTH_TEMPORARY_UNAVAILABLE` |
+
+---
+
+### `POST /api/auth/logout`
+
+| 상황 | code |
+|---|---|
+| 인증 정보 없음 | `AUTH_UNAUTHENTICATED` |
+| Authorization 헤더 누락 | `AUTH_INVALID_AUTHORIZATION` |
+| Authorization 헤더 형식 오류 | `AUTH_INVALID_AUTHORIZATION` |
+| Access Token 파싱 실패 | `AUTH_INVALID_AUTHORIZATION` |
+
+---
+
+## 주의사항
+
+### 로그인 실패 메시지 통합
+
+로그인 실패 시 로그인 ID가 존재하지 않는 경우와 비밀번호가 틀린 경우는 모두 아래 코드로 통합합니다.
+
+```text
+AUTH_INVALID_CREDENTIALS
+```
+
+계정 존재 여부 추측을 막기 위한 정책입니다.
+
+---
+
+### `message`는 표시용입니다
+
+프론트엔드는 `message`를 분기 기준으로 사용하지 않습니다.
+
+허용:
+
+```ts
+switch (error.code) {
+  case 'AUTH_PASSWORD_REQUIRED':
+    setPasswordError(error.message);
+    break;
+}
+```
+
+비허용:
+
+```ts
+if (error.message === '비밀번호는 비어 있을 수 없습니다.') {
+  setPasswordError(error.message);
+}
+```
+
+---
+
+### `field`가 null인 경우
+
+`field`가 `null`이면 특정 입력 필드가 아니라 인증 상태 전체에 대한 에러입니다.
+
+예:
+
+```json
+{
+  "code": "AUTH_INVALID_CREDENTIALS",
+  "message": "로그인 ID 또는 비밀번호가 올바르지 않습니다.",
+  "field": null
+}
+```
+
+프론트엔드는 이런 에러를 form 상단 또는 toast 영역에 표시합니다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
@@ -9,6 +9,8 @@ import io.github.ascrew.monomatbe.domain.auth.dto.RefreshTokenRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.RefreshTokenResponse;
 import io.github.ascrew.monomatbe.domain.auth.dto.RegisterRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.service.GuestAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.LoginAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.LogoutAuthService;
@@ -28,7 +30,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
@@ -73,6 +74,7 @@ public class AuthController {
                 request.password(),
                 request.nickname()
         );
+
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -91,6 +93,7 @@ public class AuthController {
                 resolveClientIp(httpServletRequest),
                 httpServletRequest.getHeader("User-Agent")
         );
+
         return ResponseEntity.ok(response);
     }
 
@@ -105,6 +108,7 @@ public class AuthController {
                 resolveClientIp(httpServletRequest),
                 httpServletRequest.getHeader("User-Agent")
         );
+
         return ResponseEntity.ok(response);
     }
 
@@ -115,8 +119,9 @@ public class AuthController {
             @RequestHeader("Authorization") String authorizationHeader
     ) {
         if (principal == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 정보가 없습니다.");
+            throw new AuthException(AuthErrorCode.AUTH_UNAUTHENTICATED);
         }
+
         logoutAuthService.logout(principal.userId(), principal.userIdentifier(), authorizationHeader);
         return ResponseEntity.ok(new LogoutResponse("로그아웃이 완료되었습니다."));
     }
@@ -124,10 +129,12 @@ public class AuthController {
     private String resolveClientIp(HttpServletRequest request) {
         if (trustForwardedHeaders) {
             String forwardedFor = request.getHeader("X-Forwarded-For");
+
             if (forwardedFor != null && !forwardedFor.isBlank()) {
                 return forwardedFor.split(",")[0].trim();
             }
         }
+
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController {
 
     /**
      * 게스트 로그인 엔드포인트
-     * 닉네임 기반으로 게스트 계정/세션을 생성하고 토큰 정보를 반환
+     * 닉네임 기반으로 게스트 계정/세션을 생성하고 토큰 정보를 반환한다.
      */
     @Operation(summary = "게스트 로그인", description = "닉네임으로 게스트 계정/세션을 생성하고 토큰 정보를 반환합니다.")
     @PostMapping("/guest")
@@ -63,8 +63,7 @@ public class AuthController {
     }
 
     /**
-     * 회원가입 엔드포인트.
-     * (#34 범위: 계정 생성만 처리, 토큰 발급은 #35 로그인에서 처리)
+     * 회원가입 엔드포인트
      */
     @Operation(summary = "회원가입", description = "로그인 ID/비밀번호/닉네임으로 정식 회원 계정을 생성합니다.")
     @PostMapping("/register")
@@ -79,7 +78,7 @@ public class AuthController {
     }
 
     /**
-     * 자체 로그인 엔드포인트.
+     * 자체 로그인 엔드포인트
      */
     @Operation(summary = "자체 로그인", description = "로그인 ID/비밀번호로 인증하고 토큰/세션 정보를 발급합니다.")
     @PostMapping("/login")
@@ -116,7 +115,7 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
             @AuthenticationPrincipal CustomPrincipal principal,
-            @RequestHeader("Authorization") String authorizationHeader
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader
     ) {
         if (principal == null) {
             throw new AuthException(AuthErrorCode.AUTH_UNAUTHENTICATED);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/AuthErrorResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/AuthErrorResponse.java
@@ -1,0 +1,32 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+
+/**
+ * 인증 API 에러 응답 DTO
+ *
+ * [응답 예시]
+ * {
+ *   "code": "AUTH_INVALID_CREDENTIALS",
+ *   "message": "로그인 ID 또는 비밀번호가 올바르지 않습니다.",
+ *   "field": null
+ * }
+ *
+ * [주의]
+ * httpStatus는 HTTP status line에 이미 포함되므로 body에는 포함하지 않는다.
+ * 프론트엔드는 code와 field를 기준으로 분기하고, message는 사용자 표시용으로만 사용한다.
+ */
+public record AuthErrorResponse(
+        String code,
+        String message,
+        String field
+) {
+
+    public static AuthErrorResponse from(AuthErrorCode errorCode) {
+        return new AuthErrorResponse(
+                errorCode.name(),
+                errorCode.getMessage(),
+                errorCode.getField()
+        );
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/GuestLoginRequest.java
@@ -4,14 +4,18 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 /**
- * 게스트 로그인 요청 DTO.
+ * 게스트 로그인 요청 DTO
  *
- * 클라이언트는 닉네임만 전달하고,
- * 서버가 게스트 계정 생성/세션 발급을 담당합니다.
+ * 클라이언트는 닉네임만 전달하고, 서버가 게스트 계정 생성/세션 발급을 담당한다.
+ *
+ * [Validation message 정책]
+ * message에는 사용자 표시 문구가 아니라 AuthErrorCode enum 이름을 넣는다.
+ * 실제 사용자 표시 메시지는 AuthErrorCode에서 관리하고,
+ * AuthExceptionHandler가 code/message/field 응답으로 변환한다.
  */
 public record GuestLoginRequest(
-        @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
-        @Size(max = 8, message = "닉네임은 8자를 초과할 수 없습니다.")
+        @NotBlank(message = "AUTH_NICKNAME_REQUIRED")
+        @Size(min = 2, max = 12, message = "AUTH_NICKNAME_INVALID_LENGTH")
         String nickname
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginRequest.java
@@ -1,26 +1,22 @@
 package io.github.ascrew.monomatbe.domain.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * 자체 로그인 요청 DTO
  *
  * [Validation message 정책]
  * message에는 사용자 표시 문구가 아니라 AuthErrorCode enum 이름을 넣는다.
- * 실제 사용자 표시 메시지는 AuthErrorCode에서 관리하고,
- * AuthExceptionHandler가 code/message/field 응답으로 변환한다.
+ *
+ * [주의]
+ * 로그인 API에서는 기존 회원 호환성을 위해 loginId 포맷 검증을 수행하지 않는다.
+ * 포맷이 신규 정책과 다르더라도 DB 조회 후 인증 실패 시 AUTH_INVALID_CREDENTIALS로 처리한다.
  */
 public record LoginRequest(
         @NotBlank(message = "AUTH_LOGIN_ID_REQUIRED")
-        @Size(min = 4, max = 50, message = "AUTH_LOGIN_ID_INVALID_LENGTH")
-        @Pattern(regexp = "^[A-Za-z0-9]+$", message = "AUTH_LOGIN_ID_INVALID_FORMAT")
         String loginId,
 
         @NotBlank(message = "AUTH_PASSWORD_REQUIRED")
-        @Size(min = 8, max = 100, message = "AUTH_PASSWORD_INVALID_LENGTH")
-        @Pattern(regexp = "^\\S+$", message = "AUTH_PASSWORD_CONTAINS_WHITESPACE")
         String password
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/LoginRequest.java
@@ -5,17 +5,22 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 /**
- * 자체 로그인 요청 DTO.
+ * 자체 로그인 요청 DTO
+ *
+ * [Validation message 정책]
+ * message에는 사용자 표시 문구가 아니라 AuthErrorCode enum 이름을 넣는다.
+ * 실제 사용자 표시 메시지는 AuthErrorCode에서 관리하고,
+ * AuthExceptionHandler가 code/message/field 응답으로 변환한다.
  */
 public record LoginRequest(
-        @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "로그인 ID는 50자를 초과할 수 없습니다.")
-        @Pattern(regexp = "^\\S+$", message = "로그인 ID에는 공백을 포함할 수 없습니다.")
+        @NotBlank(message = "AUTH_LOGIN_ID_REQUIRED")
+        @Size(min = 4, max = 50, message = "AUTH_LOGIN_ID_INVALID_LENGTH")
+        @Pattern(regexp = "^[A-Za-z0-9]+$", message = "AUTH_LOGIN_ID_INVALID_FORMAT")
         String loginId,
 
-        @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
-        @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
-        @Pattern(regexp = "^\\S+$", message = "비밀번호에는 공백을 포함할 수 없습니다.")
+        @NotBlank(message = "AUTH_PASSWORD_REQUIRED")
+        @Size(min = 8, max = 100, message = "AUTH_PASSWORD_INVALID_LENGTH")
+        @Pattern(regexp = "^\\S+$", message = "AUTH_PASSWORD_CONTAINS_WHITESPACE")
         String password
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RefreshTokenRequest.java
@@ -3,15 +3,19 @@ package io.github.ascrew.monomatbe.domain.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 
 /**
- * Refresh Token 재발급 요청 DTO.
+ * Refresh Token 재발급 요청 DTO
  *
  * [Validation message 정책]
  * message에는 사용자 표시 문구가 아니라 AuthErrorCode enum 이름을 넣는다.
  * 실제 사용자 표시 메시지는 AuthErrorCode에서 관리하고,
  * AuthExceptionHandler가 code/message/field 응답으로 변환한다.
+ *
+ * [에러 정책]
+ * - refreshToken 필드 누락/빈 값: AUTH_REFRESH_TOKEN_REQUIRED, 400
+ * - refreshToken 형식 오류/불일치/위조: AUTH_INVALID_REFRESH_TOKEN, 401
  */
 public record RefreshTokenRequest(
-        @NotBlank(message = "AUTH_INVALID_REFRESH_TOKEN")
+        @NotBlank(message = "AUTH_REFRESH_TOKEN_REQUIRED")
         String refreshToken
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RefreshTokenRequest.java
@@ -2,8 +2,16 @@ package io.github.ascrew.monomatbe.domain.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * Refresh Token 재발급 요청 DTO.
+ *
+ * [Validation message 정책]
+ * message에는 사용자 표시 문구가 아니라 AuthErrorCode enum 이름을 넣는다.
+ * 실제 사용자 표시 메시지는 AuthErrorCode에서 관리하고,
+ * AuthExceptionHandler가 code/message/field 응답으로 변환한다.
+ */
 public record RefreshTokenRequest(
-        @NotBlank(message = "Refresh Token은 비어 있을 수 없습니다.")
+        @NotBlank(message = "AUTH_INVALID_REFRESH_TOKEN")
         String refreshToken
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/RegisterRequest.java
@@ -5,21 +5,26 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 /**
- * 회원가입 요청 DTO.
+ * 회원가입 요청 DTO
+ *
+ * [Validation message 정책]
+ * message에는 사용자 표시 문구가 아니라 AuthErrorCode enum 이름을 넣는다.
+ * 실제 사용자 표시 메시지는 AuthErrorCode에서 관리하고,
+ * AuthExceptionHandler가 code/message/field 응답으로 변환한다.
  */
 public record RegisterRequest(
-        @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "로그인 ID는 50자를 초과할 수 없습니다.")
-        @Pattern(regexp = "^\\S+$", message = "로그인 ID에는 공백을 포함할 수 없습니다.")
+        @NotBlank(message = "AUTH_LOGIN_ID_REQUIRED")
+        @Size(min = 4, max = 50, message = "AUTH_LOGIN_ID_INVALID_LENGTH")
+        @Pattern(regexp = "^[A-Za-z0-9]+$", message = "AUTH_LOGIN_ID_INVALID_FORMAT")
         String loginId,
 
-        @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
-        @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
-        @Pattern(regexp = "^\\S+$", message = "비밀번호에는 공백을 포함할 수 없습니다.")
+        @NotBlank(message = "AUTH_PASSWORD_REQUIRED")
+        @Size(min = 8, max = 100, message = "AUTH_PASSWORD_INVALID_LENGTH")
+        @Pattern(regexp = "^\\S+$", message = "AUTH_PASSWORD_CONTAINS_WHITESPACE")
         String password,
 
-        @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
-        @Size(max = 8, message = "닉네임은 8자를 초과할 수 없습니다.")
+        @NotBlank(message = "AUTH_NICKNAME_REQUIRED")
+        @Size(min = 2, max = 12, message = "AUTH_NICKNAME_INVALID_LENGTH")
         String nickname
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -5,12 +5,24 @@ import org.springframework.http.HttpStatus;
 import java.util.Arrays;
 
 /**
- * 인증 도메인 전용 에러 코드
- * - FE에서는 message 문자열이 아니라 code와 field를 기준으로 에러 UI 제어
+ * 인증 도메인 전용 에러 코드.
+ *
+ * [설계 의도]
+ * - FE는 message 문자열이 아니라 code와 field를 기준으로 에러 UI를 제어한다.
  * - 사용자 표시 메시지는 서버에서 관리하되, FE 분기 기준은 안정적인 code 값으로 고정한다.
- * - field가 null인 에러는 특정 입력 필드가 아니라 인증/세션 전체 상태와 관련된 에러
+ * - field가 null인 에러는 특정 입력 필드가 아니라 인증/세션 전체 상태와 관련된 에러다.
  */
 public enum AuthErrorCode {
+
+    // =========================================================
+    // Request
+    // =========================================================
+
+    AUTH_INVALID_REQUEST_BODY(
+            HttpStatus.BAD_REQUEST,
+            "요청 본문 형식이 올바르지 않습니다.",
+            null
+    ),
 
     // =========================================================
     // Login ID
@@ -165,6 +177,10 @@ public enum AuthErrorCode {
     }
 
     public static AuthErrorCode fromCode(String code) {
+        if (code == null || code.isBlank()) {
+            return AUTH_TEMPORARY_UNAVAILABLE;
+        }
+
         return Arrays.stream(values())
                 .filter(errorCode -> errorCode.name().equals(code))
                 .findFirst()
@@ -173,7 +189,7 @@ public enum AuthErrorCode {
 
     /**
      * 인증 API field 이름 상수
-     * DTO field 이름과 FE form field 이름을 동일하게 유지하기 위해 문자열을 한 곳에서만 관리
+     * DTO field 이름과 프론트엔드 form field 이름을 동일하게 유지하기 위해 문자열을 한 곳에서만 관리한다.
      */
     private static final class AuthErrorFields {
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -5,10 +5,10 @@ import org.springframework.http.HttpStatus;
 import java.util.Arrays;
 
 /**
- * 인증 도메인 전용 에러 코드.
+ * 인증 도메인 전용 에러 코드
  *
  * [설계 의도]
- * - FE는 message 문자열이 아니라 code와 field를 기준으로 에러 UI를 제어한다.
+ * - 프론트엔드는 message 문자열이 아니라 code와 field를 기준으로 에러 UI를 제어한다.
  * - 사용자 표시 메시지는 서버에서 관리하되, FE 분기 기준은 안정적인 code 값으로 고정한다.
  * - field가 null인 에러는 특정 입력 필드가 아니라 인증/세션 전체 상태와 관련된 에러다.
  */
@@ -178,17 +178,18 @@ public enum AuthErrorCode {
 
     public static AuthErrorCode fromCode(String code) {
         if (code == null || code.isBlank()) {
-            return AUTH_TEMPORARY_UNAVAILABLE;
+            return AUTH_INVALID_REQUEST_BODY;
         }
 
         return Arrays.stream(values())
                 .filter(errorCode -> errorCode.name().equals(code))
                 .findFirst()
-                .orElse(AUTH_TEMPORARY_UNAVAILABLE);
+                .orElse(AUTH_INVALID_REQUEST_BODY);
     }
 
     /**
      * 인증 API field 이름 상수
+     *
      * DTO field 이름과 프론트엔드 form field 이름을 동일하게 유지하기 위해 문자열을 한 곳에서만 관리한다.
      */
     private static final class AuthErrorFields {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,187 @@
+package io.github.ascrew.monomatbe.domain.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+
+/**
+ * 인증 도메인 전용 에러 코드
+ * - FE에서는 message 문자열이 아니라 code와 field를 기준으로 에러 UI 제어
+ * - 사용자 표시 메시지는 서버에서 관리하되, FE 분기 기준은 안정적인 code 값으로 고정한다.
+ * - field가 null인 에러는 특정 입력 필드가 아니라 인증/세션 전체 상태와 관련된 에러
+ */
+public enum AuthErrorCode {
+
+    // =========================================================
+    // Login ID
+    // =========================================================
+
+    AUTH_LOGIN_ID_REQUIRED(
+            HttpStatus.BAD_REQUEST,
+            "로그인 ID는 비어 있을 수 없습니다.",
+            AuthErrorFields.LOGIN_ID
+    ),
+
+    AUTH_LOGIN_ID_INVALID_LENGTH(
+            HttpStatus.BAD_REQUEST,
+            "로그인 ID는 4자 이상 50자 이하여야 합니다.",
+            AuthErrorFields.LOGIN_ID
+    ),
+
+    AUTH_LOGIN_ID_INVALID_FORMAT(
+            HttpStatus.BAD_REQUEST,
+            "로그인 ID는 영문과 숫자만 사용할 수 있습니다.",
+            AuthErrorFields.LOGIN_ID
+    ),
+
+    AUTH_LOGIN_ID_CONTAINS_WHITESPACE(
+            HttpStatus.BAD_REQUEST,
+            "로그인 ID에는 공백을 포함할 수 없습니다.",
+            AuthErrorFields.LOGIN_ID
+    ),
+
+    AUTH_LOGIN_ID_DUPLICATED(
+            HttpStatus.CONFLICT,
+            "이미 사용 중인 로그인 ID입니다.",
+            AuthErrorFields.LOGIN_ID
+    ),
+
+    // =========================================================
+    // Password
+    // =========================================================
+
+    AUTH_PASSWORD_REQUIRED(
+            HttpStatus.BAD_REQUEST,
+            "비밀번호는 비어 있을 수 없습니다.",
+            AuthErrorFields.PASSWORD
+    ),
+
+    AUTH_PASSWORD_INVALID_LENGTH(
+            HttpStatus.BAD_REQUEST,
+            "비밀번호는 8자 이상 100자 이하여야 합니다.",
+            AuthErrorFields.PASSWORD
+    ),
+
+    AUTH_PASSWORD_CONTAINS_WHITESPACE(
+            HttpStatus.BAD_REQUEST,
+            "비밀번호에는 공백을 포함할 수 없습니다.",
+            AuthErrorFields.PASSWORD
+    ),
+
+    // =========================================================
+    // Nickname
+    // =========================================================
+
+    AUTH_NICKNAME_REQUIRED(
+            HttpStatus.BAD_REQUEST,
+            "닉네임은 비어 있을 수 없습니다.",
+            AuthErrorFields.NICKNAME
+    ),
+
+    AUTH_NICKNAME_INVALID_LENGTH(
+            HttpStatus.BAD_REQUEST,
+            "닉네임은 2자 이상 12자 이하여야 합니다.",
+            AuthErrorFields.NICKNAME
+    ),
+
+    AUTH_NICKNAME_DUPLICATED(
+            HttpStatus.CONFLICT,
+            "이미 사용 중인 닉네임입니다.",
+            AuthErrorFields.NICKNAME
+    ),
+
+    AUTH_NICKNAME_FORBIDDEN_WORD(
+            HttpStatus.BAD_REQUEST,
+            "사용할 수 없는 닉네임입니다.",
+            AuthErrorFields.NICKNAME
+    ),
+
+    // =========================================================
+    // Login / Session
+    // =========================================================
+
+    AUTH_INVALID_CREDENTIALS(
+            HttpStatus.UNAUTHORIZED,
+            "로그인 ID 또는 비밀번호가 올바르지 않습니다.",
+            null
+    ),
+
+    AUTH_ACCOUNT_LOCKED(
+            HttpStatus.LOCKED,
+            "로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.",
+            null
+    ),
+
+    AUTH_UNAUTHENTICATED(
+            HttpStatus.UNAUTHORIZED,
+            "인증 정보가 없습니다.",
+            null
+    ),
+
+    AUTH_INVALID_AUTHORIZATION(
+            HttpStatus.UNAUTHORIZED,
+            "Authorization 헤더가 유효하지 않습니다.",
+            null
+    ),
+
+    AUTH_INVALID_REFRESH_TOKEN(
+            HttpStatus.UNAUTHORIZED,
+            "Refresh Token이 유효하지 않습니다.",
+            null
+    ),
+
+    AUTH_SESSION_EXPIRED(
+            HttpStatus.UNAUTHORIZED,
+            "세션이 만료되었습니다.",
+            null
+    ),
+
+    AUTH_TEMPORARY_UNAVAILABLE(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+            null
+    );
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    AuthErrorCode(HttpStatus httpStatus, String message, String field) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.field = field;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public static AuthErrorCode fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(errorCode -> errorCode.name().equals(code))
+                .findFirst()
+                .orElse(AUTH_TEMPORARY_UNAVAILABLE);
+    }
+
+    /**
+     * 인증 API field 이름 상수
+     * DTO field 이름과 FE form field 이름을 동일하게 유지하기 위해 문자열을 한 곳에서만 관리
+     */
+    private static final class AuthErrorFields {
+
+        private static final String LOGIN_ID = "loginId";
+        private static final String PASSWORD = "password";
+        private static final String NICKNAME = "nickname";
+
+        private AuthErrorFields() {
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -136,6 +136,12 @@ public enum AuthErrorCode {
             null
     ),
 
+    AUTH_REFRESH_TOKEN_REQUIRED(
+            HttpStatus.BAD_REQUEST,
+            "Refresh Token은 비어 있을 수 없습니다.",
+            AuthErrorFields.REFRESH_TOKEN
+    ),
+
     AUTH_INVALID_REFRESH_TOKEN(
             HttpStatus.UNAUTHORIZED,
             "Refresh Token이 유효하지 않습니다.",
@@ -197,6 +203,7 @@ public enum AuthErrorCode {
         private static final String LOGIN_ID = "loginId";
         private static final String PASSWORD = "password";
         private static final String NICKNAME = "nickname";
+        private static final String REFRESH_TOKEN = "refreshToken";
 
         private AuthErrorFields() {
         }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthException.java
@@ -1,0 +1,26 @@
+package io.github.ascrew.monomatbe.domain.auth.exception;
+
+/**
+ * 인증 도메인 전용 예외
+ *
+ * AuthException은 AuthErrorCode를 강제하여
+ * 모든 인증 실패 응답이 code/message/field 계약을 따르도록 한다.
+ */
+public class AuthException extends RuntimeException {
+
+    private final AuthErrorCode errorCode;
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public AuthException(AuthErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public AuthErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -65,23 +64,6 @@ public class AuthExceptionHandler {
         AuthErrorCode errorCode = resolveAuthErrorCode(
                 exception.getBindingResult().getFieldErrors()
         );
-
-        return ResponseEntity
-                .status(errorCode.getHttpStatus())
-                .body(AuthErrorResponse.from(errorCode));
-    }
-
-    /**
-     * Authorization 헤더 누락을 인증 API 표준 응답으로 변환한다.
-     *
-     * 로그아웃처럼 Authorization 헤더가 필요한 API에서
-     * 컨트롤러 진입 전에 Spring MVC가 MissingRequestHeaderException을 던지는 경우를 방어한다.
-     */
-    @ExceptionHandler(MissingRequestHeaderException.class)
-    public ResponseEntity<AuthErrorResponse> handleMissingRequestHeaderException(
-            MissingRequestHeaderException exception
-    ) {
-        AuthErrorCode errorCode = AuthErrorCode.AUTH_INVALID_AUTHORIZATION;
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
@@ -51,12 +51,6 @@ public class AuthExceptionHandler {
      * 1. 빈 값(null, blank)은 REQUIRED 계열로 처리
      * 2. 로그인 ID/비밀번호의 순수 공백 포함은 CONTAINS_WHITESPACE로 처리
      * 3. 그 외에는 DTO annotation message에 지정된 AuthErrorCode를 사용
-     *
-     * [이유]
-     * 하나의 값이 여러 제약을 동시에 위반할 수 있다.
-     * 예: loginId="" 는 @NotBlank와 @Size를 동시에 위반한다.
-     * Spring Validation의 FieldError 순서에 의존하면 REQUIRED 대신 INVALID_LENGTH가 내려갈 수 있으므로,
-     * 인증 API에서는 서버가 명시적으로 우선순위를 결정한다.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<AuthErrorResponse> handleValidationException(
@@ -91,14 +85,14 @@ public class AuthExceptionHandler {
     /**
      * JSON body 파싱 실패를 인증 API 표준 응답으로 변환한다.
      *
-     * 현재 #128 권장 에러 코드에 요청 본문 형식 오류 전용 코드가 없으므로
-     * 기존 AUTH_TEMPORARY_UNAVAILABLE을 사용한다.
+     * 잘못된 JSON은 서버 장애가 아니라 클라이언트 요청 오류이므로
+     * 503이 아니라 400 BAD_REQUEST를 반환한다.
      */
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<AuthErrorResponse> handleHttpMessageNotReadableException(
             HttpMessageNotReadableException exception
     ) {
-        AuthErrorCode errorCode = AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+        AuthErrorCode errorCode = AuthErrorCode.AUTH_INVALID_REQUEST_BODY;
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
@@ -195,7 +189,7 @@ public class AuthExceptionHandler {
     }
 
     /**
-     * 여러 FieldError가 동시에 발생했을 때 사용자에게 가장 정확한 에러를 먼저 반환하기 위한 우선순위.
+     * 여러 FieldError가 동시에 발생했을 때 사용자에게 가장 정확한 에러를 먼저 반환하기 위한 우선순위
      */
     private static final class AuthValidationErrorPriority {
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
@@ -1,9 +1,6 @@
-package io.github.ascrew.monomatbe.global.exception;
+package io.github.ascrew.monomatbe.domain.auth.exception;
 
-import io.github.ascrew.monomatbe.domain.auth.controller.AuthController;
 import io.github.ascrew.monomatbe.domain.auth.dto.AuthErrorResponse;
-import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
-import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -15,17 +12,20 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.List;
 
 /**
- * 인증 API 전용 예외 핸들러.
+ * 인증 API 전용 예외 핸들러
  *
  * [적용 범위]
- * - AuthController에서 발생한 예외만 처리한다.
+ * - io.github.ascrew.monomatbe.domain.auth 패키지 하위 컨트롤러에서 발생한 예외만 처리한다.
  *
  * [설계 의도]
+ * - global 패키지가 domain.auth를 직접 의존하지 않도록 인증 도메인 내부에 위치시킨다.
  * - 로비/맵/신고 등 다른 도메인의 기존 에러 응답 포맷에 영향을 주지 않는다.
  * - #128 범위에서는 인증 API의 에러 응답만 code/message/field 포맷으로 표준화한다.
  */
-@RestControllerAdvice(assignableTypes = AuthController.class)
+@RestControllerAdvice(basePackages = AuthExceptionHandler.AUTH_BASE_PACKAGE)
 public class AuthExceptionHandler {
+
+    static final String AUTH_BASE_PACKAGE = "io.github.ascrew.monomatbe.domain.auth";
 
     private static final String FIELD_LOGIN_ID = "loginId";
     private static final String FIELD_PASSWORD = "password";

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
@@ -181,7 +181,7 @@ public class AuthExceptionHandler {
             case FIELD_LOGIN_ID -> AuthErrorCode.AUTH_LOGIN_ID_REQUIRED;
             case FIELD_PASSWORD -> AuthErrorCode.AUTH_PASSWORD_REQUIRED;
             case FIELD_NICKNAME -> AuthErrorCode.AUTH_NICKNAME_REQUIRED;
-            case FIELD_REFRESH_TOKEN -> AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN;
+            case FIELD_REFRESH_TOKEN -> AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED;
             default -> {
                 log.warn("Unknown required auth field - field: {}", field);
                 yield AuthErrorCode.AUTH_INVALID_REQUEST_BODY;
@@ -201,7 +201,7 @@ public class AuthExceptionHandler {
     }
 
     /**
-     * 여러 FieldError가 동시에 발생했을 때 사용자에게 가장 정확한 에러를 먼저 반환하기 위한 우선순위
+     * 여러 FieldError가 동시에 발생했을 때 사용자에게 가장 정확한 에러를 먼저 반환하기 위한 우선순위.
      */
     private static final class AuthValidationErrorPriority {
 
@@ -217,7 +217,7 @@ public class AuthExceptionHandler {
                 case AUTH_LOGIN_ID_REQUIRED,
                      AUTH_PASSWORD_REQUIRED,
                      AUTH_NICKNAME_REQUIRED,
-                     AUTH_INVALID_REFRESH_TOKEN -> 1;
+                     AUTH_REFRESH_TOKEN_REQUIRED -> 1;
 
                 case AUTH_LOGIN_ID_CONTAINS_WHITESPACE,
                      AUTH_PASSWORD_CONTAINS_WHITESPACE -> 2;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.auth.exception;
 
 import io.github.ascrew.monomatbe.domain.auth.dto.AuthErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -22,6 +23,7 @@ import java.util.List;
  * - 로비/맵/신고 등 다른 도메인의 기존 에러 응답 포맷에 영향을 주지 않는다.
  * - #128 범위에서는 인증 API의 에러 응답만 code/message/field 포맷으로 표준화한다.
  */
+@Slf4j
 @RestControllerAdvice(basePackages = AuthExceptionHandler.AUTH_BASE_PACKAGE)
 public class AuthExceptionHandler {
 
@@ -51,6 +53,10 @@ public class AuthExceptionHandler {
      * 1. 빈 값(null, blank)은 REQUIRED 계열로 처리
      * 2. 로그인 ID/비밀번호의 순수 공백 포함은 CONTAINS_WHITESPACE로 처리
      * 3. 그 외에는 DTO annotation message에 지정된 AuthErrorCode를 사용
+     *
+     * [주의]
+     * DTO annotation message가 AuthErrorCode enum 이름과 일치하지 않으면
+     * 5xx가 아니라 AUTH_INVALID_REQUEST_BODY(400)로 fallback하고 warn 로그를 남긴다.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<AuthErrorResponse> handleValidationException(
@@ -101,18 +107,20 @@ public class AuthExceptionHandler {
 
     private AuthErrorCode resolveAuthErrorCode(List<FieldError> fieldErrors) {
         if (fieldErrors == null || fieldErrors.isEmpty()) {
-            return AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+            log.warn("Auth validation failed but field errors are empty");
+            return AuthErrorCode.AUTH_INVALID_REQUEST_BODY;
         }
 
         return fieldErrors.stream()
                 .map(this::resolveAuthErrorCode)
                 .min(AuthValidationErrorPriority::compare)
-                .orElse(AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE);
+                .orElse(AuthErrorCode.AUTH_INVALID_REQUEST_BODY);
     }
 
     private AuthErrorCode resolveAuthErrorCode(FieldError fieldError) {
         if (fieldError == null) {
-            return AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+            log.warn("Auth validation field error is null");
+            return AuthErrorCode.AUTH_INVALID_REQUEST_BODY;
         }
 
         String field = fieldError.getField();
@@ -126,7 +134,23 @@ public class AuthExceptionHandler {
             return resolveWhitespaceErrorCode(field);
         }
 
-        return AuthErrorCode.fromCode(fieldError.getDefaultMessage());
+        return resolveDefinedAuthErrorCode(fieldError);
+    }
+
+    private AuthErrorCode resolveDefinedAuthErrorCode(FieldError fieldError) {
+        String rawCode = fieldError.getDefaultMessage();
+        AuthErrorCode errorCode = AuthErrorCode.fromCode(rawCode);
+
+        if (errorCode == AuthErrorCode.AUTH_INVALID_REQUEST_BODY) {
+            log.warn(
+                    "Unknown auth validation error code - field: {}, rejectedValue: {}, defaultMessage: {}",
+                    fieldError.getField(),
+                    fieldError.getRejectedValue(),
+                    rawCode
+            );
+        }
+
+        return errorCode;
     }
 
     private boolean isBlankValue(Object rejectedValue) {
@@ -176,7 +200,10 @@ public class AuthExceptionHandler {
             case FIELD_PASSWORD -> AuthErrorCode.AUTH_PASSWORD_REQUIRED;
             case FIELD_NICKNAME -> AuthErrorCode.AUTH_NICKNAME_REQUIRED;
             case FIELD_REFRESH_TOKEN -> AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN;
-            default -> AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+            default -> {
+                log.warn("Unknown required auth field - field: {}", field);
+                yield AuthErrorCode.AUTH_INVALID_REQUEST_BODY;
+            }
         };
     }
 
@@ -184,7 +211,10 @@ public class AuthExceptionHandler {
         return switch (field) {
             case FIELD_LOGIN_ID -> AuthErrorCode.AUTH_LOGIN_ID_CONTAINS_WHITESPACE;
             case FIELD_PASSWORD -> AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE;
-            default -> AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+            default -> {
+                log.warn("Unknown whitespace auth field - field: {}", field);
+                yield AuthErrorCode.AUTH_INVALID_REQUEST_BODY;
+            }
         };
     }
 
@@ -215,6 +245,8 @@ public class AuthExceptionHandler {
                      AUTH_NICKNAME_INVALID_LENGTH -> 3;
 
                 case AUTH_LOGIN_ID_INVALID_FORMAT -> 4;
+
+                case AUTH_INVALID_REQUEST_BODY -> 90;
 
                 default -> 100;
             };

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthLoginFailureException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthLoginFailureException.java
@@ -1,0 +1,25 @@
+package io.github.ascrew.monomatbe.domain.auth.exception;
+
+/**
+ * 로그인 실패 상태 변경을 커밋해야 하는 인증 예외
+ *
+ * [사용 범위]
+ * - 비밀번호 불일치로 failedLoginCount를 증가시킨 뒤 예외를 던지는 경우
+ * - failedLoginCount가 임계값에 도달해 lockedUntil을 설정한 뒤 예외를 던지는 경우
+ *
+ * [주의]
+ * 모든 AuthException을 noRollbackFor로 처리하면 향후 login() 내부에서
+ * DB write 이후 다른 인증 예외가 발생했을 때 의도하지 않은 부분 커밋이 발생할 수 있다.
+ * 따라서 트랜잭션 롤백 제외 범위는 로그인 실패 상태 변경을 커밋해야 하는
+ * 이 예외 타입으로만 제한한다.
+ */
+public class AuthLoginFailureException extends AuthException {
+
+    public AuthLoginFailureException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthLoginFailureException(AuthErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
@@ -7,9 +7,11 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
-import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
@@ -18,12 +20,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -47,6 +47,9 @@ public class GuestAuthService {
 
     private static final Duration GUEST_SESSION_TTL = Duration.ofDays(30);
 
+    private static final int MIN_NICKNAME_LENGTH = 2;
+    private static final int MAX_NICKNAME_LENGTH = 12;
+
     private final UserRepository userRepository;
     private final GuestSessionRepository guestSessionRepository;
     private final UserSessionRepository userSessionRepository;
@@ -67,9 +70,10 @@ public class GuestAuthService {
         validateNicknameAvailability(nickname);
 
         LocalDateTime now = LocalDateTime.now();
+
         User savedUser;
+
         try {
-            // users: 게스트 사용자 기본 정보 저장 (saveAndFlush로 즉시 쿼리 실행하여 중복 예외 캐치)
             savedUser = userRepository.saveAndFlush(User.builder()
                     .username(nickname)
                     .userType(UserType.GUEST)
@@ -77,14 +81,11 @@ public class GuestAuthService {
                     .lastLoginAt(now)
                     .build());
         } catch (DataIntegrityViolationException e) {
-            // Check-then-Act 구간 사이 다른 요청으로 인해 닉네임 중복이 발생한 경우
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_DUPLICATED, e);
         }
 
-        // 게스트/회원 공통 식별 정책: userIdentifier는 UUID 사용
         String userIdentifier = UUID.randomUUID().toString();
 
-        // guest_sessions: UUID와 사용자 매핑 저장 (TTL 상수로 교체)
         guestSessionRepository.save(GuestSession.builder()
                 .user(savedUser)
                 .guestToken(userIdentifier)
@@ -97,11 +98,13 @@ public class GuestAuthService {
                 savedUser.getUserType(),
                 userIdentifier
         );
+
         TokenWithExpiry refreshToken = jwtTokenProvider.createRefreshToken(
                 savedUser.getId(),
                 savedUser.getUserType(),
                 userIdentifier
         );
+
         String refreshTokenHash = TokenHashUtils.sha256(refreshToken.token());
 
         userSessionRepository.save(UserSession.builder()
@@ -116,17 +119,24 @@ public class GuestAuthService {
                 .status(UserSessionStatus.ACTIVE)
                 .build());
 
-        userSessionLifecycleService.enforceActiveSessionLimit(savedUser.getId(), savedUser.getUserType(), userIdentifier, now);
+        userSessionLifecycleService.enforceActiveSessionLimit(
+                savedUser.getId(),
+                savedUser.getUserType(),
+                userIdentifier,
+                now
+        );
 
-        // Redis에는 DB 트랜잭션이 성공적으로 커밋된 이후에만 세션 정보를 저장합니다. (고아 데이터 방지)
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 try {
                     storeGuestSessionToRedis(savedUser, userIdentifier, refreshTokenHash);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     log.error("Redis 게스트 세션 저장 실패 - userId: {}", savedUser.getId(), e);
-                    userSessionLifecycleService.markSessionRevokedCompensating(userIdentifier, LocalDateTime.now());
+                    userSessionLifecycleService.markSessionRevokedCompensating(
+                            userIdentifier,
+                            LocalDateTime.now()
+                    );
                 }
             }
         });
@@ -143,22 +153,41 @@ public class GuestAuthService {
                 .build();
     }
 
-    /**
-     * 입력 닉네임을 trim 합니다.
-     * (null 체크나 길이 검증은 Controller의 @Valid에서 수행되므로 중복 검증 제거)
-     */
-    private String normalizeNickname(String rawNickname) {
-        return rawNickname.trim();
+    private String normalizeNickname(String value) {
+        String nickname = normalizeRequiredWithTrim(value, AuthErrorCode.AUTH_NICKNAME_REQUIRED);
+
+        if (nickname.length() < MIN_NICKNAME_LENGTH || nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH);
+        }
+
+        return nickname;
+    }
+
+    private String normalizeRequiredWithTrim(String value, AuthErrorCode requiredErrorCode) {
+        if (value == null) {
+            throw new AuthException(requiredErrorCode);
+        }
+
+        String normalized = value.trim();
+
+        if (normalized.isBlank()) {
+            throw new AuthException(requiredErrorCode);
+        }
+
+        return normalized;
     }
 
     private String normalizeOptionalLength(String value, int maxLength) {
         if (value == null) {
             return null;
         }
+
         String normalized = value.trim();
+
         if (normalized.isEmpty()) {
             return null;
         }
+
         return normalized.length() > maxLength
                 ? normalized.substring(0, maxLength)
                 : normalized;
@@ -171,14 +200,11 @@ public class GuestAuthService {
      */
     private void validateNicknameAvailability(String nickname) {
         if (userRepository.existsByUsernameAndUserType(nickname, UserType.REGISTERED)) {
-            throw new ResponseStatusException(
-                    HttpStatus.CONFLICT,
-                    "다른 회원이 이미 사용 중인 닉네임입니다."
-            );
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_DUPLICATED);
         }
 
         if (userRepository.existsByUsername(nickname)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_DUPLICATED);
         }
     }
 
@@ -190,16 +216,20 @@ public class GuestAuthService {
     private void storeGuestSessionToRedis(User user, String userIdentifier, String refreshTokenHash) {
         String guestSessionKey = RedisKeys.guestSessionKey(userIdentifier);
 
-        // RedisKeys.FIELD_GUEST_* 상수로 Hash 필드 키 참조 (오타 방지)
         redisTemplate.opsForHash().putAll(guestSessionKey, Map.of(
                 RedisKeys.FIELD_GUEST_USER_ID, String.valueOf(user.getId()),
                 RedisKeys.FIELD_GUEST_USERNAME, user.getUsername(),
                 RedisKeys.FIELD_GUEST_USER_TYPE, user.getUserType().name()
         ));
+
         redisTemplate.expire(guestSessionKey, GUEST_SESSION_TTL);
 
         String refreshTokenKey = RedisKeys.refreshTokenKey(userIdentifier);
         redisTemplate.opsForValue().set(refreshTokenKey, refreshTokenHash, jwtTokenProvider.refreshTokenTtl());
-        redisTemplate.opsForValue().set(RedisKeys.activeSessionKey(userIdentifier), "1", jwtTokenProvider.refreshTokenTtl());
+        redisTemplate.opsForValue().set(
+                RedisKeys.activeSessionKey(userIdentifier),
+                "1",
+                jwtTokenProvider.refreshTokenTtl()
+        );
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
@@ -6,6 +6,8 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
@@ -16,13 +18,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -37,8 +37,12 @@ public class LoginAuthService {
     private static final int LOCK_THRESHOLD = 5;
     private static final Duration LOCK_DURATION = Duration.ofMinutes(15);
 
-    private static final String ERR_INVALID_CREDENTIALS = "로그인 ID 또는 비밀번호가 올바르지 않습니다.";
-    private static final String ERR_ACCOUNT_LOCKED = "로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.";
+    private static final int MIN_LOGIN_ID_LENGTH = 4;
+    private static final int MAX_LOGIN_ID_LENGTH = 50;
+    private static final int MIN_PASSWORD_LENGTH = 8;
+    private static final int MAX_PASSWORD_LENGTH = 100;
+
+    private static final String LOGIN_ID_PATTERN = "^[A-Za-z0-9]+$";
 
     private final UserCredentialRepository userCredentialRepository;
     private final UserSessionRepository userSessionRepository;
@@ -50,45 +54,54 @@ public class LoginAuthService {
     @Value("${auth.redis.refresh-store-enabled:true}")
     private boolean refreshStoreEnabled;
 
-    @Transactional(noRollbackFor = ResponseStatusException.class)
+    /**
+     * 로그인 실패 시 failedLoginCount 증가를 커밋해야 하므로
+     * 인증 실패 예외(AuthException)는 트랜잭션 롤백 대상에서 제외한다.
+     */
+    @Transactional(noRollbackFor = AuthException.class)
     public LoginResponse login(String rawLoginId, String rawPassword, String ipAddress, String userAgent) {
-        String loginId = normalizeRequiredWithTrim(rawLoginId, "로그인 ID");
-        validateNoWhitespace(loginId, "로그인 ID");
-
-        String password = validateNoWhitespace(rawPassword, "비밀번호");
+        String loginId = normalizeLoginId(rawLoginId);
+        String password = normalizePassword(rawPassword);
 
         UserCredential credential = userCredentialRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_CREDENTIALS));
+                .orElseThrow(() -> new AuthException(AuthErrorCode.AUTH_INVALID_CREDENTIALS));
 
         LocalDateTime now = LocalDateTime.now();
+
         if (credential.isLockedAt(now)) {
-            throw new ResponseStatusException(HttpStatus.LOCKED, ERR_ACCOUNT_LOCKED);
+            throw new AuthException(AuthErrorCode.AUTH_ACCOUNT_LOCKED);
         }
 
         if (!passwordEncoder.matches(password, credential.getPasswordHash())) {
             credential.increaseFailedLoginCount();
+
             if (credential.getFailedLoginCount() >= LOCK_THRESHOLD) {
                 credential.lockUntil(now.plus(LOCK_DURATION));
             }
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_CREDENTIALS);
+
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_CREDENTIALS);
         }
 
         credential.resetFailedLoginState();
+
         User user = credential.getUser();
         user.updateLastLoginAt(now);
-        UserType userType = user.getUserType();
 
+        UserType userType = user.getUserType();
         String userIdentifier = UUID.randomUUID().toString();
+
         TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(
                 user.getId(),
                 userType,
                 userIdentifier
         );
+
         TokenWithExpiry refreshToken = jwtTokenProvider.createRefreshToken(
                 user.getId(),
                 userType,
                 userIdentifier
         );
+
         String refreshTokenHash = TokenHashUtils.sha256(refreshToken.token());
 
         userSessionRepository.save(UserSession.builder()
@@ -103,19 +116,36 @@ public class LoginAuthService {
                 .status(UserSessionStatus.ACTIVE)
                 .build());
 
-        userSessionLifecycleService.enforceActiveSessionLimit(user.getId(), userType, userIdentifier, now);
+        userSessionLifecycleService.enforceActiveSessionLimit(
+                user.getId(),
+                userType,
+                userIdentifier,
+                now
+        );
 
         if (refreshStoreEnabled) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
                     String refreshTokenKey = RedisKeys.refreshTokenKey(userIdentifier);
+
                     try {
-                        redisTemplate.opsForValue().set(refreshTokenKey, refreshTokenHash, jwtTokenProvider.refreshTokenTtl());
-                        redisTemplate.opsForValue().set(RedisKeys.activeSessionKey(userIdentifier), "1", jwtTokenProvider.refreshTokenTtl());
+                        redisTemplate.opsForValue().set(
+                                refreshTokenKey,
+                                refreshTokenHash,
+                                jwtTokenProvider.refreshTokenTtl()
+                        );
+                        redisTemplate.opsForValue().set(
+                                RedisKeys.activeSessionKey(userIdentifier),
+                                "1",
+                                jwtTokenProvider.refreshTokenTtl()
+                        );
                     } catch (RuntimeException e) {
                         log.error("로그인 후 Redis 세션 저장 실패 - sessionId: {}", userIdentifier, e);
-                        userSessionLifecycleService.markSessionRevokedCompensating(userIdentifier, LocalDateTime.now());
+                        userSessionLifecycleService.markSessionRevokedCompensating(
+                                userIdentifier,
+                                LocalDateTime.now()
+                        );
                     }
                 }
             });
@@ -134,35 +164,71 @@ public class LoginAuthService {
                 .build();
     }
 
-    private String normalizeRequiredWithTrim(String value, String fieldName) {
-        if (value == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+    private String normalizeLoginId(String value) {
+        String loginId = normalizeRequiredWithTrim(value, AuthErrorCode.AUTH_LOGIN_ID_REQUIRED);
+
+        if (containsWhitespace(loginId)) {
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_CONTAINS_WHITESPACE);
         }
-        String normalized = value.trim();
+
+        if (loginId.length() < MIN_LOGIN_ID_LENGTH || loginId.length() > MAX_LOGIN_ID_LENGTH) {
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_INVALID_LENGTH);
+        }
+
+        if (!loginId.matches(LOGIN_ID_PATTERN)) {
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_INVALID_FORMAT);
+        }
+
+        return loginId;
+    }
+
+    private String normalizePassword(String value) {
+        String password = normalizeRequired(value, AuthErrorCode.AUTH_PASSWORD_REQUIRED);
+
+        if (containsWhitespace(password)) {
+            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE);
+        }
+
+        if (password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
+            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_INVALID_LENGTH);
+        }
+
+        return password;
+    }
+
+    private String normalizeRequiredWithTrim(String value, AuthErrorCode requiredErrorCode) {
+        String normalized = normalizeRequired(value, requiredErrorCode).trim();
+
         if (normalized.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+            throw new AuthException(requiredErrorCode);
         }
+
         return normalized;
     }
 
-    private String validateNoWhitespace(String value, String fieldName) {
+    private String normalizeRequired(String value, AuthErrorCode requiredErrorCode) {
         if (value == null || value.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+            throw new AuthException(requiredErrorCode);
         }
-        if (value.chars().anyMatch(Character::isWhitespace)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "에는 공백을 포함할 수 없습니다.");
-        }
+
         return value;
+    }
+
+    private boolean containsWhitespace(String value) {
+        return value.chars().anyMatch(Character::isWhitespace);
     }
 
     private String normalizeOptionalLength(String value, int maxLength) {
         if (value == null) {
             return null;
         }
+
         String normalized = value.trim();
+
         if (normalized.isEmpty()) {
             return null;
         }
+
         return normalized.length() > maxLength
                 ? normalized.substring(0, maxLength)
                 : normalized;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
@@ -8,6 +8,7 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthLoginFailureException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
@@ -50,9 +51,15 @@ public class LoginAuthService {
     /**
      * 자체 로그인
      *
-     * [중요]
-     * 로그인 실패 시 failedLoginCount 증가를 커밋해야 하므로
-     * AuthException은 트랜잭션 롤백 대상에서 제외한다.
+     * [트랜잭션 정책]
+     * 비밀번호 불일치 시 failedLoginCount 증가와 lockedUntil 설정은 반드시 커밋되어야 한다.
+     * 따라서 해당 상태 변경 이후에는 AuthLoginFailureException을 던지고,
+     * 이 예외만 noRollbackFor 대상으로 제한한다.
+     *
+     * [주의]
+     * AuthException 전체를 noRollbackFor로 지정하지 않는다.
+     * AuthException은 계정 잠금, 인증 정보 없음, refresh token 오류 등 다양한 인증 예외를 포괄하므로,
+     * 향후 login() 내부에서 DB write 이후 다른 AuthException이 추가될 경우 의도하지 않은 부분 커밋이 발생할 수 있다.
      *
      * [호환성 정책]
      * 회원가입 정책과 로그인 정책은 분리한다.
@@ -62,7 +69,7 @@ public class LoginAuthService {
      * 따라서 loginId는 null/blank만 차단하고,
      * DB 조회 실패 또는 비밀번호 불일치는 AUTH_INVALID_CREDENTIALS로 통합 처리한다.
      */
-    @Transactional(noRollbackFor = AuthException.class)
+    @Transactional(noRollbackFor = AuthLoginFailureException.class)
     public LoginResponse login(String rawLoginId, String rawPassword, String ipAddress, String userAgent) {
         String loginId = normalizeLoginId(rawLoginId);
         String password = normalizePassword(rawPassword);
@@ -83,7 +90,7 @@ public class LoginAuthService {
                 credential.lockUntil(now.plus(LOCK_DURATION));
             }
 
-            throw new AuthException(AuthErrorCode.AUTH_INVALID_CREDENTIALS);
+            throw new AuthLoginFailureException(AuthErrorCode.AUTH_INVALID_CREDENTIALS);
         }
 
         credential.resetFailedLoginState();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
@@ -37,13 +37,6 @@ public class LoginAuthService {
     private static final int LOCK_THRESHOLD = 5;
     private static final Duration LOCK_DURATION = Duration.ofMinutes(15);
 
-    private static final int MIN_LOGIN_ID_LENGTH = 4;
-    private static final int MAX_LOGIN_ID_LENGTH = 50;
-    private static final int MIN_PASSWORD_LENGTH = 8;
-    private static final int MAX_PASSWORD_LENGTH = 100;
-
-    private static final String LOGIN_ID_PATTERN = "^[A-Za-z0-9]+$";
-
     private final UserCredentialRepository userCredentialRepository;
     private final UserSessionRepository userSessionRepository;
     private final PasswordEncoder passwordEncoder;
@@ -55,8 +48,19 @@ public class LoginAuthService {
     private boolean refreshStoreEnabled;
 
     /**
+     * 자체 로그인
+     *
+     * [중요]
      * 로그인 실패 시 failedLoginCount 증가를 커밋해야 하므로
-     * 인증 실패 예외(AuthException)는 트랜잭션 롤백 대상에서 제외한다.
+     * AuthException은 트랜잭션 롤백 대상에서 제외한다.
+     *
+     * [호환성 정책]
+     * 회원가입 정책과 로그인 정책은 분리한다.
+     * 회원가입에서는 신규 loginId 포맷을 강제할 수 있지만,
+     * 로그인에서는 과거에 생성된 계정의 호환성을 위해 loginId 포맷 검증을 하지 않는다.
+     *
+     * 따라서 loginId는 null/blank만 차단하고,
+     * DB 조회 실패 또는 비밀번호 불일치는 AUTH_INVALID_CREDENTIALS로 통합 처리한다.
      */
     @Transactional(noRollbackFor = AuthException.class)
     public LoginResponse login(String rawLoginId, String rawPassword, String ipAddress, String userAgent) {
@@ -165,35 +169,19 @@ public class LoginAuthService {
     }
 
     private String normalizeLoginId(String value) {
-        String loginId = normalizeRequiredWithTrim(value, AuthErrorCode.AUTH_LOGIN_ID_REQUIRED);
-
-        if (containsWhitespace(loginId)) {
-            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_CONTAINS_WHITESPACE);
-        }
-
-        if (loginId.length() < MIN_LOGIN_ID_LENGTH || loginId.length() > MAX_LOGIN_ID_LENGTH) {
-            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_INVALID_LENGTH);
-        }
-
-        if (!loginId.matches(LOGIN_ID_PATTERN)) {
-            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_INVALID_FORMAT);
-        }
-
-        return loginId;
+        return normalizeRequiredWithTrim(value, AuthErrorCode.AUTH_LOGIN_ID_REQUIRED);
     }
 
+    /**
+     * 로그인 비밀번호는 null/blank만 차단한다.
+     *
+     * [이유]
+     * 로그인 시점에 비밀번호 길이/포맷을 과하게 검증하면
+     * 기존 계정 호환성 또는 정책 변경 전 계정의 로그인을 막을 수 있다.
+     * 실제 인증 실패는 passwordEncoder.matches() 결과를 통해 AUTH_INVALID_CREDENTIALS로 통합 처리한다.
+     */
     private String normalizePassword(String value) {
-        String password = normalizeRequired(value, AuthErrorCode.AUTH_PASSWORD_REQUIRED);
-
-        if (containsWhitespace(password)) {
-            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE);
-        }
-
-        if (password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
-            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_INVALID_LENGTH);
-        }
-
-        return password;
+        return normalizeRequired(value, AuthErrorCode.AUTH_PASSWORD_REQUIRED);
     }
 
     private String normalizeRequiredWithTrim(String value, AuthErrorCode requiredErrorCode) {
@@ -212,10 +200,6 @@ public class LoginAuthService {
         }
 
         return value;
-    }
-
-    private boolean containsWhitespace(String value) {
-        return value.chars().anyMatch(Character::isWhitespace);
     }
 
     private String normalizeOptionalLength(String value, int maxLength) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LogoutAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LogoutAuthService.java
@@ -1,15 +1,15 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -27,12 +27,14 @@ public class LogoutAuthService {
     @Transactional
     public void logout(Long userId, String sessionId, String authorizationHeader) {
         String accessToken = extractBearerToken(authorizationHeader);
+
         Duration ttl;
         try {
             ttl = jwtTokenProvider.accessTokenRemainingTtl(accessToken);
         } catch (JwtException | IllegalArgumentException e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 유효하지 않습니다.");
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_AUTHORIZATION, e);
         }
+
         if (!ttl.isZero() && !ttl.isNegative()) {
             String hash = TokenHashUtils.sha256(accessToken);
             redisTemplate.opsForValue().set(RedisKeys.accessTokenBlacklistKey(hash), "1", ttl);
@@ -43,12 +45,15 @@ public class LogoutAuthService {
 
     private String extractBearerToken(String authorizationHeader) {
         if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 유효하지 않습니다.");
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_AUTHORIZATION);
         }
+
         String token = authorizationHeader.substring(BEARER_PREFIX.length()).trim();
+
         if (token.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 유효하지 않습니다.");
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_AUTHORIZATION);
         }
+
         return token;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthService.java
@@ -3,6 +3,8 @@ package io.github.ascrew.monomatbe.domain.auth.service;
 import io.github.ascrew.monomatbe.domain.auth.dto.RefreshTokenResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.JwtClaims;
@@ -10,16 +12,15 @@ import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenWithExpiry;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -28,9 +29,6 @@ import java.time.ZoneId;
 @Service
 @RequiredArgsConstructor
 public class RefreshAuthService {
-
-    private static final String ERR_INVALID_REFRESH_TOKEN = "Refresh Token이 유효하지 않습니다.";
-    private static final String ERR_SESSION_STORE_TEMPORARY = "세션 저장소에 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
 
     private final JwtTokenProvider jwtTokenProvider;
     private final StringRedisTemplate redisTemplate;
@@ -51,31 +49,36 @@ public class RefreshAuthService {
         UserSession session = userSessionRepository.findBySessionIdForUpdate(sessionId)
                 .orElse(null);
 
-        if (session == null || !session.getUser().getId().equals(userId) || !session.isActiveAt(now)) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_REFRESH_TOKEN);
+        if (session == null || !session.getUser().getId().equals(userId)) {
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
+        }
+
+        if (!session.isActiveAt(now)) {
+            throw new AuthException(AuthErrorCode.AUTH_SESSION_EXPIRED);
         }
 
         if (!matchesStoredRefreshToken(session.getSessionToken(), refreshToken, refreshTokenHash)) {
             userSessionLifecycleService.revokeAllActiveSessions(userId, now);
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
         }
 
         String storedRefreshTokenHash;
         try {
             storedRefreshTokenHash = redisTemplate.opsForValue().get(RedisKeys.refreshTokenKey(sessionId));
         } catch (RuntimeException e) {
-            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, ERR_SESSION_STORE_TEMPORARY);
+            throw new AuthException(AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE, e);
         }
 
         if (storedRefreshTokenHash != null
                 && !matchesStoredRefreshToken(storedRefreshTokenHash, refreshToken, refreshTokenHash)) {
             userSessionLifecycleService.revokeAllActiveSessions(userId, now);
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
         }
 
         TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(userId, userType, sessionId);
         TokenWithExpiry rotatedRefreshToken = jwtTokenProvider.createRefreshToken(userId, userType, sessionId);
         String rotatedRefreshTokenHash = TokenHashUtils.sha256(rotatedRefreshToken.token());
+
         session.rotate(
                 rotatedRefreshTokenHash,
                 LocalDateTime.ofInstant(rotatedRefreshToken.expiresAt(), ZoneId.systemDefault()),
@@ -100,7 +103,10 @@ public class RefreshAuthService {
                     );
                 } catch (RuntimeException e) {
                     log.error("Refresh 후 Redis 갱신 실패 - sessionId: {}", sessionId, e);
-                    userSessionLifecycleService.markSessionRevokedCompensating(sessionId, LocalDateTime.now());
+                    userSessionLifecycleService.markSessionRevokedCompensating(
+                            sessionId,
+                            LocalDateTime.now()
+                    );
                 }
             }
         });
@@ -120,14 +126,17 @@ public class RefreshAuthService {
         if (storedValue == null || storedValue.isBlank()) {
             return false;
         }
+
         return storedValue.equals(requestHash) || storedValue.equals(requestRawToken);
     }
 
     private Claims parseRefreshClaims(String refreshToken) {
         try {
             return jwtTokenProvider.parseClaims(refreshToken);
-        } catch (JwtException e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_REFRESH_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.AUTH_SESSION_EXPIRED, e);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN, e);
         }
     }
 
@@ -135,7 +144,7 @@ public class RefreshAuthService {
         try {
             return Long.valueOf(claims.getSubject());
         } catch (NumberFormatException | NullPointerException e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN, e);
         }
     }
 
@@ -144,26 +153,31 @@ public class RefreshAuthService {
             String value = claims.get(JwtClaims.USER_TYPE, String.class);
             return UserType.valueOf(value);
         } catch (IllegalArgumentException | NullPointerException e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN, e);
         }
     }
 
     private String extractSessionId(Claims claims) {
         String sessionId = claims.get(JwtClaims.SESSION_ID, String.class);
+
         if (sessionId == null || sessionId.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERR_INVALID_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
         }
+
         return sessionId;
     }
 
     private String normalizeRequired(String value) {
         if (value == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh Token은 비어 있을 수 없습니다.");
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
         }
+
         String normalized = value.trim();
+
         if (normalized.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh Token은 비어 있을 수 없습니다.");
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
         }
+
         return normalized;
     }
 
@@ -171,10 +185,13 @@ public class RefreshAuthService {
         if (value == null) {
             return null;
         }
+
         String normalized = value.trim();
+
         if (normalized.isEmpty()) {
             return null;
         }
+
         return normalized.length() > maxLength
                 ? normalized.substring(0, maxLength)
                 : normalized;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthService.java
@@ -169,13 +169,13 @@ public class RefreshAuthService {
 
     private String normalizeRequired(String value) {
         if (value == null) {
-            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED);
         }
 
         String normalized = value.trim();
 
         if (normalized.isBlank()) {
-            throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED);
         }
 
         return normalized;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -5,26 +5,35 @@ import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 /**
- * 회원가입 비즈니스 로직.
+ * 회원가입 비즈니스 로직
+ *
+ * [에러 응답 정책]
+ * 인증 도메인 에러는 AuthException + AuthErrorCode로 처리한다.
+ * FE는 message가 아니라 code와 field를 기준으로 에러 UI를 제어한다.
  */
 @Service
 @RequiredArgsConstructor
 public class RegisterAuthService {
 
-    private static final String ERR_DUPLICATE_LOGIN_ID = "이미 사용 중인 로그인 ID입니다.";
-    private static final String ERR_DUPLICATE_NICKNAME = "이미 사용 중인 닉네임입니다.";
-    private static final int MAX_NICKNAME_LENGTH = 8;
+    private static final int MIN_LOGIN_ID_LENGTH = 4;
+    private static final int MAX_LOGIN_ID_LENGTH = 50;
+    private static final int MIN_PASSWORD_LENGTH = 8;
+    private static final int MAX_PASSWORD_LENGTH = 100;
+    private static final int MIN_NICKNAME_LENGTH = 2;
+    private static final int MAX_NICKNAME_LENGTH = 12;
+
+    private static final String LOGIN_ID_PATTERN = "^[A-Za-z0-9]+$";
 
     private final UserRepository userRepository;
     private final UserCredentialRepository userCredentialRepository;
@@ -32,19 +41,19 @@ public class RegisterAuthService {
 
     @Transactional
     public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
-        String loginId = normalizeRequiredWithTrim(rawLoginId, "로그인 ID");
-        validateNoWhitespace(loginId, "로그인 ID");
+        String loginId = normalizeLoginId(rawLoginId);
+        String password = normalizePassword(rawPassword);
+        String nickname = normalizeNickname(rawNickname);
 
-        String password = validateNoWhitespace(rawPassword, "비밀번호");
-
-        String nickname = normalizeRequiredWithTrim(rawNickname, "닉네임");
-        validateNicknameLength(nickname);
         validateDuplicate(loginId, nickname);
 
         User savedUser;
 
-        // user_credentials 저장 실패 시 @Transactional에 의해 users 저장도 함께 롤백됨
-        // ResponseStatusException은 런타임 예외이므로 롤백 대상에 포함됨
+        /*
+         * user_credentials 저장 실패 시 @Transactional에 의해 users 저장도 함께 롤백된다.
+         * DB unique 제약과 애플리케이션 중복 검증 사이의 race condition은
+         * DataIntegrityViolationException을 AuthException으로 변환해 동일한 응답 계약을 유지한다.
+         */
         try {
             savedUser = userRepository.saveAndFlush(User.builder()
                     .username(nickname)
@@ -52,7 +61,7 @@ public class RegisterAuthService {
                     .status(UserStatus.ACTIVE)
                     .build());
         } catch (DataIntegrityViolationException e) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_NICKNAME);
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_DUPLICATED, e);
         }
 
         try {
@@ -62,7 +71,7 @@ public class RegisterAuthService {
                     .passwordHash(passwordEncoder.encode(password))
                     .build());
         } catch (DataIntegrityViolationException e) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_LOGIN_ID);
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_DUPLICATED, e);
         }
 
         return RegisterResponse.builder()
@@ -75,40 +84,75 @@ public class RegisterAuthService {
 
     private void validateDuplicate(String loginId, String nickname) {
         if (userCredentialRepository.existsByLoginId(loginId)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_LOGIN_ID);
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_DUPLICATED);
         }
+
         if (userRepository.existsByUsername(nickname)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, ERR_DUPLICATE_NICKNAME);
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_DUPLICATED);
         }
     }
 
-    /**
-     * 서비스 직접 호출 경로를 위한 최소 방어선: trim + null/blank 차단.
-     */
-    private String normalizeRequiredWithTrim(String value, String fieldName) {
-        if (value == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+    private String normalizeLoginId(String value) {
+        String loginId = normalizeRequiredWithTrim(value, AuthErrorCode.AUTH_LOGIN_ID_REQUIRED);
+
+        if (containsWhitespace(loginId)) {
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_CONTAINS_WHITESPACE);
         }
-        String normalized = value.trim();
+
+        if (loginId.length() < MIN_LOGIN_ID_LENGTH || loginId.length() > MAX_LOGIN_ID_LENGTH) {
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_INVALID_LENGTH);
+        }
+
+        if (!loginId.matches(LOGIN_ID_PATTERN)) {
+            throw new AuthException(AuthErrorCode.AUTH_LOGIN_ID_INVALID_FORMAT);
+        }
+
+        return loginId;
+    }
+
+    private String normalizePassword(String value) {
+        String password = normalizeRequired(value, AuthErrorCode.AUTH_PASSWORD_REQUIRED);
+
+        if (containsWhitespace(password)) {
+            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE);
+        }
+
+        if (password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
+            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_INVALID_LENGTH);
+        }
+
+        return password;
+    }
+
+    private String normalizeNickname(String value) {
+        String nickname = normalizeRequiredWithTrim(value, AuthErrorCode.AUTH_NICKNAME_REQUIRED);
+
+        if (nickname.length() < MIN_NICKNAME_LENGTH || nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH);
+        }
+
+        return nickname;
+    }
+
+    private String normalizeRequiredWithTrim(String value, AuthErrorCode requiredErrorCode) {
+        String normalized = normalizeRequired(value, requiredErrorCode).trim();
+
         if (normalized.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+            throw new AuthException(requiredErrorCode);
         }
+
         return normalized;
     }
 
-    private String validateNoWhitespace(String value, String fieldName) {
+    private String normalizeRequired(String value, AuthErrorCode requiredErrorCode) {
         if (value == null || value.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "는 비어 있을 수 없습니다.");
+            throw new AuthException(requiredErrorCode);
         }
-        if (value.chars().anyMatch(Character::isWhitespace)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + "에는 공백을 포함할 수 없습니다.");
-        }
+
         return value;
     }
 
-    private void validateNicknameLength(String nickname) {
-        if (nickname.length() > MAX_NICKNAME_LENGTH) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 8자를 초과할 수 없습니다.");
-        }
+    private boolean containsWhitespace(String value) {
+        return value.chars().anyMatch(Character::isWhitespace);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.List;
+
 /**
  * 인증 API 전용 예외 핸들러
  *
@@ -23,9 +25,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(assignableTypes = AuthController.class)
 public class AuthExceptionHandler {
 
-    /**
-     * 인증 도메인 전용 예외를 표준 응답으로 변환한다.
-     */
+    private static final String FIELD_LOGIN_ID = "loginId";
+    private static final String FIELD_PASSWORD = "password";
+    private static final String FIELD_NICKNAME = "nickname";
+
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<AuthErrorResponse> handleAuthException(AuthException exception) {
         AuthErrorCode errorCode = exception.getErrorCode();
@@ -38,36 +41,145 @@ public class AuthExceptionHandler {
     /**
      * @Valid 검증 실패를 인증 에러 코드 응답으로 변환한다.
      *
-     * [중요]
-     * DTO validation message에는 AuthErrorCode enum 이름을 넣는 방식으로 매핑한다.
+     * [우선순위]
+     * 1. 빈 값(null, blank)은 REQUIRED로 처리
+     * 2. 로그인 ID/비밀번호의 순수 공백 포함은 CONTAINS_WHITESPACE로 처리
+     * 3. 그 외에는 DTO annotation message에 지정된 AuthErrorCode를 사용
      *
-     * 예:
-     * @NotBlank(message = "AUTH_LOGIN_ID_REQUIRED")
-     *
-     * 이렇게 해야 message 문자열 변경과 FE 분기 코드가 분리된다.
+     * [이유]
+     * 하나의 값이 여러 제약을 동시에 위반할 수 있다.
+     * 예: loginId="" 는 @NotBlank와 @Size를 동시에 위반한다.
+     * Spring Validation의 FieldError 순서에 의존하면 REQUIRED 대신 INVALID_LENGTH가 내려갈 수 있으므로,
+     * 인증 API에서는 서버가 명시적으로 우선순위를 결정한다.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<AuthErrorResponse> handleValidationException(
             MethodArgumentNotValidException exception
     ) {
-        AuthErrorCode errorCode = resolveAuthErrorCode(exception);
+        AuthErrorCode errorCode = resolveAuthErrorCode(exception.getBindingResult().getFieldErrors());
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(AuthErrorResponse.from(errorCode));
     }
 
-    private AuthErrorCode resolveAuthErrorCode(MethodArgumentNotValidException exception) {
-        FieldError fieldError = exception.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .findFirst()
-                .orElse(null);
+    private AuthErrorCode resolveAuthErrorCode(List<FieldError> fieldErrors) {
+        if (fieldErrors == null || fieldErrors.isEmpty()) {
+            return AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+        }
 
+        return fieldErrors.stream()
+                .map(this::resolveAuthErrorCode)
+                .min(AuthValidationErrorPriority::compare)
+                .orElse(AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE);
+    }
+
+    private AuthErrorCode resolveAuthErrorCode(FieldError fieldError) {
         if (fieldError == null) {
             return AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
         }
 
+        String field = fieldError.getField();
+        Object rejectedValue = fieldError.getRejectedValue();
+
+        if (isBlankValue(rejectedValue)) {
+            return resolveRequiredErrorCode(field);
+        }
+
+        if (hasOnlyWhitespaceViolation(field, rejectedValue)) {
+            return resolveWhitespaceErrorCode(field);
+        }
+
         return AuthErrorCode.fromCode(fieldError.getDefaultMessage());
+    }
+
+    private boolean isBlankValue(Object rejectedValue) {
+        if (rejectedValue == null) {
+            return true;
+        }
+
+        if (rejectedValue instanceof String value) {
+            return value.isBlank();
+        }
+
+        return false;
+    }
+
+    /**
+     * 순수 공백 위반만 CONTAINS_WHITESPACE로 분리한다.
+     *
+     * 예:
+     * - "test id"  -> whitespace 위반
+     * - "test id!" -> 특수문자도 포함하므로 invalid format
+     * - "test!"    -> invalid format
+     */
+    private boolean hasOnlyWhitespaceViolation(String field, Object rejectedValue) {
+        if (!(rejectedValue instanceof String value)) {
+            return false;
+        }
+
+        if (!FIELD_LOGIN_ID.equals(field) && !FIELD_PASSWORD.equals(field)) {
+            return false;
+        }
+
+        if (value.chars().noneMatch(Character::isWhitespace)) {
+            return false;
+        }
+
+        if (FIELD_PASSWORD.equals(field)) {
+            return true;
+        }
+
+        String valueWithoutWhitespace = value.replaceAll("\\s+", "");
+        return valueWithoutWhitespace.matches("^[A-Za-z0-9]+$");
+    }
+
+    private AuthErrorCode resolveRequiredErrorCode(String field) {
+        return switch (field) {
+            case FIELD_LOGIN_ID -> AuthErrorCode.AUTH_LOGIN_ID_REQUIRED;
+            case FIELD_PASSWORD -> AuthErrorCode.AUTH_PASSWORD_REQUIRED;
+            case FIELD_NICKNAME -> AuthErrorCode.AUTH_NICKNAME_REQUIRED;
+            default -> AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+        };
+    }
+
+    private AuthErrorCode resolveWhitespaceErrorCode(String field) {
+        return switch (field) {
+            case FIELD_LOGIN_ID -> AuthErrorCode.AUTH_LOGIN_ID_CONTAINS_WHITESPACE;
+            case FIELD_PASSWORD -> AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE;
+            default -> AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+        };
+    }
+
+    /**
+     * 여러 FieldError가 동시에 발생했을 때 사용자에게 가장 정확한 에러를 먼저 반환하기 위한 우선순위.
+     */
+    private static final class AuthValidationErrorPriority {
+
+        private AuthValidationErrorPriority() {
+        }
+
+        private static int compare(AuthErrorCode left, AuthErrorCode right) {
+            return Integer.compare(priority(left), priority(right));
+        }
+
+        private static int priority(AuthErrorCode errorCode) {
+            return switch (errorCode) {
+                case AUTH_LOGIN_ID_REQUIRED,
+                     AUTH_PASSWORD_REQUIRED,
+                     AUTH_NICKNAME_REQUIRED -> 1;
+
+                case AUTH_LOGIN_ID_CONTAINS_WHITESPACE,
+                     AUTH_PASSWORD_CONTAINS_WHITESPACE -> 2;
+
+                case AUTH_LOGIN_ID_INVALID_LENGTH,
+                     AUTH_PASSWORD_INVALID_LENGTH,
+                     AUTH_NICKNAME_INVALID_LENGTH -> 3;
+
+                case AUTH_LOGIN_ID_INVALID_FORMAT -> 4;
+
+                default -> 100;
+            };
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
@@ -28,7 +28,11 @@ public class AuthExceptionHandler {
     private static final String FIELD_LOGIN_ID = "loginId";
     private static final String FIELD_PASSWORD = "password";
     private static final String FIELD_NICKNAME = "nickname";
+    private static final String FIELD_REFRESH_TOKEN = "refreshToken";
 
+    /**
+     * 인증 도메인 전용 예외를 표준 응답으로 변환한다.
+     */
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<AuthErrorResponse> handleAuthException(AuthException exception) {
         AuthErrorCode errorCode = exception.getErrorCode();
@@ -42,7 +46,7 @@ public class AuthExceptionHandler {
      * @Valid 검증 실패를 인증 에러 코드 응답으로 변환한다.
      *
      * [우선순위]
-     * 1. 빈 값(null, blank)은 REQUIRED로 처리
+     * 1. 빈 값(null, blank)은 REQUIRED 계열로 처리
      * 2. 로그인 ID/비밀번호의 순수 공백 포함은 CONTAINS_WHITESPACE로 처리
      * 3. 그 외에는 DTO annotation message에 지정된 AuthErrorCode를 사용
      *
@@ -56,7 +60,9 @@ public class AuthExceptionHandler {
     public ResponseEntity<AuthErrorResponse> handleValidationException(
             MethodArgumentNotValidException exception
     ) {
-        AuthErrorCode errorCode = resolveAuthErrorCode(exception.getBindingResult().getFieldErrors());
+        AuthErrorCode errorCode = resolveAuthErrorCode(
+                exception.getBindingResult().getFieldErrors()
+        );
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
@@ -139,6 +145,7 @@ public class AuthExceptionHandler {
             case FIELD_LOGIN_ID -> AuthErrorCode.AUTH_LOGIN_ID_REQUIRED;
             case FIELD_PASSWORD -> AuthErrorCode.AUTH_PASSWORD_REQUIRED;
             case FIELD_NICKNAME -> AuthErrorCode.AUTH_NICKNAME_REQUIRED;
+            case FIELD_REFRESH_TOKEN -> AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN;
             default -> AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
         };
     }
@@ -167,7 +174,8 @@ public class AuthExceptionHandler {
             return switch (errorCode) {
                 case AUTH_LOGIN_ID_REQUIRED,
                      AUTH_PASSWORD_REQUIRED,
-                     AUTH_NICKNAME_REQUIRED -> 1;
+                     AUTH_NICKNAME_REQUIRED,
+                     AUTH_INVALID_REFRESH_TOKEN -> 1;
 
                 case AUTH_LOGIN_ID_CONTAINS_WHITESPACE,
                      AUTH_PASSWORD_CONTAINS_WHITESPACE -> 2;

--- a/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
@@ -5,7 +5,9 @@ import io.github.ascrew.monomatbe.domain.auth.dto.AuthErrorResponse;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,7 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.List;
 
 /**
- * 인증 API 전용 예외 핸들러
+ * 인증 API 전용 예외 핸들러.
  *
  * [적용 범위]
  * - AuthController에서 발생한 예외만 처리한다.
@@ -63,6 +65,40 @@ public class AuthExceptionHandler {
         AuthErrorCode errorCode = resolveAuthErrorCode(
                 exception.getBindingResult().getFieldErrors()
         );
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(AuthErrorResponse.from(errorCode));
+    }
+
+    /**
+     * Authorization 헤더 누락을 인증 API 표준 응답으로 변환한다.
+     *
+     * 로그아웃처럼 Authorization 헤더가 필요한 API에서
+     * 컨트롤러 진입 전에 Spring MVC가 MissingRequestHeaderException을 던지는 경우를 방어한다.
+     */
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<AuthErrorResponse> handleMissingRequestHeaderException(
+            MissingRequestHeaderException exception
+    ) {
+        AuthErrorCode errorCode = AuthErrorCode.AUTH_INVALID_AUTHORIZATION;
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(AuthErrorResponse.from(errorCode));
+    }
+
+    /**
+     * JSON body 파싱 실패를 인증 API 표준 응답으로 변환한다.
+     *
+     * 현재 #128 권장 에러 코드에 요청 본문 형식 오류 전용 코드가 없으므로
+     * 기존 AUTH_TEMPORARY_UNAVAILABLE을 사용한다.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<AuthErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException exception
+    ) {
+        AuthErrorCode errorCode = AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/exception/AuthExceptionHandler.java
@@ -1,0 +1,73 @@
+package io.github.ascrew.monomatbe.global.exception;
+
+import io.github.ascrew.monomatbe.domain.auth.controller.AuthController;
+import io.github.ascrew.monomatbe.domain.auth.dto.AuthErrorResponse;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 인증 API 전용 예외 핸들러
+ *
+ * [적용 범위]
+ * - AuthController에서 발생한 예외만 처리한다.
+ *
+ * [설계 의도]
+ * - 로비/맵/신고 등 다른 도메인의 기존 에러 응답 포맷에 영향을 주지 않는다.
+ * - #128 범위에서는 인증 API의 에러 응답만 code/message/field 포맷으로 표준화한다.
+ */
+@RestControllerAdvice(assignableTypes = AuthController.class)
+public class AuthExceptionHandler {
+
+    /**
+     * 인증 도메인 전용 예외를 표준 응답으로 변환한다.
+     */
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<AuthErrorResponse> handleAuthException(AuthException exception) {
+        AuthErrorCode errorCode = exception.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(AuthErrorResponse.from(errorCode));
+    }
+
+    /**
+     * @Valid 검증 실패를 인증 에러 코드 응답으로 변환한다.
+     *
+     * [중요]
+     * DTO validation message에는 AuthErrorCode enum 이름을 넣는 방식으로 매핑한다.
+     *
+     * 예:
+     * @NotBlank(message = "AUTH_LOGIN_ID_REQUIRED")
+     *
+     * 이렇게 해야 message 문자열 변경과 FE 분기 코드가 분리된다.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<AuthErrorResponse> handleValidationException(
+            MethodArgumentNotValidException exception
+    ) {
+        AuthErrorCode errorCode = resolveAuthErrorCode(exception);
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(AuthErrorResponse.from(errorCode));
+    }
+
+    private AuthErrorCode resolveAuthErrorCode(MethodArgumentNotValidException exception) {
+        FieldError fieldError = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        if (fieldError == null) {
+            return AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE;
+        }
+
+        return AuthErrorCode.fromCode(fieldError.getDefaultMessage());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthControllerTest.java
@@ -3,16 +3,16 @@ package io.github.ascrew.monomatbe.domain.auth.controller;
 import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.GuestLoginResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.service.GuestAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.LoginAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.LogoutAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.RefreshAuthService;
 import io.github.ascrew.monomatbe.domain.auth.service.RegisterAuthService;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 class AuthControllerTest {
 
     @Test
-    void logout_nullPrincipal_returnsUnauthorized() {
+    void logout_nullPrincipal_returnsUnauthenticatedAuthError() {
         AuthController controller = new AuthController(
                 mock(GuestAuthService.class),
                 mock(RegisterAuthService.class),
@@ -33,18 +33,18 @@ class AuthControllerTest {
                 mock(LogoutAuthService.class)
         );
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> controller.logout(null, "Bearer token")
         );
 
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
-        assertEquals("인증 정보가 없습니다.", exception.getReason());
+        assertEquals(AuthErrorCode.AUTH_UNAUTHENTICATED, exception.getErrorCode());
     }
 
     @Test
     void guestLogin_whenTrustForwardedHeadersFalse_usesRemoteAddr() {
         GuestAuthService guestAuthService = mock(GuestAuthService.class);
+
         when(guestAuthService.loginAsGuest("guest", "127.0.0.10", "JUnit-Agent"))
                 .thenReturn(GuestLoginResponse.builder()
                         .userId(1L)
@@ -62,6 +62,7 @@ class AuthControllerTest {
                 mock(RefreshAuthService.class),
                 mock(LogoutAuthService.class)
         );
+
         ReflectionTestUtils.setField(controller, "trustForwardedHeaders", false);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -70,12 +71,14 @@ class AuthControllerTest {
         request.setRemoteAddr("127.0.0.10");
 
         assertDoesNotThrow(() -> controller.guestLogin(new GuestLoginRequest("guest"), request));
+
         verify(guestAuthService).loginAsGuest("guest", "127.0.0.10", "JUnit-Agent");
     }
 
     @Test
     void guestLogin_whenTrustForwardedHeadersTrue_usesForwardedForFirstIp() {
         GuestAuthService guestAuthService = mock(GuestAuthService.class);
+
         when(guestAuthService.loginAsGuest("guest", "198.51.100.10", "JUnit-Agent"))
                 .thenReturn(GuestLoginResponse.builder()
                         .userId(1L)
@@ -93,6 +96,7 @@ class AuthControllerTest {
                 mock(RefreshAuthService.class),
                 mock(LogoutAuthService.class)
         );
+
         ReflectionTestUtils.setField(controller, "trustForwardedHeaders", true);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -101,6 +105,7 @@ class AuthControllerTest {
         request.setRemoteAddr("127.0.0.10");
 
         assertDoesNotThrow(() -> controller.guestLogin(new GuestLoginRequest("guest"), request));
+
         verify(guestAuthService).loginAsGuest("guest", "198.51.100.10", "JUnit-Agent");
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/AuthControllerTest.java
@@ -42,6 +42,24 @@ class AuthControllerTest {
     }
 
     @Test
+    void logout_nullPrincipalAndMissingAuthorization_returnsUnauthenticatedAuthErrorFirst() {
+        AuthController controller = new AuthController(
+                mock(GuestAuthService.class),
+                mock(RegisterAuthService.class),
+                mock(LoginAuthService.class),
+                mock(RefreshAuthService.class),
+                mock(LogoutAuthService.class)
+        );
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> controller.logout(null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_UNAUTHENTICATED, exception.getErrorCode());
+    }
+
+    @Test
     void guestLogin_whenTrustForwardedHeadersFalse_usesRemoteAddr() {
         GuestAuthService guestAuthService = mock(GuestAuthService.class);
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandlerTest.java
@@ -2,14 +2,19 @@ package io.github.ascrew.monomatbe.domain.auth.exception;
 
 import io.github.ascrew.monomatbe.domain.auth.dto.AuthErrorResponse;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,6 +38,56 @@ class AuthExceptionHandlerTest {
         assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.name(), response.getBody().code());
         assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.getMessage(), response.getBody().message());
         assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.getField(), response.getBody().field());
+    }
+
+    @Test
+    void handleValidationException_unknownValidationCode_returnsInvalidRequestBodyWithBadRequest()
+            throws NoSuchMethodException {
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(
+                new TestAuthRequest("test"),
+                "testAuthRequest"
+        );
+
+        bindingResult.addError(new FieldError(
+                "testAuthRequest",
+                "loginId",
+                "test",
+                false,
+                null,
+                null,
+                "AUTH_LOGINID_REQUIRED"
+        ));
+
+        Method method = TestAuthController.class.getDeclaredMethod(
+                "test",
+                TestAuthRequest.class
+        );
+
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(
+                methodParameter,
+                bindingResult
+        );
+
+        ResponseEntity<AuthErrorResponse> response =
+                authExceptionHandler.handleValidationException(exception);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.name(), response.getBody().code());
+        assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.getMessage(), response.getBody().message());
+        assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.getField(), response.getBody().field());
+    }
+
+    private record TestAuthRequest(String loginId) {
+    }
+
+    private static final class TestAuthController {
+
+        @SuppressWarnings("unused")
+        void test(TestAuthRequest request) {
+        }
     }
 
     private static final class TestHttpInputMessage implements HttpInputMessage {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandlerTest.java
@@ -1,0 +1,50 @@
+package io.github.ascrew.monomatbe.domain.auth.exception;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.AuthErrorResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class AuthExceptionHandlerTest {
+
+    private final AuthExceptionHandler authExceptionHandler = new AuthExceptionHandler();
+
+    @Test
+    void handleHttpMessageNotReadableException_returnsInvalidRequestBodyWithBadRequest() {
+        HttpMessageNotReadableException exception = new HttpMessageNotReadableException(
+                "Malformed JSON",
+                new TestHttpInputMessage()
+        );
+
+        ResponseEntity<AuthErrorResponse> response =
+                authExceptionHandler.handleHttpMessageNotReadableException(exception);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.name(), response.getBody().code());
+        assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.getMessage(), response.getBody().message());
+        assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.getField(), response.getBody().field());
+    }
+
+    private static final class TestHttpInputMessage implements HttpInputMessage {
+
+        @Override
+        public InputStream getBody() {
+            return new ByteArrayInputStream("{".getBytes());
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return new HttpHeaders();
+        }
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthExceptionHandlerTest.java
@@ -80,13 +80,60 @@ class AuthExceptionHandlerTest {
         assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY.getField(), response.getBody().field());
     }
 
+    @Test
+    void handleValidationException_blankRefreshToken_returnsRefreshTokenRequiredWithBadRequest()
+            throws NoSuchMethodException {
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(
+                new TestRefreshTokenRequest(""),
+                "testRefreshTokenRequest"
+        );
+
+        bindingResult.addError(new FieldError(
+                "testRefreshTokenRequest",
+                "refreshToken",
+                "",
+                false,
+                null,
+                null,
+                "AUTH_REFRESH_TOKEN_REQUIRED"
+        ));
+
+        Method method = TestAuthController.class.getDeclaredMethod(
+                "refresh",
+                TestRefreshTokenRequest.class
+        );
+
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(
+                methodParameter,
+                bindingResult
+        );
+
+        ResponseEntity<AuthErrorResponse> response =
+                authExceptionHandler.handleValidationException(exception);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED.name(), response.getBody().code());
+        assertEquals(AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED.getMessage(), response.getBody().message());
+        assertEquals(AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED.getField(), response.getBody().field());
+    }
+
     private record TestAuthRequest(String loginId) {
+    }
+
+    private record TestRefreshTokenRequest(String refreshToken) {
     }
 
     private static final class TestAuthController {
 
         @SuppressWarnings("unused")
         void test(TestAuthRequest request) {
+        }
+
+        @SuppressWarnings("unused")
+        void refresh(TestRefreshTokenRequest request) {
         }
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
@@ -90,6 +90,57 @@ class LoginAuthServiceTest {
     }
 
     @Test
+    void login_legacyLoginIdWithUnderscore_success() {
+        String loginId = "legacy_" + System.nanoTime();
+        String password = "password123";
+        String nickname = uniqueNickname();
+
+        UserCredential credential = createCredential(loginId, password, nickname);
+
+        LoginResponse response = loginAuthService.login(
+                loginId,
+                password,
+                "127.0.0.1",
+                "JUnit-Agent"
+        );
+
+        assertEquals(credential.getUser().getId(), response.userId());
+        assertEquals(loginId, response.loginId());
+        assertEquals(nickname, response.nickname());
+        assertEquals(UserType.REGISTERED, response.userType());
+    }
+
+    @Test
+    void login_legacyLoginIdWithSpecialCharacter_success() {
+        String loginId = "legacy-" + System.nanoTime();
+        String password = "password123";
+        String nickname = uniqueNickname();
+
+        UserCredential credential = createCredential(loginId, password, nickname);
+
+        LoginResponse response = loginAuthService.login(
+                loginId,
+                password,
+                "127.0.0.1",
+                "JUnit-Agent"
+        );
+
+        assertEquals(credential.getUser().getId(), response.userId());
+        assertEquals(loginId, response.loginId());
+        assertEquals(nickname, response.nickname());
+        assertEquals(UserType.REGISTERED, response.userType());
+    }
+
+    @Test
+    void login_unknownLoginId_returnsInvalidCredentials() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login("unknown!", "password123", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_CREDENTIALS, exception.getErrorCode());
+    }
+
+    @Test
     void login_wrongPassword_incrementsFailedCount() {
         String loginId = uniqueLoginId();
 
@@ -175,21 +226,43 @@ class LoginAuthServiceTest {
     }
 
     @Test
-    void login_loginIdInvalidFormat_throwsLoginIdInvalidFormatError() {
+    void login_nullLoginId_throwsLoginIdRequiredError() {
         AuthException exception = assertThrows(AuthException.class, () ->
-                loginAuthService.login("abcd!", "password123", null, null)
+                loginAuthService.login(null, "password123", null, null)
         );
 
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_FORMAT, exception.getErrorCode());
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_REQUIRED, exception.getErrorCode());
     }
 
     @Test
-    void login_passwordWithWhitespace_throwsPasswordWhitespaceError() {
+    void login_blankPassword_throwsPasswordRequiredError() {
         AuthException exception = assertThrows(AuthException.class, () ->
-                loginAuthService.login(uniqueLoginId(), "pass word123", null, null)
+                loginAuthService.login(uniqueLoginId(), "   ", null, null)
         );
 
-        assertEquals(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE, exception.getErrorCode());
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void login_nullPassword_throwsPasswordRequiredError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login(uniqueLoginId(), null, null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void login_passwordWithWhitespace_isHandledAsInvalidCredentialsAfterLookup() {
+        String loginId = uniqueLoginId();
+
+        createCredential(loginId, "password123", uniqueNickname());
+
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login(loginId, "pass word123", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_CREDENTIALS, exception.getErrorCode());
     }
 
     private UserCredential createCredential(String loginId, String rawPassword, String nickname) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
@@ -5,16 +5,16 @@ import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -44,11 +44,19 @@ class LoginAuthServiceTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    private String uniqueLoginId() {
+        return "member" + System.nanoTime();
+    }
+
+    private String uniqueNickname() {
+        return "n" + (System.nanoTime() % 1_000_000);
+    }
+
     @Test
     void login_success() {
-        String loginId = "member_" + System.nanoTime();
+        String loginId = uniqueLoginId();
         String password = "password123";
-        String nickname = "n" + (System.nanoTime() % 1_000_000);
+        String nickname = uniqueNickname();
         long sessionCountBefore = userSessionRepository.count();
 
         UserCredential credential = createCredential(loginId, password, nickname);
@@ -83,14 +91,15 @@ class LoginAuthServiceTest {
 
     @Test
     void login_wrongPassword_incrementsFailedCount() {
-        String loginId = "member_" + System.nanoTime();
-        createCredential(loginId, "password123", "n" + (System.nanoTime() % 1_000_000));
+        String loginId = uniqueLoginId();
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                loginAuthService.login(loginId, "wrong-password", null, null));
+        createCredential(loginId, "password123", uniqueNickname());
 
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
-        assertEquals("로그인 ID 또는 비밀번호가 올바르지 않습니다.", exception.getReason());
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login(loginId, "wrong-password", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_CREDENTIALS, exception.getErrorCode());
 
         UserCredential savedCredential = userCredentialRepository.findByLoginId(loginId).orElseThrow();
         assertEquals(1, savedCredential.getFailedLoginCount());
@@ -99,12 +108,16 @@ class LoginAuthServiceTest {
 
     @Test
     void login_fiveFailures_locksAccount() {
-        String loginId = "member_" + System.nanoTime();
-        createCredential(loginId, "password123", "n" + (System.nanoTime() % 1_000_000));
+        String loginId = uniqueLoginId();
+
+        createCredential(loginId, "password123", uniqueNickname());
 
         for (int i = 0; i < 5; i++) {
-            assertThrows(ResponseStatusException.class, () ->
-                    loginAuthService.login(loginId, "wrong-password", null, null));
+            AuthException exception = assertThrows(AuthException.class, () ->
+                    loginAuthService.login(loginId, "wrong-password", null, null)
+            );
+
+            assertEquals(AuthErrorCode.AUTH_INVALID_CREDENTIALS, exception.getErrorCode());
         }
 
         UserCredential savedCredential = userCredentialRepository.findByLoginId(loginId).orElseThrow();
@@ -112,29 +125,34 @@ class LoginAuthServiceTest {
         assertNotNull(savedCredential.getLockedUntil());
         assertTrue(savedCredential.getLockedUntil().isAfter(LocalDateTime.now()));
 
-        ResponseStatusException lockedException = assertThrows(ResponseStatusException.class, () ->
-                loginAuthService.login(loginId, "password123", null, null));
-        assertEquals(HttpStatus.LOCKED, lockedException.getStatusCode());
+        AuthException lockedException = assertThrows(AuthException.class, () ->
+                loginAuthService.login(loginId, "password123", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_ACCOUNT_LOCKED, lockedException.getErrorCode());
     }
 
     @Test
-    void login_lockedAccount_returnsLocked() {
-        String loginId = "member_" + System.nanoTime();
-        UserCredential credential = createCredential(loginId, "password123", "n" + (System.nanoTime() % 1_000_000));
+    void login_lockedAccount_returnsLockedError() {
+        String loginId = uniqueLoginId();
+
+        UserCredential credential = createCredential(loginId, "password123", uniqueNickname());
         credential.lockUntil(LocalDateTime.now().plusMinutes(10));
         userCredentialRepository.saveAndFlush(credential);
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                loginAuthService.login(loginId, "password123", null, null));
-        assertEquals(HttpStatus.LOCKED, exception.getStatusCode());
-        assertEquals("로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.", exception.getReason());
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login(loginId, "password123", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_ACCOUNT_LOCKED, exception.getErrorCode());
     }
 
     @Test
     void login_success_resetsFailedState() {
-        String loginId = "member_" + System.nanoTime();
+        String loginId = uniqueLoginId();
         String password = "password123";
-        UserCredential credential = createCredential(loginId, password, "n" + (System.nanoTime() % 1_000_000));
+
+        UserCredential credential = createCredential(loginId, password, uniqueNickname());
         credential.increaseFailedLoginCount();
         credential.increaseFailedLoginCount();
         credential.lockUntil(LocalDateTime.now().minusMinutes(1));
@@ -145,6 +163,33 @@ class LoginAuthServiceTest {
         UserCredential savedCredential = userCredentialRepository.findByLoginId(loginId).orElseThrow();
         assertEquals(0, savedCredential.getFailedLoginCount());
         assertNull(savedCredential.getLockedUntil());
+    }
+
+    @Test
+    void login_blankLoginId_throwsLoginIdRequiredError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login("   ", "password123", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void login_loginIdInvalidFormat_throwsLoginIdInvalidFormatError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login("abcd!", "password123", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_FORMAT, exception.getErrorCode());
+    }
+
+    @Test
+    void login_passwordWithWhitespace_throwsPasswordWhitespaceError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                loginAuthService.login(uniqueLoginId(), "pass word123", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE, exception.getErrorCode());
     }
 
     private UserCredential createCredential(String loginId, String rawPassword, String nickname) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthServiceTest.java
@@ -7,6 +7,7 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthLoginFailureException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
@@ -250,6 +251,19 @@ class LoginAuthServiceTest {
         );
 
         assertEquals(AuthErrorCode.AUTH_PASSWORD_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void login_wrongPassword_throwsLoginFailureExceptionForNoRollback() {
+        String loginId = uniqueLoginId();
+
+        createCredential(loginId, "password123", uniqueNickname());
+
+        AuthLoginFailureException exception = assertThrows(AuthLoginFailureException.class, () ->
+                loginAuthService.login(loginId, "wrong-password", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_CREDENTIALS, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LogoutAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/LogoutAuthServiceTest.java
@@ -1,16 +1,17 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
+import io.jsonwebtoken.JwtException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 
@@ -25,8 +26,10 @@ class LogoutAuthServiceTest {
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+
     @Mock
     private StringRedisTemplate redisTemplate;
+
     @Mock
     private UserSessionLifecycleService userSessionLifecycleService;
 
@@ -40,10 +43,13 @@ class LogoutAuthServiceTest {
 
         String accessToken = "access-token";
         String header = "Bearer " + accessToken;
-        when(jwtTokenProvider.accessTokenRemainingTtl(accessToken)).thenReturn(Duration.ofMinutes(10));
+
+        when(jwtTokenProvider.accessTokenRemainingTtl(accessToken))
+                .thenReturn(Duration.ofMinutes(10));
 
         @SuppressWarnings("unchecked")
         ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         logoutAuthService.logout(1L, "session-1", header);
@@ -53,22 +59,64 @@ class LogoutAuthServiceTest {
                 "1",
                 Duration.ofMinutes(10)
         );
-        verify(userSessionLifecycleService).markSessionLogout(org.mockito.ArgumentMatchers.eq(1L), org.mockito.ArgumentMatchers.eq("session-1"), org.mockito.ArgumentMatchers.any());
+
+        verify(userSessionLifecycleService).markSessionLogout(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.eq("session-1"),
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 
     @Test
-    void logout_invalidAuthorizationHeader_throwsUnauthorized() {
+    void logout_invalidAuthorizationHeader_throwsInvalidAuthorizationError() {
         LogoutAuthService logoutAuthService = new LogoutAuthService(
                 jwtTokenProvider,
                 redisTemplate,
                 userSessionLifecycleService
         );
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> logoutAuthService.logout(1L, "session-1", "invalid")
         );
 
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertEquals(AuthErrorCode.AUTH_INVALID_AUTHORIZATION, exception.getErrorCode());
+    }
+
+    @Test
+    void logout_blankBearerToken_throwsInvalidAuthorizationError() {
+        LogoutAuthService logoutAuthService = new LogoutAuthService(
+                jwtTokenProvider,
+                redisTemplate,
+                userSessionLifecycleService
+        );
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> logoutAuthService.logout(1L, "session-1", "Bearer ")
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_AUTHORIZATION, exception.getErrorCode());
+    }
+
+    @Test
+    void logout_invalidAccessToken_throwsInvalidAuthorizationError() {
+        LogoutAuthService logoutAuthService = new LogoutAuthService(
+                jwtTokenProvider,
+                redisTemplate,
+                userSessionLifecycleService
+        );
+
+        String accessToken = "invalid-token";
+
+        when(jwtTokenProvider.accessTokenRemainingTtl(accessToken))
+                .thenThrow(new JwtException("invalid token"));
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> logoutAuthService.logout(1L, "session-1", "Bearer " + accessToken)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_AUTHORIZATION, exception.getErrorCode());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthServiceTest.java
@@ -6,6 +6,8 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.JwtClaims;
@@ -13,6 +15,7 @@ import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenWithExpiry;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,9 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.http.HttpStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,10 +44,13 @@ class RefreshAuthServiceTest {
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+
     @Mock
     private StringRedisTemplate redisTemplate;
+
     @Mock
     private UserSessionRepository userSessionRepository;
+
     @Mock
     private UserSessionLifecycleService userSessionLifecycleService;
 
@@ -59,6 +64,7 @@ class RefreshAuthServiceTest {
                 userSessionRepository,
                 userSessionLifecycleService
         );
+
         TransactionSynchronizationManager.initSynchronization();
     }
 
@@ -75,35 +81,46 @@ class RefreshAuthServiceTest {
         String sessionId = "session-123";
         Long userId = 1L;
 
-        Claims claims = mock(Claims.class);
-        when(claims.getSubject()).thenReturn(String.valueOf(userId));
-        when(claims.get(JwtClaims.USER_TYPE, String.class)).thenReturn(UserType.REGISTERED.name());
-        when(claims.get(JwtClaims.SESSION_ID, String.class)).thenReturn(sessionId);
+        Claims claims = mockRefreshClaims(userId, UserType.REGISTERED, sessionId);
         when(jwtTokenProvider.parseClaims(requestRefreshToken)).thenReturn(claims);
 
         @SuppressWarnings("unchecked")
         ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(RedisKeys.refreshTokenKey(sessionId)))
                 .thenReturn(TokenHashUtils.sha256(requestRefreshToken));
 
-        UserSession session = UserSession.builder()
-                .user(User.builder().id(userId).username("tester").userType(UserType.REGISTERED).status(UserStatus.ACTIVE).build())
-                .sessionId(sessionId)
-                .sessionToken(TokenHashUtils.sha256(requestRefreshToken))
-                .expiresAt(LocalDateTime.now().plusMinutes(10))
-                .createdAt(LocalDateTime.now().minusMinutes(1))
-                .updatedAt(LocalDateTime.now().minusMinutes(1))
-                .status(UserSessionStatus.ACTIVE)
-                .build();
-        when(userSessionRepository.findBySessionIdForUpdate(sessionId)).thenReturn(Optional.of(session));
+        UserSession session = activeSession(
+                userId,
+                sessionId,
+                TokenHashUtils.sha256(requestRefreshToken),
+                LocalDateTime.now().plusMinutes(10)
+        );
 
-        TokenWithExpiry accessToken = new TokenWithExpiry("access-token-new", Instant.now().plusSeconds(600));
-        TokenWithExpiry refreshToken = new TokenWithExpiry("refresh-token-new", Instant.now().plusSeconds(3600));
-        when(jwtTokenProvider.createAccessToken(userId, UserType.REGISTERED, sessionId)).thenReturn(accessToken);
-        when(jwtTokenProvider.createRefreshToken(userId, UserType.REGISTERED, sessionId)).thenReturn(refreshToken);
+        when(userSessionRepository.findBySessionIdForUpdate(sessionId))
+                .thenReturn(Optional.of(session));
 
-        RefreshTokenResponse response = refreshAuthService.refresh(requestRefreshToken, "127.0.0.1", "JUnit");
+        TokenWithExpiry accessToken = new TokenWithExpiry(
+                "access-token-new",
+                Instant.now().plusSeconds(600)
+        );
+
+        TokenWithExpiry refreshToken = new TokenWithExpiry(
+                "refresh-token-new",
+                Instant.now().plusSeconds(3600)
+        );
+
+        when(jwtTokenProvider.createAccessToken(userId, UserType.REGISTERED, sessionId))
+                .thenReturn(accessToken);
+        when(jwtTokenProvider.createRefreshToken(userId, UserType.REGISTERED, sessionId))
+                .thenReturn(refreshToken);
+
+        RefreshTokenResponse response = refreshAuthService.refresh(
+                requestRefreshToken,
+                "127.0.0.1",
+                "JUnit"
+        );
 
         assertEquals(userId, response.userId());
         assertEquals(UserType.REGISTERED, response.userType());
@@ -111,7 +128,10 @@ class RefreshAuthServiceTest {
         assertEquals("access-token-new", response.accessToken());
         assertEquals("refresh-token-new", response.refreshToken());
         assertEquals(TokenHashUtils.sha256("refresh-token-new"), session.getSessionToken());
-        assertEquals(LocalDateTime.ofInstant(refreshToken.expiresAt(), ZoneId.systemDefault()), session.getExpiresAt());
+        assertEquals(
+                LocalDateTime.ofInstant(refreshToken.expiresAt(), ZoneId.systemDefault()),
+                session.getExpiresAt()
+        );
     }
 
     @Test
@@ -120,30 +140,151 @@ class RefreshAuthServiceTest {
         String sessionId = "session-123";
         Long userId = 1L;
 
-        Claims claims = mock(Claims.class);
-        when(claims.getSubject()).thenReturn(String.valueOf(userId));
-        when(claims.get(JwtClaims.USER_TYPE, String.class)).thenReturn(UserType.REGISTERED.name());
-        when(claims.get(JwtClaims.SESSION_ID, String.class)).thenReturn(sessionId);
+        Claims claims = mockRefreshClaims(userId, UserType.REGISTERED, sessionId);
         when(jwtTokenProvider.parseClaims(requestRefreshToken)).thenReturn(claims);
 
-        UserSession session = UserSession.builder()
-                .user(User.builder().id(userId).username("tester").userType(UserType.REGISTERED).status(UserStatus.ACTIVE).build())
+        UserSession session = activeSession(
+                userId,
+                sessionId,
+                "different-hash",
+                LocalDateTime.now().plusMinutes(10)
+        );
+
+        when(userSessionRepository.findBySessionIdForUpdate(sessionId))
+                .thenReturn(Optional.of(session));
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> refreshAuthService.refresh(requestRefreshToken, null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN, exception.getErrorCode());
+
+        verify(userSessionLifecycleService)
+                .revokeAllActiveSessions(eq(userId), any(LocalDateTime.class));
+    }
+
+    @Test
+    void refresh_invalidJwt_throwsInvalidRefreshTokenError() {
+        String requestRefreshToken = "invalid-refresh-token";
+
+        when(jwtTokenProvider.parseClaims(requestRefreshToken))
+                .thenThrow(new JwtException("invalid refresh token"));
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> refreshAuthService.refresh(requestRefreshToken, null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    void refresh_missingSession_throwsInvalidRefreshTokenError() {
+        String requestRefreshToken = "refresh-token-old";
+        String sessionId = "session-123";
+        Long userId = 1L;
+
+        Claims claims = mockRefreshClaims(userId, UserType.REGISTERED, sessionId);
+        when(jwtTokenProvider.parseClaims(requestRefreshToken)).thenReturn(claims);
+
+        when(userSessionRepository.findBySessionIdForUpdate(sessionId))
+                .thenReturn(Optional.empty());
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> refreshAuthService.refresh(requestRefreshToken, null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    void refresh_inactiveSession_throwsSessionExpiredError() {
+        String requestRefreshToken = "refresh-token-old";
+        String sessionId = "session-123";
+        Long userId = 1L;
+
+        Claims claims = mockRefreshClaims(userId, UserType.REGISTERED, sessionId);
+        when(jwtTokenProvider.parseClaims(requestRefreshToken)).thenReturn(claims);
+
+        UserSession session = activeSession(
+                userId,
+                sessionId,
+                TokenHashUtils.sha256(requestRefreshToken),
+                LocalDateTime.now().minusMinutes(1)
+        );
+
+        when(userSessionRepository.findBySessionIdForUpdate(sessionId))
+                .thenReturn(Optional.of(session));
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> refreshAuthService.refresh(requestRefreshToken, null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_SESSION_EXPIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void refresh_redisFailure_throwsTemporaryUnavailableError() {
+        String requestRefreshToken = "refresh-token-old";
+        String sessionId = "session-123";
+        Long userId = 1L;
+
+        Claims claims = mockRefreshClaims(userId, UserType.REGISTERED, sessionId);
+        when(jwtTokenProvider.parseClaims(requestRefreshToken)).thenReturn(claims);
+
+        UserSession session = activeSession(
+                userId,
+                sessionId,
+                TokenHashUtils.sha256(requestRefreshToken),
+                LocalDateTime.now().plusMinutes(10)
+        );
+
+        when(userSessionRepository.findBySessionIdForUpdate(sessionId))
+                .thenReturn(Optional.of(session));
+
+        when(redisTemplate.opsForValue())
+                .thenThrow(new IllegalStateException("Redis unavailable"));
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> refreshAuthService.refresh(requestRefreshToken, null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_TEMPORARY_UNAVAILABLE, exception.getErrorCode());
+    }
+
+    private Claims mockRefreshClaims(Long userId, UserType userType, String sessionId) {
+        Claims claims = mock(Claims.class);
+
+        when(claims.getSubject()).thenReturn(String.valueOf(userId));
+        when(claims.get(JwtClaims.USER_TYPE, String.class)).thenReturn(userType.name());
+        when(claims.get(JwtClaims.SESSION_ID, String.class)).thenReturn(sessionId);
+
+        return claims;
+    }
+
+    private UserSession activeSession(
+            Long userId,
+            String sessionId,
+            String sessionToken,
+            LocalDateTime expiresAt
+    ) {
+        return UserSession.builder()
+                .user(User.builder()
+                        .id(userId)
+                        .username("tester")
+                        .userType(UserType.REGISTERED)
+                        .status(UserStatus.ACTIVE)
+                        .build())
                 .sessionId(sessionId)
-                .sessionToken("different-hash")
-                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .sessionToken(sessionToken)
+                .expiresAt(expiresAt)
                 .createdAt(LocalDateTime.now().minusMinutes(1))
                 .updatedAt(LocalDateTime.now().minusMinutes(1))
                 .status(UserSessionStatus.ACTIVE)
                 .build();
-        when(userSessionRepository.findBySessionIdForUpdate(sessionId)).thenReturn(Optional.of(session));
-
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> refreshAuthService.refresh(requestRefreshToken, null, null)
-        );
-
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
-        assertEquals("Refresh Token이 유효하지 않습니다.", exception.getReason());
-        org.mockito.Mockito.verify(userSessionLifecycleService).revokeAllActiveSessions(eq(userId), any(LocalDateTime.class));
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthServiceTest.java
@@ -227,6 +227,26 @@ class RefreshAuthServiceTest {
     }
 
     @Test
+    void refresh_nullRefreshToken_throwsRefreshTokenRequiredError() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> refreshAuthService.refresh(null, null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void refresh_blankRefreshToken_throwsRefreshTokenRequiredError() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> refreshAuthService.refresh("   ", null, null)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_REFRESH_TOKEN_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
     void refresh_redisFailure_throwsTemporaryUnavailableError() {
         String requestRefreshToken = "refresh-token-old";
         String sessionId = "session-123";

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -4,14 +4,14 @@ import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,115 +28,156 @@ class RegisterAuthServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+    private String uniqueLoginId() {
+        return "member" + System.nanoTime();
+    }
+
     private String uniqueNickname() {
         return "n" + (System.nanoTime() % 1_000_000);
     }
 
     @Test
     void register_success() {
-        String uniqueLoginId = "member_" + System.nanoTime();
-        String uniqueNickname = uniqueNickname();
+        String loginId = uniqueLoginId();
+        String nickname = uniqueNickname();
 
         RegisterResponse response = registerAuthService.register(
-                uniqueLoginId,
+                loginId,
                 "password123",
-                uniqueNickname
+                nickname
         );
 
         assertNotNull(response.userId());
-        assertEquals(uniqueLoginId, response.loginId());
-        assertEquals(uniqueNickname, response.nickname());
+        assertEquals(loginId, response.loginId());
+        assertEquals(nickname, response.nickname());
         assertEquals(UserType.REGISTERED, response.userType());
     }
 
     @Test
     void register_trimsLoginIdAndNickname() {
-        String uniqueLoginId = "member_" + System.nanoTime();
-        String uniqueNickname = uniqueNickname();
+        String loginId = uniqueLoginId();
+        String nickname = uniqueNickname();
 
         RegisterResponse response = registerAuthService.register(
-                "  " + uniqueLoginId + "  ",
+                "  " + loginId + "  ",
                 "password123",
-                "  " + uniqueNickname + "  "
+                "  " + nickname + "  "
         );
 
-        assertEquals(uniqueLoginId, response.loginId());
-        assertEquals(uniqueNickname, response.nickname());
+        assertEquals(loginId, response.loginId());
+        assertEquals(nickname, response.nickname());
     }
 
     @Test
-    void register_passwordWithWhitespace_throwsBadRequest() {
-        String uniqueLoginId = "member_" + System.nanoTime();
-        String uniqueNickname = uniqueNickname();
-        String rawPassword = "  password123  ";
+    void register_passwordWithWhitespace_throwsPasswordWhitespaceError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(uniqueLoginId(), "  password123  ", uniqueNickname())
+        );
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register(uniqueLoginId, rawPassword, uniqueNickname));
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        assertEquals("비밀번호에는 공백을 포함할 수 없습니다.", exception.getReason());
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE, exception.getErrorCode());
     }
 
     @Test
-    void register_duplicateLoginId_throwsConflict() {
-        String loginId = "dup_login_" + System.nanoTime();
+    void register_duplicateLoginId_throwsDuplicatedLoginIdError() {
+        String loginId = uniqueLoginId();
 
         registerAuthService.register(loginId, "password123", uniqueNickname());
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register(loginId, "password123", uniqueNickname()));
-        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
-        assertEquals("이미 사용 중인 로그인 ID입니다.", exception.getReason());
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(loginId, "password123", uniqueNickname())
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_DUPLICATED, exception.getErrorCode());
     }
 
     @Test
-    void register_duplicateNickname_throwsConflict() {
+    void register_duplicateNickname_throwsDuplicatedNicknameError() {
         String nickname = uniqueNickname();
+
         userRepository.saveAndFlush(User.builder()
                 .username(nickname)
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.ACTIVE)
                 .build());
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("anotherLogin_" + System.nanoTime(), "password123", nickname));
-        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
-        assertEquals("이미 사용 중인 닉네임입니다.", exception.getReason());
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(uniqueLoginId(), "password123", nickname)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_DUPLICATED, exception.getErrorCode());
     }
 
     @Test
-    void register_nullPassword_throwsBadRequest() {
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("login_" + System.nanoTime(), null, uniqueNickname()));
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        assertEquals("비밀번호는 비어 있을 수 없습니다.", exception.getReason());
+    void register_nullPassword_throwsPasswordRequiredError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(uniqueLoginId(), null, uniqueNickname())
+        );
+
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_REQUIRED, exception.getErrorCode());
     }
 
     @Test
-    void register_blankLoginId_throwsBadRequest() {
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("   ", "password123", uniqueNickname()));
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        assertEquals("로그인 ID는 비어 있을 수 없습니다.", exception.getReason());
+    void register_blankLoginId_throwsLoginIdRequiredError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register("   ", "password123", uniqueNickname())
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_REQUIRED, exception.getErrorCode());
     }
 
     @Test
-    void register_nicknameTooLong_throwsBadRequest() {
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register("login_" + System.nanoTime(), "password123", "123456789"));
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        assertEquals("닉네임은 8자를 초과할 수 없습니다.", exception.getReason());
+    void register_loginIdTooShort_throwsLoginIdInvalidLengthError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register("abc", "password123", uniqueNickname())
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_LENGTH, exception.getErrorCode());
     }
 
     @Test
-    void register_loginIdWithWhitespace_throwsBadRequest() {
-        // given
-        String loginIdWithWhitespace = "abc def";
-        String uniqueNickname = uniqueNickname();
+    void register_loginIdTooLong_throwsLoginIdInvalidLengthError() {
+        String tooLongLoginId = "a".repeat(51);
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                registerAuthService.register(loginIdWithWhitespace, "password123", uniqueNickname));
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(tooLongLoginId, "password123", uniqueNickname())
+        );
 
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        assertEquals("로그인 ID에는 공백을 포함할 수 없습니다.", exception.getReason());
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_LENGTH, exception.getErrorCode());
+    }
+
+    @Test
+    void register_loginIdWithWhitespace_throwsLoginIdWhitespaceError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register("abc def", "password123", uniqueNickname())
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_CONTAINS_WHITESPACE, exception.getErrorCode());
+    }
+
+    @Test
+    void register_loginIdInvalidFormat_throwsLoginIdInvalidFormatError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register("abcd!", "password123", uniqueNickname())
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_FORMAT, exception.getErrorCode());
+    }
+
+    @Test
+    void register_nicknameTooShort_throwsNicknameInvalidLengthError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(uniqueLoginId(), "password123", "a")
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH, exception.getErrorCode());
+    }
+
+    @Test
+    void register_nicknameTooLong_throwsNicknameInvalidLengthError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(uniqueLoginId(), "password123", "1234567890123")
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH, exception.getErrorCode());
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
- #128

## 📝 Summary
- 인증 API에서 발생하는 에러 응답을 `code`, `message`, `field` 기반 포맷으로 표준화했습니다.
- 인증 도메인 전용 `AuthErrorCode`, `AuthException`, `AuthErrorResponse`를 추가했습니다.
- `AuthExceptionHandler`를 추가하여 인증 API의 예외 응답을 프론트엔드가 안정적으로 처리할 수 있는 형태로 변환했습니다.
- 로그인, 회원가입, 게스트 로그인, 토큰 재발급, 로그아웃 API의 기존 `ResponseStatusException` 기반 문자열 의존 로직을 `AuthException` 기반으로 교체했습니다.
- DTO validation message를 사용자 표시 문구가 아닌 `AuthErrorCode` 값으로 변경했습니다.
- Validation 에러가 여러 개 발생할 때 `REQUIRED → WHITESPACE → LENGTH → FORMAT` 순서로 우선순위를 적용하도록 보정했습니다.
- `refreshToken` 누락, Authorization 헤더 누락/형식 오류, 잘못된 요청 body 등 인증 API 경계 예외도 표준 응답 포맷으로 처리하도록 보완했습니다.
- 인증 에러 코드 목록을 `docs/AUTH_ERROR_CODES.md`에 문서화했습니다.
- 기존 인증 테스트를 `AuthException + AuthErrorCode` 기준으로 수정하고, 누락된 실패 케이스 테스트를 추가했습니다.

## 🙏PR point
- 프론트엔드는 앞으로 인증 API 에러 처리 시 `message` 문자열이 아니라 `code`와 `field`를 기준으로 분기해야 합니다.
- 응답 예시는 다음과 같습니다.

```json
{
  "code": "AUTH_INVALID_CREDENTIALS",
  "message": "로그인 ID 또는 비밀번호가 올바르지 않습니다.",
  "field": null
}
````

* `field`가 있는 에러는 해당 입력 필드에 표시하면 됩니다.

  * 예: `AUTH_LOGIN_ID_DUPLICATED` → `loginId`
  * 예: `AUTH_PASSWORD_REQUIRED` → `password`
  * 예: `AUTH_NICKNAME_INVALID_LENGTH` → `nickname`
* `field`가 `null`인 에러는 form 상단 또는 toast 영역에 표시하는 것을 권장합니다.

  * 예: `AUTH_INVALID_CREDENTIALS`
  * 예: `AUTH_ACCOUNT_LOCKED`
  * 예: `AUTH_INVALID_REFRESH_TOKEN`
* 로그인 실패는 계정 존재 여부 추측을 막기 위해 로그인 ID 미존재와 비밀번호 불일치를 모두 `AUTH_INVALID_CREDENTIALS`로 통합했습니다.
* `AUTH_NICKNAME_FORBIDDEN_WORD`는 에러 코드에는 포함되어 있지만, 실제 금칙어 검증 로직은 별도 이슈에서 구현하는 것이 적절합니다.
* 로그인 ID 검증 정책은 영문/숫자 4자 이상 50자 이하 기준으로 정리되었습니다.
* 닉네임 검증 정책은 2자 이상 12자 이하 기준으로 정리되었습니다.

## 📬 Reference

* `docs/AUTH_ERROR_CODES.md`
* 프론트엔드 인증 화면에서 사용할 에러 코드 목록 및 필드 매핑 기준을 문서화했습니다.

