### PR TITLE
[Feat/#118] 맵 문제 순서 재정렬 API 구현

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/MapItemPolicy.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/MapItemPolicy.java
@@ -1,0 +1,8 @@
+package io.github.ascrew.monomatbe.domain.map;
+
+public final class MapItemPolicy {
+
+    public static final int MAX_ITEMS_PER_MAP = 200;
+
+    private MapItemPolicy() {}
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapItemController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapItemController.java
@@ -71,7 +71,7 @@ public class MapItemController {
     @Operation(summary = "맵 문제 순서 재정렬", description = "맵 소유자만 변경할 수 있으며 활성 문제 전체의 ID를 원하는 순서대로 전달해야 합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "재정렬 성공"),
-            @ApiResponse(responseCode = "400", description = "중복 ID / 누락 문제 / 다른 맵의 itemId / soft delete된 문제 포함"),
+            @ApiResponse(responseCode = "400", description = "중복 ID / 누락 문제 / 요청한 itemId가 현재 맵의 활성 문제 목록과 일치하지 않음"),
             @ApiResponse(responseCode = "401", description = "미인증"),
             @ApiResponse(responseCode = "403", description = "정식 회원(REGISTERED)이 아님 또는 맵 소유자가 아님"),
             @ApiResponse(responseCode = "404", description = "mapId에 해당하는 맵 없음"),

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapItemController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapItemController.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.map.controller;
 
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapItemResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.ReorderMapItemsRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.service.MapItemService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
@@ -63,6 +64,18 @@ public class MapItemController {
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
         return ResponseEntity.ok(mapItemService.updateMapItem(mapId, itemId, request, principal));
+    }
+
+    @Operation(summary = "맵 문제 순서 재정렬", description = "맵 소유자만 변경할 수 있으며 활성 문제 전체의 ID를 원하는 순서대로 전달해야 합니다.")
+    @PutMapping("/order")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> reorderMapItems(
+            @PathVariable Long mapId,
+            @Valid @RequestBody ReorderMapItemsRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        mapItemService.reorderMapItems(mapId, request, principal);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "맵 문제 삭제", description = "맵 소유자만 삭제할 수 있으며 soft delete 처리됩니다.")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapItemController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapItemController.java
@@ -7,6 +7,8 @@ import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.service.MapItemService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -67,6 +69,14 @@ public class MapItemController {
     }
 
     @Operation(summary = "맵 문제 순서 재정렬", description = "맵 소유자만 변경할 수 있으며 활성 문제 전체의 ID를 원하는 순서대로 전달해야 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "재정렬 성공"),
+            @ApiResponse(responseCode = "400", description = "중복 ID / 누락 문제 / 다른 맵의 itemId / soft delete된 문제 포함"),
+            @ApiResponse(responseCode = "401", description = "미인증"),
+            @ApiResponse(responseCode = "403", description = "정식 회원(REGISTERED)이 아님 또는 맵 소유자가 아님"),
+            @ApiResponse(responseCode = "404", description = "mapId에 해당하는 맵 없음"),
+            @ApiResponse(responseCode = "409", description = "동시 요청으로 인한 순서 제약 충돌")
+    })
     @PutMapping("/order")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> reorderMapItems(

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/ReorderMapItemsRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/ReorderMapItemsRequest.java
@@ -2,10 +2,12 @@ package io.github.ascrew.monomatbe.domain.map.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record ReorderMapItemsRequest(
+        @Size(max = 200, message = "한 번에 재정렬할 수 있는 문제는 최대 200개입니다.")
         @NotEmpty(message = "문제 ID 목록은 비어 있을 수 없습니다.")
         List<@NotNull Long> itemIds
 ) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/ReorderMapItemsRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/ReorderMapItemsRequest.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.domain.map.dto;
 
+import io.github.ascrew.monomatbe.domain.map.MapItemPolicy;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -7,7 +8,8 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record ReorderMapItemsRequest(
-        @Size(max = 200, message = "한 번에 재정렬할 수 있는 문제는 최대 200개입니다.")
+        @Size(max = MapItemPolicy.MAX_ITEMS_PER_MAP,
+                message = "한 번에 재정렬할 수 있는 문제는 최대 " + MapItemPolicy.MAX_ITEMS_PER_MAP + "개입니다.")
         @NotEmpty(message = "문제 ID 목록은 비어 있을 수 없습니다.")
         List<@NotNull Long> itemIds
 ) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/ReorderMapItemsRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/ReorderMapItemsRequest.java
@@ -1,0 +1,12 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record ReorderMapItemsRequest(
+        @NotEmpty(message = "문제 ID 목록은 비어 있을 수 없습니다.")
+        List<@NotNull Long> itemIds
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapItem.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapItem.java
@@ -147,7 +147,6 @@ public class MapItem {
 
     public void reorder(int newOrderNum) {
         this.orderNum = newOrderNum;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void softDelete() {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapItem.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapItem.java
@@ -147,6 +147,7 @@ public class MapItem {
 
     public void reorder(int newOrderNum) {
         this.orderNum = newOrderNum;
+        this.updatedAt = LocalDateTime.now();
     }
 
     public void softDelete() {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapItem.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapItem.java
@@ -145,6 +145,10 @@ public class MapItem {
         this.hintTime = hintTime;
     }
 
+    public void reorder(int newOrderNum) {
+        this.orderNum = newOrderNum;
+    }
+
     public void softDelete() {
         this.isDeleted = true;
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/MapItemJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/MapItemJpaRepository.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.map.repository;
 
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,4 +27,10 @@ public interface MapItemJpaRepository extends JpaRepository<MapItem, Long> {
             where mi.map.id = :mapId and mi.isDeleted = false
             """)
     Long sumPlayTimeByMapId(@Param("mapId") Long mapId);
+
+    // 순서 재배치 시 UNIQUE(map_id, active_order_num) 제약 충돌을 피하기 위해
+    // 1단계에서 임시 고유값(id + offset)으로 일괄 변경한다.
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE MapItem mi SET mi.orderNum = mi.id + :offset WHERE mi.map.id = :mapId AND mi.isDeleted = false")
+    void setTemporaryOrderNums(@Param("mapId") Long mapId, @Param("offset") int offset);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/MapItemJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/MapItemJpaRepository.java
@@ -29,8 +29,8 @@ public interface MapItemJpaRepository extends JpaRepository<MapItem, Long> {
     Long sumPlayTimeByMapId(@Param("mapId") Long mapId);
 
     // 순서 재배치 시 UNIQUE(map_id, active_order_num) 제약 충돌을 피하기 위해
-    // 1단계에서 임시 고유값(id + offset)으로 일괄 변경한다.
+    // 1단계에서 -id(음수)로 일괄 변경한다. 최종 orderNum은 양수(1~N)이므로 겹칠 수 없다.
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE MapItem mi SET mi.orderNum = mi.id + :offset WHERE mi.map.id = :mapId AND mi.isDeleted = false")
-    void setTemporaryOrderNums(@Param("mapId") Long mapId, @Param("offset") int offset);
+    @Query("UPDATE MapItem mi SET mi.orderNum = -mi.id WHERE mi.map.id = :mapId AND mi.isDeleted = false")
+    void setTemporaryOrderNums(@Param("mapId") Long mapId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
@@ -24,4 +24,8 @@ public interface QuizMapJpaRepository
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT m FROM QuizMap m WHERE m.id = :mapId AND m.isDeleted = false")
     Optional<QuizMap> findByIdAndIsDeletedFalseForUpdate(@Param("mapId") Long mapId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM QuizMap m WHERE m.id = :mapId AND m.owner.id = :ownerId AND m.isDeleted = false")
+    Optional<QuizMap> findOwnedByIdAndIsDeletedFalseForUpdate(@Param("mapId") Long mapId, @Param("ownerId") Long ownerId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapJpaRepository.java
@@ -1,10 +1,14 @@
 package io.github.ascrew.monomatbe.domain.map.repository;
 
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -16,4 +20,8 @@ public interface QuizMapJpaRepository
     Optional<QuizMap> findByIdAndIsDeletedFalseAndIsPublicTrue(Long id);
 
     Optional<QuizMap> findByIdAndIsDeletedFalse(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM QuizMap m WHERE m.id = :mapId AND m.isDeleted = false")
+    Optional<QuizMap> findByIdAndIsDeletedFalseForUpdate(@Param("mapId") Long mapId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
@@ -12,16 +12,26 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class MapItemPersistenceService {
+
+    private static final int TEMP_ORDER_OFFSET = 10_000;
 
     private static final String ERROR_MAP_NOT_FOUND = "맵을 찾을 수 없습니다.";
     private static final String ERROR_MAP_FORBIDDEN = "본인 소유의 맵만 문제를 관리할 수 있습니다.";
     private static final String ERROR_MAP_ITEM_NOT_FOUND = "문제를 찾을 수 없습니다.";
     private static final String ERROR_DUPLICATE_ORDER = "이미 사용 중인 문제 순서입니다.";
+    private static final String ERROR_DUPLICATE_ITEM_ID = "중복된 문제 ID가 있습니다.";
+    private static final String ERROR_MISSING_ITEMS = "모든 문제의 순서를 지정해야 합니다.";
+    private static final String ERROR_INVALID_ITEM_ID = "유효하지 않은 문제 ID가 포함되어 있습니다.";
 
     private final QuizMapJpaRepository quizMapJpaRepository;
     private final MapItemJpaRepository mapItemJpaRepository;
@@ -116,6 +126,28 @@ public class MapItemPersistenceService {
     }
 
     @Transactional
+    public void reorder(Long mapId, Long ownerId, List<Long> orderedItemIds) {
+        getOwnedMapOrThrow(mapId, ownerId);
+
+        List<MapItem> activeItems = mapItemJpaRepository
+                .findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(mapId);
+
+        validateReorderRequest(activeItems, orderedItemIds);
+
+        // Phase 1: 임시 고유값으로 일괄 변경 (UNIQUE(map_id, active_order_num) 충돌 방지)
+        mapItemJpaRepository.setTemporaryOrderNums(mapId, TEMP_ORDER_OFFSET);
+
+        // Phase 2: L1 캐시 클리어 후 재조회, 최종 orderNum 할당
+        Map<Long, MapItem> itemById = mapItemJpaRepository
+                .findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(mapId)
+                .stream().collect(Collectors.toMap(MapItem::getId, Function.identity()));
+
+        for (int i = 0; i < orderedItemIds.size(); i++) {
+            itemById.get(orderedItemIds.get(i)).reorder(i + 1);
+        }
+    }
+
+    @Transactional
     public void delete(Long mapId, Long itemId, Long ownerId) {
         QuizMap quizMap = getOwnedMapOrThrow(mapId, ownerId);
 
@@ -161,6 +193,22 @@ public class MapItemPersistenceService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_MAP_FORBIDDEN);
         }
         return quizMap;
+    }
+
+    private void validateReorderRequest(List<MapItem> activeItems, List<Long> orderedItemIds) {
+        Set<Long> deduplicated = new HashSet<>(orderedItemIds);
+        if (deduplicated.size() != orderedItemIds.size()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_DUPLICATE_ITEM_ID);
+        }
+        if (orderedItemIds.size() != activeItems.size()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_MISSING_ITEMS);
+        }
+        Set<Long> activeIds = activeItems.stream().map(MapItem::getId).collect(Collectors.toSet());
+        for (Long id : orderedItemIds) {
+            if (!activeIds.contains(id)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_ITEM_ID);
+            }
+        }
     }
 
     private void validateOrderDuplicatedOnCreate(Long mapId, Integer orderNum) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
@@ -62,7 +62,7 @@ public class MapItemPersistenceService {
             String hint,
             int hintTime
     ) {
-        QuizMap quizMap = getOwnedMapOrThrow(mapId, ownerId);
+        QuizMap quizMap = getOwnedMapForWriteOrThrow(mapId, ownerId);
         validateOrderDuplicatedOnCreate(mapId, request.orderNum());
 
         MapItem saved = mapItemJpaRepository.save(MapItem.builder()
@@ -97,7 +97,7 @@ public class MapItemPersistenceService {
             String hint,
             int hintTime
     ) {
-        QuizMap quizMap = getOwnedMapOrThrow(mapId, ownerId);
+        QuizMap quizMap = getOwnedMapForWriteOrThrow(mapId, ownerId);
 
         MapItem mapItem = mapItemJpaRepository.findByIdAndMapIdAndIsDeletedFalse(itemId, mapId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_MAP_ITEM_NOT_FOUND));
@@ -125,7 +125,7 @@ public class MapItemPersistenceService {
 
     @Transactional
     public void reorder(Long mapId, Long ownerId, List<Long> orderedItemIds) {
-        getOwnedMapOrThrow(mapId, ownerId);
+        getOwnedMapForWriteOrThrow(mapId, ownerId);
 
         List<MapItem> activeItems = mapItemJpaRepository
                 .findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(mapId);
@@ -147,7 +147,7 @@ public class MapItemPersistenceService {
 
     @Transactional
     public void delete(Long mapId, Long itemId, Long ownerId) {
-        QuizMap quizMap = getOwnedMapOrThrow(mapId, ownerId);
+        QuizMap quizMap = getOwnedMapForWriteOrThrow(mapId, ownerId);
 
         MapItem mapItem = mapItemJpaRepository.findByIdAndMapIdAndIsDeletedFalse(itemId, mapId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_MAP_ITEM_NOT_FOUND));
@@ -186,6 +186,16 @@ public class MapItemPersistenceService {
 
     private QuizMap getOwnedMapOrThrow(Long mapId, Long ownerId) {
         QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalse(mapId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
+        if (!Objects.equals(quizMap.getOwner().getId(), ownerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_MAP_FORBIDDEN);
+        }
+        return quizMap;
+    }
+
+    // 같은 mapId에 대한 create/update/delete/reorder를 직렬화하기 위해 PESSIMISTIC_WRITE 락을 잡는다.
+    private QuizMap getOwnedMapForWriteOrThrow(Long mapId, Long ownerId) {
+        QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(mapId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
         if (!Objects.equals(quizMap.getOwner().getId(), ownerId)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_MAP_FORBIDDEN);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.domain.map.service;
 
+import io.github.ascrew.monomatbe.domain.map.MapItemPolicy;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
@@ -30,6 +31,8 @@ public class MapItemPersistenceService {
     private static final String ERROR_DUPLICATE_ITEM_ID = "중복된 문제 ID가 있습니다.";
     private static final String ERROR_MISSING_ITEMS = "모든 문제의 순서를 지정해야 합니다.";
     private static final String ERROR_INVALID_ITEM_ID = "유효하지 않은 문제 ID가 포함되어 있습니다.";
+    private static final String ERROR_MAP_ITEM_LIMIT_EXCEEDED =
+            "한 맵에 등록할 수 있는 문제는 최대 " + MapItemPolicy.MAX_ITEMS_PER_MAP + "개입니다.";
 
     private final QuizMapJpaRepository quizMapJpaRepository;
     private final MapItemJpaRepository mapItemJpaRepository;
@@ -63,6 +66,7 @@ public class MapItemPersistenceService {
             int hintTime
     ) {
         QuizMap quizMap = getOwnedMapForWriteOrThrow(mapId, ownerId);
+        validateItemCount(mapId);
         validateOrderDuplicatedOnCreate(mapId, request.orderNum());
 
         MapItem saved = mapItemJpaRepository.save(MapItem.builder()
@@ -194,13 +198,15 @@ public class MapItemPersistenceService {
     }
 
     // 같은 mapId에 대한 create/update/delete/reorder를 직렬화하기 위해 PESSIMISTIC_WRITE 락을 잡는다.
+    // 소유자 조건을 락 쿼리에 포함해 비소유자 요청이 write lock을 획득하지 않도록 한다.
     private QuizMap getOwnedMapForWriteOrThrow(Long mapId, Long ownerId) {
-        QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(mapId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND));
-        if (!Objects.equals(quizMap.getOwner().getId(), ownerId)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_MAP_FORBIDDEN);
-        }
-        return quizMap;
+        return quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(mapId, ownerId)
+                .orElseThrow(() -> {
+                    if (quizMapJpaRepository.findByIdAndIsDeletedFalse(mapId).isEmpty()) {
+                        return new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_MAP_NOT_FOUND);
+                    }
+                    return new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_MAP_FORBIDDEN);
+                });
     }
 
     private void validateReorderRequest(List<MapItem> activeItems, List<Long> orderedItemIds) {
@@ -216,6 +222,12 @@ public class MapItemPersistenceService {
             if (!activeIds.contains(id)) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_ITEM_ID);
             }
+        }
+    }
+
+    private void validateItemCount(Long mapId) {
+        if (mapItemJpaRepository.countByMapIdAndIsDeletedFalse(mapId) >= MapItemPolicy.MAX_ITEMS_PER_MAP) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_MAP_ITEM_LIMIT_EXCEEDED);
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceService.java
@@ -23,8 +23,6 @@ import java.util.stream.Collectors;
 @Service
 public class MapItemPersistenceService {
 
-    private static final int TEMP_ORDER_OFFSET = 10_000;
-
     private static final String ERROR_MAP_NOT_FOUND = "맵을 찾을 수 없습니다.";
     private static final String ERROR_MAP_FORBIDDEN = "본인 소유의 맵만 문제를 관리할 수 있습니다.";
     private static final String ERROR_MAP_ITEM_NOT_FOUND = "문제를 찾을 수 없습니다.";
@@ -134,8 +132,8 @@ public class MapItemPersistenceService {
 
         validateReorderRequest(activeItems, orderedItemIds);
 
-        // Phase 1: 임시 고유값으로 일괄 변경 (UNIQUE(map_id, active_order_num) 충돌 방지)
-        mapItemJpaRepository.setTemporaryOrderNums(mapId, TEMP_ORDER_OFFSET);
+        // Phase 1: -id(음수)로 일괄 변경 (최종값 1~N과 겹치지 않아 UNIQUE 충돌 없음)
+        mapItemJpaRepository.setTemporaryOrderNums(mapId);
 
         // Phase 2: L1 캐시 클리어 후 재조회, 최종 orderNum 할당
         Map<Long, MapItem> itemById = mapItemJpaRepository

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
@@ -135,7 +135,11 @@ public class MapItemService {
     public void reorderMapItems(Long mapId, ReorderMapItemsRequest request, CustomPrincipal principal) {
         validateRegisteredPrincipal(principal);
 
-        persistenceService.reorder(mapId, principal.userId(), request.itemIds());
+        try {
+            persistenceService.reorder(mapId, principal.userId(), request.itemIds());
+        } catch (DataIntegrityViolationException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_DUPLICATE_ORDER, e);
+        }
 
         mapCacheEvictor.evictPublicMapCaches(mapId);
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
@@ -3,6 +3,7 @@ package io.github.ascrew.monomatbe.domain.map.service;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapItemResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.ReorderMapItemsRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.support.HintTextGenerator;
@@ -127,6 +128,14 @@ public class MapItemService {
         validateRegisteredPrincipal(principal);
 
         persistenceService.delete(mapId, itemId, principal.userId());
+
+        mapCacheEvictor.evictPublicMapCaches(mapId);
+    }
+
+    public void reorderMapItems(Long mapId, ReorderMapItemsRequest request, CustomPrincipal principal) {
+        validateRegisteredPrincipal(principal);
+
+        persistenceService.reorder(mapId, principal.userId(), request.itemIds());
 
         mapCacheEvictor.evictPublicMapCaches(mapId);
     }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
@@ -65,7 +65,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void create_orderDuplicated_conflict() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(true);
 
         CreateMapItemRequest request = createRequest(1);
@@ -83,7 +83,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void create_success_recalculatesMetadata() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(false);
         when(mapItemJpaRepository.save(any(MapItem.class))).thenAnswer(invocation -> {
             MapItem input = invocation.getArgument(0);
@@ -123,7 +123,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void delete_success_softDeletesAndRecalculatesMetadata() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(50L)
@@ -158,7 +158,7 @@ class MapItemPersistenceServiceTest {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.setPendingPublicIntent(true);
 
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(false);
         when(mapItemJpaRepository.save(any(MapItem.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(mapItemJpaRepository.countByMapIdAndIsDeletedFalse(1L)).thenReturn(1L);
@@ -180,7 +180,7 @@ class MapItemPersistenceServiceTest {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.setPendingPublicIntent(true);
 
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(false);
         when(mapItemJpaRepository.save(any(MapItem.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(mapItemJpaRepository.countByMapIdAndIsDeletedFalse(1L)).thenReturn(1L);
@@ -201,7 +201,7 @@ class MapItemPersistenceServiceTest {
     void delete_lastItemFromPublicMap_autoFlipToPrivate_keepsPendingTrue() {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.markAsPublished(); // 공개 상태
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(50L)
@@ -235,7 +235,7 @@ class MapItemPersistenceServiceTest {
     void delete_nonLastItemFromPublicMap_remainsPublic() {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.markAsPublished();
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(51L)
@@ -271,7 +271,7 @@ class MapItemPersistenceServiceTest {
         // (데이터 오염, 수동 DB 수정, 향후 부분 수정 API 도입 등으로 공개 맵이 무효 상태에 놓이는 케이스)
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.markAsPublished();
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(60L)
@@ -305,7 +305,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_success_assignsOrderNumsByRequestSequence() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
@@ -323,28 +323,11 @@ class MapItemPersistenceServiceTest {
         assertThat(item2.getOrderNum()).isEqualTo(3);
     }
 
-    @Test
-    void reorder_success_updatesUpdatedAt() {
-        QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
-
-        java.time.LocalDateTime past = java.time.LocalDateTime.now().minusSeconds(10);
-        MapItem item1 = mapItemWithUpdatedAt(1L, quizMap, 1, past);
-        MapItem item2 = mapItemWithUpdatedAt(2L, quizMap, 2, past);
-        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
-                .thenReturn(List.of(item1, item2))
-                .thenReturn(List.of(item1, item2));
-
-        persistenceService.reorder(1L, 10L, List.of(2L, 1L));
-
-        assertThat(item1.getUpdatedAt()).isAfter(past);
-        assertThat(item2.getUpdatedAt()).isAfter(past);
-    }
 
     @Test
     void reorder_notOwner_forbidden() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         assertThatThrownBy(() -> persistenceService.reorder(1L, 99L, List.of(1L, 2L)))
                 .isInstanceOf(ResponseStatusException.class)
@@ -356,7 +339,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_duplicateItemId_badRequest() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
@@ -373,7 +356,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_missingItem_badRequest() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
@@ -392,7 +375,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_invalidItemId_badRequest() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
@@ -408,10 +391,6 @@ class MapItemPersistenceServiceTest {
     }
 
     private MapItem mapItem(Long id, QuizMap quizMap, int orderNum) {
-        return mapItemWithUpdatedAt(id, quizMap, orderNum, java.time.LocalDateTime.now());
-    }
-
-    private MapItem mapItemWithUpdatedAt(Long id, QuizMap quizMap, int orderNum, java.time.LocalDateTime updatedAt) {
         return MapItem.builder()
                 .id(id)
                 .map(quizMap)
@@ -428,7 +407,6 @@ class MapItemPersistenceServiceTest {
                 .hint("ㅈㄷ")
                 .hintTime(15)
                 .isDeleted(false)
-                .updatedAt(updatedAt)
                 .build();
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -298,6 +300,114 @@ class MapItemPersistenceServiceTest {
 
         assertThat(quizMap.getIsPublic()).isFalse();
         assertThat(quizMap.getPendingPublic()).isTrue();
+    }
+
+    @Test
+    void reorder_success_assignsOrderNumsByRequestSequence() {
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+
+        MapItem item1 = mapItem(1L, quizMap, 1);
+        MapItem item2 = mapItem(2L, quizMap, 2);
+        MapItem item3 = mapItem(3L, quizMap, 3);
+        // 첫 번째 조회: active items 반환
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item1, item2, item3))  // Phase 1 전 조회
+                .thenReturn(List.of(item1, item2, item3)); // Phase 2 재조회
+
+        // [3, 1, 2] 순서로 재정렬 요청
+        persistenceService.reorder(1L, 10L, List.of(3L, 1L, 2L));
+
+        verify(mapItemJpaRepository).setTemporaryOrderNums(eq(1L), anyInt());
+        assertThat(item3.getOrderNum()).isEqualTo(1);
+        assertThat(item1.getOrderNum()).isEqualTo(2);
+        assertThat(item2.getOrderNum()).isEqualTo(3);
+    }
+
+    @Test
+    void reorder_notOwner_forbidden() {
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+
+        assertThatThrownBy(() -> persistenceService.reorder(1L, 99L, List.of(1L, 2L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("본인 소유의 맵만 문제를 관리할 수 있습니다.");
+
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+    }
+
+    @Test
+    void reorder_duplicateItemId_badRequest() {
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+
+        MapItem item1 = mapItem(1L, quizMap, 1);
+        MapItem item2 = mapItem(2L, quizMap, 2);
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item1, item2));
+
+        assertThatThrownBy(() -> persistenceService.reorder(1L, 10L, List.of(1L, 1L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("중복된 문제 ID가 있습니다.");
+
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+    }
+
+    @Test
+    void reorder_missingItem_badRequest() {
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+
+        MapItem item1 = mapItem(1L, quizMap, 1);
+        MapItem item2 = mapItem(2L, quizMap, 2);
+        MapItem item3 = mapItem(3L, quizMap, 3);
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item1, item2, item3));
+
+        // item3 누락
+        assertThatThrownBy(() -> persistenceService.reorder(1L, 10L, List.of(1L, 2L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("모든 문제의 순서를 지정해야 합니다.");
+
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+    }
+
+    @Test
+    void reorder_invalidItemId_badRequest() {
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+
+        MapItem item1 = mapItem(1L, quizMap, 1);
+        MapItem item2 = mapItem(2L, quizMap, 2);
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item1, item2));
+
+        // 999L은 이 맵에 속하지 않는 ID
+        assertThatThrownBy(() -> persistenceService.reorder(1L, 10L, List.of(1L, 999L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("유효하지 않은 문제 ID가 포함되어 있습니다.");
+
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+    }
+
+    private MapItem mapItem(Long id, QuizMap quizMap, int orderNum) {
+        return MapItem.builder()
+                .id(id)
+                .map(quizMap)
+                .orderNum(orderNum)
+                .youtubeUrl("u")
+                .videoId("v")
+                .startTime(0)
+                .endTime(30)
+                .title("t")
+                .artist("a")
+                .thumbnailUrl("th")
+                .answer("정답")
+                .altAnswers(null)
+                .hint("ㅈㄷ")
+                .hintTime(15)
+                .isDeleted(false)
+                .build();
     }
 
     private CreateMapItemRequest createRequest(int orderNum) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
@@ -310,10 +310,9 @@ class MapItemPersistenceServiceTest {
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
         MapItem item3 = mapItem(3L, quizMap, 3);
-        // 첫 번째 조회: active items 반환
         when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
-                .thenReturn(List.of(item1, item2, item3))  // Phase 1 전 조회
-                .thenReturn(List.of(item1, item2, item3)); // Phase 2 재조회
+                .thenReturn(List.of(item1, item2, item3))
+                .thenReturn(List.of(item1, item2, item3));
 
         // [3, 1, 2] 순서로 재정렬 요청
         persistenceService.reorder(1L, 10L, List.of(3L, 1L, 2L));
@@ -322,6 +321,24 @@ class MapItemPersistenceServiceTest {
         assertThat(item3.getOrderNum()).isEqualTo(1);
         assertThat(item1.getOrderNum()).isEqualTo(2);
         assertThat(item2.getOrderNum()).isEqualTo(3);
+    }
+
+    @Test
+    void reorder_success_updatesUpdatedAt() {
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
+
+        java.time.LocalDateTime past = java.time.LocalDateTime.now().minusSeconds(10);
+        MapItem item1 = mapItemWithUpdatedAt(1L, quizMap, 1, past);
+        MapItem item2 = mapItemWithUpdatedAt(2L, quizMap, 2, past);
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item1, item2))
+                .thenReturn(List.of(item1, item2));
+
+        persistenceService.reorder(1L, 10L, List.of(2L, 1L));
+
+        assertThat(item1.getUpdatedAt()).isAfter(past);
+        assertThat(item2.getUpdatedAt()).isAfter(past);
     }
 
     @Test
@@ -391,6 +408,10 @@ class MapItemPersistenceServiceTest {
     }
 
     private MapItem mapItem(Long id, QuizMap quizMap, int orderNum) {
+        return mapItemWithUpdatedAt(id, quizMap, orderNum, java.time.LocalDateTime.now());
+    }
+
+    private MapItem mapItemWithUpdatedAt(Long id, QuizMap quizMap, int orderNum, java.time.LocalDateTime updatedAt) {
         return MapItem.builder()
                 .id(id)
                 .map(quizMap)
@@ -407,6 +428,7 @@ class MapItemPersistenceServiceTest {
                 .hint("ㅈㄷ")
                 .hintTime(15)
                 .isDeleted(false)
+                .updatedAt(updatedAt)
                 .build();
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
@@ -317,7 +317,7 @@ class MapItemPersistenceServiceTest {
         // [3, 1, 2] 순서로 재정렬 요청
         persistenceService.reorder(1L, 10L, List.of(3L, 1L, 2L));
 
-        verify(mapItemJpaRepository).setTemporaryOrderNums(eq(1L), anyInt());
+        verify(mapItemJpaRepository).setTemporaryOrderNums(eq(1L));
         assertThat(item3.getOrderNum()).isEqualTo(1);
         assertThat(item1.getOrderNum()).isEqualTo(2);
         assertThat(item2.getOrderNum()).isEqualTo(3);
@@ -350,7 +350,7 @@ class MapItemPersistenceServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("본인 소유의 맵만 문제를 관리할 수 있습니다.");
 
-        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any());
     }
 
     @Test
@@ -367,7 +367,7 @@ class MapItemPersistenceServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("중복된 문제 ID가 있습니다.");
 
-        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any());
     }
 
     @Test
@@ -386,7 +386,7 @@ class MapItemPersistenceServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("모든 문제의 순서를 지정해야 합니다.");
 
-        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any());
     }
 
     @Test
@@ -404,7 +404,7 @@ class MapItemPersistenceServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("유효하지 않은 문제 ID가 포함되어 있습니다.");
 
-        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any(), anyInt());
+        verify(mapItemJpaRepository, never()).setTemporaryOrderNums(any());
     }
 
     private MapItem mapItem(Long id, QuizMap quizMap, int orderNum) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
@@ -6,6 +6,7 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ReorderMapItemsRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import org.springframework.dao.DataIntegrityViolationException;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.youtube.model.YoutubeMetadata;
@@ -175,6 +176,19 @@ class MapItemServiceTest {
         InOrder inOrder = inOrder(persistenceService, mapCacheEvictor);
         inOrder.verify(persistenceService).reorder(1L, 10L, List.of(3L, 1L, 2L));
         inOrder.verify(mapCacheEvictor).evictPublicMapCaches(1L);
+    }
+
+    @Test
+    void reorderMapItems_dataIntegrityViolation_throwsConflict() {
+        ReorderMapItemsRequest request = new ReorderMapItemsRequest(List.of(1L, 2L));
+        org.mockito.Mockito.doThrow(new DataIntegrityViolationException("unique"))
+                .when(persistenceService).reorder(1L, 10L, List.of(1L, 2L));
+
+        assertThatThrownBy(() -> mapItemService.reorderMapItems(1L, request, principal(10L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("이미 사용 중인 문제 순서입니다.");
+
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
@@ -4,6 +4,7 @@ import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapItemRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.ReorderMapItemsRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
@@ -163,6 +164,30 @@ class MapItemServiceTest {
 
         assertThat(response).hasSize(1);
         assertThat(response.get(0).id()).isEqualTo(50L);
+    }
+
+    @Test
+    void reorderMapItems_success_callsPersistenceThenEvictsCache() {
+        ReorderMapItemsRequest request = new ReorderMapItemsRequest(List.of(3L, 1L, 2L));
+
+        mapItemService.reorderMapItems(1L, request, principal(10L));
+
+        InOrder inOrder = inOrder(persistenceService, mapCacheEvictor);
+        inOrder.verify(persistenceService).reorder(1L, 10L, List.of(3L, 1L, 2L));
+        inOrder.verify(mapCacheEvictor).evictPublicMapCaches(1L);
+    }
+
+    @Test
+    void reorderMapItems_guestPrincipal_throwsForbiddenBeforePersistence() {
+        ReorderMapItemsRequest request = new ReorderMapItemsRequest(List.of(1L, 2L));
+        CustomPrincipal guest = new CustomPrincipal(10L, "u-10", UserType.GUEST);
+
+        assertThatThrownBy(() -> mapItemService.reorderMapItems(1L, request, guest))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("정식 회원만 맵 문제를 관리할 수 있습니다.");
+
+        verify(persistenceService, never()).reorder(any(), any(), any());
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
     }
 
     private User owner(Long id) {


### PR DESCRIPTION
## 📣 Related Issue
- #118 

## 📝 Summary
- PUT /api/maps/{mapId}/items/order 엔드포인트 추가 — 맵 소유자가 활성 문제 전체의 순서를 한 번에 재정렬할 수 있는 API 구현
- UNIQUE(map_id, active_order_num) 제약 충돌 방지를 위해 2단계 업데이트 전략 적용 (임시값 일괄 변경 → 최종값 할당)
- 비소유자 접근, 중복 ID, 누락 문제, 다른 맵 ID 혼입에 대한 검증 추가
- 성공/실패 케이스 단위 테스트 추가 (MapItemPersistenceServiceTest, MapItemServiceTest)

## 🙏PR point
- map_item 테이블의 active_order_num은 MySQL GENERATED 컬럼으로, 순열 교환 시 중간 상태에서 UNIQUE 제약 위반이 발생할 수 있습니다. 이를 해결하기 위해 1단계에서 order_num = id + 10000 형태의 임시 고유값으로 일괄 UPDATE한 뒤 2단계에서 최종값을 할당하는 방식을 사용했습니다.
- bulk UPDATE 후 JPA L1 캐시 불일치를 막기 위해 @Modifying(clearAutomatically = true, flushAutomatically = true)를 적용했습니다.


## 📬 Reference
