### PR TITLE
[Feat/#127] 로그인 ID 검증 정책 정리

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -30,13 +30,13 @@ public enum AuthErrorCode {
 
     AUTH_LOGIN_ID_REQUIRED(
             HttpStatus.BAD_REQUEST,
-            "로그인 ID는 비어 있을 수 없습니다.",
+            "로그인 ID를 입력해주세요.",
             AuthErrorFields.LOGIN_ID
     ),
 
     AUTH_LOGIN_ID_INVALID_LENGTH(
             HttpStatus.BAD_REQUEST,
-            "로그인 ID는 4자 이상 50자 이하여야 합니다.",
+            "로그인 ID는 4자 이상 50자 이하로 입력해주세요.",
             AuthErrorFields.LOGIN_ID
     ),
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -180,4 +180,13 @@ class RegisterAuthServiceTest {
 
         assertEquals(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH, exception.getErrorCode());
     }
+
+    @Test
+    void register_nullLoginId_throwsLoginIdRequiredError() {
+        AuthException exception = assertThrows(AuthException.class, () ->
+                registerAuthService.register(null, "password123", uniqueNickname())
+        );
+
+        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_REQUIRED, exception.getErrorCode());
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #127

## 📝 Summary

- 회원가입 로그인 ID 검증 메시지를 정책 문구에 맞게 정리했습니다.
- 로그인 ID null 입력 시 필수값 검증 에러가 발생하는 테스트를 추가했습니다.
- 기존 로그인 ID 검증 정책인 4~50자, 영문/숫자 허용, 공백 불가, 중복 검증은 유지했습니다.

## 🙏PR point

- 현재 `RegisterRequest`와 `RegisterAuthService` 양쪽에서 로그인 ID 검증을 수행하고 있습니다.
- DTO 레벨에서는 요청 바인딩/입력 검증을 담당하고, 서비스 레이어에서는 직접 호출 및 우회 경로에 대한 방어 검증을 유지합니다.
- 프로젝트 정책상 `global → domain` 의존을 만들지 않기 위해 로그인 ID 정책은 global 패키지로 분리하지 않았습니다.

## 📬 Reference
