### PR TITLE
[Feat/#121] 내 사용자 정보 조회 API 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -86,6 +86,67 @@
 ```text
 비밀번호가 일치하지 않습니다.
 ```
+---
+
+### 사용자 (User)
+
+로그인한 사용자의 기본 정보를 조회합니다.
+
+#### 내 사용자 정보 조회
+
+```http
+GET /api/users/me
+````
+
+JWT Access Token이 필요합니다.
+
+프론트엔드는 이 API를 사용해 상단 프로필 영역, 닉네임 표시, 게스트/회원 분기 처리 등에 필요한 사용자 정보를 조회할 수 있습니다.
+
+**Request Header**
+
+| 헤더              | 필수 | 설명                     |
+| --------------- | -- | ---------------------- |
+| `Authorization` | ✅  | `Bearer {accessToken}` |
+
+**Response `200 OK`**
+
+```json
+{
+  "userId": 1,
+  "username": "모노유저",
+  "userType": "REGISTERED",
+  "status": "ACTIVE",
+  "createdAt": "2026-05-29T12:00:00"
+}
+```
+
+**Response Fields**
+
+| 필드          | 타입     | 설명                                    |
+| ----------- | ------ | ------------------------------------- |
+| `userId`    | Long   | 사용자 고유 ID. `users.id`                 |
+| `username`  | String | 서비스 표시 닉네임                            |
+| `userType`  | String | 사용자 유형. `GUEST`, `REGISTERED`         |
+| `status`    | String | 사용자 상태. `ACTIVE`, `BANNED`, `DELETED` |
+| `createdAt` | String | 사용자 생성 시각. ISO-8601 LocalDateTime 형식  |
+
+**Error**
+
+| 상태 코드              | 설명                                                |
+| ------------------ | ------------------------------------------------- |
+| `401 Unauthorized` | 인증 정보 없음, 유효하지 않은 Access Token, DB에서 사용자를 찾을 수 없음 |
+| `401 Unauthorized` | 탈퇴 또는 삭제된 사용자                                     |
+| `403 Forbidden`    | 정지된 사용자                                           |
+| `409 Conflict`     | 사용자 상태 값이 비정상인 경우                                 |
+
+**프론트엔드 처리 기준**
+
+| 상황                 | 처리 방식                                  |
+| ------------------ | -------------------------------------- |
+| `200 OK`           | 사용자 정보를 전역 auth/user 상태에 저장            |
+| `401 Unauthorized` | 토큰 만료 또는 세션 무효 처리 후 로그인/게스트 진입 화면으로 이동 |
+| `403 Forbidden`    | 정지 계정 안내 화면 또는 toast 표시                |
+| `409 Conflict`     | 일시적 상태 불일치 안내 후 재로그인 유도                |
 
 ---
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/controller/UserController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/controller/UserController.java
@@ -1,0 +1,69 @@
+package io.github.ascrew.monomatbe.domain.user.controller;
+
+import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
+import io.github.ascrew.monomatbe.domain.user.service.UserQueryService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 사용자 조회 REST API를 처리하는 컨트롤러
+ *
+ * Controller는 HTTP 요청을 받고 인증 주체를 Service에 전달하는 역할만 담당한다.
+ * 사용자 상태 검증, 조회 정책, 응답 DTO 변환은 UserQueryService에서 처리한다.
+ */
+@Slf4j
+@Tag(name = "User", description = "사용자 REST API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private static final String LOG_GET_MY_INFO_REQUEST =
+            "요청 수신: 내 사용자 정보 조회 [GET /api/users/me] - userId: {}, userIdentifier: {}";
+    private static final String LOG_GET_MY_INFO_RESPONSE =
+            "조회 완료: 내 사용자 정보 반환 - userId: {}, userType: {}, status: {}";
+
+    private final UserQueryService userQueryService;
+
+    /**
+     * 로그인한 사용자의 기본 정보를 조회
+     *
+     * @param principal JWT 인증 후 SecurityContext에 저장된 사용자 주체
+     * @return 내 사용자 기본 정보
+     */
+    @Operation(
+            summary = "내 사용자 정보 조회",
+            description = "로그인한 사용자의 기본 정보(userId, username, userType, status, createdAt)를 조회합니다."
+    )
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MyUserInfoResponse> getMyInfo(
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        log.info(
+                LOG_GET_MY_INFO_REQUEST,
+                principal != null ? principal.userId() : null,
+                principal != null ? principal.userIdentifier() : null
+        );
+
+        MyUserInfoResponse response = userQueryService.getMyInfo(principal);
+
+        log.info(
+                LOG_GET_MY_INFO_RESPONSE,
+                response.userId(),
+                response.userType(),
+                response.status()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/dto/MyUserInfoResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/dto/MyUserInfoResponse.java
@@ -1,0 +1,22 @@
+package io.github.ascrew.monomatbe.domain.user.dto;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 로그인한 사용자의 기본 정보 조회 응답 DTO
+ *
+ * FE 상단 프로필, 닉네임 표시, 게스트/회원 분기 처리에 필요한 최소 사용자 정보를 제공한다.
+ */
+@Builder
+public record MyUserInfoResponse(
+        Long userId,
+        String username,
+        UserType userType,
+        UserStatus status,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryService.java
@@ -1,0 +1,99 @@
+package io.github.ascrew.monomatbe.domain.user.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 사용자 조회 유스케이스를 담당하는 서비스
+ *
+ * 현재 단계에서는 로그인한 사용자의 기본 정보 조회만 담당한다.
+ * 사용자 수정, 탈퇴, 프로필 이미지 등 쓰기 유스케이스가 추가되면 별도의 CommandService로 분리한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+
+    private static final String ERROR_INVALID_PRINCIPAL =
+            "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
+    private static final String ERROR_USER_NOT_FOUND =
+            "사용자 정보를 찾을 수 없습니다. 다시 로그인해주세요.";
+    private static final String ERROR_USER_BANNED =
+            "정지된 사용자는 서비스를 이용할 수 없습니다.";
+    private static final String ERROR_USER_DELETED =
+            "탈퇴 또는 삭제된 사용자입니다. 다시 로그인해주세요.";
+    private static final String ERROR_UNSUPPORTED_USER_STATUS =
+            "사용자 상태가 유효하지 않습니다.";
+
+    private final UserRepository userRepository;
+
+    /**
+     * 로그인한 사용자의 기본 정보를 조회한다.
+     *
+     * @param principal JWT 인증 후 SecurityContext에 저장된 사용자 주체
+     * @return 내 사용자 기본 정보
+     */
+    @Transactional(readOnly = true)
+    public MyUserInfoResponse getMyInfo(CustomPrincipal principal) {
+        validatePrincipal(principal);
+
+        User user = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED,
+                        ERROR_USER_NOT_FOUND
+                ));
+
+        validateUsableUser(user.getStatus());
+
+        return toResponse(user);
+    }
+
+    private void validatePrincipal(CustomPrincipal principal) {
+        if (principal == null || principal.userId() == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    ERROR_INVALID_PRINCIPAL
+            );
+        }
+    }
+
+    private void validateUsableUser(UserStatus status) {
+        if (status == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_UNSUPPORTED_USER_STATUS
+            );
+        }
+
+        switch (status) {
+            case ACTIVE -> {
+                return;
+            }
+            case BANNED -> throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_USER_BANNED
+            );
+            case DELETED -> throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    ERROR_USER_DELETED
+            );
+        }
+    }
+
+    private MyUserInfoResponse toResponse(User user) {
+        return MyUserInfoResponse.builder()
+                .userId(user.getId())
+                .username(user.getUsername())
+                .userType(user.getUserType())
+                .status(user.getStatus())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryService.java
@@ -84,6 +84,10 @@ public class UserQueryService {
                     HttpStatus.UNAUTHORIZED,
                     ERROR_USER_DELETED
             );
+            default -> throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_UNSUPPORTED_USER_STATUS
+            );
         }
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,63 @@
+package io.github.ascrew.monomatbe.domain.user.controller;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
+import io.github.ascrew.monomatbe.domain.user.service.UserQueryService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+    private static final String USERNAME = "모노유저";
+    private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 5, 29, 12, 0);
+
+    @Mock
+    private UserQueryService userQueryService;
+
+    @InjectMocks
+    private UserController userController;
+
+    @Test
+    @DisplayName("GET /api/users/me 요청을 서비스에 위임하고 200 OK로 반환한다")
+    void getMyInfo_delegatesToServiceAndReturnsOk() {
+        CustomPrincipal principal = new CustomPrincipal(
+                USER_ID,
+                USER_IDENTIFIER,
+                UserType.REGISTERED
+        );
+
+        MyUserInfoResponse serviceResponse = MyUserInfoResponse.builder()
+                .userId(USER_ID)
+                .username(USERNAME)
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .createdAt(CREATED_AT)
+                .build();
+
+        when(userQueryService.getMyInfo(principal)).thenReturn(serviceResponse);
+
+        ResponseEntity<MyUserInfoResponse> response = userController.getMyInfo(principal);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(serviceResponse);
+
+        verify(userQueryService).getMyInfo(principal);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryServiceTest.java
@@ -1,0 +1,170 @@
+package io.github.ascrew.monomatbe.domain.user.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserQueryServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+    private static final String USERNAME = "모노유저";
+    private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 5, 29, 12, 0);
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserQueryService userQueryService;
+
+    @Nested
+    @DisplayName("내 사용자 정보 조회")
+    class GetMyInfo {
+
+        @Test
+        @DisplayName("ACTIVE 사용자는 내 사용자 정보를 조회할 수 있다")
+        void getMyInfo_returnsMyUserInfo_whenUserIsActive() {
+            CustomPrincipal principal = registeredPrincipal(USER_ID);
+            User user = user(UserStatus.ACTIVE);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+            MyUserInfoResponse response = userQueryService.getMyInfo(principal);
+
+            assertThat(response.userId()).isEqualTo(USER_ID);
+            assertThat(response.username()).isEqualTo(USERNAME);
+            assertThat(response.userType()).isEqualTo(UserType.REGISTERED);
+            assertThat(response.status()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(response.createdAt()).isEqualTo(CREATED_AT);
+
+            verify(userRepository).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("principal이 null이면 401을 반환한다")
+        void getMyInfo_throwsUnauthorized_whenPrincipalIsNull() {
+            assertThatThrownBy(() -> userQueryService.getMyInfo(null))
+                    .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+                            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED)
+                    );
+        }
+
+        @Test
+        @DisplayName("principal의 userId가 null이면 401을 반환한다")
+        void getMyInfo_throwsUnauthorized_whenPrincipalUserIdIsNull() {
+            CustomPrincipal principal = new CustomPrincipal(
+                    null,
+                    USER_IDENTIFIER,
+                    UserType.REGISTERED
+            );
+
+            assertThatThrownBy(() -> userQueryService.getMyInfo(principal))
+                    .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+                            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED)
+                    );
+        }
+
+        @Test
+        @DisplayName("DB에서 사용자를 찾을 수 없으면 401을 반환한다")
+        void getMyInfo_throwsUnauthorized_whenUserDoesNotExist() {
+            CustomPrincipal principal = registeredPrincipal(USER_ID);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userQueryService.getMyInfo(principal))
+                    .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+                            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED)
+                    );
+
+            verify(userRepository).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("BANNED 사용자는 403을 반환한다")
+        void getMyInfo_throwsForbidden_whenUserIsBanned() {
+            CustomPrincipal principal = registeredPrincipal(USER_ID);
+            User user = user(UserStatus.BANNED);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> userQueryService.getMyInfo(principal))
+                    .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+                            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN)
+                    );
+
+            verify(userRepository).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("DELETED 사용자는 401을 반환한다")
+        void getMyInfo_throwsUnauthorized_whenUserIsDeleted() {
+            CustomPrincipal principal = registeredPrincipal(USER_ID);
+            User user = user(UserStatus.DELETED);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> userQueryService.getMyInfo(principal))
+                    .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+                            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED)
+                    );
+
+            verify(userRepository).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("사용자 상태가 null이면 409를 반환한다")
+        void getMyInfo_throwsConflict_whenUserStatusIsNull() {
+            CustomPrincipal principal = registeredPrincipal(USER_ID);
+            User user = user(null);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> userQueryService.getMyInfo(principal))
+                    .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+                            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.CONFLICT)
+                    );
+
+            verify(userRepository).findById(USER_ID);
+        }
+    }
+
+    private CustomPrincipal registeredPrincipal(Long userId) {
+        return new CustomPrincipal(
+                userId,
+                USER_IDENTIFIER,
+                UserType.REGISTERED
+        );
+    }
+
+    private User user(UserStatus status) {
+        return User.builder()
+                .id(USER_ID)
+                .username(USERNAME)
+                .userType(UserType.REGISTERED)
+                .status(status)
+                .createdAt(CREATED_AT)
+                .updatedAt(CREATED_AT)
+                .build();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserQueryServiceTest.java
@@ -43,10 +43,10 @@ class UserQueryServiceTest {
     class GetMyInfo {
 
         @Test
-        @DisplayName("ACTIVE 사용자는 내 사용자 정보를 조회할 수 있다")
-        void getMyInfo_returnsMyUserInfo_whenUserIsActive() {
-            CustomPrincipal principal = registeredPrincipal(USER_ID);
-            User user = user(UserStatus.ACTIVE);
+        @DisplayName("ACTIVE 회원 사용자는 내 사용자 정보를 조회할 수 있다")
+        void getMyInfo_returnsMyUserInfo_whenRegisteredUserIsActive() {
+            CustomPrincipal principal = principal(USER_ID, UserType.REGISTERED);
+            User user = user(UserType.REGISTERED, UserStatus.ACTIVE);
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
@@ -55,6 +55,25 @@ class UserQueryServiceTest {
             assertThat(response.userId()).isEqualTo(USER_ID);
             assertThat(response.username()).isEqualTo(USERNAME);
             assertThat(response.userType()).isEqualTo(UserType.REGISTERED);
+            assertThat(response.status()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(response.createdAt()).isEqualTo(CREATED_AT);
+
+            verify(userRepository).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("ACTIVE 게스트 사용자는 userType이 GUEST로 매핑되어 반환된다")
+        void getMyInfo_returnsGuestUserType_whenGuestUserIsActive() {
+            CustomPrincipal principal = principal(USER_ID, UserType.GUEST);
+            User user = user(UserType.GUEST, UserStatus.ACTIVE);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+            MyUserInfoResponse response = userQueryService.getMyInfo(principal);
+
+            assertThat(response.userId()).isEqualTo(USER_ID);
+            assertThat(response.username()).isEqualTo(USERNAME);
+            assertThat(response.userType()).isEqualTo(UserType.GUEST);
             assertThat(response.status()).isEqualTo(UserStatus.ACTIVE);
             assertThat(response.createdAt()).isEqualTo(CREATED_AT);
 
@@ -73,11 +92,7 @@ class UserQueryServiceTest {
         @Test
         @DisplayName("principal의 userId가 null이면 401을 반환한다")
         void getMyInfo_throwsUnauthorized_whenPrincipalUserIdIsNull() {
-            CustomPrincipal principal = new CustomPrincipal(
-                    null,
-                    USER_IDENTIFIER,
-                    UserType.REGISTERED
-            );
+            CustomPrincipal principal = principal(null, UserType.REGISTERED);
 
             assertThatThrownBy(() -> userQueryService.getMyInfo(principal))
                     .isInstanceOfSatisfying(ResponseStatusException.class, exception ->
@@ -88,7 +103,7 @@ class UserQueryServiceTest {
         @Test
         @DisplayName("DB에서 사용자를 찾을 수 없으면 401을 반환한다")
         void getMyInfo_throwsUnauthorized_whenUserDoesNotExist() {
-            CustomPrincipal principal = registeredPrincipal(USER_ID);
+            CustomPrincipal principal = principal(USER_ID, UserType.REGISTERED);
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
 
@@ -103,8 +118,8 @@ class UserQueryServiceTest {
         @Test
         @DisplayName("BANNED 사용자는 403을 반환한다")
         void getMyInfo_throwsForbidden_whenUserIsBanned() {
-            CustomPrincipal principal = registeredPrincipal(USER_ID);
-            User user = user(UserStatus.BANNED);
+            CustomPrincipal principal = principal(USER_ID, UserType.REGISTERED);
+            User user = user(UserType.REGISTERED, UserStatus.BANNED);
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
@@ -119,8 +134,8 @@ class UserQueryServiceTest {
         @Test
         @DisplayName("DELETED 사용자는 401을 반환한다")
         void getMyInfo_throwsUnauthorized_whenUserIsDeleted() {
-            CustomPrincipal principal = registeredPrincipal(USER_ID);
-            User user = user(UserStatus.DELETED);
+            CustomPrincipal principal = principal(USER_ID, UserType.REGISTERED);
+            User user = user(UserType.REGISTERED, UserStatus.DELETED);
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
@@ -135,8 +150,8 @@ class UserQueryServiceTest {
         @Test
         @DisplayName("사용자 상태가 null이면 409를 반환한다")
         void getMyInfo_throwsConflict_whenUserStatusIsNull() {
-            CustomPrincipal principal = registeredPrincipal(USER_ID);
-            User user = user(null);
+            CustomPrincipal principal = principal(USER_ID, UserType.REGISTERED);
+            User user = user(UserType.REGISTERED, null);
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
@@ -149,19 +164,19 @@ class UserQueryServiceTest {
         }
     }
 
-    private CustomPrincipal registeredPrincipal(Long userId) {
+    private CustomPrincipal principal(Long userId, UserType userType) {
         return new CustomPrincipal(
                 userId,
                 USER_IDENTIFIER,
-                UserType.REGISTERED
+                userType
         );
     }
 
-    private User user(UserStatus status) {
+    private User user(UserType userType, UserStatus status) {
         return User.builder()
                 .id(USER_ID)
                 .username(USERNAME)
-                .userType(UserType.REGISTERED)
+                .userType(userType)
                 .status(status)
                 .createdAt(CREATED_AT)
                 .updatedAt(CREATED_AT)


### PR DESCRIPTION
## 📣 Related Issue

- #121 

## 📝 Summary

로그인한 사용자의 기본 정보를 조회할 수 있는 `GET /api/users/me` API를 추가했습니다.
이번 API는 프론트엔드 상단 프로필 영역, 닉네임 표시, 게스트/회원 분기 처리에서 사용할 수 있도록 다음 정보를 반환합니다.

- `userId`
- `username`
- `userType`
- `status`
- `createdAt`


## 🙏PR point

- `User` 엔티티와 `UserRepository`는 기존 `domain.auth`에 있으므로, 이번 이슈에서는 새 엔티티를 만들지 않고 조회용 `domain/user` 계층만 분리했습니다.
- Controller에는 비즈니스 검증을 넣지 않고, principal 검증/사용자 상태 검증/DTO 변환은 `UserQueryService`에서 처리했습니다.
- `BANNED` 사용자는 인증은 되었지만 서비스 이용이 차단된 상태이므로 `403 Forbidden`으로 처리했습니다.
- `DELETED` 사용자와 DB에서 찾을 수 없는 사용자는 현재 토큰을 더 이상 유효한 사용자 세션으로 보기 어렵기 때문에 `401 Unauthorized`로 처리했습니다.

## 📬 Reference

- `GET /api/users/me`
- 인증 필요: `Authorization: Bearer {accessToken}`