### PR TITLE
[Feat/#126] 닉네임 길이 및 금칙어 검증 정책 추가

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -204,20 +204,28 @@ Access Token 기반으로 요청자를 식별하여 로그아웃 처리합니다
 
 닉네임 금칙어 목록을 관리자 API로 조회, 추가, 삭제합니다.
 
-현재 프로젝트에는 별도 `ROLE_ADMIN` 권한 체계가 없으므로, 임시로 설정 기반 관리자 `userIdentifier` allow-list를 사용합니다.
+현재 프로젝트에는 별도 `ROLE_ADMIN` 권한 체계가 없으므로, 임시로 설정 기반 관리자 `users.id` allow-list를 사용합니다.
 
 관리자 API를 호출하려면 다음 조건을 모두 만족해야 합니다.
 
 - JWT Access Token이 유효해야 합니다.
-- JWT에서 추출한 `userIdentifier`가 `monomat.admin.user-identifiers` 설정에 포함되어 있어야 합니다.
+- JWT에서 추출한 `userId`가 `monomat.admin.user-ids` 설정에 포함되어 있어야 합니다.
 
 운영 설정 예시:
 
 ```properties
-MONOMAT_ADMIN_USER_IDENTIFIERS=uuid-1,uuid-2
-````
+MONOMAT_ADMIN_USER_IDS=1,2
+```
 
-> 추후 관리자 권한 체계가 추가되면 `ROLE_ADMIN` 기반 접근 제어로 교체할 수 있습니다.
+Spring 설정 키:
+
+```env
+monomat.admin.user-ids=${MONOMAT_ADMIN_USER_IDS:}
+```
+
+> userIdentifier는 로그인/세션 식별자 성격이 강하므로 관리자 권한 기준으로 사용하지 않습니다.
+> 관리자 API 접근 기준은 DB users.id입니다.
+> 추후 관리자 권한 체계가 추가되면 ROLE_ADMIN 기반 접근 제어로 교체할 수 있습니다.
 
 ---
 
@@ -252,8 +260,7 @@ GET /api/admin/forbidden-nicknames
 | 상태 코드              | 설명                               |
 | ------------------ | -------------------------------- |
 | `401 Unauthorized` | 인증 정보 없음 또는 유효하지 않은 Access Token |
-| `403 Forbidden`    | 관리자 allow-list에 포함되지 않은 사용자      |
-
+| `403 Forbidden`    | `users.id`가 관리자 allow-list에 포함되지 않은 사용자 |
 ---
 
 #### 금칙어 추가
@@ -311,7 +318,7 @@ POST /api/admin/forbidden-nicknames
 | ------------------ | -------------------------------- |
 | `400 Bad Request`  | 금칙어가 비어 있음 또는 요청 형식 오류           |
 | `401 Unauthorized` | 인증 정보 없음 또는 유효하지 않은 Access Token |
-| `403 Forbidden`    | 관리자 allow-list에 포함되지 않은 사용자      |
+| `403 Forbidden`    | `users.id`가 관리자 allow-list에 포함되지 않은 사용자 |
 | `409 Conflict`     | 이미 등록된 금칙어                       |
 
 ---
@@ -343,7 +350,7 @@ DELETE /api/admin/forbidden-nicknames/{id}
 | 상태 코드              | 설명                               |
 | ------------------ | -------------------------------- |
 | `401 Unauthorized` | 인증 정보 없음 또는 유효하지 않은 Access Token |
-| `403 Forbidden`    | 관리자 allow-list에 포함되지 않은 사용자      |
+| `403 Forbidden`    | `users.id`가 관리자 allow-list에 포함되지 않은 사용자 |
 | `404 Not Found`    | 존재하지 않는 금칙어                      |
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -200,6 +200,185 @@ Access Token 기반으로 요청자를 식별하여 로그아웃 처리합니다
 
 ---
 
+### 관리자 - 닉네임 금칙어 관리
+
+닉네임 금칙어 목록을 관리자 API로 조회, 추가, 삭제합니다.
+
+현재 프로젝트에는 별도 `ROLE_ADMIN` 권한 체계가 없으므로, 임시로 설정 기반 관리자 `userIdentifier` allow-list를 사용합니다.
+
+관리자 API를 호출하려면 다음 조건을 모두 만족해야 합니다.
+
+- JWT Access Token이 유효해야 합니다.
+- JWT에서 추출한 `userIdentifier`가 `monomat.admin.user-identifiers` 설정에 포함되어 있어야 합니다.
+
+운영 설정 예시:
+
+```properties
+MONOMAT_ADMIN_USER_IDENTIFIERS=uuid-1,uuid-2
+````
+
+> 추후 관리자 권한 체계가 추가되면 `ROLE_ADMIN` 기반 접근 제어로 교체할 수 있습니다.
+
+---
+
+#### 금칙어 목록 조회
+
+```http
+GET /api/admin/forbidden-nicknames
+```
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+
+**Response `200 OK`**
+
+```json
+[
+  {
+    "id": 1,
+    "word": "관리자",
+    "normalizedWord": "관리자",
+    "createdAt": "2026-05-28T19:00:00",
+    "updatedAt": "2026-05-28T19:00:00"
+  }
+]
+```
+
+**Error**
+
+| 상태 코드              | 설명                               |
+| ------------------ | -------------------------------- |
+| `401 Unauthorized` | 인증 정보 없음 또는 유효하지 않은 Access Token |
+| `403 Forbidden`    | 관리자 allow-list에 포함되지 않은 사용자      |
+
+---
+
+#### 금칙어 추가
+
+```http
+POST /api/admin/forbidden-nicknames
+```
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+| `Content-Type`  | ✅  | `application/json`     |
+
+**Request Body**
+
+```json
+{
+  "word": "관리자"
+}
+```
+
+| 필드     | 타입     | 필수 | 설명                   |
+| ------ | ------ | -- | -------------------- |
+| `word` | String | ✅  | 등록할 닉네임 금칙어. 최대 100자 |
+
+**Response `201 Created`**
+
+```json
+{
+  "id": 1,
+  "word": "관리자",
+  "normalizedWord": "관리자",
+  "createdAt": "2026-05-28T19:00:00",
+  "updatedAt": "2026-05-28T19:00:00"
+}
+```
+
+**정규화 정책**
+
+금칙어는 비교 및 중복 방지를 위해 정규화됩니다.
+
+| 입력값         | normalizedWord |
+| ----------- | -------------- |
+| `Admin`     | `admin`        |
+| `A d m i n` | `admin`        |
+| `관 리 자`     | `관리자`          |
+
+동일한 `normalizedWord`를 가진 금칙어는 중복 등록할 수 없습니다.
+
+**Error**
+
+| 상태 코드              | 설명                               |
+| ------------------ | -------------------------------- |
+| `400 Bad Request`  | 금칙어가 비어 있음 또는 요청 형식 오류           |
+| `401 Unauthorized` | 인증 정보 없음 또는 유효하지 않은 Access Token |
+| `403 Forbidden`    | 관리자 allow-list에 포함되지 않은 사용자      |
+| `409 Conflict`     | 이미 등록된 금칙어                       |
+
+---
+
+#### 금칙어 삭제
+
+```http
+DELETE /api/admin/forbidden-nicknames/{id}
+```
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+
+**Path Variable**
+
+| 이름   | 타입   | 설명         |
+| ---- | ---- | ---------- |
+| `id` | Long | 삭제할 금칙어 ID |
+
+**Response `204 No Content`**
+
+응답 본문 없음.
+
+**Error**
+
+| 상태 코드              | 설명                               |
+| ------------------ | -------------------------------- |
+| `401 Unauthorized` | 인증 정보 없음 또는 유효하지 않은 Access Token |
+| `403 Forbidden`    | 관리자 allow-list에 포함되지 않은 사용자      |
+| `404 Not Found`    | 존재하지 않는 금칙어                      |
+
+---
+
+#### 닉네임 검증 정책
+
+회원가입 및 게스트 로그인에서 닉네임은 다음 정책을 따릅니다.
+
+| 정책  | 설명                     |
+| --- | ---------------------- |
+| 길이  | 2자 이상 12자 이하           |
+| 중복  | 기존 회원/게스트 닉네임과 중복 불가   |
+| 금칙어 | 관리자 API로 등록된 금칙어 포함 불가 |
+
+금칙어 검증은 대소문자와 공백 우회를 고려합니다.
+
+예를 들어 `admin`이 금칙어로 등록되어 있다면 아래 닉네임은 모두 차단됩니다.
+
+```text
+admin123
+Admin123
+a d m i n123
+```
+
+금칙어 포함 시 응답은 `400 Bad Request`입니다.
+
+```json
+{
+  "code": "AUTH_NICKNAME_FORBIDDEN_WORD",
+  "message": "금칙어가 포함된 닉네임은 사용할 수 없습니다.",
+  "field": "nickname"
+}
+```
+
+---
 ### 로비 (Lobby)
 
 #### 로비 생성

--- a/docs/API.md
+++ b/docs/API.md
@@ -204,29 +204,43 @@ Access Token 기반으로 요청자를 식별하여 로그아웃 처리합니다
 
 닉네임 금칙어 목록을 관리자 API로 조회, 추가, 삭제합니다.
 
-현재 프로젝트에는 별도 `ROLE_ADMIN` 권한 체계가 없으므로, 임시로 설정 기반 관리자 `users.id` allow-list를 사용합니다.
+현재 프로젝트에는 별도 `ROLE_ADMIN` 권한 체계가 없으므로, 관리자 API 접근은 `admin_users` 테이블 기반으로 제한합니다.
 
 관리자 API를 호출하려면 다음 조건을 모두 만족해야 합니다.
 
 - JWT Access Token이 유효해야 합니다.
-- JWT에서 추출한 `userId`가 `monomat.admin.user-ids` 설정에 포함되어 있어야 합니다.
+- JWT에서 추출한 `userId`가 `admin_users.user_id`에 등록되어 있어야 합니다.
+- 해당 사용자의 `user_type`이 `REGISTERED`여야 합니다.
 
-운영 설정 예시:
+관리자 등록 예시:
 
-```properties
-MONOMAT_ADMIN_USER_IDS=1,2
+```sql
+INSERT IGNORE INTO admin_users (user_id, created_at, updated_at)
+VALUES (105, NOW(), NOW());
 ```
 
-Spring 설정 키:
+**관리자 확인 예시:**
+```sql
+SELECT au.id, au.user_id, u.username, u.user_type
+FROM admin_users au
+JOIN users u ON u.id = au.user_id
+WHERE au.user_id = 105;
+```
 
-```env
+**Fallback 설정**
+DB 장애 또는 local/dev 긴급 접근을 위해 환경변수 fallback allow-list를 사용할 수 있습니다.
+```
+MONOMAT_ADMIN_USER_IDS=105
+```
+
+**Spring 설정 키:**
+```
 monomat.admin.user-ids=${MONOMAT_ADMIN_USER_IDS:}
 ```
 
-> userIdentifier는 로그인/세션 식별자 성격이 강하므로 관리자 권한 기준으로 사용하지 않습니다.
-> 관리자 API 접근 기준은 DB users.id입니다.
-> 추후 관리자 권한 체계가 추가되면 ROLE_ADMIN 기반 접근 제어로 교체할 수 있습니다.
-
+> MONOMAT_ADMIN_USER_IDS는 운영 주 권한 저장소가 아닙니다.
+기본 관리자 권한은 admin_users 테이블 기준으로 관리합니다.
+userIdentifier는 로그인/세션 식별자 성격이므로 관리자 권한 기준으로 사용하지 않습니다.
 ---
 
 #### 금칙어 목록 조회

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminController.java
@@ -1,0 +1,91 @@
+package io.github.ascrew.monomatbe.domain.auth.controller;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameCreateRequest;
+import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameResponse;
+import io.github.ascrew.monomatbe.domain.auth.service.AdminAccessValidator;
+import io.github.ascrew.monomatbe.domain.auth.service.ForbiddenNicknameService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 관리자 닉네임 금칙어 관리 API
+ *
+ * [현재 권한 정책]
+ * - JWT 인증은 Spring Security @PreAuthorize로 1차 확인한다.
+ * - 관리자 여부는 AdminAccessValidator가 설정 기반 allow-list로 2차 확인한다.
+ *
+ * [주의]
+ * - 현재 프로젝트에 ROLE_ADMIN 권한 체계가 없으므로 hasRole('ADMIN')을 사용하지 않는다.
+ * - 추후 관리자 권한 체계가 추가되면 AdminAccessValidator 내부 구현을 교체한다.
+ */
+@Tag(name = "Forbidden Nickname Admin", description = "관리자 닉네임 금칙어 관리 API")
+@RestController
+@RequestMapping("/api/admin/forbidden-nicknames")
+@RequiredArgsConstructor
+public class ForbiddenNicknameAdminController {
+
+    private final ForbiddenNicknameService forbiddenNicknameService;
+    private final AdminAccessValidator adminAccessValidator;
+
+    @Operation(summary = "닉네임 금칙어 목록 조회")
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<ForbiddenNicknameResponse>> getForbiddenNicknames(
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        adminAccessValidator.validate(principal);
+
+        List<ForbiddenNicknameResponse> response = forbiddenNicknameService.getForbiddenWords()
+                .stream()
+                .map(ForbiddenNicknameResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "닉네임 금칙어 추가")
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ForbiddenNicknameResponse> createForbiddenNickname(
+            @Valid @RequestBody ForbiddenNicknameCreateRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        adminAccessValidator.validate(principal);
+
+        ForbiddenNicknameResponse response = ForbiddenNicknameResponse.from(
+                forbiddenNicknameService.addForbiddenWord(request.word())
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "닉네임 금칙어 삭제")
+    @DeleteMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteForbiddenNickname(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        adminAccessValidator.validate(principal);
+
+        forbiddenNicknameService.deleteForbiddenWord(id);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminController.java
@@ -3,13 +3,16 @@ package io.github.ascrew.monomatbe.domain.auth.controller;
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameCreateRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameResponse;
 import io.github.ascrew.monomatbe.domain.auth.service.ForbiddenNicknameService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,17 +24,22 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 /**
- * 관리자 닉네임 금칙어 관리 API
+ * 관리자 닉네임 금칙어 관리 API.
  *
  * [현재 권한 정책]
- * - 현재 프로젝트에 ROLE_ADMIN 권한 체계가 없으므로 users.id allow-list 기반으로 관리자 접근을 제한한다.
+ * - 현재 프로젝트에 ROLE_ADMIN 권한 체계가 없으므로 admin_users 테이블 기반으로 관리자 접근을 제한한다.
  * - 관리자 여부는 @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")에서 중앙집중적으로 판단한다.
+ *
+ * [감사 로그]
+ * - 금칙어 추가/삭제는 운영 영향이 있는 관리자 행위이므로 admin userId와 대상 정보를 audit log로 남긴다.
+ * - 조회 API는 상태 변경이 없으므로 이번 감사 로그 대상에서 제외한다.
  *
  * [주의]
  * - Controller 내부에서 수동으로 관리자 검증 메서드를 호출하지 않는다.
  * - 관리자 검증을 수동 호출로 분산하면 새 엔드포인트 추가 시 누락 위험이 생긴다.
  * - 추후 ROLE_ADMIN 권한 체계가 추가되면 AdminAccessValidator 내부 구현만 교체한다.
  */
+@Slf4j
 @Tag(name = "Forbidden Nickname Admin", description = "관리자 닉네임 금칙어 관리 API")
 @RestController
 @RequestMapping("/api/admin/forbidden-nicknames")
@@ -56,10 +64,19 @@ public class ForbiddenNicknameAdminController {
     @PostMapping
     @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
     public ResponseEntity<ForbiddenNicknameResponse> createForbiddenNickname(
-            @Valid @RequestBody ForbiddenNicknameCreateRequest request
+            @Valid @RequestBody ForbiddenNicknameCreateRequest request,
+            Authentication authentication
     ) {
         ForbiddenNicknameResponse response = ForbiddenNicknameResponse.from(
                 forbiddenNicknameService.addForbiddenWord(request.word())
+        );
+
+        log.info(
+                "관리자 닉네임 금칙어 추가 - adminUserId: {}, forbiddenNicknameWordId: {}, word: {}, normalizedWord: {}",
+                extractAdminUserId(authentication),
+                response.id(),
+                response.word(),
+                response.normalizedWord()
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -68,9 +85,26 @@ public class ForbiddenNicknameAdminController {
     @Operation(summary = "닉네임 금칙어 삭제")
     @DeleteMapping("/{id}")
     @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
-    public ResponseEntity<Void> deleteForbiddenNickname(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteForbiddenNickname(
+            @PathVariable Long id,
+            Authentication authentication
+    ) {
         forbiddenNicknameService.deleteForbiddenWord(id);
 
+        log.info(
+                "관리자 닉네임 금칙어 삭제 - adminUserId: {}, forbiddenNicknameWordId: {}",
+                extractAdminUserId(authentication),
+                id
+        );
+
         return ResponseEntity.noContent().build();
+    }
+
+    private Long extractAdminUserId(Authentication authentication) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomPrincipal principal)) {
+            return null;
+        }
+
+        return principal.userId();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminController.java
@@ -2,9 +2,7 @@ package io.github.ascrew.monomatbe.domain.auth.controller;
 
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameCreateRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameResponse;
-import io.github.ascrew.monomatbe.domain.auth.service.AdminAccessValidator;
 import io.github.ascrew.monomatbe.domain.auth.service.ForbiddenNicknameService;
-import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,12 +24,13 @@ import java.util.List;
  * 관리자 닉네임 금칙어 관리 API
  *
  * [현재 권한 정책]
- * - JWT 인증은 Spring Security @PreAuthorize로 1차 확인한다.
- * - 관리자 여부는 AdminAccessValidator가 설정 기반 allow-list로 2차 확인한다.
+ * - 현재 프로젝트에 ROLE_ADMIN 권한 체계가 없으므로 users.id allow-list 기반으로 관리자 접근을 제한한다.
+ * - 관리자 여부는 @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")에서 중앙집중적으로 판단한다.
  *
  * [주의]
- * - 현재 프로젝트에 ROLE_ADMIN 권한 체계가 없으므로 hasRole('ADMIN')을 사용하지 않는다.
- * - 추후 관리자 권한 체계가 추가되면 AdminAccessValidator 내부 구현을 교체한다.
+ * - Controller 내부에서 수동으로 관리자 검증 메서드를 호출하지 않는다.
+ * - 관리자 검증을 수동 호출로 분산하면 새 엔드포인트 추가 시 누락 위험이 생긴다.
+ * - 추후 ROLE_ADMIN 권한 체계가 추가되면 AdminAccessValidator 내부 구현만 교체한다.
  */
 @Tag(name = "Forbidden Nickname Admin", description = "관리자 닉네임 금칙어 관리 API")
 @RestController
@@ -41,16 +39,11 @@ import java.util.List;
 public class ForbiddenNicknameAdminController {
 
     private final ForbiddenNicknameService forbiddenNicknameService;
-    private final AdminAccessValidator adminAccessValidator;
 
     @Operation(summary = "닉네임 금칙어 목록 조회")
     @GetMapping
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<ForbiddenNicknameResponse>> getForbiddenNicknames(
-            @AuthenticationPrincipal CustomPrincipal principal
-    ) {
-        adminAccessValidator.validate(principal);
-
+    @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
+    public ResponseEntity<List<ForbiddenNicknameResponse>> getForbiddenNicknames() {
         List<ForbiddenNicknameResponse> response = forbiddenNicknameService.getForbiddenWords()
                 .stream()
                 .map(ForbiddenNicknameResponse::from)
@@ -61,13 +54,10 @@ public class ForbiddenNicknameAdminController {
 
     @Operation(summary = "닉네임 금칙어 추가")
     @PostMapping
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
     public ResponseEntity<ForbiddenNicknameResponse> createForbiddenNickname(
-            @Valid @RequestBody ForbiddenNicknameCreateRequest request,
-            @AuthenticationPrincipal CustomPrincipal principal
+            @Valid @RequestBody ForbiddenNicknameCreateRequest request
     ) {
-        adminAccessValidator.validate(principal);
-
         ForbiddenNicknameResponse response = ForbiddenNicknameResponse.from(
                 forbiddenNicknameService.addForbiddenWord(request.word())
         );
@@ -77,13 +67,8 @@ public class ForbiddenNicknameAdminController {
 
     @Operation(summary = "닉네임 금칙어 삭제")
     @DeleteMapping("/{id}")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<Void> deleteForbiddenNickname(
-            @PathVariable Long id,
-            @AuthenticationPrincipal CustomPrincipal principal
-    ) {
-        adminAccessValidator.validate(principal);
-
+    @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
+    public ResponseEntity<Void> deleteForbiddenNickname(@PathVariable Long id) {
         forbiddenNicknameService.deleteForbiddenWord(id);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/ForbiddenNicknameCreateRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/ForbiddenNicknameCreateRequest.java
@@ -1,0 +1,15 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 관리자 금칙어 생성 요청 DTO
+ */
+public record ForbiddenNicknameCreateRequest(
+
+        @NotBlank(message = "금칙어는 비어 있을 수 없습니다.")
+        @Size(max = 100, message = "금칙어는 100자 이하로 입력해주세요.")
+        String word
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/ForbiddenNicknameResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/dto/ForbiddenNicknameResponse.java
@@ -1,0 +1,29 @@
+package io.github.ascrew.monomatbe.domain.auth.dto;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 금칙어 응답 DTO
+ */
+@Builder
+public record ForbiddenNicknameResponse(
+        Long id,
+        String word,
+        String normalizedWord,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static ForbiddenNicknameResponse from(ForbiddenNicknameWord forbiddenNicknameWord) {
+        return ForbiddenNicknameResponse.builder()
+                .id(forbiddenNicknameWord.getId())
+                .word(forbiddenNicknameWord.getWord())
+                .normalizedWord(forbiddenNicknameWord.getNormalizedWord())
+                .createdAt(forbiddenNicknameWord.getCreatedAt())
+                .updatedAt(forbiddenNicknameWord.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/AdminUser.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/AdminUser.java
@@ -1,0 +1,85 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 권한 엔티티
+ *
+ * [책임]
+ * - 현재 프로젝트에 ROLE_ADMIN 권한 체계가 없으므로, 관리자 API 접근 허용 대상을 별도 테이블로 관리한다.
+ * - admin_users.user_id에 등록된 users.id만 관리자 API에 접근할 수 있다.
+ *
+ * [설계 의도]
+ * - users 테이블에 role 컬럼을 바로 추가하지 않고, 기존 인증 모델 영향 없이 관리자 권한을 분리한다.
+ * - 운영 중 DB insert/delete만으로 관리자 접근 권한을 변경할 수 있도록 한다.
+ *
+ * [확장 방향]
+ * - 추후 ROLE_ADMIN 또는 user_roles 테이블을 도입하면 이 엔티티는 마이그레이션 대상이 된다.
+ */
+@Getter
+@Entity
+@Table(
+        name = "admin_users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_admin_users_user_id",
+                        columnNames = "user_id"
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 관리자 권한을 가진 사용자
+     */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    private AdminUser(User user) {
+        this.user = user;
+    }
+
+    public static AdminUser create(User user) {
+        return new AdminUser(user);
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/ForbiddenNicknameWord.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/ForbiddenNicknameWord.java
@@ -1,0 +1,91 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 닉네임 금칙어 엔티티
+ *
+ * [책임]
+ * - 회원가입/게스트 로그인 닉네임 검증에 사용할 금칙어를 저장한다.
+ * - 관리자 금칙어 관리 API에서 조회/추가/삭제 대상이 된다.
+ *
+ * [설계 의도]
+ * - word는 관리자가 입력한 원본 금칙어다.
+ * - normalizedWord는 실제 닉네임 검증과 중복 방지에 사용하는 비교용 값이다.
+ *
+ * 예:
+ * - word: "A d m i n"
+ * - normalizedWord: "admin"
+ */
+@Getter
+@Entity
+@Table(
+        name = "forbidden_nickname_word",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_forbidden_nickname_word_normalized",
+                        columnNames = "normalized_word"
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ForbiddenNicknameWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 관리자가 입력한 원본 금칙어
+     */
+    @Column(name = "word", nullable = false, length = 100)
+    private String word;
+
+    /**
+     * 비교용 정규화 금칙어
+     *
+     * 중복 등록 방지와 닉네임 검증에 사용한다.
+     */
+    @Column(name = "normalized_word", nullable = false, unique = true, length = 100)
+    private String normalizedWord;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    private ForbiddenNicknameWord(String word, String normalizedWord) {
+        this.word = word;
+        this.normalizedWord = normalizedWord;
+    }
+
+    public static ForbiddenNicknameWord create(String word, String normalizedWord) {
+        return new ForbiddenNicknameWord(word, normalizedWord);
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -109,6 +109,28 @@ public enum AuthErrorCode {
     ),
 
     // =========================================================
+    // Forbidden Nickname Admin
+    // =========================================================
+
+    AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED(
+            HttpStatus.BAD_REQUEST,
+            "금칙어는 비어 있을 수 없습니다.",
+            "word"
+    ),
+
+    AUTH_FORBIDDEN_NICKNAME_WORD_DUPLICATED(
+            HttpStatus.CONFLICT,
+            "이미 등록된 금칙어입니다.",
+            "word"
+    ),
+
+    AUTH_FORBIDDEN_NICKNAME_WORD_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "존재하지 않는 금칙어입니다.",
+            null
+    ),
+
+    // =========================================================
     // Login / Session
     // =========================================================
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -130,6 +130,12 @@ public enum AuthErrorCode {
             null
     ),
 
+    AUTH_FORBIDDEN_NICKNAME_CACHE_EVICT_FAILED(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            "금칙어 캐시 갱신에 실패했습니다. 잠시 후 다시 시도해주세요.",
+            null
+    ),
+
     // =========================================================
     // Login / Session
     // =========================================================

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -92,7 +92,7 @@ public enum AuthErrorCode {
 
     AUTH_NICKNAME_INVALID_LENGTH(
             HttpStatus.BAD_REQUEST,
-            "닉네임은 2자 이상 12자 이하여야 합니다.",
+            "닉네임은 2자 이상 12자 이하로 입력해주세요.",
             AuthErrorFields.NICKNAME
     ),
 
@@ -104,7 +104,7 @@ public enum AuthErrorCode {
 
     AUTH_NICKNAME_FORBIDDEN_WORD(
             HttpStatus.BAD_REQUEST,
-            "사용할 수 없는 닉네임입니다.",
+            "금칙어가 포함된 닉네임은 사용할 수 없습니다.",
             AuthErrorFields.NICKNAME
     ),
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/AdminUserRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/AdminUserRepository.java
@@ -1,19 +1,12 @@
 package io.github.ascrew.monomatbe.domain.auth.repository;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.AdminUser;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-/**
- * 관리자 사용자 Repository
- *
- * [책임]
- * - users.id 기준 관리자 여부 확인
- *
- * [주의]
- * - 현재는 관리자 API 접근 제어 용도로만 사용한다.
- * - 관리자 권한 부여/회수 API는 아직 제공하지 않는다.
- */
 public interface AdminUserRepository extends JpaRepository<AdminUser, Long> {
 
     boolean existsByUserId(Long userId);
+
+    boolean existsByUserIdAndUserUserType(Long userId, UserType userType);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/AdminUserRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/AdminUserRepository.java
@@ -1,0 +1,19 @@
+package io.github.ascrew.monomatbe.domain.auth.repository;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.AdminUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 관리자 사용자 Repository
+ *
+ * [책임]
+ * - users.id 기준 관리자 여부 확인
+ *
+ * [주의]
+ * - 현재는 관리자 API 접근 제어 용도로만 사용한다.
+ * - 관리자 권한 부여/회수 API는 아직 제공하지 않는다.
+ */
+public interface AdminUserRepository extends JpaRepository<AdminUser, Long> {
+
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/ForbiddenNicknameWordRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/ForbiddenNicknameWordRepository.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.auth.repository;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,12 +25,23 @@ public interface ForbiddenNicknameWordRepository extends JpaRepository<Forbidden
     List<ForbiddenNicknameWord> findAllByOrderByCreatedAtDesc();
 
     /**
+     * 닉네임 검증용 정규화 금칙어 목록만 조회한다.
+     *
+     * [필요 이유]
+     * - 닉네임 검증에는 id, word, createdAt, updatedAt이 필요 없다.
+     * - 전체 엔티티를 매번 가져오지 않고 normalizedWord만 조회해 조회 비용을 줄인다.
+     */
+    @Query("select word.normalizedWord from ForbiddenNicknameWord word")
+    List<String> findAllNormalizedWords();
+
+    /**
      * 정규화 금칙어 기준 중복 여부를 확인한다.
      */
     boolean existsByNormalizedWord(String normalizedWord);
 
     /**
      * 정규화 금칙어 기준 단건 조회
+     *
      * 중복 등록 race condition 처리나 테스트에서 사용할 수 있다.
      */
     Optional<ForbiddenNicknameWord> findByNormalizedWord(String normalizedWord);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/ForbiddenNicknameWordRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/ForbiddenNicknameWordRepository.java
@@ -1,0 +1,36 @@
+package io.github.ascrew.monomatbe.domain.auth.repository;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 닉네임 금칙어 Repository
+ *
+ * [책임]
+ * - 금칙어 목록 조회
+ * - 정규화 금칙어 기준 중복 확인
+ * - 관리자 API의 추가/삭제 기능 지원
+ */
+public interface ForbiddenNicknameWordRepository extends JpaRepository<ForbiddenNicknameWord, Long> {
+
+    /**
+     * 관리자 목록 조회용
+     *
+     * 최신 등록 금칙어가 먼저 보이도록 정렬한다.
+     */
+    List<ForbiddenNicknameWord> findAllByOrderByCreatedAtDesc();
+
+    /**
+     * 정규화 금칙어 기준 중복 여부를 확인한다.
+     */
+    boolean existsByNormalizedWord(String normalizedWord);
+
+    /**
+     * 정규화 금칙어 기준 단건 조회
+     * 중복 등록 race condition 처리나 테스트에서 사용할 수 있다.
+     */
+    Optional<ForbiddenNicknameWord> findByNormalizedWord(String normalizedWord);
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -24,10 +25,16 @@ import java.util.stream.Collectors;
  * - userIdentifier는 로그인/세션 식별자 성격이 강하므로 관리자 권한 기준으로 부적절하다.
  * - users.id는 계정 기준 식별자이므로 임시 관리자 allow-list 기준으로 더 안정적이다.
  *
+ * [운영 안전성]
+ * - 관리자 allow-list는 부가 기능 설정이다.
+ * - 환경변수 오타 때문에 전체 애플리케이션이 부팅 실패하면 안 된다.
+ * - 잘못된 값은 warn 로그만 남기고 무시한다.
+ *
  * [확장 방향]
  * - 추후 users 테이블 또는 별도 role 테이블에 관리자 권한이 추가되면
  *   이 컴포넌트 내부 구현만 ROLE_ADMIN 검증으로 교체한다.
  */
+@Slf4j
 @Component
 public class AdminAccessValidator {
 
@@ -62,18 +69,28 @@ public class AdminAccessValidator {
         return Arrays.stream(value.split(","))
                 .map(String::trim)
                 .filter(userId -> !userId.isBlank())
-                .map(this::parseUserId)
+                .map(this::parseUserIdOrNull)
+                .filter(userId -> userId != null)
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    private Long parseUserId(String value) {
+    /**
+     * 관리자 userId 설정값을 Long으로 변환한다.
+     *
+     * [정책]
+     * - 숫자가 아닌 값은 전체 서버 부팅을 막지 않는다.
+     * - 잘못된 값은 warn 로그만 남기고 무시한다.
+     * - 결과적으로 잘못 설정된 관리자 ID는 관리자 API에 접근할 수 없다.
+     */
+    private Long parseUserIdOrNull(String value) {
         try {
             return Long.parseLong(value);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                    "관리자 userId 설정은 숫자만 사용할 수 있습니다. value=" + value,
-                    e
+            log.warn(
+                    "관리자 userId 설정값이 숫자가 아니어서 무시합니다. value={}",
+                    value
             );
+            return null;
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
@@ -1,0 +1,62 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 관리자 API 접근 검증 컴포넌트
+ *
+ * [현재 정책]
+ * - 프로젝트에 ROLE_ADMIN 권한 체계가 아직 없으므로 설정 기반 allow-list로 관리자 접근을 제한한다.
+ * - principal.userIdentifier()가 monomat.admin.user-identifiers 설정에 포함되어 있어야 한다.
+ *
+ * [설정 예시]
+ * monomat.admin.user-identifiers=uuid-1,uuid-2
+ *
+ * [확장 방향]
+ * - 추후 users 테이블 또는 별도 role 테이블에 관리자 권한이 추가되면 이 컴포넌트 내부 구현만 ROLE_ADMIN 검증으로 교체한다.
+ */
+@Component
+public class AdminAccessValidator {
+
+    private static final String ERROR_UNAUTHENTICATED =
+            "인증 정보가 없습니다.";
+    private static final String ERROR_ADMIN_FORBIDDEN =
+            "관리자 권한이 필요합니다.";
+
+    private final Set<String> adminUserIdentifiers;
+
+    public AdminAccessValidator(
+            @Value("${monomat.admin.user-identifiers:}") String adminUserIdentifiers
+    ) {
+        this.adminUserIdentifiers = parseAdminUserIdentifiers(adminUserIdentifiers);
+    }
+
+    public void validate(CustomPrincipal principal) {
+        if (principal == null || principal.userIdentifier() == null || principal.userIdentifier().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_UNAUTHENTICATED);
+        }
+
+        if (!adminUserIdentifiers.contains(principal.userIdentifier())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_ADMIN_FORBIDDEN);
+        }
+    }
+
+    private Set<String> parseAdminUserIdentifiers(String value) {
+        if (value == null || value.isBlank()) {
+            return Set.of();
+        }
+
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(identifier -> !identifier.isBlank())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
@@ -3,28 +3,57 @@ package io.github.ascrew.monomatbe.domain.auth.service;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.repository.AdminUserRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * 관리자 API 접근 검증 컴포넌트
+ *
+ * [현재 정책]
+ * - ROLE_ADMIN 권한 체계가 아직 없으므로 admin_users 테이블 기반으로 관리자 접근을 제한한다.
+ * - admin_users.user_id에 등록된 REGISTERED 사용자만 관리자 API에 접근할 수 있다.
+ *
+ * [fallback 정책]
+ * - MONOMAT_ADMIN_USER_IDS는 운영 주 권한 저장소가 아니다.
+ * - DB 장애 또는 local/dev 긴급 접근을 위한 비상 fallback이다.
+ * - fallback으로 접근을 허용할 경우 metric과 warn 로그를 남긴다.
+ *
+ * [보안 설정 검증]
+ * - fallback 설정값에 숫자가 아닌 값이 있으면 애플리케이션 시작을 막는다.
+ * - 잘못된 관리자 설정이 조용히 무시되면 운영자가 런타임에서야 권한 누락을 발견할 수 있기 때문이다.
+ */
 @Slf4j
 @Component("adminAccessValidator")
 public class AdminAccessValidator {
 
+    private static final String ADMIN_DB_FAILURE_METRIC_NAME =
+            "monomat.admin.access.db.failure";
+
+    private static final String ADMIN_FALLBACK_ALLOWED_METRIC_NAME =
+            "monomat.admin.access.fallback.allowed";
+
     private final AdminUserRepository adminUserRepository;
+    private final MeterRegistry meterRegistry;
     private final Set<Long> fallbackAdminUserIds;
 
     public AdminAccessValidator(
             AdminUserRepository adminUserRepository,
+            MeterRegistry meterRegistry,
             @Value("${monomat.admin.user-ids:}") String fallbackAdminUserIds
     ) {
         this.adminUserRepository = adminUserRepository;
+        this.meterRegistry = meterRegistry;
         this.fallbackAdminUserIds = parseFallbackAdminUserIds(fallbackAdminUserIds);
 
         if (this.fallbackAdminUserIds.isEmpty()) {
@@ -36,6 +65,12 @@ public class AdminAccessValidator {
         }
     }
 
+    /**
+     * Spring Method Security SpEL에서 호출하는 관리자 여부 판단 메서드.
+     *
+     * 사용 예:
+     * @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
+     */
     public boolean isAdmin(Authentication authentication) {
         if (authentication == null || !authentication.isAuthenticated()) {
             return false;
@@ -54,40 +89,69 @@ public class AdminAccessValidator {
             return false;
         }
 
-        if (isAdminByDatabase(userId)) {
+        AdminDatabaseCheckResult databaseCheckResult = checkAdminByDatabase(userId);
+
+        if (databaseCheckResult.admin()) {
             return true;
         }
 
-        return isAdminByFallback(userId);
+        if (databaseCheckResult.failed()) {
+            return isAdminByFallback(userId, "db_failure");
+        }
+
+        return isAdminByFallback(userId, "not_registered");
     }
 
-    private boolean isAdminByDatabase(Long userId) {
+    private AdminDatabaseCheckResult checkAdminByDatabase(Long userId) {
         try {
-            return adminUserRepository.existsByUserIdAndUserUserType(
+            boolean exists = adminUserRepository.existsByUserIdAndUserUserType(
                     userId,
                     UserType.REGISTERED
             );
+
+            return AdminDatabaseCheckResult.success(exists);
         } catch (DataAccessException e) {
+            incrementAdminDatabaseFailureMetric();
+
             log.error(
                     "관리자 권한 DB 조회 실패 - fallback allow-list 확인으로 대체합니다. userId: {}",
                     userId,
                     e
             );
-            return false;
+
+            return AdminDatabaseCheckResult.failure();
         }
     }
 
-    private boolean isAdminByFallback(Long userId) {
+    private boolean isAdminByFallback(Long userId, String reason) {
         boolean allowed = fallbackAdminUserIds.contains(userId);
 
         if (allowed) {
+            incrementFallbackAllowedMetric(reason);
+
             log.warn(
-                    "관리자 fallback allow-list로 접근을 허용합니다. userId: {}",
-                    userId
+                    "관리자 fallback allow-list로 접근을 허용합니다. userId: {}, reason: {}",
+                    userId,
+                    reason
             );
         }
 
         return allowed;
+    }
+
+    private void incrementAdminDatabaseFailureMetric() {
+        Counter.builder(ADMIN_DB_FAILURE_METRIC_NAME)
+                .description("Number of admin access database check failures")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    private void incrementFallbackAllowedMetric(String reason) {
+        Counter.builder(ADMIN_FALLBACK_ALLOWED_METRIC_NAME)
+                .description("Number of admin accesses allowed by fallback allow-list")
+                .tag("reason", reason)
+                .register(meterRegistry)
+                .increment();
     }
 
     private Set<Long> parseFallbackAdminUserIds(String value) {
@@ -95,23 +159,46 @@ public class AdminAccessValidator {
             return Set.of();
         }
 
-        return Arrays.stream(value.split(","))
+        List<String> invalidTokens = new ArrayList<>();
+
+        Set<Long> parsedUserIds = Arrays.stream(value.split(","))
                 .map(String::trim)
                 .filter(userId -> !userId.isBlank())
-                .map(this::parseUserIdOrNull)
+                .map(userId -> parseUserIdOrNull(userId, invalidTokens))
                 .filter(userId -> userId != null)
                 .collect(Collectors.toUnmodifiableSet());
+
+        if (!invalidTokens.isEmpty()) {
+            throw new IllegalStateException(
+                    "관리자 fallback userId 설정값에 숫자가 아닌 값이 포함되어 있습니다. " +
+                            "MONOMAT_ADMIN_USER_IDS 또는 monomat.admin.user-ids를 확인하세요. " +
+                            "invalidValues=" + invalidTokens
+            );
+        }
+
+        return parsedUserIds;
     }
 
-    private Long parseUserIdOrNull(String value) {
+    private Long parseUserIdOrNull(String value, List<String> invalidTokens) {
         try {
             return Long.parseLong(value);
         } catch (NumberFormatException e) {
-            log.warn(
-                    "관리자 fallback userId 설정값이 숫자가 아니어서 무시합니다. value={}",
-                    value
-            );
+            invalidTokens.add(value);
             return null;
+        }
+    }
+
+    private record AdminDatabaseCheckResult(
+            boolean admin,
+            boolean failed
+    ) {
+
+        private static AdminDatabaseCheckResult success(boolean admin) {
+            return new AdminDatabaseCheckResult(admin, false);
+        }
+
+        private static AdminDatabaseCheckResult failure() {
+            return new AdminDatabaseCheckResult(false, true);
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
@@ -15,13 +15,18 @@ import java.util.stream.Collectors;
  *
  * [현재 정책]
  * - 프로젝트에 ROLE_ADMIN 권한 체계가 아직 없으므로 설정 기반 allow-list로 관리자 접근을 제한한다.
- * - principal.userIdentifier()가 monomat.admin.user-identifiers 설정에 포함되어 있어야 한다.
+ * - principal.userId()가 monomat.admin.user-ids 설정에 포함되어 있어야 한다.
  *
  * [설정 예시]
- * monomat.admin.user-identifiers=uuid-1,uuid-2
+ * monomat.admin.user-ids=1,2
+ *
+ * [설계 이유]
+ * - userIdentifier는 로그인/세션 식별자 성격이 강하므로 관리자 권한 기준으로 부적절하다.
+ * - users.id는 계정 기준 식별자이므로 임시 관리자 allow-list 기준으로 더 안정적이다.
  *
  * [확장 방향]
- * - 추후 users 테이블 또는 별도 role 테이블에 관리자 권한이 추가되면 이 컴포넌트 내부 구현만 ROLE_ADMIN 검증으로 교체한다.
+ * - 추후 users 테이블 또는 별도 role 테이블에 관리자 권한이 추가되면
+ *   이 컴포넌트 내부 구현만 ROLE_ADMIN 검증으로 교체한다.
  */
 @Component
 public class AdminAccessValidator {
@@ -31,32 +36,44 @@ public class AdminAccessValidator {
     private static final String ERROR_ADMIN_FORBIDDEN =
             "관리자 권한이 필요합니다.";
 
-    private final Set<String> adminUserIdentifiers;
+    private final Set<Long> adminUserIds;
 
     public AdminAccessValidator(
-            @Value("${monomat.admin.user-identifiers:}") String adminUserIdentifiers
+            @Value("${monomat.admin.user-ids:}") String adminUserIds
     ) {
-        this.adminUserIdentifiers = parseAdminUserIdentifiers(adminUserIdentifiers);
+        this.adminUserIds = parseAdminUserIds(adminUserIds);
     }
 
     public void validate(CustomPrincipal principal) {
-        if (principal == null || principal.userIdentifier() == null || principal.userIdentifier().isBlank()) {
+        if (principal == null || principal.userId() == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_UNAUTHENTICATED);
         }
 
-        if (!adminUserIdentifiers.contains(principal.userIdentifier())) {
+        if (!adminUserIds.contains(principal.userId())) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_ADMIN_FORBIDDEN);
         }
     }
 
-    private Set<String> parseAdminUserIdentifiers(String value) {
+    private Set<Long> parseAdminUserIds(String value) {
         if (value == null || value.isBlank()) {
             return Set.of();
         }
 
         return Arrays.stream(value.split(","))
                 .map(String::trim)
-                .filter(identifier -> !identifier.isBlank())
+                .filter(userId -> !userId.isBlank())
+                .map(this::parseUserId)
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Long parseUserId(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "관리자 userId 설정은 숫자만 사용할 수 있습니다. value=" + value,
+                    e
+            );
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
@@ -3,9 +3,8 @@ package io.github.ascrew.monomatbe.domain.auth.service;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
  *
  * [현재 정책]
  * - 프로젝트에 ROLE_ADMIN 권한 체계가 아직 없으므로 설정 기반 allow-list로 관리자 접근을 제한한다.
- * - principal.userId()가 monomat.admin.user-ids 설정에 포함되어 있어야 한다.
+ * - Authentication principal의 CustomPrincipal.userId()가 monomat.admin.user-ids 설정에 포함되어 있어야 한다.
  *
  * [설정 예시]
  * monomat.admin.user-ids=1,2
@@ -30,18 +29,18 @@ import java.util.stream.Collectors;
  * - 환경변수 오타 때문에 전체 애플리케이션이 부팅 실패하면 안 된다.
  * - 잘못된 값은 warn 로그만 남기고 무시한다.
  *
+ * [인가 정책]
+ * - Controller에서 수동으로 validate()를 호출하지 않는다.
+ * - @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")로 중앙집중화한다.
+ * - 새 관리자 API가 추가되어도 동일한 어노테이션만 붙이면 인가 정책을 일관되게 적용할 수 있다.
+ *
  * [확장 방향]
  * - 추후 users 테이블 또는 별도 role 테이블에 관리자 권한이 추가되면
  *   이 컴포넌트 내부 구현만 ROLE_ADMIN 검증으로 교체한다.
  */
 @Slf4j
-@Component
+@Component("adminAccessValidator")
 public class AdminAccessValidator {
-
-    private static final String ERROR_UNAUTHENTICATED =
-            "인증 정보가 없습니다.";
-    private static final String ERROR_ADMIN_FORBIDDEN =
-            "관리자 권한이 필요합니다.";
 
     private final Set<Long> adminUserIds;
 
@@ -51,14 +50,29 @@ public class AdminAccessValidator {
         this.adminUserIds = parseAdminUserIds(adminUserIds);
     }
 
-    public void validate(CustomPrincipal principal) {
-        if (principal == null || principal.userId() == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_UNAUTHENTICATED);
+    /**
+     * Spring Method Security SpEL에서 호출하는 관리자 여부 판단 메서드
+     *
+     * 사용 예:
+     * @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
+     *
+     * @param authentication Spring Security 인증 객체
+     * @return 관리자 접근 가능 여부
+     */
+    public boolean isAdmin(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
         }
 
-        if (!adminUserIds.contains(principal.userId())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ERROR_ADMIN_FORBIDDEN);
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof CustomPrincipal customPrincipal)) {
+            return false;
         }
+
+        Long userId = customPrincipal.userId();
+
+        return userId != null && adminUserIds.contains(userId);
     }
 
     private Set<Long> parseAdminUserIds(String value) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidator.java
@@ -1,8 +1,11 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.AdminUserRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -10,55 +13,29 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-/**
- * 관리자 API 접근 검증 컴포넌트
- *
- * [현재 정책]
- * - 프로젝트에 ROLE_ADMIN 권한 체계가 아직 없으므로 설정 기반 allow-list로 관리자 접근을 제한한다.
- * - Authentication principal의 CustomPrincipal.userId()가 monomat.admin.user-ids 설정에 포함되어 있어야 한다.
- *
- * [설정 예시]
- * monomat.admin.user-ids=1,2
- *
- * [설계 이유]
- * - userIdentifier는 로그인/세션 식별자 성격이 강하므로 관리자 권한 기준으로 부적절하다.
- * - users.id는 계정 기준 식별자이므로 임시 관리자 allow-list 기준으로 더 안정적이다.
- *
- * [운영 안전성]
- * - 관리자 allow-list는 부가 기능 설정이다.
- * - 환경변수 오타 때문에 전체 애플리케이션이 부팅 실패하면 안 된다.
- * - 잘못된 값은 warn 로그만 남기고 무시한다.
- *
- * [인가 정책]
- * - Controller에서 수동으로 validate()를 호출하지 않는다.
- * - @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")로 중앙집중화한다.
- * - 새 관리자 API가 추가되어도 동일한 어노테이션만 붙이면 인가 정책을 일관되게 적용할 수 있다.
- *
- * [확장 방향]
- * - 추후 users 테이블 또는 별도 role 테이블에 관리자 권한이 추가되면
- *   이 컴포넌트 내부 구현만 ROLE_ADMIN 검증으로 교체한다.
- */
 @Slf4j
 @Component("adminAccessValidator")
 public class AdminAccessValidator {
 
-    private final Set<Long> adminUserIds;
+    private final AdminUserRepository adminUserRepository;
+    private final Set<Long> fallbackAdminUserIds;
 
     public AdminAccessValidator(
-            @Value("${monomat.admin.user-ids:}") String adminUserIds
+            AdminUserRepository adminUserRepository,
+            @Value("${monomat.admin.user-ids:}") String fallbackAdminUserIds
     ) {
-        this.adminUserIds = parseAdminUserIds(adminUserIds);
+        this.adminUserRepository = adminUserRepository;
+        this.fallbackAdminUserIds = parseFallbackAdminUserIds(fallbackAdminUserIds);
+
+        if (this.fallbackAdminUserIds.isEmpty()) {
+            log.warn(
+                    "관리자 fallback userId allow-list가 비어 있습니다. " +
+                            "admin_users 테이블에 등록된 REGISTERED 사용자만 관리자 API에 접근할 수 있습니다. " +
+                            "긴급 fallback이 필요하면 MONOMAT_ADMIN_USER_IDS 또는 monomat.admin.user-ids를 설정하세요."
+            );
+        }
     }
 
-    /**
-     * Spring Method Security SpEL에서 호출하는 관리자 여부 판단 메서드
-     *
-     * 사용 예:
-     * @PreAuthorize("@adminAccessValidator.isAdmin(authentication)")
-     *
-     * @param authentication Spring Security 인증 객체
-     * @return 관리자 접근 가능 여부
-     */
     public boolean isAdmin(Authentication authentication) {
         if (authentication == null || !authentication.isAuthenticated()) {
             return false;
@@ -71,11 +48,49 @@ public class AdminAccessValidator {
         }
 
         Long userId = customPrincipal.userId();
+        UserType userType = customPrincipal.userType();
 
-        return userId != null && adminUserIds.contains(userId);
+        if (userId == null || userType != UserType.REGISTERED) {
+            return false;
+        }
+
+        if (isAdminByDatabase(userId)) {
+            return true;
+        }
+
+        return isAdminByFallback(userId);
     }
 
-    private Set<Long> parseAdminUserIds(String value) {
+    private boolean isAdminByDatabase(Long userId) {
+        try {
+            return adminUserRepository.existsByUserIdAndUserUserType(
+                    userId,
+                    UserType.REGISTERED
+            );
+        } catch (DataAccessException e) {
+            log.error(
+                    "관리자 권한 DB 조회 실패 - fallback allow-list 확인으로 대체합니다. userId: {}",
+                    userId,
+                    e
+            );
+            return false;
+        }
+    }
+
+    private boolean isAdminByFallback(Long userId) {
+        boolean allowed = fallbackAdminUserIds.contains(userId);
+
+        if (allowed) {
+            log.warn(
+                    "관리자 fallback allow-list로 접근을 허용합니다. userId: {}",
+                    userId
+            );
+        }
+
+        return allowed;
+    }
+
+    private Set<Long> parseFallbackAdminUserIds(String value) {
         if (value == null || value.isBlank()) {
             return Set.of();
         }
@@ -88,20 +103,12 @@ public class AdminAccessValidator {
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    /**
-     * 관리자 userId 설정값을 Long으로 변환한다.
-     *
-     * [정책]
-     * - 숫자가 아닌 값은 전체 서버 부팅을 막지 않는다.
-     * - 잘못된 값은 warn 로그만 남기고 무시한다.
-     * - 결과적으로 잘못 설정된 관리자 ID는 관리자 API에 접근할 수 없다.
-     */
     private Long parseUserIdOrNull(String value) {
         try {
             return Long.parseLong(value);
         } catch (NumberFormatException e) {
             log.warn(
-                    "관리자 userId 설정값이 숫자가 아니어서 무시합니다. value={}",
+                    "관리자 fallback userId 설정값이 숫자가 아니어서 무시합니다. value={}",
                     value
             );
             return null;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
@@ -24,13 +24,8 @@ import java.util.Set;
  * - 금칙어 삭제
  * - 닉네임에 금칙어가 포함되어 있는지 판단
  *
- * [설계 의도]
- * - 금칙어 저장소 접근 책임을 이 서비스로 분리한다.
- * - RegisterAuthService, GuestAuthService는 금칙어 저장 방식(DB, Redis, 설정 파일)을 몰라도 된다.
- * - 관리자 API Controller는 이 서비스를 통해 금칙어를 관리한다.
- *
  * [성능 정책]
- * - 닉네임 검증은 회원가입/게스트 로그인 진입점에 붙어 있으므로 매 요청마다 DB findAll()을 수행하면 안 된다.
+ * - 닉네임 검증은 회원가입/게스트 로그인 진입점에 붙어 있으므로 매 요청마다 DB findAll()을 수행하지 않는다.
  * - Redis에 정규화 금칙어 목록을 캐싱하고, 관리자 추가/삭제 시 캐시를 무효화한다.
  * - Redis 장애 시에는 인증 기능 전체가 막히지 않도록 DB 직접 조회로 degrade한다.
  */
@@ -46,59 +41,25 @@ public class ForbiddenNicknameService {
     private static final String ERROR_FORBIDDEN_WORD_NOT_FOUND =
             "존재하지 않는 금칙어입니다.";
 
-    /**
-     * 정규화 금칙어 목록 Redis Set key
-     */
     private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_KEY =
             "auth:forbidden_nickname_words:normalized";
 
-    /**
-     * 빈 금칙어 목록도 캐시하기 위한 loaded marker key
-     *
-     * Redis Set은 값이 없으면 key 자체가 없어질 수 있으므로,
-     * "DB에서 한 번 로드했다"는 상태를 별도 key로 관리한다.
-     */
     private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY =
             "auth:forbidden_nickname_words:loaded";
 
     private static final String CACHE_LOADED_VALUE = "1";
 
-    /**
-     * 금칙어 캐시 TTL
-     *
-     * 관리자 추가/삭제 시 즉시 evict하므로 TTL은 장애 복구용 안전장치에 가깝다.
-     */
     private static final Duration FORBIDDEN_WORD_CACHE_TTL = Duration.ofMinutes(10);
 
     private final ForbiddenNicknameWordRepository forbiddenNicknameWordRepository;
     private final NicknameNormalizer nicknameNormalizer;
     private final StringRedisTemplate stringRedisTemplate;
 
-    /**
-     * 관리자 목록 조회용 금칙어 전체 목록을 조회한다.
-     *
-     * @return 최신 등록순 금칙어 목록
-     */
     @Transactional(readOnly = true)
     public List<ForbiddenNicknameWord> getForbiddenWords() {
         return forbiddenNicknameWordRepository.findAllByOrderByCreatedAtDesc();
     }
 
-    /**
-     * 금칙어를 추가한다.
-     *
-     * [중복 기준]
-     * - 원본 word가 아니라 normalizedWord 기준으로 중복을 판단한다.
-     *
-     * 예:
-     * - "admin"
-     * - "a d m i n"
-     *
-     * 위 두 값은 같은 normalizedWord("admin")로 판단되어 중복 등록을 막는다.
-     *
-     * @param rawWord 관리자가 입력한 원본 금칙어
-     * @return 저장된 금칙어 엔티티
-     */
     @Transactional
     public ForbiddenNicknameWord addForbiddenWord(String rawWord) {
         String word = normalizeRequiredWord(rawWord);
@@ -121,49 +82,28 @@ public class ForbiddenNicknameService {
 
             return savedWord;
         } catch (DataIntegrityViolationException e) {
-            /*
-             * 애플리케이션 중복 검증과 DB unique 제약 사이의 race condition 대응.
-             * 동시에 같은 normalizedWord가 들어오면 DB unique 제약이 최종 방어선이 된다.
-             */
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_FORBIDDEN_WORD_DUPLICATED, e);
         }
     }
 
-    /**
-     * 금칙어를 삭제한다.
-     *
-     * @param id 금칙어 ID
-     */
     @Transactional
     public void deleteForbiddenWord(Long id) {
         if (id == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_NOT_FOUND);
         }
 
-        if (!forbiddenNicknameWordRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_FORBIDDEN_WORD_NOT_FOUND);
-        }
+        ForbiddenNicknameWord forbiddenWord = forbiddenNicknameWordRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_FORBIDDEN_WORD_NOT_FOUND
+                ));
 
-        forbiddenNicknameWordRepository.deleteById(id);
+        forbiddenNicknameWordRepository.delete(forbiddenWord);
         forbiddenNicknameWordRepository.flush();
 
         evictForbiddenWordCache();
     }
 
-    /**
-     * 닉네임에 등록된 금칙어가 포함되어 있는지 판단한다.
-     *
-     * [비교 기준]
-     * - 닉네임과 금칙어 모두 NicknameNormalizer 기준으로 정규화 후 비교한다.
-     *
-     * [성능 정책]
-     * - Redis 캐시가 있으면 Redis Set만 조회한다.
-     * - 캐시가 없으면 DB에서 normalizedWord만 조회한 뒤 Redis에 저장한다.
-     * - Redis 장애 시 DB 직접 조회로 fallback한다.
-     *
-     * @param nickname 정규화 전 또는 후 닉네임
-     * @return 금칙어 포함 여부
-     */
     @Transactional(readOnly = true)
     public boolean containsForbiddenWord(String nickname) {
         String normalizedNickname = nicknameNormalizer.normalizeForComparison(nickname);
@@ -201,11 +141,6 @@ public class ForbiddenNicknameService {
         }
     }
 
-    /**
-     * Redis 캐시에서 정규화 금칙어 목록을 조회한다.
-     *
-     * @return 캐시가 로드된 상태면 목록 반환, 캐시 미스면 null
-     */
     private List<String> getNormalizedForbiddenWordsFromCache() {
         Boolean loaded = stringRedisTemplate.hasKey(FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY);
 
@@ -223,11 +158,6 @@ public class ForbiddenNicknameService {
         return List.copyOf(cachedWords);
     }
 
-    /**
-     * DB에서 조회한 정규화 금칙어 목록을 Redis에 저장한다.
-     *
-     * 빈 목록도 loaded marker를 저장하여 반복 DB 조회를 방지한다.
-     */
     private void cacheNormalizedForbiddenWords(List<String> normalizedWords) {
         stringRedisTemplate.delete(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
 
@@ -252,12 +182,6 @@ public class ForbiddenNicknameService {
         );
     }
 
-    /**
-     * 관리자 금칙어 추가/삭제 후 캐시를 무효화한다.
-     *
-     * Redis 캐시 삭제 실패가 관리자 DB 변경 자체를 실패시킬 필요는 없다.
-     * 다음 TTL 만료 또는 후속 캐시 재생성으로 복구 가능하므로 warning만 남긴다.
-     */
     private void evictForbiddenWordCache() {
         try {
             stringRedisTemplate.delete(List.of(

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
@@ -12,11 +12,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
- * 닉네임 금칙어 관리 서비스.
+ * 닉네임 금칙어 관리 서비스
  *
  * [책임]
  * - 금칙어 목록 조회
@@ -28,6 +29,12 @@ import java.util.Set;
  * - 닉네임 검증은 회원가입/게스트 로그인 진입점에 붙어 있으므로 매 요청마다 DB findAll()을 수행하지 않는다.
  * - Redis에 정규화 금칙어 목록을 캐싱하고, 관리자 추가/삭제 시 캐시를 무효화한다.
  * - Redis 장애 시에는 인증 기능 전체가 막히지 않도록 DB 직접 조회로 degrade한다.
+ *
+ * [캐시 정책]
+ * - 캐시 일관성을 단순화하기 위해 Redis key 하나만 사용한다.
+ * - 금칙어 목록은 개행 문자로 join한 String value로 저장한다.
+ * - 금칙어가 0개인 상태도 빈 문자열("")로 캐싱한다.
+ * - Set key + loaded marker key 조합은 두 key의 TTL/eviction 불일치 가능성이 있어 사용하지 않는다.
  */
 @Slf4j
 @Service
@@ -37,10 +44,7 @@ public class ForbiddenNicknameService {
     private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_KEY =
             "auth:forbidden_nickname_words:normalized";
 
-    private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY =
-            "auth:forbidden_nickname_words:loaded";
-
-    private static final String CACHE_LOADED_VALUE = "1";
+    private static final String CACHE_WORD_DELIMITER = "\n";
 
     private static final Duration FORBIDDEN_WORD_CACHE_TTL = Duration.ofMinutes(10);
 
@@ -124,7 +128,14 @@ public class ForbiddenNicknameService {
 
     private List<String> getNormalizedForbiddenWordsSafely() {
         try {
-            return getNormalizedForbiddenWordsFromCache();
+            String cachedValue = stringRedisTemplate.opsForValue()
+                    .get(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
+
+            if (cachedValue == null) {
+                return null;
+            }
+
+            return deserializeNormalizedWords(cachedValue);
         } catch (RuntimeException e) {
             log.warn(
                     "닉네임 금칙어 Redis 캐시 조회 실패 - DB 직접 조회로 대체합니다.",
@@ -132,23 +143,6 @@ public class ForbiddenNicknameService {
             );
             return null;
         }
-    }
-
-    private List<String> getNormalizedForbiddenWordsFromCache() {
-        Boolean loaded = stringRedisTemplate.hasKey(FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY);
-
-        if (!Boolean.TRUE.equals(loaded)) {
-            return null;
-        }
-
-        Set<String> cachedWords = stringRedisTemplate.opsForSet()
-                .members(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
-
-        if (cachedWords == null || cachedWords.isEmpty()) {
-            return null;
-        }
-
-        return List.copyOf(cachedWords);
     }
 
     private void cacheNormalizedForbiddenWordsSafely(List<String> normalizedWords) {
@@ -163,35 +157,35 @@ public class ForbiddenNicknameService {
     }
 
     private void cacheNormalizedForbiddenWords(List<String> normalizedWords) {
-        stringRedisTemplate.delete(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
-
-        List<String> validWords = normalizedWords.stream()
-                .filter(word -> word != null && !word.isBlank())
-                .toList();
-
-        if (!validWords.isEmpty()) {
-            stringRedisTemplate.opsForSet()
-                    .add(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY, validWords.toArray(String[]::new));
-
-            stringRedisTemplate.expire(
-                    FORBIDDEN_NICKNAME_WORDS_CACHE_KEY,
-                    FORBIDDEN_WORD_CACHE_TTL
-            );
-        }
+        String serializedWords = serializeNormalizedWords(normalizedWords);
 
         stringRedisTemplate.opsForValue().set(
-                FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY,
-                CACHE_LOADED_VALUE,
+                FORBIDDEN_NICKNAME_WORDS_CACHE_KEY,
+                serializedWords,
                 FORBIDDEN_WORD_CACHE_TTL
         );
     }
 
+    private String serializeNormalizedWords(List<String> normalizedWords) {
+        return normalizedWords.stream()
+                .filter(word -> word != null && !word.isBlank())
+                .distinct()
+                .collect(Collectors.joining(CACHE_WORD_DELIMITER));
+    }
+
+    private List<String> deserializeNormalizedWords(String cachedValue) {
+        if (cachedValue.isBlank()) {
+            return List.of();
+        }
+
+        return Arrays.stream(cachedValue.split(CACHE_WORD_DELIMITER))
+                .filter(word -> word != null && !word.isBlank())
+                .toList();
+    }
+
     private void evictForbiddenWordCache() {
         try {
-            stringRedisTemplate.delete(List.of(
-                    FORBIDDEN_NICKNAME_WORDS_CACHE_KEY,
-                    FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY
-            ));
+            stringRedisTemplate.delete(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
         } catch (RuntimeException e) {
             log.warn("닉네임 금칙어 Redis 캐시 무효화 실패", e);
         }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * 닉네임 금칙어 관리 서비스
+ * 닉네임 금칙어 관리 서비스.
  *
  * [책임]
  * - 금칙어 목록 조회
@@ -120,24 +120,27 @@ public class ForbiddenNicknameService {
     }
 
     private List<String> getNormalizedForbiddenWords() {
+        List<String> cachedWords = getNormalizedForbiddenWordsSafely();
+
+        if (cachedWords != null) {
+            return cachedWords;
+        }
+
+        List<String> dbWords = forbiddenNicknameWordRepository.findAllNormalizedWords();
+        cacheNormalizedForbiddenWordsSafely(dbWords);
+
+        return dbWords;
+    }
+
+    private List<String> getNormalizedForbiddenWordsSafely() {
         try {
-            List<String> cachedWords = getNormalizedForbiddenWordsFromCache();
-
-            if (cachedWords != null) {
-                return cachedWords;
-            }
-
-            List<String> dbWords = forbiddenNicknameWordRepository.findAllNormalizedWords();
-            cacheNormalizedForbiddenWords(dbWords);
-
-            return dbWords;
+            return getNormalizedForbiddenWordsFromCache();
         } catch (RuntimeException e) {
             log.warn(
-                    "닉네임 금칙어 Redis 캐시 조회/저장 실패 - DB 직접 조회로 대체합니다.",
+                    "닉네임 금칙어 Redis 캐시 조회 실패 - DB 직접 조회로 대체합니다.",
                     e
             );
-
-            return forbiddenNicknameWordRepository.findAllNormalizedWords();
+            return null;
         }
     }
 
@@ -151,11 +154,26 @@ public class ForbiddenNicknameService {
         Set<String> cachedWords = stringRedisTemplate.opsForSet()
                 .members(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
 
+        /*
+         * loaded marker는 있지만 Set이 비어 있으면 Redis eviction/부분 삭제 가능성이 있다.
+         * 이 경우 빈 금칙어 목록으로 신뢰하지 않고 cache miss로 판단하여 DB에서 재조회한다.
+         */
         if (cachedWords == null || cachedWords.isEmpty()) {
-            return List.of();
+            return null;
         }
 
         return List.copyOf(cachedWords);
+    }
+
+    private void cacheNormalizedForbiddenWordsSafely(List<String> normalizedWords) {
+        try {
+            cacheNormalizedForbiddenWords(normalizedWords);
+        } catch (RuntimeException e) {
+            log.warn(
+                    "닉네임 금칙어 Redis 캐시 저장 실패 - DB 조회 결과로 검증을 계속합니다.",
+                    e
+            );
+        }
     }
 
     private void cacheNormalizedForbiddenWords(List<String> normalizedWords) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
@@ -1,0 +1,152 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import io.github.ascrew.monomatbe.domain.auth.repository.ForbiddenNicknameWordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+/**
+ * 닉네임 금칙어 관리 서비스
+ *
+ * [책임]
+ * - 금칙어 목록 조회
+ * - 금칙어 추가
+ * - 금칙어 삭제
+ * - 닉네임에 금칙어가 포함되어 있는지 판단
+ *
+ * [설계 의도]
+ * - 금칙어 저장소 접근 책임을 이 서비스로 분리한다.
+ * - RegisterAuthService, GuestAuthService는 금칙어 저장 방식(DB, Redis, 설정 파일)을 몰라도 된다.
+ * - 관리자 API Controller는 이 서비스를 통해 금칙어를 관리한다.
+ *
+ * [현재 구현]
+ * - DB 직접 조회 기반
+ *
+ * [확장 방향]
+ * - 금칙어 목록이 커지거나 요청량이 많아지면 Redis/로컬 캐시를 이 서비스 내부에 추가한다.
+ * - 외부 서비스는 containsForbiddenWord() 계약만 유지하면 된다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ForbiddenNicknameService {
+
+    private static final String ERROR_FORBIDDEN_WORD_REQUIRED =
+            "금칙어는 비어 있을 수 없습니다.";
+    private static final String ERROR_FORBIDDEN_WORD_DUPLICATED =
+            "이미 등록된 금칙어입니다.";
+    private static final String ERROR_FORBIDDEN_WORD_NOT_FOUND =
+            "존재하지 않는 금칙어입니다.";
+
+    private final ForbiddenNicknameWordRepository forbiddenNicknameWordRepository;
+    private final NicknameNormalizer nicknameNormalizer;
+
+    /**
+     * 관리자 목록 조회용 금칙어 전체 목록을 조회한다.
+     *
+     * @return 최신 등록순 금칙어 목록
+     */
+    @Transactional(readOnly = true)
+    public List<ForbiddenNicknameWord> getForbiddenWords() {
+        return forbiddenNicknameWordRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    /**
+     * 금칙어를 추가한다.
+     *
+     * [중복 기준]
+     * - 원본 word가 아니라 normalizedWord 기준으로 중복을 판단한다.
+     *
+     * 예:
+     * - "admin"
+     * - "a d m i n"
+     * 위 두 값은 같은 normalizedWord("admin")로 판단되어 중복 등록을 막는다.
+     *
+     * @param rawWord 관리자가 입력한 원본 금칙어
+     * @return 저장된 금칙어 엔티티
+     */
+    @Transactional
+    public ForbiddenNicknameWord addForbiddenWord(String rawWord) {
+        String word = normalizeRequiredWord(rawWord);
+        String normalizedWord = nicknameNormalizer.normalizeForComparison(word);
+
+        if (normalizedWord.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_REQUIRED);
+        }
+
+        if (forbiddenNicknameWordRepository.existsByNormalizedWord(normalizedWord)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_FORBIDDEN_WORD_DUPLICATED);
+        }
+
+        try {
+            return forbiddenNicknameWordRepository.saveAndFlush(
+                    ForbiddenNicknameWord.create(word, normalizedWord)
+            );
+        } catch (DataIntegrityViolationException e) {
+            /*
+             * 애플리케이션 중복 검증과 DB unique 제약 사이의 race condition 대응
+             * 동시에 같은 normalizedWord가 들어오면 DB unique 제약이 최종 방어선이 된다.
+             */
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_FORBIDDEN_WORD_DUPLICATED, e);
+        }
+    }
+
+    /**
+     * 금칙어를 삭제한다.
+     *
+     * @param id 금칙어 ID
+     */
+    @Transactional
+    public void deleteForbiddenWord(Long id) {
+        if (id == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_NOT_FOUND);
+        }
+
+        if (!forbiddenNicknameWordRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ERROR_FORBIDDEN_WORD_NOT_FOUND);
+        }
+
+        forbiddenNicknameWordRepository.deleteById(id);
+    }
+
+    /**
+     * 닉네임에 등록된 금칙어가 포함되어 있는지 판단한다.
+     *
+     * [비교 기준]
+     * - 닉네임과 금칙어 모두 NicknameNormalizer 기준으로 정규화 후 비교한다.
+     *
+     * @param nickname 정규화 전 또는 후 닉네임
+     * @return 금칙어 포함 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean containsForbiddenWord(String nickname) {
+        String normalizedNickname = nicknameNormalizer.normalizeForComparison(nickname);
+
+        if (normalizedNickname.isBlank()) {
+            return false;
+        }
+
+        return forbiddenNicknameWordRepository.findAll().stream()
+                .map(ForbiddenNicknameWord::getNormalizedWord)
+                .anyMatch(normalizedNickname::contains);
+    }
+
+    private String normalizeRequiredWord(String rawWord) {
+        if (rawWord == null || rawWord.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_REQUIRED);
+        }
+
+        String word = rawWord.trim();
+
+        if (word.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_REQUIRED);
+        }
+
+        return word;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
@@ -3,13 +3,17 @@ package io.github.ascrew.monomatbe.domain.auth.service;
 import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
 import io.github.ascrew.monomatbe.domain.auth.repository.ForbiddenNicknameWordRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 
 /**
  * 닉네임 금칙어 관리 서비스
@@ -25,13 +29,12 @@ import java.util.List;
  * - RegisterAuthService, GuestAuthService는 금칙어 저장 방식(DB, Redis, 설정 파일)을 몰라도 된다.
  * - 관리자 API Controller는 이 서비스를 통해 금칙어를 관리한다.
  *
- * [현재 구현]
- * - DB 직접 조회 기반
- *
- * [확장 방향]
- * - 금칙어 목록이 커지거나 요청량이 많아지면 Redis/로컬 캐시를 이 서비스 내부에 추가한다.
- * - 외부 서비스는 containsForbiddenWord() 계약만 유지하면 된다.
+ * [성능 정책]
+ * - 닉네임 검증은 회원가입/게스트 로그인 진입점에 붙어 있으므로 매 요청마다 DB findAll()을 수행하면 안 된다.
+ * - Redis에 정규화 금칙어 목록을 캐싱하고, 관리자 추가/삭제 시 캐시를 무효화한다.
+ * - Redis 장애 시에는 인증 기능 전체가 막히지 않도록 DB 직접 조회로 degrade한다.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ForbiddenNicknameService {
@@ -43,8 +46,33 @@ public class ForbiddenNicknameService {
     private static final String ERROR_FORBIDDEN_WORD_NOT_FOUND =
             "존재하지 않는 금칙어입니다.";
 
+    /**
+     * 정규화 금칙어 목록 Redis Set key
+     */
+    private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_KEY =
+            "auth:forbidden_nickname_words:normalized";
+
+    /**
+     * 빈 금칙어 목록도 캐시하기 위한 loaded marker key
+     *
+     * Redis Set은 값이 없으면 key 자체가 없어질 수 있으므로,
+     * "DB에서 한 번 로드했다"는 상태를 별도 key로 관리한다.
+     */
+    private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY =
+            "auth:forbidden_nickname_words:loaded";
+
+    private static final String CACHE_LOADED_VALUE = "1";
+
+    /**
+     * 금칙어 캐시 TTL
+     *
+     * 관리자 추가/삭제 시 즉시 evict하므로 TTL은 장애 복구용 안전장치에 가깝다.
+     */
+    private static final Duration FORBIDDEN_WORD_CACHE_TTL = Duration.ofMinutes(10);
+
     private final ForbiddenNicknameWordRepository forbiddenNicknameWordRepository;
     private final NicknameNormalizer nicknameNormalizer;
+    private final StringRedisTemplate stringRedisTemplate;
 
     /**
      * 관리자 목록 조회용 금칙어 전체 목록을 조회한다.
@@ -65,6 +93,7 @@ public class ForbiddenNicknameService {
      * 예:
      * - "admin"
      * - "a d m i n"
+     *
      * 위 두 값은 같은 normalizedWord("admin")로 판단되어 중복 등록을 막는다.
      *
      * @param rawWord 관리자가 입력한 원본 금칙어
@@ -84,12 +113,16 @@ public class ForbiddenNicknameService {
         }
 
         try {
-            return forbiddenNicknameWordRepository.saveAndFlush(
+            ForbiddenNicknameWord savedWord = forbiddenNicknameWordRepository.saveAndFlush(
                     ForbiddenNicknameWord.create(word, normalizedWord)
             );
+
+            evictForbiddenWordCache();
+
+            return savedWord;
         } catch (DataIntegrityViolationException e) {
             /*
-             * 애플리케이션 중복 검증과 DB unique 제약 사이의 race condition 대응
+             * 애플리케이션 중복 검증과 DB unique 제약 사이의 race condition 대응.
              * 동시에 같은 normalizedWord가 들어오면 DB unique 제약이 최종 방어선이 된다.
              */
             throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_FORBIDDEN_WORD_DUPLICATED, e);
@@ -112,6 +145,9 @@ public class ForbiddenNicknameService {
         }
 
         forbiddenNicknameWordRepository.deleteById(id);
+        forbiddenNicknameWordRepository.flush();
+
+        evictForbiddenWordCache();
     }
 
     /**
@@ -119,6 +155,11 @@ public class ForbiddenNicknameService {
      *
      * [비교 기준]
      * - 닉네임과 금칙어 모두 NicknameNormalizer 기준으로 정규화 후 비교한다.
+     *
+     * [성능 정책]
+     * - Redis 캐시가 있으면 Redis Set만 조회한다.
+     * - 캐시가 없으면 DB에서 normalizedWord만 조회한 뒤 Redis에 저장한다.
+     * - Redis 장애 시 DB 직접 조회로 fallback한다.
      *
      * @param nickname 정규화 전 또는 후 닉네임
      * @return 금칙어 포함 여부
@@ -131,9 +172,101 @@ public class ForbiddenNicknameService {
             return false;
         }
 
-        return forbiddenNicknameWordRepository.findAll().stream()
-                .map(ForbiddenNicknameWord::getNormalizedWord)
+        List<String> normalizedForbiddenWords = getNormalizedForbiddenWords();
+
+        return normalizedForbiddenWords.stream()
+                .filter(word -> word != null && !word.isBlank())
                 .anyMatch(normalizedNickname::contains);
+    }
+
+    private List<String> getNormalizedForbiddenWords() {
+        try {
+            List<String> cachedWords = getNormalizedForbiddenWordsFromCache();
+
+            if (cachedWords != null) {
+                return cachedWords;
+            }
+
+            List<String> dbWords = forbiddenNicknameWordRepository.findAllNormalizedWords();
+            cacheNormalizedForbiddenWords(dbWords);
+
+            return dbWords;
+        } catch (RuntimeException e) {
+            log.warn(
+                    "닉네임 금칙어 Redis 캐시 조회/저장 실패 - DB 직접 조회로 대체합니다.",
+                    e
+            );
+
+            return forbiddenNicknameWordRepository.findAllNormalizedWords();
+        }
+    }
+
+    /**
+     * Redis 캐시에서 정규화 금칙어 목록을 조회한다.
+     *
+     * @return 캐시가 로드된 상태면 목록 반환, 캐시 미스면 null
+     */
+    private List<String> getNormalizedForbiddenWordsFromCache() {
+        Boolean loaded = stringRedisTemplate.hasKey(FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY);
+
+        if (!Boolean.TRUE.equals(loaded)) {
+            return null;
+        }
+
+        Set<String> cachedWords = stringRedisTemplate.opsForSet()
+                .members(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
+
+        if (cachedWords == null || cachedWords.isEmpty()) {
+            return List.of();
+        }
+
+        return List.copyOf(cachedWords);
+    }
+
+    /**
+     * DB에서 조회한 정규화 금칙어 목록을 Redis에 저장한다.
+     *
+     * 빈 목록도 loaded marker를 저장하여 반복 DB 조회를 방지한다.
+     */
+    private void cacheNormalizedForbiddenWords(List<String> normalizedWords) {
+        stringRedisTemplate.delete(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
+
+        List<String> validWords = normalizedWords.stream()
+                .filter(word -> word != null && !word.isBlank())
+                .toList();
+
+        if (!validWords.isEmpty()) {
+            stringRedisTemplate.opsForSet()
+                    .add(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY, validWords.toArray(String[]::new));
+
+            stringRedisTemplate.expire(
+                    FORBIDDEN_NICKNAME_WORDS_CACHE_KEY,
+                    FORBIDDEN_WORD_CACHE_TTL
+            );
+        }
+
+        stringRedisTemplate.opsForValue().set(
+                FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY,
+                CACHE_LOADED_VALUE,
+                FORBIDDEN_WORD_CACHE_TTL
+        );
+    }
+
+    /**
+     * 관리자 금칙어 추가/삭제 후 캐시를 무효화한다.
+     *
+     * Redis 캐시 삭제 실패가 관리자 DB 변경 자체를 실패시킬 필요는 없다.
+     * 다음 TTL 만료 또는 후속 캐시 재생성으로 복구 가능하므로 warning만 남긴다.
+     */
+    private void evictForbiddenWordCache() {
+        try {
+            stringRedisTemplate.delete(List.of(
+                    FORBIDDEN_NICKNAME_WORDS_CACHE_KEY,
+                    FORBIDDEN_NICKNAME_WORDS_CACHE_LOADED_KEY
+            ));
+        } catch (RuntimeException e) {
+            log.warn("닉네임 금칙어 Redis 캐시 무효화 실패", e);
+        }
     }
 
     private String normalizeRequiredWord(String rawWord) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
@@ -1,5 +1,8 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
@@ -12,9 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 /**
  * 닉네임 금칙어 관리 서비스
@@ -31,10 +33,14 @@ import java.util.stream.Collectors;
  * - Redis 장애 시에는 인증 기능 전체가 막히지 않도록 DB 직접 조회로 degrade한다.
  *
  * [캐시 정책]
- * - 캐시 일관성을 단순화하기 위해 Redis key 하나만 사용한다.
- * - 금칙어 목록은 개행 문자로 join한 String value로 저장한다.
- * - 금칙어가 0개인 상태도 빈 문자열("")로 캐싱한다.
- * - Set key + loaded marker key 조합은 두 key의 TTL/eviction 불일치 가능성이 있어 사용하지 않는다.
+ * - Redis key 하나만 사용한다.
+ * - 금칙어 목록은 JSON 배열 문자열로 저장한다.
+ * - 금칙어가 0개인 상태도 JSON 빈 배열("[]")로 캐싱한다.
+ * - 개행 문자 구분자 방식은 정규화 정책과 암묵적으로 결합될 수 있으므로 사용하지 않는다.
+ *
+ * [관리자 변경 반영 정책]
+ * - 금칙어 추가/삭제 후 Redis 캐시 무효화에 실패하면 관리자 API를 성공 처리하지 않는다.
+ * - 성공 응답을 반환했는데 TTL 동안 stale cache가 남는 상태를 방지하기 위함이다.
  */
 @Slf4j
 @Service
@@ -44,9 +50,13 @@ public class ForbiddenNicknameService {
     private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_KEY =
             "auth:forbidden_nickname_words:normalized";
 
-    private static final String CACHE_WORD_DELIMITER = "\n";
-
     private static final Duration FORBIDDEN_WORD_CACHE_TTL = Duration.ofMinutes(10);
+
+    private static final TypeReference<List<String>> STRING_LIST_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    private static final JsonMapper CACHE_JSON_MAPPER = JsonMapper.builder().build();
 
     private final ForbiddenNicknameWordRepository forbiddenNicknameWordRepository;
     private final NicknameNormalizer nicknameNormalizer;
@@ -108,6 +118,15 @@ public class ForbiddenNicknameService {
 
         List<String> normalizedForbiddenWords = getNormalizedForbiddenWords();
 
+        /*
+         * [금칙어 판정 정책]
+         * - 현재 정책은 완전 일치 차단이 아니라 부분 포함 차단이다.
+         * - 정규화된 닉네임 안에 정규화된 금칙어가 포함되면 차단한다.
+         *
+         * 예:
+         * - 금칙어: "admin"
+         * - 차단: "admin", "superadmin", "a d m i n", "madministrator"
+         */
         return normalizedForbiddenWords.stream()
                 .filter(word -> word != null && !word.isBlank())
                 .anyMatch(normalizedNickname::contains);
@@ -167,10 +186,17 @@ public class ForbiddenNicknameService {
     }
 
     private String serializeNormalizedWords(List<String> normalizedWords) {
-        return normalizedWords.stream()
-                .filter(word -> word != null && !word.isBlank())
+        List<String> cacheableWords = normalizedWords.stream()
+                .filter(Objects::nonNull)
+                .filter(word -> !word.isBlank())
                 .distinct()
-                .collect(Collectors.joining(CACHE_WORD_DELIMITER));
+                .toList();
+
+        try {
+            return CACHE_JSON_MAPPER.writeValueAsString(cacheableWords);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("닉네임 금칙어 캐시 직렬화에 실패했습니다.", e);
+        }
     }
 
     private List<String> deserializeNormalizedWords(String cachedValue) {
@@ -178,16 +204,23 @@ public class ForbiddenNicknameService {
             return List.of();
         }
 
-        return Arrays.stream(cachedValue.split(CACHE_WORD_DELIMITER))
-                .filter(word -> word != null && !word.isBlank())
-                .toList();
+        try {
+            return CACHE_JSON_MAPPER.readValue(cachedValue, STRING_LIST_TYPE_REFERENCE)
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .filter(word -> !word.isBlank())
+                    .toList();
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("닉네임 금칙어 캐시 역직렬화에 실패했습니다.", e);
+        }
     }
 
     private void evictForbiddenWordCache() {
         try {
             stringRedisTemplate.delete(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
         } catch (RuntimeException e) {
-            log.warn("닉네임 금칙어 Redis 캐시 무효화 실패", e);
+            log.error("닉네임 금칙어 Redis 캐시 무효화 실패", e);
+            throw new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_CACHE_EVICT_FAILED, e);
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameService.java
@@ -1,15 +1,15 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.ForbiddenNicknameWordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.util.List;
@@ -33,13 +33,6 @@ import java.util.Set;
 @Service
 @RequiredArgsConstructor
 public class ForbiddenNicknameService {
-
-    private static final String ERROR_FORBIDDEN_WORD_REQUIRED =
-            "금칙어는 비어 있을 수 없습니다.";
-    private static final String ERROR_FORBIDDEN_WORD_DUPLICATED =
-            "이미 등록된 금칙어입니다.";
-    private static final String ERROR_FORBIDDEN_WORD_NOT_FOUND =
-            "존재하지 않는 금칙어입니다.";
 
     private static final String FORBIDDEN_NICKNAME_WORDS_CACHE_KEY =
             "auth:forbidden_nickname_words:normalized";
@@ -66,11 +59,11 @@ public class ForbiddenNicknameService {
         String normalizedWord = nicknameNormalizer.normalizeForComparison(word);
 
         if (normalizedWord.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED);
         }
 
         if (forbiddenNicknameWordRepository.existsByNormalizedWord(normalizedWord)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_FORBIDDEN_WORD_DUPLICATED);
+            throw new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_DUPLICATED);
         }
 
         try {
@@ -82,21 +75,18 @@ public class ForbiddenNicknameService {
 
             return savedWord;
         } catch (DataIntegrityViolationException e) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_FORBIDDEN_WORD_DUPLICATED, e);
+            throw new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_DUPLICATED, e);
         }
     }
 
     @Transactional
     public void deleteForbiddenWord(Long id) {
         if (id == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_NOT_FOUND);
+            throw new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_NOT_FOUND);
         }
 
         ForbiddenNicknameWord forbiddenWord = forbiddenNicknameWordRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND,
-                        ERROR_FORBIDDEN_WORD_NOT_FOUND
-                ));
+                .orElseThrow(() -> new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_NOT_FOUND));
 
         forbiddenNicknameWordRepository.delete(forbiddenWord);
         forbiddenNicknameWordRepository.flush();
@@ -154,10 +144,6 @@ public class ForbiddenNicknameService {
         Set<String> cachedWords = stringRedisTemplate.opsForSet()
                 .members(FORBIDDEN_NICKNAME_WORDS_CACHE_KEY);
 
-        /*
-         * loaded marker는 있지만 Set이 비어 있으면 Redis eviction/부분 삭제 가능성이 있다.
-         * 이 경우 빈 금칙어 목록으로 신뢰하지 않고 cache miss로 판단하여 DB에서 재조회한다.
-         */
         if (cachedWords == null || cachedWords.isEmpty()) {
             return null;
         }
@@ -213,13 +199,13 @@ public class ForbiddenNicknameService {
 
     private String normalizeRequiredWord(String rawWord) {
         if (rawWord == null || rawWord.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED);
         }
 
         String word = rawWord.trim();
 
         if (word.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_FORBIDDEN_WORD_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED);
         }
 
         return word;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
@@ -56,6 +56,7 @@ public class GuestAuthService {
     private final StringRedisTemplate redisTemplate;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserSessionLifecycleService userSessionLifecycleService;
+    private final NicknamePolicyValidator nicknamePolicyValidator;
 
     /**
      * 게스트 로그인 메인 플로우
@@ -67,6 +68,7 @@ public class GuestAuthService {
     @Transactional
     public GuestLoginResponse loginAsGuest(String rawNickname, String ipAddress, String userAgent) {
         String nickname = normalizeNickname(rawNickname);
+        nicknamePolicyValidator.validate(nickname);
         validateNicknameAvailability(nickname);
 
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizer.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizer.java
@@ -1,0 +1,39 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+/**
+ * 닉네임 및 금칙어 비교용 정규화 컴포넌트
+ *
+ * [책임]
+ * - 닉네임과 금칙어를 동일한 기준으로 비교할 수 있도록 정규화한다.
+ *
+ * [정규화 정책]
+ * - 앞뒤 공백 제거
+ * - 대소문자 차이 제거
+ * - 모든 공백 문자 제거
+ *
+ * [예시]
+ * - "Admin"      -> "admin"
+ * - "A d m i n"  -> "admin"
+ * - "관 리 자"    -> "관리자"
+ *
+ * [주의]
+ * - 이 컴포넌트는 필수값 검증을 하지 않는다.
+ * - null/blank 여부는 호출하는 서비스에서 도메인 정책에 맞게 판단한다.
+ */
+@Component
+public class NicknameNormalizer {
+
+    public String normalizeForComparison(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.trim()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", "");
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizer.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizer.java
@@ -11,7 +11,6 @@ import java.util.Locale;
  * - 닉네임과 금칙어를 동일한 기준으로 비교할 수 있도록 정규화한다.
  *
  * [정규화 정책]
- * - 앞뒤 공백 제거
  * - 대소문자 차이 제거
  * - 모든 공백 문자 제거
  *
@@ -32,8 +31,17 @@ public class NicknameNormalizer {
             return "";
         }
 
-        return value.trim()
-                .toLowerCase(Locale.ROOT)
-                .replaceAll("\\s+", "");
+        String lowerCasedValue = value.toLowerCase(Locale.ROOT);
+        StringBuilder normalizedValue = new StringBuilder(lowerCasedValue.length());
+
+        for (int i = 0; i < lowerCasedValue.length(); i++) {
+            char current = lowerCasedValue.charAt(i);
+
+            if (!Character.isWhitespace(current)) {
+                normalizedValue.append(current);
+            }
+        }
+
+        return normalizedValue.toString();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/NicknamePolicyValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/NicknamePolicyValidator.java
@@ -1,0 +1,40 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 닉네임 정책 검증 컴포넌트
+ *
+ * [책임]
+ * - 회원가입/게스트 로그인에서 공통으로 사용하는 닉네임 정책을 검증한다.
+ * - 현재는 DB 기반 금칙어 포함 여부를 검증한다.
+ *
+ * [설계 의도]
+ * - RegisterAuthService, GuestAuthService 내부에 금칙어 조회/비교 로직을 넣지 않는다.
+ * - 닉네임 검증 정책을 별도 컴포넌트로 분리하여 인증 서비스의 책임을 줄인다.
+ *
+ * [주의]
+ * - null/blank/길이 검증은 기존 DTO Validation 및 각 서비스의 normalizeNickname()에서 처리한다.
+ * - 이 컴포넌트에는 trim 및 길이 검증이 끝난 닉네임을 전달한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class NicknamePolicyValidator {
+
+    private final ForbiddenNicknameService forbiddenNicknameService;
+
+    /**
+     * 닉네임 정책을 검증한다.
+     *
+     * @param nickname 정규화 및 길이 검증이 완료된 닉네임
+     * @throws AuthException 금칙어가 포함된 경우
+     */
+    public void validate(String nickname) {
+        if (forbiddenNicknameService.containsForbiddenWord(nickname)) {
+            throw new AuthException(AuthErrorCode.AUTH_NICKNAME_FORBIDDEN_WORD);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -38,6 +38,7 @@ public class RegisterAuthService {
     private final UserRepository userRepository;
     private final UserCredentialRepository userCredentialRepository;
     private final PasswordEncoder passwordEncoder;
+    private final NicknamePolicyValidator nicknamePolicyValidator;
 
     @Transactional
     public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
@@ -45,6 +46,7 @@ public class RegisterAuthService {
         String password = normalizePassword(rawPassword);
         String nickname = normalizeNickname(rawNickname);
 
+        nicknamePolicyValidator.validate(nickname);
         validateDuplicate(loginId, nickname);
 
         User savedUser;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,8 +21,9 @@ youtube.oembed.request-timeout=${YOUTUBE_OEMBED_REQUEST_TIMEOUT:5s}
 report.policy.lobby-review-threshold=${REPORT_POLICY_LOBBY_REVIEW_THRESHOLD:5}
 report.policy.auto-private-enabled=${REPORT_POLICY_AUTO_PRIVATE_ENABLED:false}
 
-# 관리자 접근 정책
-# 현재는 별도 ROLE_ADMIN 권한 체계가 없으므로, 관리자 users.id allow-list로 /api/admin/** 접근을 제한한다.
+# 관리자 접근 fallback 정책
+# 관리자 API 접근은 기본적으로 admin_users 테이블을 기준으로 판단한다.
+# 이 값은 DB 장애 또는 local/dev 긴급 접근을 위한 fallback allow-list다.
 # 여러 명은 콤마로 구분한다. 예: 1,2
 monomat.admin.user-ids=${MONOMAT_ADMIN_USER_IDS:}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,9 +22,9 @@ report.policy.lobby-review-threshold=${REPORT_POLICY_LOBBY_REVIEW_THRESHOLD:5}
 report.policy.auto-private-enabled=${REPORT_POLICY_AUTO_PRIVATE_ENABLED:false}
 
 # 관리자 접근 정책
-# 현재는 별도 ROLE_ADMIN 권한 체계가 없으므로, 관리자 userIdentifier allow-list로 /api/admin/** 접근을 제한한다.
-# 여러 명은 콤마로 구분한다. 예: uuid-1,uuid-2
-monomat.admin.user-identifiers=${MONOMAT_ADMIN_USER_IDENTIFIERS:}
+# 현재는 별도 ROLE_ADMIN 권한 체계가 없으므로, 관리자 users.id allow-list로 /api/admin/** 접근을 제한한다.
+# 여러 명은 콤마로 구분한다. 예: 1,2
+monomat.admin.user-ids=${MONOMAT_ADMIN_USER_IDS:}
 
 # Flyway: 모든 스키마 변경은 src/main/resources/db/migration 의 Vn__*.sql 로만 관리.
 # baseline-on-migrate=true: 기존 운영/dev DB(이미 ddl-auto/수동 ALTER 로 만들어진 스키마)에 처음 적용될 때

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,11 @@ youtube.oembed.request-timeout=${YOUTUBE_OEMBED_REQUEST_TIMEOUT:5s}
 report.policy.lobby-review-threshold=${REPORT_POLICY_LOBBY_REVIEW_THRESHOLD:5}
 report.policy.auto-private-enabled=${REPORT_POLICY_AUTO_PRIVATE_ENABLED:false}
 
+# 관리자 접근 정책
+# 현재는 별도 ROLE_ADMIN 권한 체계가 없으므로, 관리자 userIdentifier allow-list로 /api/admin/** 접근을 제한한다.
+# 여러 명은 콤마로 구분한다. 예: uuid-1,uuid-2
+monomat.admin.user-identifiers=${MONOMAT_ADMIN_USER_IDENTIFIERS:}
+
 # Flyway: 모든 스키마 변경은 src/main/resources/db/migration 의 Vn__*.sql 로만 관리.
 # baseline-on-migrate=true: 기존 운영/dev DB(이미 ddl-auto/수동 ALTER 로 만들어진 스키마)에 처음 적용될 때
 #   schema_history 테이블만 생성하고 baseline-version까지를 실행 없이 baseline 으로 마킹한다.

--- a/src/main/resources/db/migration/V7__create_forbidden_nickname_word_table.sql
+++ b/src/main/resources/db/migration/V7__create_forbidden_nickname_word_table.sql
@@ -1,0 +1,14 @@
+-- ============================================================================
+-- V7__create_forbidden_nickname_word_table.sql
+-- 닉네임 금칙어 테이블 생성
+-- ============================================================================
+
+CREATE TABLE forbidden_nickname_word (
+                                         id              BIGINT       NOT NULL AUTO_INCREMENT COMMENT '닉네임 금칙어 고유 식별자',
+                                         word            VARCHAR(100) NOT NULL                COMMENT '관리자가 등록한 원본 금칙어',
+                                         normalized_word VARCHAR(100) NOT NULL                COMMENT '비교용 정규화 금칙어',
+                                         created_at      DATETIME     NOT NULL                COMMENT '금칙어 등록 일시',
+                                         updated_at      DATETIME     NOT NULL                COMMENT '금칙어 수정 일시',
+                                         CONSTRAINT pk_forbidden_nickname_word PRIMARY KEY (id),
+                                         CONSTRAINT uq_forbidden_nickname_word_normalized UNIQUE (normalized_word)
+);

--- a/src/main/resources/db/migration/V8__create_admin_users_table.sql
+++ b/src/main/resources/db/migration/V8__create_admin_users_table.sql
@@ -1,0 +1,14 @@
+-- ============================================================================
+-- V8__create_admin_users_table.sql
+-- 관리자 사용자 테이블 생성
+-- ============================================================================
+
+CREATE TABLE admin_users (
+                             id          BIGINT   NOT NULL AUTO_INCREMENT COMMENT '관리자 권한 고유 식별자',
+                             user_id     BIGINT   NOT NULL                COMMENT '관리자 권한을 가진 users.id',
+                             created_at  DATETIME NOT NULL                COMMENT '관리자 권한 등록 일시',
+                             updated_at  DATETIME NOT NULL                COMMENT '관리자 권한 수정 일시',
+                             CONSTRAINT pk_admin_users PRIMARY KEY (id),
+                             CONSTRAINT uq_admin_users_user_id UNIQUE (user_id),
+                             CONSTRAINT fk_admin_users_user_id FOREIGN KEY (user_id) REFERENCES users (id)
+);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminControllerTest.java
@@ -3,51 +3,35 @@ package io.github.ascrew.monomatbe.domain.auth.controller;
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameCreateRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
-import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
-import io.github.ascrew.monomatbe.domain.auth.service.AdminAccessValidator;
 import io.github.ascrew.monomatbe.domain.auth.service.ForbiddenNicknameService;
-import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.security.access.prepost.PreAuthorize;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class ForbiddenNicknameAdminControllerTest {
 
-    private ForbiddenNicknameService forbiddenNicknameService;
-    private AdminAccessValidator adminAccessValidator;
-    private ForbiddenNicknameAdminController controller;
+    private static final String ADMIN_PRE_AUTHORIZE_EXPRESSION =
+            "@adminAccessValidator.isAdmin(authentication)";
 
-    private CustomPrincipal adminPrincipal;
+    private ForbiddenNicknameService forbiddenNicknameService;
+    private ForbiddenNicknameAdminController controller;
 
     @BeforeEach
     void setUp() {
         forbiddenNicknameService = mock(ForbiddenNicknameService.class);
-        adminAccessValidator = mock(AdminAccessValidator.class);
-
-        controller = new ForbiddenNicknameAdminController(
-                forbiddenNicknameService,
-                adminAccessValidator
-        );
-
-        adminPrincipal = new CustomPrincipal(
-                1L,
-                "admin-user-identifier",
-                UserType.REGISTERED
-        );
+        controller = new ForbiddenNicknameAdminController(forbiddenNicknameService);
     }
 
     @Test
@@ -59,7 +43,7 @@ class ForbiddenNicknameAdminControllerTest {
                 .thenReturn(List.of(forbiddenWord));
 
         ResponseEntity<List<ForbiddenNicknameResponse>> response =
-                controller.getForbiddenNicknames(adminPrincipal);
+                controller.getForbiddenNicknames();
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
@@ -67,7 +51,6 @@ class ForbiddenNicknameAdminControllerTest {
         assertEquals("관리자", response.getBody().get(0).word());
         assertEquals("관리자", response.getBody().get(0).normalizedWord());
 
-        verify(adminAccessValidator).validate(adminPrincipal);
         verify(forbiddenNicknameService).getForbiddenWords();
     }
 
@@ -81,14 +64,13 @@ class ForbiddenNicknameAdminControllerTest {
                 .thenReturn(savedWord);
 
         ResponseEntity<ForbiddenNicknameResponse> response =
-                controller.createForbiddenNickname(request, adminPrincipal);
+                controller.createForbiddenNickname(request);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertNotNull(response.getBody());
         assertEquals("관리자", response.getBody().word());
         assertEquals("관리자", response.getBody().normalizedWord());
 
-        verify(adminAccessValidator).validate(adminPrincipal);
         verify(forbiddenNicknameService).addForbiddenWord("관리자");
     }
 
@@ -96,64 +78,47 @@ class ForbiddenNicknameAdminControllerTest {
     @DisplayName("관리자 금칙어를 삭제한다")
     void deleteForbiddenNickname() {
         ResponseEntity<Void> response =
-                controller.deleteForbiddenNickname(1L, adminPrincipal);
+                controller.deleteForbiddenNickname(1L);
 
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
 
-        verify(adminAccessValidator).validate(adminPrincipal);
         verify(forbiddenNicknameService).deleteForbiddenWord(1L);
     }
 
     @Test
-    @DisplayName("관리자 권한이 없으면 목록 조회 서비스로 진입하지 않는다")
-    void rejectGetForbiddenNicknamesWithoutAdminPermission() {
-        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."))
-                .when(adminAccessValidator)
-                .validate(adminPrincipal);
+    @DisplayName("금칙어 목록 조회 API는 관리자 인가 SpEL을 사용한다")
+    void getForbiddenNicknamesHasAdminPreAuthorize() throws NoSuchMethodException {
+        Method method = ForbiddenNicknameAdminController.class.getMethod("getForbiddenNicknames");
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> controller.getForbiddenNicknames(adminPrincipal)
-        );
-
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
-        verify(adminAccessValidator).validate(adminPrincipal);
-        verifyNoInteractions(forbiddenNicknameService);
+        assertAdminPreAuthorize(method);
     }
 
     @Test
-    @DisplayName("관리자 권한이 없으면 금칙어 추가 서비스로 진입하지 않는다")
-    void rejectCreateForbiddenNicknameWithoutAdminPermission() {
-        ForbiddenNicknameCreateRequest request = new ForbiddenNicknameCreateRequest("관리자");
-
-        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."))
-                .when(adminAccessValidator)
-                .validate(adminPrincipal);
-
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> controller.createForbiddenNickname(request, adminPrincipal)
+    @DisplayName("금칙어 추가 API는 관리자 인가 SpEL을 사용한다")
+    void createForbiddenNicknameHasAdminPreAuthorize() throws NoSuchMethodException {
+        Method method = ForbiddenNicknameAdminController.class.getMethod(
+                "createForbiddenNickname",
+                ForbiddenNicknameCreateRequest.class
         );
 
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
-        verify(adminAccessValidator).validate(adminPrincipal);
-        verifyNoInteractions(forbiddenNicknameService);
+        assertAdminPreAuthorize(method);
     }
 
     @Test
-    @DisplayName("관리자 권한이 없으면 금칙어 삭제 서비스로 진입하지 않는다")
-    void rejectDeleteForbiddenNicknameWithoutAdminPermission() {
-        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."))
-                .when(adminAccessValidator)
-                .validate(adminPrincipal);
-
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> controller.deleteForbiddenNickname(1L, adminPrincipal)
+    @DisplayName("금칙어 삭제 API는 관리자 인가 SpEL을 사용한다")
+    void deleteForbiddenNicknameHasAdminPreAuthorize() throws NoSuchMethodException {
+        Method method = ForbiddenNicknameAdminController.class.getMethod(
+                "deleteForbiddenNickname",
+                Long.class
         );
 
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
-        verify(adminAccessValidator).validate(adminPrincipal);
-        verifyNoInteractions(forbiddenNicknameService);
+        assertAdminPreAuthorize(method);
+    }
+
+    private void assertAdminPreAuthorize(Method method) {
+        PreAuthorize preAuthorize = method.getAnnotation(PreAuthorize.class);
+
+        assertNotNull(preAuthorize);
+        assertEquals(ADMIN_PRE_AUTHORIZE_EXPRESSION, preAuthorize.value());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminControllerTest.java
@@ -1,0 +1,159 @@
+package io.github.ascrew.monomatbe.domain.auth.controller;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameCreateRequest;
+import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameResponse;
+import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.service.AdminAccessValidator;
+import io.github.ascrew.monomatbe.domain.auth.service.ForbiddenNicknameService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ForbiddenNicknameAdminControllerTest {
+
+    private ForbiddenNicknameService forbiddenNicknameService;
+    private AdminAccessValidator adminAccessValidator;
+    private ForbiddenNicknameAdminController controller;
+
+    private CustomPrincipal adminPrincipal;
+
+    @BeforeEach
+    void setUp() {
+        forbiddenNicknameService = mock(ForbiddenNicknameService.class);
+        adminAccessValidator = mock(AdminAccessValidator.class);
+
+        controller = new ForbiddenNicknameAdminController(
+                forbiddenNicknameService,
+                adminAccessValidator
+        );
+
+        adminPrincipal = new CustomPrincipal(
+                1L,
+                "admin-user-identifier",
+                UserType.REGISTERED
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 금칙어 목록을 조회한다")
+    void getForbiddenNicknames() {
+        ForbiddenNicknameWord forbiddenWord = ForbiddenNicknameWord.create("관리자", "관리자");
+
+        when(forbiddenNicknameService.getForbiddenWords())
+                .thenReturn(List.of(forbiddenWord));
+
+        ResponseEntity<List<ForbiddenNicknameResponse>> response =
+                controller.getForbiddenNicknames(adminPrincipal);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        assertEquals("관리자", response.getBody().get(0).word());
+        assertEquals("관리자", response.getBody().get(0).normalizedWord());
+
+        verify(adminAccessValidator).validate(adminPrincipal);
+        verify(forbiddenNicknameService).getForbiddenWords();
+    }
+
+    @Test
+    @DisplayName("관리자 금칙어를 추가한다")
+    void createForbiddenNickname() {
+        ForbiddenNicknameCreateRequest request = new ForbiddenNicknameCreateRequest("관리자");
+        ForbiddenNicknameWord savedWord = ForbiddenNicknameWord.create("관리자", "관리자");
+
+        when(forbiddenNicknameService.addForbiddenWord("관리자"))
+                .thenReturn(savedWord);
+
+        ResponseEntity<ForbiddenNicknameResponse> response =
+                controller.createForbiddenNickname(request, adminPrincipal);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("관리자", response.getBody().word());
+        assertEquals("관리자", response.getBody().normalizedWord());
+
+        verify(adminAccessValidator).validate(adminPrincipal);
+        verify(forbiddenNicknameService).addForbiddenWord("관리자");
+    }
+
+    @Test
+    @DisplayName("관리자 금칙어를 삭제한다")
+    void deleteForbiddenNickname() {
+        ResponseEntity<Void> response =
+                controller.deleteForbiddenNickname(1L, adminPrincipal);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+        verify(adminAccessValidator).validate(adminPrincipal);
+        verify(forbiddenNicknameService).deleteForbiddenWord(1L);
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 목록 조회 서비스로 진입하지 않는다")
+    void rejectGetForbiddenNicknamesWithoutAdminPermission() {
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."))
+                .when(adminAccessValidator)
+                .validate(adminPrincipal);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> controller.getForbiddenNicknames(adminPrincipal)
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(adminAccessValidator).validate(adminPrincipal);
+        verifyNoInteractions(forbiddenNicknameService);
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 금칙어 추가 서비스로 진입하지 않는다")
+    void rejectCreateForbiddenNicknameWithoutAdminPermission() {
+        ForbiddenNicknameCreateRequest request = new ForbiddenNicknameCreateRequest("관리자");
+
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."))
+                .when(adminAccessValidator)
+                .validate(adminPrincipal);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> controller.createForbiddenNickname(request, adminPrincipal)
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(adminAccessValidator).validate(adminPrincipal);
+        verifyNoInteractions(forbiddenNicknameService);
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 금칙어 삭제 서비스로 진입하지 않는다")
+    void rejectDeleteForbiddenNicknameWithoutAdminPermission() {
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."))
+                .when(adminAccessValidator)
+                .validate(adminPrincipal);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> controller.deleteForbiddenNickname(1L, adminPrincipal)
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(adminAccessValidator).validate(adminPrincipal);
+        verifyNoInteractions(forbiddenNicknameService);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/controller/ForbiddenNicknameAdminControllerTest.java
@@ -3,13 +3,17 @@ package io.github.ascrew.monomatbe.domain.auth.controller;
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameCreateRequest;
 import io.github.ascrew.monomatbe.domain.auth.dto.ForbiddenNicknameResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.service.ForbiddenNicknameService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -27,11 +31,15 @@ class ForbiddenNicknameAdminControllerTest {
 
     private ForbiddenNicknameService forbiddenNicknameService;
     private ForbiddenNicknameAdminController controller;
+    private Authentication authentication;
 
     @BeforeEach
     void setUp() {
         forbiddenNicknameService = mock(ForbiddenNicknameService.class);
         controller = new ForbiddenNicknameAdminController(forbiddenNicknameService);
+        authentication = authenticatedToken(
+                new CustomPrincipal(1L, "admin-session-identifier", UserType.REGISTERED)
+        );
     }
 
     @Test
@@ -64,7 +72,7 @@ class ForbiddenNicknameAdminControllerTest {
                 .thenReturn(savedWord);
 
         ResponseEntity<ForbiddenNicknameResponse> response =
-                controller.createForbiddenNickname(request);
+                controller.createForbiddenNickname(request, authentication);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertNotNull(response.getBody());
@@ -78,7 +86,7 @@ class ForbiddenNicknameAdminControllerTest {
     @DisplayName("관리자 금칙어를 삭제한다")
     void deleteForbiddenNickname() {
         ResponseEntity<Void> response =
-                controller.deleteForbiddenNickname(1L);
+                controller.deleteForbiddenNickname(1L, authentication);
 
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
 
@@ -98,7 +106,8 @@ class ForbiddenNicknameAdminControllerTest {
     void createForbiddenNicknameHasAdminPreAuthorize() throws NoSuchMethodException {
         Method method = ForbiddenNicknameAdminController.class.getMethod(
                 "createForbiddenNickname",
-                ForbiddenNicknameCreateRequest.class
+                ForbiddenNicknameCreateRequest.class,
+                Authentication.class
         );
 
         assertAdminPreAuthorize(method);
@@ -109,7 +118,8 @@ class ForbiddenNicknameAdminControllerTest {
     void deleteForbiddenNicknameHasAdminPreAuthorize() throws NoSuchMethodException {
         Method method = ForbiddenNicknameAdminController.class.getMethod(
                 "deleteForbiddenNickname",
-                Long.class
+                Long.class,
+                Authentication.class
         );
 
         assertAdminPreAuthorize(method);
@@ -120,5 +130,13 @@ class ForbiddenNicknameAdminControllerTest {
 
         assertNotNull(preAuthorize);
         assertEquals(ADMIN_PRE_AUTHORIZE_EXPRESSION, preAuthorize.value());
+    }
+
+    private Authentication authenticatedToken(Object principal) {
+        return new TestingAuthenticationToken(
+                principal,
+                null,
+                "ROLE_USER"
+        );
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
@@ -14,13 +14,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AdminAccessValidatorTest {
 
     @Test
-    @DisplayName("설정된 관리자 userIdentifier이면 접근을 허용한다")
-    void validateAdminUserIdentifier() {
-        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid");
+    @DisplayName("설정된 관리자 userId이면 접근을 허용한다")
+    void validateAdminUserId() {
+        AdminAccessValidator validator = new AdminAccessValidator("1");
 
         CustomPrincipal principal = new CustomPrincipal(
                 1L,
-                "admin-uuid",
+                "any-session-identifier",
                 UserType.REGISTERED
         );
 
@@ -28,13 +28,13 @@ class AdminAccessValidatorTest {
     }
 
     @Test
-    @DisplayName("설정되지 않은 userIdentifier이면 403으로 차단한다")
-    void rejectNonAdminUserIdentifier() {
-        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid");
+    @DisplayName("설정되지 않은 userId이면 403으로 차단한다")
+    void rejectNonAdminUserId() {
+        AdminAccessValidator validator = new AdminAccessValidator("1");
 
         CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "normal-user-uuid",
+                2L,
+                "normal-user-identifier",
                 UserType.REGISTERED
         );
 
@@ -49,7 +49,7 @@ class AdminAccessValidatorTest {
     @Test
     @DisplayName("인증 정보가 없으면 401로 차단한다")
     void rejectUnauthenticatedPrincipal() {
-        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid");
+        AdminAccessValidator validator = new AdminAccessValidator("1");
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
@@ -60,13 +60,13 @@ class AdminAccessValidatorTest {
     }
 
     @Test
-    @DisplayName("관리자 식별자는 콤마 구분 목록으로 여러 개 설정할 수 있다")
-    void validateMultipleAdminUserIdentifiers() {
-        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid-1, admin-uuid-2");
+    @DisplayName("관리자 userId는 콤마 구분 목록으로 여러 개 설정할 수 있다")
+    void validateMultipleAdminUserIds() {
+        AdminAccessValidator validator = new AdminAccessValidator("1, 2");
 
         CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "admin-uuid-2",
+                2L,
+                "any-session-identifier",
                 UserType.REGISTERED
         );
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
@@ -3,13 +3,16 @@ package io.github.ascrew.monomatbe.domain.auth.service;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.repository.AdminUserRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -20,16 +23,22 @@ import static org.mockito.Mockito.when;
 class AdminAccessValidatorTest {
 
     private AdminUserRepository adminUserRepository;
+    private SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
         adminUserRepository = mock(AdminUserRepository.class);
+        meterRegistry = new SimpleMeterRegistry();
     }
 
     @Test
     @DisplayName("admin_users 테이블에 등록된 REGISTERED userId이면 true를 반환한다")
     void isAdminWithDatabaseAdminUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                ""
+        );
 
         when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
                 .thenReturn(true);
@@ -40,12 +49,18 @@ class AdminAccessValidatorTest {
 
         assertTrue(validator.isAdmin(authentication));
         verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+
+        assertEquals(0.0, meterRegistry.counter("monomat.admin.access.db.failure").count());
     }
 
     @Test
     @DisplayName("DB에 관리자 권한이 없고 fallback에도 없으면 false를 반환한다")
     void isAdminRejectsNonAdminUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                ""
+        );
 
         when(adminUserRepository.existsByUserIdAndUserUserType(2L, UserType.REGISTERED))
                 .thenReturn(false);
@@ -59,9 +74,13 @@ class AdminAccessValidatorTest {
     }
 
     @Test
-    @DisplayName("DB에 관리자 권한이 없지만 fallback allow-list에 있으면 true를 반환한다")
-    void isAdminWithFallbackAdminUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+    @DisplayName("DB에는 없지만 fallback allow-list에 있으면 접근을 허용하고 not_registered metric을 증가시킨다")
+    void isAdminWithFallbackWhenNotRegisteredInDatabaseIncrementsMetrics() {
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1"
+        );
 
         when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
                 .thenReturn(false);
@@ -72,12 +91,25 @@ class AdminAccessValidatorTest {
 
         assertTrue(validator.isAdmin(authentication));
         verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+
+        assertEquals(
+                1.0,
+                meterRegistry.counter(
+                        "monomat.admin.access.fallback.allowed",
+                        "reason",
+                        "not_registered"
+                ).count()
+        );
     }
 
     @Test
-    @DisplayName("DB 조회 실패 시 fallback allow-list에 있으면 true를 반환한다")
-    void isAdminWithFallbackWhenDatabaseFails() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+    @DisplayName("DB 조회 실패 시 fallback allow-list에 있으면 접근을 허용하고 metric을 증가시킨다")
+    void isAdminWithFallbackWhenDatabaseFailsIncrementsMetrics() {
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1"
+        );
 
         when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
                 .thenThrow(new DataAccessResourceFailureException("db down"));
@@ -88,15 +120,126 @@ class AdminAccessValidatorTest {
 
         assertTrue(validator.isAdmin(authentication));
         verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+
+        assertEquals(
+                1.0,
+                meterRegistry.counter("monomat.admin.access.db.failure").count()
+        );
+        assertEquals(
+                1.0,
+                meterRegistry.counter(
+                        "monomat.admin.access.fallback.allowed",
+                        "reason",
+                        "db_failure"
+                ).count()
+        );
     }
 
     @Test
-    @DisplayName("DB 조회 실패 시 fallback allow-list에도 없으면 false를 반환한다")
+    @DisplayName("DB 조회 실패 시 fallback allow-list에도 없으면 false를 반환하고 DB 실패 metric만 증가시킨다")
     void rejectWhenDatabaseFailsAndFallbackDoesNotContainUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                ""
+        );
 
         when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
                 .thenThrow(new DataAccessResourceFailureException("db down"));
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
+        );
+
+        assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+
+        assertEquals(
+                1.0,
+                meterRegistry.counter("monomat.admin.access.db.failure").count()
+        );
+        assertEquals(
+                0.0,
+                meterRegistry.counter(
+                        "monomat.admin.access.fallback.allowed",
+                        "reason",
+                        "db_failure"
+                ).count()
+        );
+    }
+
+    @Test
+    @DisplayName("fallback 설정에 숫자가 아닌 값이 있으면 애플리케이션 시작을 막는다")
+    void rejectInvalidFallbackAdminUserIdSetting() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new AdminAccessValidator(adminUserRepository, meterRegistry, "1, admin, 2")
+        );
+
+        assertTrue(exception.getMessage().contains("관리자 fallback userId 설정값에 숫자가 아닌 값"));
+        assertTrue(exception.getMessage().contains("admin"));
+    }
+
+    @Test
+    @DisplayName("fallback 설정에 빈 토큰이 섞여 있어도 빈 토큰은 무시하고 정상 값만 반영한다")
+    void ignoreBlankTokensInFallbackAdminUserIdSetting() {
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1, , 2,   "
+        );
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenReturn(false);
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
+        );
+
+        assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+
+        assertEquals(
+                1.0,
+                meterRegistry.counter(
+                        "monomat.admin.access.fallback.allowed",
+                        "reason",
+                        "not_registered"
+                ).count()
+        );
+    }
+
+    @Test
+    @DisplayName("fallback userId는 콤마 구분 목록으로 여러 개 설정할 수 있다")
+    void isAdminWithMultipleFallbackAdminUserIds() {
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1, 2"
+        );
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(2L, UserType.REGISTERED))
+                .thenReturn(false);
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(2L, "any-session-identifier", UserType.REGISTERED)
+        );
+
+        assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(2L, UserType.REGISTERED);
+    }
+
+    @Test
+    @DisplayName("fallback 설정이 비어 있고 DB에도 없으면 false를 반환한다")
+    void rejectWhenFallbackAdminUserIdSettingIsEmpty() {
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                ""
+        );
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenReturn(false);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
@@ -109,7 +252,11 @@ class AdminAccessValidatorTest {
     @Test
     @DisplayName("Authentication이 null이면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsNullAuthentication() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1"
+        );
 
         assertFalse(validator.isAdmin(null));
         verify(adminUserRepository, never()).existsByUserIdAndUserUserType(any(), any());
@@ -118,7 +265,11 @@ class AdminAccessValidatorTest {
     @Test
     @DisplayName("인증되지 않은 Authentication이면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsUnauthenticatedAuthentication() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1"
+        );
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
@@ -132,7 +283,11 @@ class AdminAccessValidatorTest {
     @Test
     @DisplayName("principal이 CustomPrincipal이 아니면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsUnsupportedPrincipal() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1"
+        );
 
         TestingAuthenticationToken authentication = authenticatedToken("anonymousUser");
 
@@ -143,7 +298,11 @@ class AdminAccessValidatorTest {
     @Test
     @DisplayName("principal의 userId가 null이면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsNullUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1"
+        );
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(null, "any-session-identifier", UserType.REGISTERED)
@@ -156,7 +315,11 @@ class AdminAccessValidatorTest {
     @Test
     @DisplayName("principal의 userType이 GUEST이면 admin_users 등록 여부를 조회하지 않고 false를 반환한다")
     void isAdminRejectsGuestUserType() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+        AdminAccessValidator validator = new AdminAccessValidator(
+                adminUserRepository,
+                meterRegistry,
+                "1"
+        );
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "guest-session-identifier", UserType.GUEST)
@@ -164,86 +327,6 @@ class AdminAccessValidatorTest {
 
         assertFalse(validator.isAdmin(authentication));
         verify(adminUserRepository, never()).existsByUserIdAndUserUserType(any(), any());
-    }
-
-    @Test
-    @DisplayName("fallback userId는 콤마 구분 목록으로 여러 개 설정할 수 있다")
-    void isAdminWithMultipleFallbackAdminUserIds() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1, 2");
-
-        when(adminUserRepository.existsByUserIdAndUserUserType(2L, UserType.REGISTERED))
-                .thenReturn(false);
-
-        TestingAuthenticationToken authentication = authenticatedToken(
-                new CustomPrincipal(2L, "any-session-identifier", UserType.REGISTERED)
-        );
-
-        assertTrue(validator.isAdmin(authentication));
-        verify(adminUserRepository).existsByUserIdAndUserUserType(2L, UserType.REGISTERED);
-    }
-
-    @Test
-    @DisplayName("fallback 설정에 잘못된 값이 있어도 서버 부팅을 막지 않고 정상 값만 반영한다")
-    void ignoreInvalidFallbackAdminUserIdSetting() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1, abc, 2");
-
-        when(adminUserRepository.existsByUserIdAndUserUserType(2L, UserType.REGISTERED))
-                .thenReturn(false);
-
-        TestingAuthenticationToken authentication = authenticatedToken(
-                new CustomPrincipal(2L, "any-session-identifier", UserType.REGISTERED)
-        );
-
-        assertTrue(validator.isAdmin(authentication));
-        verify(adminUserRepository).existsByUserIdAndUserUserType(2L, UserType.REGISTERED);
-    }
-
-    @Test
-    @DisplayName("fallback 설정이 모두 잘못된 값이고 DB에도 없으면 false를 반환한다")
-    void rejectWhenAllFallbackAdminUserIdSettingsAreInvalid() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "abc, def");
-
-        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
-                .thenReturn(false);
-
-        TestingAuthenticationToken authentication = authenticatedToken(
-                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
-        );
-
-        assertFalse(validator.isAdmin(authentication));
-        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
-    }
-
-    @Test
-    @DisplayName("fallback 설정이 비어 있고 DB에도 없으면 false를 반환한다")
-    void rejectWhenFallbackAdminUserIdSettingIsEmpty() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
-
-        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
-                .thenReturn(false);
-
-        TestingAuthenticationToken authentication = authenticatedToken(
-                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
-        );
-
-        assertFalse(validator.isAdmin(authentication));
-        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
-    }
-
-    @Test
-    @DisplayName("fallback 설정에 빈 토큰이 섞여 있어도 무시하고 정상 값만 반영한다")
-    void ignoreBlankTokensInFallbackAdminUserIdSetting() {
-        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1, , 2,   ");
-
-        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
-                .thenReturn(false);
-
-        TestingAuthenticationToken authentication = authenticatedToken(
-                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
-        );
-
-        assertTrue(validator.isAdmin(authentication));
-        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
     }
 
     private TestingAuthenticationToken authenticatedToken(Object principal) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
@@ -4,92 +4,90 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.security.authentication.TestingAuthenticationToken;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AdminAccessValidatorTest {
 
     @Test
-    @DisplayName("설정된 관리자 userId이면 접근을 허용한다")
-    void validateAdminUserId() {
+    @DisplayName("설정된 관리자 userId이면 true를 반환한다")
+    void isAdminWithAdminUserId() {
         AdminAccessValidator validator = new AdminAccessValidator("1");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "any-session-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
-        assertDoesNotThrow(() -> validator.validate(principal));
+        assertTrue(validator.isAdmin(authentication));
     }
 
     @Test
-    @DisplayName("설정되지 않은 userId이면 403으로 차단한다")
-    void rejectNonAdminUserId() {
+    @DisplayName("설정되지 않은 userId이면 false를 반환한다")
+    void isAdminRejectsNonAdminUserId() {
         AdminAccessValidator validator = new AdminAccessValidator("1");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                2L,
-                "normal-user-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(2L, "normal-user-identifier", UserType.REGISTERED)
         );
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> validator.validate(principal)
-        );
-
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertFalse(validator.isAdmin(authentication));
     }
 
     @Test
-    @DisplayName("인증 정보가 없으면 401로 차단한다")
-    void rejectUnauthenticatedPrincipal() {
+    @DisplayName("Authentication이 null이면 false를 반환한다")
+    void isAdminRejectsNullAuthentication() {
         AdminAccessValidator validator = new AdminAccessValidator("1");
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> validator.validate(null)
-        );
-
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertFalse(validator.isAdmin(null));
     }
 
     @Test
-    @DisplayName("principal의 userId가 null이면 401로 차단한다")
-    void rejectPrincipalWithNullUserId() {
+    @DisplayName("인증되지 않은 Authentication이면 false를 반환한다")
+    void isAdminRejectsUnauthenticatedAuthentication() {
         AdminAccessValidator validator = new AdminAccessValidator("1");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                null,
-                "any-session-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
+        );
+        authentication.setAuthenticated(false);
+
+        assertFalse(validator.isAdmin(authentication));
+    }
+
+    @Test
+    @DisplayName("principal이 CustomPrincipal이 아니면 false를 반환한다")
+    void isAdminRejectsUnsupportedPrincipal() {
+        AdminAccessValidator validator = new AdminAccessValidator("1");
+
+        TestingAuthenticationToken authentication = authenticatedToken("anonymousUser");
+
+        assertFalse(validator.isAdmin(authentication));
+    }
+
+    @Test
+    @DisplayName("principal의 userId가 null이면 false를 반환한다")
+    void isAdminRejectsNullUserId() {
+        AdminAccessValidator validator = new AdminAccessValidator("1");
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(null, "any-session-identifier", UserType.REGISTERED)
         );
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> validator.validate(principal)
-        );
-
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertFalse(validator.isAdmin(authentication));
     }
 
     @Test
     @DisplayName("관리자 userId는 콤마 구분 목록으로 여러 개 설정할 수 있다")
-    void validateMultipleAdminUserIds() {
+    void isAdminWithMultipleAdminUserIds() {
         AdminAccessValidator validator = new AdminAccessValidator("1, 2");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                2L,
-                "any-session-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(2L, "any-session-identifier", UserType.REGISTERED)
         );
 
-        assertDoesNotThrow(() -> validator.validate(principal));
+        assertTrue(validator.isAdmin(authentication));
     }
 
     @Test
@@ -97,51 +95,35 @@ class AdminAccessValidatorTest {
     void ignoreInvalidAdminUserIdSetting() {
         AdminAccessValidator validator = new AdminAccessValidator("1, abc, 2");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                2L,
-                "any-session-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(2L, "any-session-identifier", UserType.REGISTERED)
         );
 
-        assertDoesNotThrow(() -> validator.validate(principal));
+        assertTrue(validator.isAdmin(authentication));
     }
 
     @Test
-    @DisplayName("관리자 userId 설정이 모두 잘못된 값이면 allow-list는 비어 있고 접근은 403으로 차단된다")
+    @DisplayName("관리자 userId 설정이 모두 잘못된 값이면 allow-list는 비어 있고 false를 반환한다")
     void rejectWhenAllAdminUserIdSettingsAreInvalid() {
         AdminAccessValidator validator = new AdminAccessValidator("abc, def");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "any-session-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> validator.validate(principal)
-        );
-
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertFalse(validator.isAdmin(authentication));
     }
 
     @Test
-    @DisplayName("관리자 userId 설정이 비어 있으면 모든 사용자의 관리자 API 접근을 403으로 차단한다")
+    @DisplayName("관리자 userId 설정이 비어 있으면 모든 사용자를 false로 판단한다")
     void rejectWhenAdminUserIdSettingIsEmpty() {
         AdminAccessValidator validator = new AdminAccessValidator("");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "any-session-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> validator.validate(principal)
-        );
-
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertFalse(validator.isAdmin(authentication));
     }
 
     @Test
@@ -149,12 +131,19 @@ class AdminAccessValidatorTest {
     void ignoreBlankTokensInAdminUserIdSetting() {
         AdminAccessValidator validator = new AdminAccessValidator("1, , 2,   ");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "any-session-identifier",
-                UserType.REGISTERED
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
-        assertDoesNotThrow(() -> validator.validate(principal));
+        assertTrue(validator.isAdmin(authentication));
+    }
+
+    private TestingAuthenticationToken authenticatedToken(Object principal) {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(
+                principal,
+                null
+        );
+        authentication.setAuthenticated(true);
+        return authentication;
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
@@ -1,0 +1,75 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AdminAccessValidatorTest {
+
+    @Test
+    @DisplayName("설정된 관리자 userIdentifier이면 접근을 허용한다")
+    void validateAdminUserIdentifier() {
+        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "admin-uuid",
+                UserType.REGISTERED
+        );
+
+        assertDoesNotThrow(() -> validator.validate(principal));
+    }
+
+    @Test
+    @DisplayName("설정되지 않은 userIdentifier이면 403으로 차단한다")
+    void rejectNonAdminUserIdentifier() {
+        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "normal-user-uuid",
+                UserType.REGISTERED
+        );
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> validator.validate(principal)
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("인증 정보가 없으면 401로 차단한다")
+    void rejectUnauthenticatedPrincipal() {
+        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid");
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> validator.validate(null)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("관리자 식별자는 콤마 구분 목록으로 여러 개 설정할 수 있다")
+    void validateMultipleAdminUserIdentifiers() {
+        AdminAccessValidator validator = new AdminAccessValidator("admin-uuid-1, admin-uuid-2");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "admin-uuid-2",
+                UserType.REGISTERED
+        );
+
+        assertDoesNotThrow(() -> validator.validate(principal));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
@@ -1,52 +1,124 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.AdminUserRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AdminAccessValidatorTest {
 
+    private AdminUserRepository adminUserRepository;
+
+    @BeforeEach
+    void setUp() {
+        adminUserRepository = mock(AdminUserRepository.class);
+    }
+
     @Test
-    @DisplayName("설정된 관리자 userId이면 true를 반환한다")
-    void isAdminWithAdminUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator("1");
+    @DisplayName("admin_users 테이블에 등록된 REGISTERED userId이면 true를 반환한다")
+    void isAdminWithDatabaseAdminUserId() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenReturn(true);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
         assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
     }
 
     @Test
-    @DisplayName("설정되지 않은 userId이면 false를 반환한다")
+    @DisplayName("DB에 관리자 권한이 없고 fallback에도 없으면 false를 반환한다")
     void isAdminRejectsNonAdminUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator("1");
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(2L, UserType.REGISTERED))
+                .thenReturn(false);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(2L, "normal-user-identifier", UserType.REGISTERED)
         );
 
         assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(2L, UserType.REGISTERED);
     }
 
     @Test
-    @DisplayName("Authentication이 null이면 false를 반환한다")
+    @DisplayName("DB에 관리자 권한이 없지만 fallback allow-list에 있으면 true를 반환한다")
+    void isAdminWithFallbackAdminUserId() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenReturn(false);
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
+        );
+
+        assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+    }
+
+    @Test
+    @DisplayName("DB 조회 실패 시 fallback allow-list에 있으면 true를 반환한다")
+    void isAdminWithFallbackWhenDatabaseFails() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenThrow(new DataAccessResourceFailureException("db down"));
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
+        );
+
+        assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+    }
+
+    @Test
+    @DisplayName("DB 조회 실패 시 fallback allow-list에도 없으면 false를 반환한다")
+    void rejectWhenDatabaseFailsAndFallbackDoesNotContainUserId() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenThrow(new DataAccessResourceFailureException("db down"));
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
+        );
+
+        assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
+    }
+
+    @Test
+    @DisplayName("Authentication이 null이면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsNullAuthentication() {
-        AdminAccessValidator validator = new AdminAccessValidator("1");
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
 
         assertFalse(validator.isAdmin(null));
+        verify(adminUserRepository, never()).existsByUserIdAndUserUserType(any(), any());
     }
 
     @Test
-    @DisplayName("인증되지 않은 Authentication이면 false를 반환한다")
+    @DisplayName("인증되지 않은 Authentication이면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsUnauthenticatedAuthentication() {
-        AdminAccessValidator validator = new AdminAccessValidator("1");
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
@@ -54,96 +126,131 @@ class AdminAccessValidatorTest {
         authentication.setAuthenticated(false);
 
         assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository, never()).existsByUserIdAndUserUserType(any(), any());
     }
 
     @Test
-    @DisplayName("principal이 CustomPrincipal이 아니면 false를 반환한다")
+    @DisplayName("principal이 CustomPrincipal이 아니면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsUnsupportedPrincipal() {
-        AdminAccessValidator validator = new AdminAccessValidator("1");
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
 
         TestingAuthenticationToken authentication = authenticatedToken("anonymousUser");
 
         assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository, never()).existsByUserIdAndUserUserType(any(), any());
     }
 
     @Test
-    @DisplayName("principal의 userId가 null이면 false를 반환한다")
+    @DisplayName("principal의 userId가 null이면 false를 반환하고 DB를 조회하지 않는다")
     void isAdminRejectsNullUserId() {
-        AdminAccessValidator validator = new AdminAccessValidator("1");
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(null, "any-session-identifier", UserType.REGISTERED)
         );
 
         assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository, never()).existsByUserIdAndUserUserType(any(), any());
     }
 
     @Test
-    @DisplayName("관리자 userId는 콤마 구분 목록으로 여러 개 설정할 수 있다")
-    void isAdminWithMultipleAdminUserIds() {
-        AdminAccessValidator validator = new AdminAccessValidator("1, 2");
+    @DisplayName("principal의 userType이 GUEST이면 admin_users 등록 여부를 조회하지 않고 false를 반환한다")
+    void isAdminRejectsGuestUserType() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1");
+
+        TestingAuthenticationToken authentication = authenticatedToken(
+                new CustomPrincipal(1L, "guest-session-identifier", UserType.GUEST)
+        );
+
+        assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository, never()).existsByUserIdAndUserUserType(any(), any());
+    }
+
+    @Test
+    @DisplayName("fallback userId는 콤마 구분 목록으로 여러 개 설정할 수 있다")
+    void isAdminWithMultipleFallbackAdminUserIds() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1, 2");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(2L, UserType.REGISTERED))
+                .thenReturn(false);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(2L, "any-session-identifier", UserType.REGISTERED)
         );
 
         assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(2L, UserType.REGISTERED);
     }
 
     @Test
-    @DisplayName("관리자 userId 설정에 잘못된 값이 있어도 서버 부팅을 막지 않고 정상 값만 반영한다")
-    void ignoreInvalidAdminUserIdSetting() {
-        AdminAccessValidator validator = new AdminAccessValidator("1, abc, 2");
+    @DisplayName("fallback 설정에 잘못된 값이 있어도 서버 부팅을 막지 않고 정상 값만 반영한다")
+    void ignoreInvalidFallbackAdminUserIdSetting() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1, abc, 2");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(2L, UserType.REGISTERED))
+                .thenReturn(false);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(2L, "any-session-identifier", UserType.REGISTERED)
         );
 
         assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(2L, UserType.REGISTERED);
     }
 
     @Test
-    @DisplayName("관리자 userId 설정이 모두 잘못된 값이면 allow-list는 비어 있고 false를 반환한다")
-    void rejectWhenAllAdminUserIdSettingsAreInvalid() {
-        AdminAccessValidator validator = new AdminAccessValidator("abc, def");
+    @DisplayName("fallback 설정이 모두 잘못된 값이고 DB에도 없으면 false를 반환한다")
+    void rejectWhenAllFallbackAdminUserIdSettingsAreInvalid() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "abc, def");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenReturn(false);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
         assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
     }
 
     @Test
-    @DisplayName("관리자 userId 설정이 비어 있으면 모든 사용자를 false로 판단한다")
-    void rejectWhenAdminUserIdSettingIsEmpty() {
-        AdminAccessValidator validator = new AdminAccessValidator("");
+    @DisplayName("fallback 설정이 비어 있고 DB에도 없으면 false를 반환한다")
+    void rejectWhenFallbackAdminUserIdSettingIsEmpty() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenReturn(false);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
         assertFalse(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
     }
 
     @Test
-    @DisplayName("관리자 userId 설정에 빈 토큰이 섞여 있어도 무시하고 정상 값만 반영한다")
-    void ignoreBlankTokensInAdminUserIdSetting() {
-        AdminAccessValidator validator = new AdminAccessValidator("1, , 2,   ");
+    @DisplayName("fallback 설정에 빈 토큰이 섞여 있어도 무시하고 정상 값만 반영한다")
+    void ignoreBlankTokensInFallbackAdminUserIdSetting() {
+        AdminAccessValidator validator = new AdminAccessValidator(adminUserRepository, "1, , 2,   ");
+
+        when(adminUserRepository.existsByUserIdAndUserUserType(1L, UserType.REGISTERED))
+                .thenReturn(false);
 
         TestingAuthenticationToken authentication = authenticatedToken(
                 new CustomPrincipal(1L, "any-session-identifier", UserType.REGISTERED)
         );
 
         assertTrue(validator.isAdmin(authentication));
+        verify(adminUserRepository).existsByUserIdAndUserUserType(1L, UserType.REGISTERED);
     }
 
     private TestingAuthenticationToken authenticatedToken(Object principal) {
-        TestingAuthenticationToken authentication = new TestingAuthenticationToken(
+        return new TestingAuthenticationToken(
                 principal,
-                null
+                null,
+                "ROLE_USER"
         );
-        authentication.setAuthenticated(true);
-        return authentication;
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/AdminAccessValidatorTest.java
@@ -60,12 +60,97 @@ class AdminAccessValidatorTest {
     }
 
     @Test
+    @DisplayName("principal의 userId가 null이면 401로 차단한다")
+    void rejectPrincipalWithNullUserId() {
+        AdminAccessValidator validator = new AdminAccessValidator("1");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                null,
+                "any-session-identifier",
+                UserType.REGISTERED
+        );
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> validator.validate(principal)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
     @DisplayName("관리자 userId는 콤마 구분 목록으로 여러 개 설정할 수 있다")
     void validateMultipleAdminUserIds() {
         AdminAccessValidator validator = new AdminAccessValidator("1, 2");
 
         CustomPrincipal principal = new CustomPrincipal(
                 2L,
+                "any-session-identifier",
+                UserType.REGISTERED
+        );
+
+        assertDoesNotThrow(() -> validator.validate(principal));
+    }
+
+    @Test
+    @DisplayName("관리자 userId 설정에 잘못된 값이 있어도 서버 부팅을 막지 않고 정상 값만 반영한다")
+    void ignoreInvalidAdminUserIdSetting() {
+        AdminAccessValidator validator = new AdminAccessValidator("1, abc, 2");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                2L,
+                "any-session-identifier",
+                UserType.REGISTERED
+        );
+
+        assertDoesNotThrow(() -> validator.validate(principal));
+    }
+
+    @Test
+    @DisplayName("관리자 userId 설정이 모두 잘못된 값이면 allow-list는 비어 있고 접근은 403으로 차단된다")
+    void rejectWhenAllAdminUserIdSettingsAreInvalid() {
+        AdminAccessValidator validator = new AdminAccessValidator("abc, def");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "any-session-identifier",
+                UserType.REGISTERED
+        );
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> validator.validate(principal)
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("관리자 userId 설정이 비어 있으면 모든 사용자의 관리자 API 접근을 403으로 차단한다")
+    void rejectWhenAdminUserIdSettingIsEmpty() {
+        AdminAccessValidator validator = new AdminAccessValidator("");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "any-session-identifier",
+                UserType.REGISTERED
+        );
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> validator.validate(principal)
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("관리자 userId 설정에 빈 토큰이 섞여 있어도 무시하고 정상 값만 반영한다")
+    void ignoreBlankTokensInAdminUserIdSetting() {
+        AdminAccessValidator validator = new AdminAccessValidator("1, , 2,   ");
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
                 "any-session-identifier",
                 UserType.REGISTERED
         );

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
@@ -1,6 +1,8 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.ForbiddenNicknameWordRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,11 +13,10 @@ import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -102,24 +103,24 @@ class ForbiddenNicknameServiceTest {
     @Test
     @DisplayName("공백 금칙어는 등록할 수 없다")
     void addBlankForbiddenWord() {
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> forbiddenNicknameService.addForbiddenWord("   ")
         );
 
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
     }
 
     @Test
     @DisplayName("정규화 결과가 공백이면 금칙어로 등록할 수 없다")
     void addForbiddenWordWithOnlyWhitespaceAfterNormalization() {
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> forbiddenNicknameService.addForbiddenWord("\t\n ")
         );
 
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
     }
 
@@ -128,28 +129,28 @@ class ForbiddenNicknameServiceTest {
     void addDuplicatedForbiddenWord() {
         when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(true);
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> forbiddenNicknameService.addForbiddenWord("a d m i n")
         );
 
-        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_DUPLICATED, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
     }
 
     @Test
-    @DisplayName("동시 등록 경쟁으로 DB unique 제약이 발생하면 409로 변환한다")
+    @DisplayName("동시 등록 경쟁으로 DB unique 제약이 발생하면 중복 에러로 변환한다")
     void addForbiddenWordWithDataIntegrityViolation() {
         when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(false);
         when(forbiddenNicknameWordRepository.saveAndFlush(any()))
                 .thenThrow(new DataIntegrityViolationException("duplicated normalized word"));
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> forbiddenNicknameService.addForbiddenWord("admin")
         );
 
-        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_DUPLICATED, exception.getErrorCode());
     }
 
     @Test
@@ -158,7 +159,7 @@ class ForbiddenNicknameServiceTest {
         ForbiddenNicknameWord forbiddenWord = ForbiddenNicknameWord.create("관리자", "관리자");
 
         when(forbiddenNicknameWordRepository.findById(1L))
-                .thenReturn(java.util.Optional.of(forbiddenWord));
+                .thenReturn(Optional.of(forbiddenWord));
 
         forbiddenNicknameService.deleteForbiddenWord(1L);
 
@@ -169,31 +170,31 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 금칙어 삭제 요청은 404를 반환한다")
+    @DisplayName("존재하지 않는 금칙어 삭제 요청은 미존재 에러를 반환한다")
     void deleteNotFoundForbiddenWord() {
         when(forbiddenNicknameWordRepository.findById(1L))
-                .thenReturn(java.util.Optional.empty());
+                .thenReturn(Optional.empty());
 
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> forbiddenNicknameService.deleteForbiddenWord(1L)
         );
 
-        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_NOT_FOUND, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository).findById(1L);
         verify(forbiddenNicknameWordRepository, never()).delete(any());
         verify(stringRedisTemplate, never()).delete(anyCollection());
     }
 
     @Test
-    @DisplayName("null ID로 금칙어 삭제 요청 시 400을 반환한다")
+    @DisplayName("null ID로 금칙어 삭제 요청 시 미존재 에러를 반환한다")
     void deleteForbiddenWordWithNullId() {
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
+        AuthException exception = assertThrows(
+                AuthException.class,
                 () -> forbiddenNicknameService.deleteForbiddenWord(null)
         );
 
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_NOT_FOUND, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).findById(any());
         verify(forbiddenNicknameWordRepository, never()).delete(any());
         verify(stringRedisTemplate, never()).delete(anyCollection());
@@ -242,7 +243,7 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("DB 금칙어 목록이 비어 있어도 loaded marker를 캐싱하여 반복 DB 조회를 줄인다")
+    @DisplayName("DB 금칙어 목록이 비어 있어도 loaded marker를 저장한다")
     void cacheEmptyForbiddenWordsWithLoadedMarker() {
         when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
@@ -317,6 +318,7 @@ class ForbiddenNicknameServiceTest {
         boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
 
         assertFalse(result);
+        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
     }
 
     @Test
@@ -363,7 +365,7 @@ class ForbiddenNicknameServiceTest {
         ForbiddenNicknameWord forbiddenWord = ForbiddenNicknameWord.create("관리자", "관리자");
 
         when(forbiddenNicknameWordRepository.findById(1L))
-                .thenReturn(java.util.Optional.of(forbiddenWord));
+                .thenReturn(Optional.of(forbiddenWord));
         when(stringRedisTemplate.delete(anyCollection()))
                 .thenThrow(new RedisConnectionFailureException("redis evict down"));
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
@@ -6,40 +6,82 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ForbiddenNicknameServiceTest {
 
+    private static final String CACHE_KEY = "auth:forbidden_nickname_words:normalized";
+    private static final String CACHE_LOADED_KEY = "auth:forbidden_nickname_words:loaded";
+
     private ForbiddenNicknameWordRepository forbiddenNicknameWordRepository;
+    private StringRedisTemplate stringRedisTemplate;
+    private SetOperations<String, String> setOperations;
+    private ValueOperations<String, String> valueOperations;
     private ForbiddenNicknameService forbiddenNicknameService;
 
     @BeforeEach
     void setUp() {
         forbiddenNicknameWordRepository = mock(ForbiddenNicknameWordRepository.class);
+        stringRedisTemplate = mock(StringRedisTemplate.class);
+        setOperations = mock(SetOperations.class);
+        valueOperations = mock(ValueOperations.class);
+
+        when(stringRedisTemplate.opsForSet()).thenReturn(setOperations);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+
         forbiddenNicknameService = new ForbiddenNicknameService(
                 forbiddenNicknameWordRepository,
-                new NicknameNormalizer()
+                new NicknameNormalizer(),
+                stringRedisTemplate
         );
     }
 
     @Test
-    @DisplayName("금칙어 추가 시 원본과 정규화 값을 저장한다")
+    @DisplayName("금칙어 목록을 최신 등록순으로 조회한다")
+    void getForbiddenWords() {
+        ForbiddenNicknameWord word = ForbiddenNicknameWord.create("관리자", "관리자");
+        when(forbiddenNicknameWordRepository.findAllByOrderByCreatedAtDesc())
+                .thenReturn(List.of(word));
+
+        List<ForbiddenNicknameWord> result = forbiddenNicknameService.getForbiddenWords();
+
+        assertEquals(1, result.size());
+        assertEquals("관리자", result.get(0).getWord());
+        assertEquals("관리자", result.get(0).getNormalizedWord());
+
+        verify(forbiddenNicknameWordRepository).findAllByOrderByCreatedAtDesc();
+    }
+
+    @Test
+    @DisplayName("금칙어 추가 시 원본과 정규화 값을 저장하고 캐시를 무효화한다")
     void addForbiddenWord() {
         when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(false);
 
         ForbiddenNicknameWord saved = ForbiddenNicknameWord.create("A d m i n", "admin");
-        when(forbiddenNicknameWordRepository.saveAndFlush(org.mockito.ArgumentMatchers.any()))
+        when(forbiddenNicknameWordRepository.saveAndFlush(any()))
                 .thenReturn(saved);
 
         ForbiddenNicknameWord result = forbiddenNicknameService.addForbiddenWord(" A d m i n ");
@@ -53,6 +95,8 @@ class ForbiddenNicknameServiceTest {
 
         assertEquals("A d m i n", captor.getValue().getWord());
         assertEquals("admin", captor.getValue().getNormalizedWord());
+
+        verify(stringRedisTemplate).delete(List.of(CACHE_KEY, CACHE_LOADED_KEY));
     }
 
     @Test
@@ -64,6 +108,19 @@ class ForbiddenNicknameServiceTest {
         );
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("정규화 결과가 공백이면 금칙어로 등록할 수 없다")
+    void addForbiddenWordWithOnlyWhitespaceAfterNormalization() {
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> forbiddenNicknameService.addForbiddenWord("\t\n ")
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -77,28 +134,34 @@ class ForbiddenNicknameServiceTest {
         );
 
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
     }
 
     @Test
-    @DisplayName("닉네임에 등록된 금칙어가 포함되어 있으면 true를 반환한다")
-    void containsForbiddenWord() {
-        when(forbiddenNicknameWordRepository.findAll())
-                .thenReturn(List.of(ForbiddenNicknameWord.create("관리자", "관리자")));
+    @DisplayName("동시 등록 경쟁으로 DB unique 제약이 발생하면 409로 변환한다")
+    void addForbiddenWordWithDataIntegrityViolation() {
+        when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(false);
+        when(forbiddenNicknameWordRepository.saveAndFlush(any()))
+                .thenThrow(new DataIntegrityViolationException("duplicated normalized word"));
 
-        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관 리 자");
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> forbiddenNicknameService.addForbiddenWord("admin")
+        );
 
-        assertTrue(result);
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
     }
 
     @Test
-    @DisplayName("닉네임에 등록된 금칙어가 포함되어 있지 않으면 false를 반환한다")
-    void doesNotContainForbiddenWord() {
-        when(forbiddenNicknameWordRepository.findAll())
-                .thenReturn(List.of(ForbiddenNicknameWord.create("관리자", "관리자")));
+    @DisplayName("금칙어 삭제 시 DB에서 삭제하고 캐시를 무효화한다")
+    void deleteForbiddenWord() {
+        when(forbiddenNicknameWordRepository.existsById(1L)).thenReturn(true);
 
-        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
+        forbiddenNicknameService.deleteForbiddenWord(1L);
 
-        assertFalse(result);
+        verify(forbiddenNicknameWordRepository).deleteById(1L);
+        verify(forbiddenNicknameWordRepository).flush();
+        verify(stringRedisTemplate).delete(List.of(CACHE_KEY, CACHE_LOADED_KEY));
     }
 
     @Test
@@ -112,5 +175,192 @@ class ForbiddenNicknameServiceTest {
         );
 
         assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        verify(forbiddenNicknameWordRepository, never()).deleteById(any());
+        verify(stringRedisTemplate, never()).delete(anyCollection());
+    }
+
+    @Test
+    @DisplayName("null ID로 금칙어 삭제 요청 시 400을 반환한다")
+    void deleteForbiddenWordWithNullId() {
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> forbiddenNicknameService.deleteForbiddenWord(null)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(forbiddenNicknameWordRepository, never()).deleteById(any());
+        verify(stringRedisTemplate, never()).delete(anyCollection());
+    }
+
+    @Test
+    @DisplayName("Redis 캐시 hit 시 DB를 조회하지 않고 캐시 데이터로 금칙어 포함 여부를 판단한다")
+    void containsForbiddenWordWithCacheHit() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(true);
+        when(setOperations.members(CACHE_KEY)).thenReturn(Set.of("관리자", "admin"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관 리 자");
+
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("Redis 캐시 hit 시 금칙어가 포함되어 있지 않으면 false를 반환한다")
+    void doesNotContainForbiddenWordWithCacheHit() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(true);
+        when(setOperations.members(CACHE_KEY)).thenReturn(Set.of("관리자", "admin"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
+
+        assertFalse(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("Redis loaded marker가 없으면 DB에서 normalizedWord만 조회하고 Redis에 캐싱한다")
+    void containsForbiddenWordWithCacheMiss() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of("관리자", "admin"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("superAdmin");
+
+        assertTrue(result);
+
+        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
+        verify(stringRedisTemplate).delete(CACHE_KEY);
+        verify(setOperations).add(eq(CACHE_KEY), eq("관리자"), eq("admin"));
+        verify(stringRedisTemplate).expire(eq(CACHE_KEY), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_LOADED_KEY), eq("1"), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("DB 금칙어 목록이 비어 있어도 loaded marker를 캐싱하여 반복 DB 조회를 줄인다")
+    void cacheEmptyForbiddenWordsWithLoadedMarker() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of());
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
+
+        assertFalse(result);
+
+        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
+        verify(stringRedisTemplate).delete(CACHE_KEY);
+        verify(setOperations, never()).add(anyString(), any(String[].class));
+        verify(stringRedisTemplate, never()).expire(eq(CACHE_KEY), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_LOADED_KEY), eq("1"), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("Redis 캐시에 loaded marker는 있지만 Set이 비어 있으면 DB를 조회하지 않고 false를 반환한다")
+    void loadedMarkerExistsButSetIsEmpty() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(true);
+        when(setOperations.members(CACHE_KEY)).thenReturn(Set.of());
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
+
+        assertFalse(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("Redis 캐시 조회 실패 시 DB 직접 조회로 fallback하여 금칙어 포함 여부를 판단한다")
+    void containsForbiddenWordFallbackToDatabaseWhenRedisReadFails() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY))
+                .thenThrow(new RedisConnectionFailureException("redis down"));
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of("관리자"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관 리 자");
+
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("Redis 캐시 저장 실패 시 DB 조회 결과로 금칙어 포함 여부를 판단한다")
+    void containsForbiddenWordFallbackToDatabaseWhenRedisWriteFails() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of("관리자"));
+        when(stringRedisTemplate.delete(CACHE_KEY))
+                .thenThrow(new RedisConnectionFailureException("redis write down"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관리자");
+
+        assertTrue(result);
+
+        /*
+         * 현재 ForbiddenNicknameService는 Redis read/write 전체를 try-catch로 감싸고,
+         * 예외 발생 시 DB 직접 조회를 한 번 더 수행한다.
+         * 따라서 findAllNormalizedWords()는 캐시 적재 시도 1회 + fallback 1회로 총 2회 호출된다.
+         */
+        verify(forbiddenNicknameWordRepository, org.mockito.Mockito.times(2))
+                .findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("Redis 장애 fallback 후 DB 조회 결과에도 금칙어가 없으면 false를 반환한다")
+    void doesNotContainForbiddenWordFallbackToDatabaseWhenRedisFails() {
+        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY))
+                .thenThrow(new RedisConnectionFailureException("redis down"));
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of("관리자"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
+
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("닉네임이 null이면 Redis와 DB를 조회하지 않고 false를 반환한다")
+    void containsForbiddenWordWithNullNickname() {
+        boolean result = forbiddenNicknameService.containsForbiddenWord(null);
+
+        assertFalse(result);
+        verify(stringRedisTemplate, never()).hasKey(anyString());
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("닉네임이 공백이면 Redis와 DB를 조회하지 않고 false를 반환한다")
+    void containsForbiddenWordWithBlankNickname() {
+        boolean result = forbiddenNicknameService.containsForbiddenWord("   ");
+
+        assertFalse(result);
+        verify(stringRedisTemplate, never()).hasKey(anyString());
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("금칙어 추가 후 캐시 무효화 실패가 발생해도 DB 저장 결과는 반환한다")
+    void addForbiddenWordEvenIfCacheEvictFails() {
+        when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(false);
+
+        ForbiddenNicknameWord saved = ForbiddenNicknameWord.create("admin", "admin");
+        when(forbiddenNicknameWordRepository.saveAndFlush(any()))
+                .thenReturn(saved);
+
+        when(stringRedisTemplate.delete(anyCollection()))
+                .thenThrow(new RedisConnectionFailureException("redis evict down"));
+
+        ForbiddenNicknameWord result = forbiddenNicknameService.addForbiddenWord("admin");
+
+        assertEquals("admin", result.getWord());
+        assertEquals("admin", result.getNormalizedWord());
+    }
+
+    @Test
+    @DisplayName("금칙어 삭제 후 캐시 무효화 실패가 발생해도 삭제 요청은 실패하지 않는다")
+    void deleteForbiddenWordEvenIfCacheEvictFails() {
+        when(forbiddenNicknameWordRepository.existsById(1L)).thenReturn(true);
+        when(stringRedisTemplate.delete(anyCollection()))
+                .thenThrow(new RedisConnectionFailureException("redis evict down"));
+
+        forbiddenNicknameService.deleteForbiddenWord(1L);
+
+        verify(forbiddenNicknameWordRepository).deleteById(1L);
+        verify(forbiddenNicknameWordRepository).flush();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
@@ -153,13 +153,17 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("금칙어 삭제 시 DB에서 삭제하고 캐시를 무효화한다")
+    @DisplayName("금칙어 삭제 시 엔티티를 조회한 뒤 삭제하고 캐시를 무효화한다")
     void deleteForbiddenWord() {
-        when(forbiddenNicknameWordRepository.existsById(1L)).thenReturn(true);
+        ForbiddenNicknameWord forbiddenWord = ForbiddenNicknameWord.create("관리자", "관리자");
+
+        when(forbiddenNicknameWordRepository.findById(1L))
+                .thenReturn(java.util.Optional.of(forbiddenWord));
 
         forbiddenNicknameService.deleteForbiddenWord(1L);
 
-        verify(forbiddenNicknameWordRepository).deleteById(1L);
+        verify(forbiddenNicknameWordRepository).findById(1L);
+        verify(forbiddenNicknameWordRepository).delete(forbiddenWord);
         verify(forbiddenNicknameWordRepository).flush();
         verify(stringRedisTemplate).delete(List.of(CACHE_KEY, CACHE_LOADED_KEY));
     }
@@ -167,7 +171,8 @@ class ForbiddenNicknameServiceTest {
     @Test
     @DisplayName("존재하지 않는 금칙어 삭제 요청은 404를 반환한다")
     void deleteNotFoundForbiddenWord() {
-        when(forbiddenNicknameWordRepository.existsById(1L)).thenReturn(false);
+        when(forbiddenNicknameWordRepository.findById(1L))
+                .thenReturn(java.util.Optional.empty());
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
@@ -175,7 +180,8 @@ class ForbiddenNicknameServiceTest {
         );
 
         assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
-        verify(forbiddenNicknameWordRepository, never()).deleteById(any());
+        verify(forbiddenNicknameWordRepository).findById(1L);
+        verify(forbiddenNicknameWordRepository, never()).delete(any());
         verify(stringRedisTemplate, never()).delete(anyCollection());
     }
 
@@ -188,7 +194,8 @@ class ForbiddenNicknameServiceTest {
         );
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        verify(forbiddenNicknameWordRepository, never()).deleteById(any());
+        verify(forbiddenNicknameWordRepository, never()).findById(any());
+        verify(forbiddenNicknameWordRepository, never()).delete(any());
         verify(stringRedisTemplate, never()).delete(anyCollection());
     }
 
@@ -354,13 +361,17 @@ class ForbiddenNicknameServiceTest {
     @Test
     @DisplayName("금칙어 삭제 후 캐시 무효화 실패가 발생해도 삭제 요청은 실패하지 않는다")
     void deleteForbiddenWordEvenIfCacheEvictFails() {
-        when(forbiddenNicknameWordRepository.existsById(1L)).thenReturn(true);
+        ForbiddenNicknameWord forbiddenWord = ForbiddenNicknameWord.create("관리자", "관리자");
+
+        when(forbiddenNicknameWordRepository.findById(1L))
+                .thenReturn(java.util.Optional.of(forbiddenWord));
         when(stringRedisTemplate.delete(anyCollection()))
                 .thenThrow(new RedisConnectionFailureException("redis evict down"));
 
         forbiddenNicknameService.deleteForbiddenWord(1L);
 
-        verify(forbiddenNicknameWordRepository).deleteById(1L);
+        verify(forbiddenNicknameWordRepository).findById(1L);
+        verify(forbiddenNicknameWordRepository).delete(forbiddenWord);
         verify(forbiddenNicknameWordRepository).flush();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -183,7 +182,6 @@ class ForbiddenNicknameServiceTest {
         verify(forbiddenNicknameWordRepository).findById(1L);
         verify(forbiddenNicknameWordRepository, never()).delete(any());
         verify(stringRedisTemplate, never()).delete(anyString());
-        verify(stringRedisTemplate, never()).delete(anyCollection());
     }
 
     @Test
@@ -198,13 +196,12 @@ class ForbiddenNicknameServiceTest {
         verify(forbiddenNicknameWordRepository, never()).findById(any());
         verify(forbiddenNicknameWordRepository, never()).delete(any());
         verify(stringRedisTemplate, never()).delete(anyString());
-        verify(stringRedisTemplate, never()).delete(anyCollection());
     }
 
     @Test
-    @DisplayName("Redis 캐시 hit 시 DB를 조회하지 않고 캐시 데이터로 금칙어 포함 여부를 판단한다")
+    @DisplayName("Redis 캐시 hit 시 DB를 조회하지 않고 JSON 캐시 데이터로 금칙어 포함 여부를 판단한다")
     void containsForbiddenWordWithCacheHit() {
-        when(valueOperations.get(CACHE_KEY)).thenReturn("관리자\nadmin");
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[\"관리자\",\"admin\"]");
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("최고관 리 자");
 
@@ -215,7 +212,7 @@ class ForbiddenNicknameServiceTest {
     @Test
     @DisplayName("Redis 캐시 hit 시 금칙어가 포함되어 있지 않으면 false를 반환한다")
     void doesNotContainForbiddenWordWithCacheHit() {
-        when(valueOperations.get(CACHE_KEY)).thenReturn("관리자\nadmin");
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[\"관리자\",\"admin\"]");
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
 
@@ -224,7 +221,7 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("Redis 캐시 miss 시 DB에서 normalizedWord만 조회하고 Redis String으로 캐싱한다")
+    @DisplayName("Redis 캐시 miss 시 DB에서 normalizedWord만 조회하고 JSON 배열 문자열로 캐싱한다")
     void containsForbiddenWordWithCacheMiss() {
         when(valueOperations.get(CACHE_KEY)).thenReturn(null);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
@@ -235,11 +232,11 @@ class ForbiddenNicknameServiceTest {
         assertTrue(result);
 
         verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
-        verify(valueOperations).set(eq(CACHE_KEY), eq("관리자\nadmin"), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_KEY), eq("[\"관리자\",\"admin\"]"), any(Duration.class));
     }
 
     @Test
-    @DisplayName("DB 금칙어 목록이 비어 있어도 빈 문자열로 캐싱한다")
+    @DisplayName("DB 금칙어 목록이 비어 있어도 JSON 빈 배열로 캐싱한다")
     void cacheEmptyForbiddenWords() {
         when(valueOperations.get(CACHE_KEY)).thenReturn(null);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
@@ -250,13 +247,13 @@ class ForbiddenNicknameServiceTest {
         assertFalse(result);
 
         verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
-        verify(valueOperations).set(eq(CACHE_KEY), eq(""), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_KEY), eq("[]"), any(Duration.class));
     }
 
     @Test
-    @DisplayName("Redis 캐시에 빈 문자열이 있으면 금칙어 0개 상태로 보고 DB를 조회하지 않는다")
-    void emptyStringCacheHitMeansNoForbiddenWords() {
-        when(valueOperations.get(CACHE_KEY)).thenReturn("");
+    @DisplayName("Redis 캐시에 JSON 빈 배열이 있으면 금칙어 0개 상태로 보고 DB를 조회하지 않는다")
+    void emptyJsonArrayCacheHitMeansNoForbiddenWords() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[]");
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
 
@@ -279,6 +276,19 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
+    @DisplayName("Redis 캐시 값이 잘못된 JSON이면 DB 직접 조회로 fallback한다")
+    void containsForbiddenWordFallbackToDatabaseWhenCachedJsonIsInvalid() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("invalid-json");
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of("관리자"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관리자");
+
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
+    }
+
+    @Test
     @DisplayName("Redis 캐시 저장 실패 시 DB 조회 결과를 재사용하고 DB를 중복 조회하지 않는다")
     void containsForbiddenWordUsesDbResultWhenRedisWriteFails() {
         when(valueOperations.get(CACHE_KEY)).thenReturn(null);
@@ -286,7 +296,7 @@ class ForbiddenNicknameServiceTest {
                 .thenReturn(List.of("관리자"));
         doThrow(new RedisConnectionFailureException("redis write down"))
                 .when(valueOperations)
-                .set(eq(CACHE_KEY), eq("관리자"), any(Duration.class));
+                .set(eq(CACHE_KEY), eq("[\"관리자\"]"), any(Duration.class));
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("최고관리자");
 
@@ -329,8 +339,8 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("금칙어 추가 후 캐시 무효화 실패가 발생해도 DB 저장 결과는 반환한다")
-    void addForbiddenWordEvenIfCacheEvictFails() {
+    @DisplayName("금칙어 추가 후 캐시 무효화 실패가 발생하면 관리자 API 성공으로 처리하지 않는다")
+    void addForbiddenWordFailsWhenCacheEvictFails() {
         when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(false);
 
         ForbiddenNicknameWord saved = ForbiddenNicknameWord.create("admin", "admin");
@@ -340,16 +350,18 @@ class ForbiddenNicknameServiceTest {
         when(stringRedisTemplate.delete(CACHE_KEY))
                 .thenThrow(new RedisConnectionFailureException("redis evict down"));
 
-        ForbiddenNicknameWord result = forbiddenNicknameService.addForbiddenWord("admin");
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> forbiddenNicknameService.addForbiddenWord("admin")
+        );
 
-        assertEquals("admin", result.getWord());
-        assertEquals("admin", result.getNormalizedWord());
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_CACHE_EVICT_FAILED, exception.getErrorCode());
         verify(stringRedisTemplate).delete(CACHE_KEY);
     }
 
     @Test
-    @DisplayName("금칙어 삭제 후 캐시 무효화 실패가 발생해도 삭제 요청은 실패하지 않는다")
-    void deleteForbiddenWordEvenIfCacheEvictFails() {
+    @DisplayName("금칙어 삭제 후 캐시 무효화 실패가 발생하면 관리자 API 성공으로 처리하지 않는다")
+    void deleteForbiddenWordFailsWhenCacheEvictFails() {
         ForbiddenNicknameWord forbiddenWord = ForbiddenNicknameWord.create("관리자", "관리자");
 
         when(forbiddenNicknameWordRepository.findById(1L))
@@ -357,8 +369,12 @@ class ForbiddenNicknameServiceTest {
         when(stringRedisTemplate.delete(CACHE_KEY))
                 .thenThrow(new RedisConnectionFailureException("redis evict down"));
 
-        forbiddenNicknameService.deleteForbiddenWord(1L);
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> forbiddenNicknameService.deleteForbiddenWord(1L)
+        );
 
+        assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_CACHE_EVICT_FAILED, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository).findById(1L);
         verify(forbiddenNicknameWordRepository).delete(forbiddenWord);
         verify(forbiddenNicknameWordRepository).flush();
@@ -366,9 +382,20 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("중복되거나 공백인 캐시 값은 검증 시 무시한다")
+    @DisplayName("JSON 배열 캐시는 금칙어 값에 개행 문자가 포함되어도 별도 금칙어로 분리하지 않는다")
+    void jsonCacheDoesNotSplitWordContainingNewline() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[\"a\\nadmin\"]");
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("admin");
+
+        assertFalse(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("중복되거나 공백인 JSON 캐시 값은 검증 시 무시한다")
     void cachedWordsIgnoreBlankValues() {
-        when(valueOperations.get(CACHE_KEY)).thenReturn("관리자\n\nadmin\n관리자");
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[\"관리자\",\"\",\"admin\",\"관리자\"]");
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("normal-admin-user");
 
@@ -377,7 +404,7 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("DB 조회 결과의 null, 공백, 중복 값은 캐싱 시 제거한다")
+    @DisplayName("DB 조회 결과의 null, 공백, 중복 값은 JSON 캐싱 시 제거한다")
     void cacheNormalizedWordsFiltersInvalidValues() {
         when(valueOperations.get(CACHE_KEY)).thenReturn(null);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
@@ -386,6 +413,39 @@ class ForbiddenNicknameServiceTest {
         boolean result = forbiddenNicknameService.containsForbiddenWord("superAdmin");
 
         assertTrue(result);
-        verify(valueOperations).set(eq(CACHE_KEY), eq("관리자\nadmin"), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_KEY), eq("[\"관리자\",\"admin\"]"), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("닉네임에 금칙어가 부분 포함되면 차단한다")
+    void containsForbiddenWordBlocksPartialMatch() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[\"admin\"]");
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("superadminuser");
+
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("공백을 섞어 금칙어를 우회해도 정규화 후 부분 포함되면 차단한다")
+    void containsForbiddenWordBlocksWhitespaceBypass() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[\"admin\"]");
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("a d m i n");
+
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("부분 포함 정책상 금칙어가 단어 내부에 포함되어도 차단한다")
+    void containsForbiddenWordBlocksEmbeddedMatchByPolicy() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("[\"admin\"]");
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("madministrator");
+
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
@@ -260,15 +260,21 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("Redis 캐시에 loaded marker는 있지만 Set이 비어 있으면 DB를 조회하지 않고 false를 반환한다")
-    void loadedMarkerExistsButSetIsEmpty() {
+    @DisplayName("Redis loaded marker는 있지만 Set이 비어 있으면 cache miss로 보고 DB를 재조회한다")
+    void loadedMarkerExistsButSetIsEmptyReloadsFromDatabase() {
         when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(true);
         when(setOperations.members(CACHE_KEY)).thenReturn(Set.of());
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of("관리자"));
 
-        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
+        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관리자");
 
-        assertFalse(result);
-        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
+        verify(stringRedisTemplate).delete(CACHE_KEY);
+        verify(setOperations).add(eq(CACHE_KEY), eq("관리자"));
+        verify(stringRedisTemplate).expire(eq(CACHE_KEY), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_LOADED_KEY), eq("1"), any(Duration.class));
     }
 
     @Test
@@ -286,8 +292,8 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("Redis 캐시 저장 실패 시 DB 조회 결과로 금칙어 포함 여부를 판단한다")
-    void containsForbiddenWordFallbackToDatabaseWhenRedisWriteFails() {
+    @DisplayName("Redis 캐시 저장 실패 시 DB 조회 결과를 재사용하고 DB를 중복 조회하지 않는다")
+    void containsForbiddenWordUsesDbResultWhenRedisWriteFails() {
         when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
                 .thenReturn(List.of("관리자"));
@@ -297,14 +303,7 @@ class ForbiddenNicknameServiceTest {
         boolean result = forbiddenNicknameService.containsForbiddenWord("최고관리자");
 
         assertTrue(result);
-
-        /*
-         * 현재 ForbiddenNicknameService는 Redis read/write 전체를 try-catch로 감싸고,
-         * 예외 발생 시 DB 직접 조회를 한 번 더 수행한다.
-         * 따라서 findAllNormalizedWords()는 캐시 적재 시도 1회 + fallback 1회로 총 2회 호출된다.
-         */
-        verify(forbiddenNicknameWordRepository, org.mockito.Mockito.times(2))
-                .findAllNormalizedWords();
+        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
@@ -1,0 +1,116 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.ForbiddenNicknameWord;
+import io.github.ascrew.monomatbe.domain.auth.repository.ForbiddenNicknameWordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ForbiddenNicknameServiceTest {
+
+    private ForbiddenNicknameWordRepository forbiddenNicknameWordRepository;
+    private ForbiddenNicknameService forbiddenNicknameService;
+
+    @BeforeEach
+    void setUp() {
+        forbiddenNicknameWordRepository = mock(ForbiddenNicknameWordRepository.class);
+        forbiddenNicknameService = new ForbiddenNicknameService(
+                forbiddenNicknameWordRepository,
+                new NicknameNormalizer()
+        );
+    }
+
+    @Test
+    @DisplayName("금칙어 추가 시 원본과 정규화 값을 저장한다")
+    void addForbiddenWord() {
+        when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(false);
+
+        ForbiddenNicknameWord saved = ForbiddenNicknameWord.create("A d m i n", "admin");
+        when(forbiddenNicknameWordRepository.saveAndFlush(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(saved);
+
+        ForbiddenNicknameWord result = forbiddenNicknameService.addForbiddenWord(" A d m i n ");
+
+        assertEquals("A d m i n", result.getWord());
+        assertEquals("admin", result.getNormalizedWord());
+
+        ArgumentCaptor<ForbiddenNicknameWord> captor =
+                ArgumentCaptor.forClass(ForbiddenNicknameWord.class);
+        verify(forbiddenNicknameWordRepository).saveAndFlush(captor.capture());
+
+        assertEquals("A d m i n", captor.getValue().getWord());
+        assertEquals("admin", captor.getValue().getNormalizedWord());
+    }
+
+    @Test
+    @DisplayName("공백 금칙어는 등록할 수 없다")
+    void addBlankForbiddenWord() {
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> forbiddenNicknameService.addForbiddenWord("   ")
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("정규화 기준으로 중복 금칙어는 등록할 수 없다")
+    void addDuplicatedForbiddenWord() {
+        when(forbiddenNicknameWordRepository.existsByNormalizedWord("admin")).thenReturn(true);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> forbiddenNicknameService.addForbiddenWord("a d m i n")
+        );
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("닉네임에 등록된 금칙어가 포함되어 있으면 true를 반환한다")
+    void containsForbiddenWord() {
+        when(forbiddenNicknameWordRepository.findAll())
+                .thenReturn(List.of(ForbiddenNicknameWord.create("관리자", "관리자")));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관 리 자");
+
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("닉네임에 등록된 금칙어가 포함되어 있지 않으면 false를 반환한다")
+    void doesNotContainForbiddenWord() {
+        when(forbiddenNicknameWordRepository.findAll())
+                .thenReturn(List.of(ForbiddenNicknameWord.create("관리자", "관리자")));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
+
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 금칙어 삭제 요청은 404를 반환한다")
+    void deleteNotFoundForbiddenWord() {
+        when(forbiddenNicknameWordRepository.existsById(1L)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> forbiddenNicknameService.deleteForbiddenWord(1L)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/ForbiddenNicknameServiceTest.java
@@ -10,14 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.RedisConnectionFailureException;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -35,11 +34,9 @@ import static org.mockito.Mockito.when;
 class ForbiddenNicknameServiceTest {
 
     private static final String CACHE_KEY = "auth:forbidden_nickname_words:normalized";
-    private static final String CACHE_LOADED_KEY = "auth:forbidden_nickname_words:loaded";
 
     private ForbiddenNicknameWordRepository forbiddenNicknameWordRepository;
     private StringRedisTemplate stringRedisTemplate;
-    private SetOperations<String, String> setOperations;
     private ValueOperations<String, String> valueOperations;
     private ForbiddenNicknameService forbiddenNicknameService;
 
@@ -47,10 +44,8 @@ class ForbiddenNicknameServiceTest {
     void setUp() {
         forbiddenNicknameWordRepository = mock(ForbiddenNicknameWordRepository.class);
         stringRedisTemplate = mock(StringRedisTemplate.class);
-        setOperations = mock(SetOperations.class);
         valueOperations = mock(ValueOperations.class);
 
-        when(stringRedisTemplate.opsForSet()).thenReturn(setOperations);
         when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
 
         forbiddenNicknameService = new ForbiddenNicknameService(
@@ -97,7 +92,7 @@ class ForbiddenNicknameServiceTest {
         assertEquals("A d m i n", captor.getValue().getWord());
         assertEquals("admin", captor.getValue().getNormalizedWord());
 
-        verify(stringRedisTemplate).delete(List.of(CACHE_KEY, CACHE_LOADED_KEY));
+        verify(stringRedisTemplate).delete(CACHE_KEY);
     }
 
     @Test
@@ -110,6 +105,7 @@ class ForbiddenNicknameServiceTest {
 
         assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
+        verify(stringRedisTemplate, never()).delete(anyString());
     }
 
     @Test
@@ -122,6 +118,7 @@ class ForbiddenNicknameServiceTest {
 
         assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_REQUIRED, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
+        verify(stringRedisTemplate, never()).delete(anyString());
     }
 
     @Test
@@ -136,6 +133,7 @@ class ForbiddenNicknameServiceTest {
 
         assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_DUPLICATED, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).saveAndFlush(any());
+        verify(stringRedisTemplate, never()).delete(anyString());
     }
 
     @Test
@@ -151,6 +149,7 @@ class ForbiddenNicknameServiceTest {
         );
 
         assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_DUPLICATED, exception.getErrorCode());
+        verify(stringRedisTemplate, never()).delete(anyString());
     }
 
     @Test
@@ -166,7 +165,7 @@ class ForbiddenNicknameServiceTest {
         verify(forbiddenNicknameWordRepository).findById(1L);
         verify(forbiddenNicknameWordRepository).delete(forbiddenWord);
         verify(forbiddenNicknameWordRepository).flush();
-        verify(stringRedisTemplate).delete(List.of(CACHE_KEY, CACHE_LOADED_KEY));
+        verify(stringRedisTemplate).delete(CACHE_KEY);
     }
 
     @Test
@@ -183,6 +182,7 @@ class ForbiddenNicknameServiceTest {
         assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_NOT_FOUND, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository).findById(1L);
         verify(forbiddenNicknameWordRepository, never()).delete(any());
+        verify(stringRedisTemplate, never()).delete(anyString());
         verify(stringRedisTemplate, never()).delete(anyCollection());
     }
 
@@ -197,14 +197,14 @@ class ForbiddenNicknameServiceTest {
         assertEquals(AuthErrorCode.AUTH_FORBIDDEN_NICKNAME_WORD_NOT_FOUND, exception.getErrorCode());
         verify(forbiddenNicknameWordRepository, never()).findById(any());
         verify(forbiddenNicknameWordRepository, never()).delete(any());
+        verify(stringRedisTemplate, never()).delete(anyString());
         verify(stringRedisTemplate, never()).delete(anyCollection());
     }
 
     @Test
     @DisplayName("Redis 캐시 hit 시 DB를 조회하지 않고 캐시 데이터로 금칙어 포함 여부를 판단한다")
     void containsForbiddenWordWithCacheHit() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(true);
-        when(setOperations.members(CACHE_KEY)).thenReturn(Set.of("관리자", "admin"));
+        when(valueOperations.get(CACHE_KEY)).thenReturn("관리자\nadmin");
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("최고관 리 자");
 
@@ -215,8 +215,7 @@ class ForbiddenNicknameServiceTest {
     @Test
     @DisplayName("Redis 캐시 hit 시 금칙어가 포함되어 있지 않으면 false를 반환한다")
     void doesNotContainForbiddenWordWithCacheHit() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(true);
-        when(setOperations.members(CACHE_KEY)).thenReturn(Set.of("관리자", "admin"));
+        when(valueOperations.get(CACHE_KEY)).thenReturn("관리자\nadmin");
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
 
@@ -225,9 +224,9 @@ class ForbiddenNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("Redis loaded marker가 없으면 DB에서 normalizedWord만 조회하고 Redis에 캐싱한다")
+    @DisplayName("Redis 캐시 miss 시 DB에서 normalizedWord만 조회하고 Redis String으로 캐싱한다")
     void containsForbiddenWordWithCacheMiss() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
+        when(valueOperations.get(CACHE_KEY)).thenReturn(null);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
                 .thenReturn(List.of("관리자", "admin"));
 
@@ -236,16 +235,13 @@ class ForbiddenNicknameServiceTest {
         assertTrue(result);
 
         verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
-        verify(stringRedisTemplate).delete(CACHE_KEY);
-        verify(setOperations).add(eq(CACHE_KEY), eq("관리자"), eq("admin"));
-        verify(stringRedisTemplate).expire(eq(CACHE_KEY), any(Duration.class));
-        verify(valueOperations).set(eq(CACHE_LOADED_KEY), eq("1"), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_KEY), eq("관리자\nadmin"), any(Duration.class));
     }
 
     @Test
-    @DisplayName("DB 금칙어 목록이 비어 있어도 loaded marker를 저장한다")
-    void cacheEmptyForbiddenWordsWithLoadedMarker() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
+    @DisplayName("DB 금칙어 목록이 비어 있어도 빈 문자열로 캐싱한다")
+    void cacheEmptyForbiddenWords() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn(null);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
                 .thenReturn(List.of());
 
@@ -254,34 +250,24 @@ class ForbiddenNicknameServiceTest {
         assertFalse(result);
 
         verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
-        verify(stringRedisTemplate).delete(CACHE_KEY);
-        verify(setOperations, never()).add(anyString(), any(String[].class));
-        verify(stringRedisTemplate, never()).expire(eq(CACHE_KEY), any(Duration.class));
-        verify(valueOperations).set(eq(CACHE_LOADED_KEY), eq("1"), any(Duration.class));
+        verify(valueOperations).set(eq(CACHE_KEY), eq(""), any(Duration.class));
     }
 
     @Test
-    @DisplayName("Redis loaded marker는 있지만 Set이 비어 있으면 cache miss로 보고 DB를 재조회한다")
-    void loadedMarkerExistsButSetIsEmptyReloadsFromDatabase() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(true);
-        when(setOperations.members(CACHE_KEY)).thenReturn(Set.of());
-        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
-                .thenReturn(List.of("관리자"));
+    @DisplayName("Redis 캐시에 빈 문자열이 있으면 금칙어 0개 상태로 보고 DB를 조회하지 않는다")
+    void emptyStringCacheHitMeansNoForbiddenWords() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("");
 
-        boolean result = forbiddenNicknameService.containsForbiddenWord("최고관리자");
+        boolean result = forbiddenNicknameService.containsForbiddenWord("정상닉네임");
 
-        assertTrue(result);
-        verify(forbiddenNicknameWordRepository).findAllNormalizedWords();
-        verify(stringRedisTemplate).delete(CACHE_KEY);
-        verify(setOperations).add(eq(CACHE_KEY), eq("관리자"));
-        verify(stringRedisTemplate).expire(eq(CACHE_KEY), any(Duration.class));
-        verify(valueOperations).set(eq(CACHE_LOADED_KEY), eq("1"), any(Duration.class));
+        assertFalse(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
     }
 
     @Test
     @DisplayName("Redis 캐시 조회 실패 시 DB 직접 조회로 fallback하여 금칙어 포함 여부를 판단한다")
     void containsForbiddenWordFallbackToDatabaseWhenRedisReadFails() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY))
+        when(valueOperations.get(CACHE_KEY))
                 .thenThrow(new RedisConnectionFailureException("redis down"));
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
                 .thenReturn(List.of("관리자"));
@@ -295,11 +281,12 @@ class ForbiddenNicknameServiceTest {
     @Test
     @DisplayName("Redis 캐시 저장 실패 시 DB 조회 결과를 재사용하고 DB를 중복 조회하지 않는다")
     void containsForbiddenWordUsesDbResultWhenRedisWriteFails() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY)).thenReturn(false);
+        when(valueOperations.get(CACHE_KEY)).thenReturn(null);
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
                 .thenReturn(List.of("관리자"));
-        when(stringRedisTemplate.delete(CACHE_KEY))
-                .thenThrow(new RedisConnectionFailureException("redis write down"));
+        doThrow(new RedisConnectionFailureException("redis write down"))
+                .when(valueOperations)
+                .set(eq(CACHE_KEY), eq("관리자"), any(Duration.class));
 
         boolean result = forbiddenNicknameService.containsForbiddenWord("최고관리자");
 
@@ -310,7 +297,7 @@ class ForbiddenNicknameServiceTest {
     @Test
     @DisplayName("Redis 장애 fallback 후 DB 조회 결과에도 금칙어가 없으면 false를 반환한다")
     void doesNotContainForbiddenWordFallbackToDatabaseWhenRedisFails() {
-        when(stringRedisTemplate.hasKey(CACHE_LOADED_KEY))
+        when(valueOperations.get(CACHE_KEY))
                 .thenThrow(new RedisConnectionFailureException("redis down"));
         when(forbiddenNicknameWordRepository.findAllNormalizedWords())
                 .thenReturn(List.of("관리자"));
@@ -327,7 +314,7 @@ class ForbiddenNicknameServiceTest {
         boolean result = forbiddenNicknameService.containsForbiddenWord(null);
 
         assertFalse(result);
-        verify(stringRedisTemplate, never()).hasKey(anyString());
+        verify(valueOperations, never()).get(anyString());
         verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
     }
 
@@ -337,7 +324,7 @@ class ForbiddenNicknameServiceTest {
         boolean result = forbiddenNicknameService.containsForbiddenWord("   ");
 
         assertFalse(result);
-        verify(stringRedisTemplate, never()).hasKey(anyString());
+        verify(valueOperations, never()).get(anyString());
         verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
     }
 
@@ -350,13 +337,14 @@ class ForbiddenNicknameServiceTest {
         when(forbiddenNicknameWordRepository.saveAndFlush(any()))
                 .thenReturn(saved);
 
-        when(stringRedisTemplate.delete(anyCollection()))
+        when(stringRedisTemplate.delete(CACHE_KEY))
                 .thenThrow(new RedisConnectionFailureException("redis evict down"));
 
         ForbiddenNicknameWord result = forbiddenNicknameService.addForbiddenWord("admin");
 
         assertEquals("admin", result.getWord());
         assertEquals("admin", result.getNormalizedWord());
+        verify(stringRedisTemplate).delete(CACHE_KEY);
     }
 
     @Test
@@ -366,7 +354,7 @@ class ForbiddenNicknameServiceTest {
 
         when(forbiddenNicknameWordRepository.findById(1L))
                 .thenReturn(Optional.of(forbiddenWord));
-        when(stringRedisTemplate.delete(anyCollection()))
+        when(stringRedisTemplate.delete(CACHE_KEY))
                 .thenThrow(new RedisConnectionFailureException("redis evict down"));
 
         forbiddenNicknameService.deleteForbiddenWord(1L);
@@ -374,5 +362,30 @@ class ForbiddenNicknameServiceTest {
         verify(forbiddenNicknameWordRepository).findById(1L);
         verify(forbiddenNicknameWordRepository).delete(forbiddenWord);
         verify(forbiddenNicknameWordRepository).flush();
+        verify(stringRedisTemplate).delete(CACHE_KEY);
+    }
+
+    @Test
+    @DisplayName("중복되거나 공백인 캐시 값은 검증 시 무시한다")
+    void cachedWordsIgnoreBlankValues() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn("관리자\n\nadmin\n관리자");
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("normal-admin-user");
+
+        assertTrue(result);
+        verify(forbiddenNicknameWordRepository, never()).findAllNormalizedWords();
+    }
+
+    @Test
+    @DisplayName("DB 조회 결과의 null, 공백, 중복 값은 캐싱 시 제거한다")
+    void cacheNormalizedWordsFiltersInvalidValues() {
+        when(valueOperations.get(CACHE_KEY)).thenReturn(null);
+        when(forbiddenNicknameWordRepository.findAllNormalizedWords())
+                .thenReturn(List.of("관리자", "", "admin", "관리자"));
+
+        boolean result = forbiddenNicknameService.containsForbiddenWord("superAdmin");
+
+        assertTrue(result);
+        verify(valueOperations).set(eq(CACHE_KEY), eq("관리자\nadmin"), any(Duration.class));
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthServiceTest.java
@@ -1,0 +1,100 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.global.security.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class GuestAuthServiceTest {
+
+    private UserRepository userRepository;
+    private GuestSessionRepository guestSessionRepository;
+    private UserSessionRepository userSessionRepository;
+    private StringRedisTemplate redisTemplate;
+    private JwtTokenProvider jwtTokenProvider;
+    private UserSessionLifecycleService userSessionLifecycleService;
+    private NicknamePolicyValidator nicknamePolicyValidator;
+    private GuestAuthService guestAuthService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        guestSessionRepository = mock(GuestSessionRepository.class);
+        userSessionRepository = mock(UserSessionRepository.class);
+        redisTemplate = mock(StringRedisTemplate.class);
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        userSessionLifecycleService = mock(UserSessionLifecycleService.class);
+        nicknamePolicyValidator = mock(NicknamePolicyValidator.class);
+
+        guestAuthService = new GuestAuthService(
+                userRepository,
+                guestSessionRepository,
+                userSessionRepository,
+                redisTemplate,
+                jwtTokenProvider,
+                userSessionLifecycleService,
+                nicknamePolicyValidator
+        );
+    }
+
+    @Test
+    @DisplayName("게스트 닉네임이 1자이면 길이 검증에서 실패한다")
+    void guestLoginWithTooShortNickname() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> guestAuthService.loginAsGuest("가", "127.0.0.1", "test-agent")
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH, exception.getErrorCode());
+        verifyNoInteractions(nicknamePolicyValidator);
+    }
+
+    @Test
+    @DisplayName("게스트 닉네임이 13자 이상이면 길이 검증에서 실패한다")
+    void guestLoginWithTooLongNickname() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> guestAuthService.loginAsGuest("가나다라마바사아자차카타파", "127.0.0.1", "test-agent")
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH, exception.getErrorCode());
+        verifyNoInteractions(nicknamePolicyValidator);
+    }
+
+    @Test
+    @DisplayName("게스트 닉네임에 금칙어가 포함되면 실패한다")
+    void guestLoginWithForbiddenNickname() {
+        doThrow(new AuthException(AuthErrorCode.AUTH_NICKNAME_FORBIDDEN_WORD))
+                .when(nicknamePolicyValidator)
+                .validate("관리자123");
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> guestAuthService.loginAsGuest("관리자123", "127.0.0.1", "test-agent")
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_FORBIDDEN_WORD, exception.getErrorCode());
+        verify(nicknamePolicyValidator).validate("관리자123");
+        verifyNoInteractions(
+                userRepository,
+                guestSessionRepository,
+                userSessionRepository,
+                redisTemplate,
+                jwtTokenProvider,
+                userSessionLifecycleService
+        );
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizerTest.java
@@ -1,0 +1,35 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NicknameNormalizerTest {
+
+    private final NicknameNormalizer nicknameNormalizer = new NicknameNormalizer();
+
+    @Test
+    @DisplayName("비교용 정규화 시 앞뒤 공백, 대소문자, 내부 공백을 제거한다")
+    void normalizeForComparison() {
+        String result = nicknameNormalizer.normalizeForComparison(" A d M i n ");
+
+        assertEquals("admin", result);
+    }
+
+    @Test
+    @DisplayName("한글 금칙어도 내부 공백을 제거해 정규화한다")
+    void normalizeKoreanWord() {
+        String result = nicknameNormalizer.normalizeForComparison(" 관 리 자 ");
+
+        assertEquals("관리자", result);
+    }
+
+    @Test
+    @DisplayName("null 입력은 빈 문자열로 정규화한다")
+    void normalizeNull() {
+        String result = nicknameNormalizer.normalizeForComparison(null);
+
+        assertEquals("", result);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/NicknameNormalizerTest.java
@@ -26,9 +26,25 @@ class NicknameNormalizerTest {
     }
 
     @Test
+    @DisplayName("탭과 줄바꿈도 공백으로 판단해 제거한다")
+    void normalizeWhitespaceCharacters() {
+        String result = nicknameNormalizer.normalizeForComparison("A\tD\nM I N");
+
+        assertEquals("admin", result);
+    }
+
+    @Test
     @DisplayName("null 입력은 빈 문자열로 정규화한다")
     void normalizeNull() {
         String result = nicknameNormalizer.normalizeForComparison(null);
+
+        assertEquals("", result);
+    }
+
+    @Test
+    @DisplayName("공백만 있는 입력은 빈 문자열로 정규화한다")
+    void normalizeBlank() {
+        String result = nicknameNormalizer.normalizeForComparison("   \t\n  ");
 
         assertEquals("", result);
     }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/NicknamePolicyValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/NicknamePolicyValidatorTest.java
@@ -1,0 +1,42 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NicknamePolicyValidatorTest {
+
+    @Test
+    @DisplayName("금칙어가 포함된 닉네임이면 AuthException을 던진다")
+    void validateForbiddenNickname() {
+        ForbiddenNicknameService forbiddenNicknameService = mock(ForbiddenNicknameService.class);
+        when(forbiddenNicknameService.containsForbiddenWord("관리자123")).thenReturn(true);
+
+        NicknamePolicyValidator validator = new NicknamePolicyValidator(forbiddenNicknameService);
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> validator.validate("관리자123")
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_FORBIDDEN_WORD, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("금칙어가 포함되지 않은 닉네임이면 예외를 던지지 않는다")
+    void validateAllowedNickname() {
+        ForbiddenNicknameService forbiddenNicknameService = mock(ForbiddenNicknameService.class);
+        when(forbiddenNicknameService.containsForbiddenWord("정상닉네임")).thenReturn(false);
+
+        NicknamePolicyValidator validator = new NicknamePolicyValidator(forbiddenNicknameService);
+
+        assertDoesNotThrow(() -> validator.validate("정상닉네임"));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -1,192 +1,82 @@
 package io.github.ascrew.monomatbe.domain.auth.service;
 
-import io.github.ascrew.monomatbe.domain.auth.dto.RegisterResponse;
-import io.github.ascrew.monomatbe.domain.auth.entity.User;
-import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
-import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Transactional
 class RegisterAuthServiceTest {
 
-    @Autowired
+    private UserRepository userRepository;
+    private UserCredentialRepository userCredentialRepository;
+    private PasswordEncoder passwordEncoder;
+    private NicknamePolicyValidator nicknamePolicyValidator;
     private RegisterAuthService registerAuthService;
 
-    @Autowired
-    private UserRepository userRepository;
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userCredentialRepository = mock(UserCredentialRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        nicknamePolicyValidator = mock(NicknamePolicyValidator.class);
 
-    private String uniqueLoginId() {
-        return "member" + System.nanoTime();
-    }
-
-    private String uniqueNickname() {
-        return "n" + (System.nanoTime() % 1_000_000);
-    }
-
-    @Test
-    void register_success() {
-        String loginId = uniqueLoginId();
-        String nickname = uniqueNickname();
-
-        RegisterResponse response = registerAuthService.register(
-                loginId,
-                "password123",
-                nickname
+        registerAuthService = new RegisterAuthService(
+                userRepository,
+                userCredentialRepository,
+                passwordEncoder,
+                nicknamePolicyValidator
         );
-
-        assertNotNull(response.userId());
-        assertEquals(loginId, response.loginId());
-        assertEquals(nickname, response.nickname());
-        assertEquals(UserType.REGISTERED, response.userType());
     }
 
     @Test
-    void register_trimsLoginIdAndNickname() {
-        String loginId = uniqueLoginId();
-        String nickname = uniqueNickname();
-
-        RegisterResponse response = registerAuthService.register(
-                "  " + loginId + "  ",
-                "password123",
-                "  " + nickname + "  "
-        );
-
-        assertEquals(loginId, response.loginId());
-        assertEquals(nickname, response.nickname());
-    }
-
-    @Test
-    void register_passwordWithWhitespace_throwsPasswordWhitespaceError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(uniqueLoginId(), "  password123  ", uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE, exception.getErrorCode());
-    }
-
-    @Test
-    void register_duplicateLoginId_throwsDuplicatedLoginIdError() {
-        String loginId = uniqueLoginId();
-
-        registerAuthService.register(loginId, "password123", uniqueNickname());
-
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(loginId, "password123", uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_DUPLICATED, exception.getErrorCode());
-    }
-
-    @Test
-    void register_duplicateNickname_throwsDuplicatedNicknameError() {
-        String nickname = uniqueNickname();
-
-        userRepository.saveAndFlush(User.builder()
-                .username(nickname)
-                .userType(UserType.REGISTERED)
-                .status(UserStatus.ACTIVE)
-                .build());
-
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(uniqueLoginId(), "password123", nickname)
-        );
-
-        assertEquals(AuthErrorCode.AUTH_NICKNAME_DUPLICATED, exception.getErrorCode());
-    }
-
-    @Test
-    void register_nullPassword_throwsPasswordRequiredError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(uniqueLoginId(), null, uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_PASSWORD_REQUIRED, exception.getErrorCode());
-    }
-
-    @Test
-    void register_blankLoginId_throwsLoginIdRequiredError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register("   ", "password123", uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_REQUIRED, exception.getErrorCode());
-    }
-
-    @Test
-    void register_loginIdTooShort_throwsLoginIdInvalidLengthError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register("abc", "password123", uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_LENGTH, exception.getErrorCode());
-    }
-
-    @Test
-    void register_loginIdTooLong_throwsLoginIdInvalidLengthError() {
-        String tooLongLoginId = "a".repeat(51);
-
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(tooLongLoginId, "password123", uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_LENGTH, exception.getErrorCode());
-    }
-
-    @Test
-    void register_loginIdWithWhitespace_throwsLoginIdWhitespaceError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register("abc def", "password123", uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_CONTAINS_WHITESPACE, exception.getErrorCode());
-    }
-
-    @Test
-    void register_loginIdInvalidFormat_throwsLoginIdInvalidFormatError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register("abcd!", "password123", uniqueNickname())
-        );
-
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_INVALID_FORMAT, exception.getErrorCode());
-    }
-
-    @Test
-    void register_nicknameTooShort_throwsNicknameInvalidLengthError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(uniqueLoginId(), "password123", "a")
+    @DisplayName("회원가입 닉네임이 1자이면 길이 검증에서 실패한다")
+    void registerWithTooShortNickname() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> registerAuthService.register("loginId1", "password123", "가")
         );
 
         assertEquals(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH, exception.getErrorCode());
+        verifyNoInteractions(nicknamePolicyValidator);
     }
 
     @Test
-    void register_nicknameTooLong_throwsNicknameInvalidLengthError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(uniqueLoginId(), "password123", "1234567890123")
+    @DisplayName("회원가입 닉네임이 13자 이상이면 길이 검증에서 실패한다")
+    void registerWithTooLongNickname() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> registerAuthService.register("loginId1", "password123", "가나다라마바사아자차카타파")
         );
 
         assertEquals(AuthErrorCode.AUTH_NICKNAME_INVALID_LENGTH, exception.getErrorCode());
+        verifyNoInteractions(nicknamePolicyValidator);
     }
 
     @Test
-    void register_nullLoginId_throwsLoginIdRequiredError() {
-        AuthException exception = assertThrows(AuthException.class, () ->
-                registerAuthService.register(null, "password123", uniqueNickname())
+    @DisplayName("회원가입 닉네임에 금칙어가 포함되면 실패한다")
+    void registerWithForbiddenNickname() {
+        doThrow(new AuthException(AuthErrorCode.AUTH_NICKNAME_FORBIDDEN_WORD))
+                .when(nicknamePolicyValidator)
+                .validate("관리자123");
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> registerAuthService.register("loginId1", "password123", "관리자123")
         );
 
-        assertEquals(AuthErrorCode.AUTH_LOGIN_ID_REQUIRED, exception.getErrorCode());
+        assertEquals(AuthErrorCode.AUTH_NICKNAME_FORBIDDEN_WORD, exception.getErrorCode());
+        verify(nicknamePolicyValidator).validate("관리자123");
+        verifyNoInteractions(userRepository, userCredentialRepository, passwordEncoder);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #126 

## 📝 Summary

- 회원가입 및 게스트 로그인 닉네임 길이 정책을 2자 이상 12자 이하로 유지/정리했습니다.
- DB 기반 닉네임 금칙어 검증 정책을 추가했습니다.
- 닉네임 금칙어 정규화 로직을 추가했습니다.
  - 대소문자 차이 제거
  - 내부 공백 제거
  - 정규화 기준 중복 금칙어 등록 방지
- 회원가입 닉네임과 게스트 로그인 닉네임에 금칙어 검증을 적용했습니다.
- 금칙어 포함 닉네임 사용 시 `400 BAD_REQUEST`를 반환하도록 처리했습니다.
- 관리자 금칙어 관리 API를 추가했습니다.
  - 금칙어 목록 조회
  - 금칙어 추가
  - 금칙어 삭제
- 현재 별도 `ROLE_ADMIN` 권한 체계가 없으므로, 관리자 API는 `MONOMAT_ADMIN_USER_IDS` 설정 기반 allow-list 방식으로 보호했습니다.
- 금칙어 저장 테이블, 엔티티, Repository, 서비스, Controller, 테스트를 추가했습니다.
- 닉네임 검증 정책 및 관리자 금칙어 관리 API 문서를 업데이트했습니다.

## 🙏PR point

- 관리자 API 접근 기준은 `userIdentifier`가 아니라 `users.id` 기반입니다.
  - `userIdentifier`는 세션 식별자 성격이 강하므로 관리자 권한 기준으로 사용하지 않았습니다.
  - 운영 시 `.env` 또는 서버 환경변수에 아래 값을 설정해야 합니다.
    ```properties
    MONOMAT_ADMIN_USER_IDS=1,2
    ```
- 현재 관리자 권한 체계가 없기 때문에 임시 allow-list 방식으로 구현했습니다.
  - 추후 `ROLE_ADMIN` 또는 별도 권한 테이블이 도입되면 `AdminAccessValidator` 내부 구현만 교체하면 됩니다.
- 금칙어 검증은 닉네임 정규화/길이 검증 이후, 닉네임 중복 검증 이전에 수행됩니다.
  - 잘못된 닉네임 정책 위반은 DB 중복 조회 전에 차단하는 것이 목적입니다.
- 금칙어 중복 여부는 원본 문자열이 아니라 `normalizedWord` 기준으로 판단합니다.
  - 예: `Admin`, `A d m i n`은 모두 `admin`으로 정규화되어 중복 등록이 차단됩니다.
- 금칙어 목록은 현재 DB 직접 조회 방식입니다.
  - 금칙어 수가 많아지거나 요청량이 증가하면 Redis 또는 로컬 캐시 적용을 검토할 수 있습니다.
- Flyway migration 파일 번호가 기존 migration과 충돌하지 않는지 확인 부탁드립니다.

### 검증 내용

- `./gradlew compileJava`
- `./gradlew compileTestJava`
- 이슈 관련 테스트 실행
- Flyway migration 적용 확인
- `forbidden_nickname_word` 테이블 생성 확인
- 관리자 API 금칙어 추가/조회/삭제 확인
- 정규화 기준 중복 금칙어 등록 시 `409 Conflict` 확인
- 회원가입 닉네임 금칙어 포함 시 `400 Bad Request` 확인
- 게스트 로그인 닉네임 금칙어 포함 시 `400 Bad Request` 확인
- 관리자 allow-list 미포함 사용자 접근 시 `403 Forbidden` 확인
- 금칙어 삭제 후 검증 대상에서 제외되는 것 확인

## 📬 Reference

- 기존 인증 도메인 에러 응답 구조
  - `AuthErrorCode`
  - `AuthException`
- 기존 회원가입/게스트 로그인 닉네임 검증 흐름
  - `RegisterAuthService`
  - `GuestAuthService`
- 기존 Flyway migration 관리 방식
  - `src/main/resources/db/migration`
- 기존 API 문서 형식
  - `docs/API.md`