### PR TITLE
[Feat/#119] 맵 공개 전 검증 정책 강화

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/MapPublicationPolicy.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/MapPublicationPolicy.java
@@ -1,0 +1,10 @@
+package io.github.ascrew.monomatbe.domain.map;
+
+public final class MapPublicationPolicy {
+
+    public static final int MIN_ITEMS = 1;
+    public static final int MIN_SEGMENT_SECONDS = 3;
+    public static final int MAX_SEGMENT_SECONDS = 30;
+
+    private MapPublicationPolicy() {}
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapPublicationValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapPublicationValidator.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.domain.map.service;
 
+import io.github.ascrew.monomatbe.domain.map.MapPublicationPolicy;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import org.springframework.http.HttpStatus;
@@ -8,14 +9,25 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Component
 public class MapPublicationValidator {
 
-    private static final String ERROR_NO_ITEMS = "공개를 위해서는 최소 1개의 문제가 필요합니다.";
+    private static final String ERROR_NO_ITEMS =
+            "공개를 위해서는 최소 " + MapPublicationPolicy.MIN_ITEMS + "개의 문제가 필요합니다.";
     private static final String ERROR_INVALID_START_TIME = "%d번 문제의 시작 시간이 0 미만입니다.";
     private static final String ERROR_INVALID_TIME_RANGE = "%d번 문제의 재생 구간이 올바르지 않습니다.";
+    private static final String ERROR_SEGMENT_TOO_SHORT =
+            "%d번 문제의 재생 구간 길이는 최소 " + MapPublicationPolicy.MIN_SEGMENT_SECONDS + "초 이상이어야 합니다.";
+    private static final String ERROR_SEGMENT_TOO_LONG =
+            "%d번 문제의 재생 구간 길이는 최대 " + MapPublicationPolicy.MAX_SEGMENT_SECONDS + "초를 초과할 수 없습니다.";
+    private static final String ERROR_BLANK_YOUTUBE_URL = "%d번 문제의 YouTube 주소가 비어 있습니다.";
+    private static final String ERROR_INVALID_VIDEO_ID = "%d번 문제의 YouTube 영상 ID가 올바르지 않습니다.";
     private static final String ERROR_BLANK_ANSWER = "%d번 문제의 정답이 비어 있습니다.";
+
+    // YoutubeValidationService.VIDEO_ID_PATTERN 과 동일한 규칙. 한쪽을 바꾸면 함께 동기화한다.
+    private static final Pattern VIDEO_ID_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{11}$");
 
     private final MapItemJpaRepository mapItemJpaRepository;
 
@@ -38,13 +50,15 @@ public class MapPublicationValidator {
 
     private String findFailureMessage(Long mapId) {
         List<MapItem> items = mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(mapId);
-        if (items.isEmpty()) {
+        if (items.size() < MapPublicationPolicy.MIN_ITEMS) {
             return ERROR_NO_ITEMS;
         }
 
         for (MapItem item : items) {
             Integer startTime = item.getStartTime();
             Integer endTime = item.getEndTime();
+            String youtubeUrl = item.getYoutubeUrl();
+            String videoId = item.getVideoId();
             String answer = item.getAnswer();
 
             if (startTime == null || startTime < 0) {
@@ -52,6 +66,21 @@ public class MapPublicationValidator {
             }
             if (endTime == null || endTime <= startTime) {
                 return String.format(ERROR_INVALID_TIME_RANGE, item.getOrderNum());
+            }
+
+            int duration = endTime - startTime;
+            if (duration < MapPublicationPolicy.MIN_SEGMENT_SECONDS) {
+                return String.format(ERROR_SEGMENT_TOO_SHORT, item.getOrderNum());
+            }
+            if (duration > MapPublicationPolicy.MAX_SEGMENT_SECONDS) {
+                return String.format(ERROR_SEGMENT_TOO_LONG, item.getOrderNum());
+            }
+
+            if (youtubeUrl == null || youtubeUrl.isBlank()) {
+                return String.format(ERROR_BLANK_YOUTUBE_URL, item.getOrderNum());
+            }
+            if (videoId == null || !VIDEO_ID_PATTERN.matcher(videoId).matches()) {
+                return String.format(ERROR_INVALID_VIDEO_ID, item.getOrderNum());
             }
             if (answer == null || answer.isBlank()) {
                 return String.format(ERROR_BLANK_ANSWER, item.getOrderNum());

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapPublicationValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapPublicationValidator.java
@@ -3,13 +3,13 @@ package io.github.ascrew.monomatbe.domain.map.service;
 import io.github.ascrew.monomatbe.domain.map.MapPublicationPolicy;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.domain.youtube.YoutubeVideoId;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 @Component
 public class MapPublicationValidator {
@@ -25,9 +25,6 @@ public class MapPublicationValidator {
     private static final String ERROR_BLANK_YOUTUBE_URL = "%d번 문제의 YouTube 주소가 비어 있습니다.";
     private static final String ERROR_INVALID_VIDEO_ID = "%d번 문제의 YouTube 영상 ID가 올바르지 않습니다.";
     private static final String ERROR_BLANK_ANSWER = "%d번 문제의 정답이 비어 있습니다.";
-
-    // YoutubeValidationService.VIDEO_ID_PATTERN 과 동일한 규칙. 한쪽을 바꾸면 함께 동기화한다.
-    private static final Pattern VIDEO_ID_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{11}$");
 
     private final MapItemJpaRepository mapItemJpaRepository;
 
@@ -79,7 +76,7 @@ public class MapPublicationValidator {
             if (youtubeUrl == null || youtubeUrl.isBlank()) {
                 return String.format(ERROR_BLANK_YOUTUBE_URL, item.getOrderNum());
             }
-            if (videoId == null || !VIDEO_ID_PATTERN.matcher(videoId).matches()) {
+            if (!YoutubeVideoId.isValid(videoId)) {
                 return String.format(ERROR_INVALID_VIDEO_ID, item.getOrderNum());
             }
             if (answer == null || answer.isBlank()) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/youtube/YoutubeVideoId.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/youtube/YoutubeVideoId.java
@@ -1,0 +1,18 @@
+package io.github.ascrew.monomatbe.domain.youtube;
+
+import java.util.regex.Pattern;
+
+/**
+ * YouTube 영상 ID 형식 규칙의 단일 출처.
+ * 영상 ID 유효성 판단이 필요한 모든 곳(URL 검증, 맵 공개 전 검증 등)은 이 클래스를 통해 일관된 규칙을 사용한다.
+ */
+public final class YoutubeVideoId {
+
+    private static final Pattern PATTERN = Pattern.compile("^[A-Za-z0-9_-]{11}$");
+
+    private YoutubeVideoId() {}
+
+    public static boolean isValid(String value) {
+        return value != null && PATTERN.matcher(value).matches();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationService.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.youtube.service;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.youtube.YoutubeVideoId;
 import io.github.ascrew.monomatbe.domain.youtube.client.YoutubeOEmbedClient;
 import io.github.ascrew.monomatbe.domain.youtube.exception.YoutubeEmbedNotAllowedException;
 import io.github.ascrew.monomatbe.domain.youtube.model.YoutubeMetadata;
@@ -21,7 +22,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -36,7 +36,6 @@ public class YoutubeValidationService {
 
     private static final Duration OEMBED_SUCCESS_TTL = Duration.ofHours(6);
     private static final Duration OEMBED_FAILURE_TTL = Duration.ofMinutes(30);
-    private static final Pattern VIDEO_ID_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{11}$");
 
     private final StringRedisTemplate redisTemplate;
     @Qualifier("pubSubJsonMapper") private final JsonMapper jsonMapper;
@@ -178,7 +177,7 @@ public class YoutubeValidationService {
     }
 
     private boolean isValidVideoId(String value) {
-        return value != null && VIDEO_ID_PATTERN.matcher(value).matches();
+        return YoutubeVideoId.isValid(value);
     }
 
     private void validateRegisteredPrincipal(CustomPrincipal principal) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPersistenceServiceTest.java
@@ -65,7 +65,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void create_orderDuplicated_conflict() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(true);
 
         CreateMapItemRequest request = createRequest(1);
@@ -83,7 +83,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void create_success_recalculatesMetadata() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(false);
         when(mapItemJpaRepository.save(any(MapItem.class))).thenAnswer(invocation -> {
             MapItem input = invocation.getArgument(0);
@@ -123,7 +123,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void delete_success_softDeletesAndRecalculatesMetadata() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(50L)
@@ -158,7 +158,7 @@ class MapItemPersistenceServiceTest {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.setPendingPublicIntent(true);
 
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(false);
         when(mapItemJpaRepository.save(any(MapItem.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(mapItemJpaRepository.countByMapIdAndIsDeletedFalse(1L)).thenReturn(1L);
@@ -180,7 +180,7 @@ class MapItemPersistenceServiceTest {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.setPendingPublicIntent(true);
 
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
         when(mapItemJpaRepository.existsByMapIdAndOrderNumAndIsDeletedFalse(1L, 1)).thenReturn(false);
         when(mapItemJpaRepository.save(any(MapItem.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(mapItemJpaRepository.countByMapIdAndIsDeletedFalse(1L)).thenReturn(1L);
@@ -201,7 +201,7 @@ class MapItemPersistenceServiceTest {
     void delete_lastItemFromPublicMap_autoFlipToPrivate_keepsPendingTrue() {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.markAsPublished(); // 공개 상태
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(50L)
@@ -235,7 +235,7 @@ class MapItemPersistenceServiceTest {
     void delete_nonLastItemFromPublicMap_remainsPublic() {
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.markAsPublished();
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(51L)
@@ -271,7 +271,7 @@ class MapItemPersistenceServiceTest {
         // (데이터 오염, 수동 DB 수정, 향후 부분 수정 API 도입 등으로 공개 맵이 무효 상태에 놓이는 케이스)
         QuizMap quizMap = quizMap(1L, owner(10L));
         quizMap.markAsPublished();
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem mapItem = MapItem.builder()
                 .id(60L)
@@ -305,7 +305,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_success_assignsOrderNumsByRequestSequence() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
@@ -327,7 +327,9 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_notOwner_forbidden() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        // 비소유자(99L) 락 조회는 빈 결과 → 맵 자체는 존재하므로 FORBIDDEN으로 분기되어야 한다.
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 99L)).thenReturn(Optional.empty());
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(quizMap));
 
         assertThatThrownBy(() -> persistenceService.reorder(1L, 99L, List.of(1L, 2L)))
                 .isInstanceOf(ResponseStatusException.class)
@@ -339,7 +341,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_duplicateItemId_badRequest() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
@@ -356,7 +358,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_missingItem_badRequest() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);
@@ -375,7 +377,7 @@ class MapItemPersistenceServiceTest {
     @Test
     void reorder_invalidItemId_badRequest() {
         QuizMap quizMap = quizMap(1L, owner(10L));
-        when(quizMapJpaRepository.findByIdAndIsDeletedFalseForUpdate(1L)).thenReturn(Optional.of(quizMap));
+        when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L)).thenReturn(Optional.of(quizMap));
 
         MapItem item1 = mapItem(1L, quizMap, 1);
         MapItem item2 = mapItem(2L, quizMap, 2);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapPublicationValidatorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapPublicationValidatorTest.java
@@ -19,6 +19,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MapPublicationValidatorTest {
 
+    private static final String VALID_YOUTUBE_URL = "https://youtu.be/dQw4w9WgXcQ";
+    private static final String VALID_VIDEO_ID = "dQw4w9WgXcQ";
+
     @Mock
     private MapItemJpaRepository mapItemJpaRepository;
 
@@ -63,6 +66,62 @@ class MapPublicationValidatorTest {
     }
 
     @Test
+    void requirePublishable_segmentTooShort_throwsConflict() {
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item(1, 0, 2, "정답")));
+
+        assertThatThrownBy(() -> validator.requirePublishable(1L))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+                .hasMessageContaining("최소")
+                .hasMessageContaining("1번 문제");
+    }
+
+    @Test
+    void requirePublishable_segmentTooLong_throwsConflict() {
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item(1, 0, 31, "정답")));
+
+        assertThatThrownBy(() -> validator.requirePublishable(1L))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+                .hasMessageContaining("최대")
+                .hasMessageContaining("1번 문제");
+    }
+
+    @Test
+    void requirePublishable_segmentBoundaryValues_doNotThrow() {
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item(1, 0, 3, "정답1"), item(2, 0, 30, "정답2")));
+
+        validator.requirePublishable(1L);
+    }
+
+    @Test
+    void requirePublishable_blankYoutubeUrl_throwsConflict() {
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item(1, 0, 30, "  ", VALID_VIDEO_ID, "정답")));
+
+        assertThatThrownBy(() -> validator.requirePublishable(1L))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+                .hasMessageContaining("YouTube 주소")
+                .hasMessageContaining("1번 문제");
+    }
+
+    @Test
+    void requirePublishable_invalidVideoId_throwsConflict() {
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
+                .thenReturn(List.of(item(1, 0, 30, VALID_YOUTUBE_URL, "short", "정답")));
+
+        assertThatThrownBy(() -> validator.requirePublishable(1L))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+                .hasMessageContaining("영상 ID")
+                .hasMessageContaining("1번 문제");
+    }
+
+    @Test
     void requirePublishable_blankAnswer_throwsConflict() {
         when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L))
                 .thenReturn(List.of(item(3, 0, 30, "   ")));
@@ -93,10 +152,16 @@ class MapPublicationValidatorTest {
     }
 
     private MapItem item(int orderNum, int startTime, int endTime, String answer) {
+        return item(orderNum, startTime, endTime, VALID_YOUTUBE_URL, VALID_VIDEO_ID, answer);
+    }
+
+    private MapItem item(int orderNum, int startTime, int endTime, String youtubeUrl, String videoId, String answer) {
         return MapItem.builder()
                 .orderNum(orderNum)
                 .startTime(startTime)
                 .endTime(endTime)
+                .youtubeUrl(youtubeUrl)
+                .videoId(videoId)
                 .answer(answer)
                 .build();
     }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/youtube/YoutubeVideoIdTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/youtube/YoutubeVideoIdTest.java
@@ -1,0 +1,35 @@
+package io.github.ascrew.monomatbe.domain.youtube;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class YoutubeVideoIdTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "dQw4w9WgXcQ",  // 일반적인 11자 ID
+            "abcde123456",  // 영문 소문자 + 숫자
+            "_-_-_-_-_-_",  // 언더스코어/하이픈 허용
+            "AAAAAAAAAAA"   // 영문 대문자만
+    })
+    void isValid_returnsTrueFor11CharAllowedChars(String videoId) {
+        assertThat(YoutubeVideoId.isValid(videoId)).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+            "abcdefg",        // 11자 미만
+            "abcdefghijklm",  // 11자 초과
+            "dQw4w9WgXc!",    // 허용되지 않는 문자(!)
+            "dQw4 9WgXcQ",    // 공백 포함
+            "한글영상아이디일일"   // 비ASCII
+    })
+    void isValid_returnsFalseForInvalidFormat(String videoId) {
+        assertThat(YoutubeVideoId.isValid(videoId)).isFalse();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
- #119 

## 📝 Summary
- 맵 공개(비공개 → 공개) 전 검증 정책을 강화했습니다. 기존 MapPublicationValidator에 누락된 규칙을 가산적으로 추가했습니다.
- 정책 상수 분리: MapPublicationPolicy 클래스 추가 (MIN_ITEMS=1, MIN_SEGMENT_SECONDS=3, MAX_SEGMENT_SECONDS=30)
- 재생 구간 길이 검증 추가: endTime - startTime이 3초 미만 또는 30초 초과 시 409 Conflict
- youtubeUrl / videoId 구조적 검증 추가: URL 비어있음, videoId 11자 패턴(^[A-Za-z0-9_-]{11}$) 불일치 시 409
- 최소 문제 수 검증 명시화: items.isEmpty() → items.size() < MIN_ITEMS
- MapPublicationValidatorTest에 신규 규칙(구간 길이 min/max·경계값, youtubeUrl/videoId)에 대한 테스트 케이스 추가
- (부가) static/test.html 맵 탭에 내 맵 목록(GET /me) + 맵 수정/공개 전환(PUT) UI를 추가해 공개 검증을 직접 테스트 가능하도록 함

## 🙏PR point
- 이슈 체크리스트 중 상당수(비공개→공개 전이 시점만 검증, 삭제 제외 카운트, startTime < endTime, 409 반환, 공개→공개 단순 수정 재검증 없음)는 이미 구현돼 있어 변경하지 않았습니다. 이번 PR은 누락분(구간 길이·youtube 구조 검증·정책 상수화)만 추가합니다.
- 재생 구간 길이(3~30초) 정책은 공개 검증 시점에만 강제합니다. 문제 등록/수정 시점에는 적용하지 않아 초안 작성과 레거시 데이터 비공개 유지는 막히지 않습니다.
- requirePublishable/isPublishable 시그니처는 유지되므로 MapService.applyPublicationChange(공개 게이트)와 MapItemPersistenceService.applyPublicationAutoFlip(공개 무결성 자동 보정)에 신규 정책이 자동 반영됩니다. 단, 공개 상태 레거시 맵의 아이템을 수정하면 새 정책 위반 시 자동 비공개(pendingPublic 보존)로 전환될 수 있습니다.
- 정책 수치(3초/30초)는 음악 퀴즈 스니펫 기준으로 정한 값이라 조정이 필요하면 MapPublicationPolicy 상수만 수정하면 됩니다.
- 참고: MapItemPersistenceServiceTest 13/14 케이스가 현재 브랜치에서 실패 중인데, 이는 본 PR과 무관한 기존 스테일 테스트입니다(프로덕션이 findOwnedByIdAndIsDeletedFalseForUpdate로 리팩터링됐으나 테스트 스텁이 구버전 메서드를 사용). 별도 처리가 필요합니다.

## 📬 Reference
