### PR TITLE
[Feat/#103] 인게임 플레이어 준비 핸드셰이크 및 YouTube IFrame 동기화 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,27 @@
 
 ## REST API
 
+### 시스템 (System)
+
+#### 서버 시간 동기화 조회
+
+```http
+GET /api/system/time
+```
+
+클라이언트가 서버와의 시간 오차(delta)를 계산하기 위해 호출합니다.
+인증 토큰 없이 누구나 호출할 수 있습니다.
+
+**Response `200 OK`**
+
+```json
+{
+  "serverTimeMillis": 1716500000000
+}
+```
+
+---
+
 ### 인증 (Auth)
 
 #### 게스트 로그인
@@ -1149,6 +1170,43 @@ SUBSCRIBE /topic/game/{code}/round
 ```
 
 > **참고**: 클라이언트 스포일러 방지를 위해 정답, 힌트, 제목, 아티스트 등의 메타데이터는 라운드 시작 시점에 전송되지 않으며, 정답 공개 시점에 별도의 채널과 DTO(`RoundMetadataDto`)를 통해 전송될 예정입니다.
+
+#### 유튜브 IFrame 로딩 완료(Ready To Play) 송신
+
+```text
+SEND /app/game/{code}/ready-to-play
+```
+
+클라이언트가 `ROUND_READY` 메시지를 수신한 후, 유튜브 IFrame 로딩이 완료되면 호출합니다.
+참가한 모든 플레이어가 해당 신호를 보내거나, 10초 타임아웃이 지나면 실제 라운드 재생(`ROUND_PLAYBACK_STARTED`)이 트리거됩니다.
+
+**Body**
+
+```json
+{
+  "roundNo": 1
+}
+```
+
+#### 라운드 동영상 재생 시작 이벤트 수신
+
+```text
+SUBSCRIBE /topic/game/{code}/round
+```
+(이전 `ROUND_READY` 메시지와 동일한 채널로 수신)
+
+모든 클라이언트의 준비 완료가 취합되거나, 10초 타임아웃이 발생하면 브로드캐스트됩니다. 클라이언트는 이 메시지를 받는 즉시 로드해둔 유튜브 영상을 재생합니다.
+
+**수신 메시지 (RoundPlaybackStartedDto)**
+
+```json
+{
+  "type": "ROUND_PLAYBACK_STARTED",
+  "roundNo": 1,
+  "serverStartedAt": 1716500000000,
+  "durationSeconds": 30
+}
+```
 
 #### 로비 유저 강퇴 송신
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
@@ -28,6 +28,11 @@ public class GameEventController {
             return;
         }
 
+        if (request == null || request.roundNo() <= 0) {
+            log.warn("GameEventController: 잘못된 ready-to-play 요청 - code: {}, request: {}", code, request);
+            return;
+        }
+
         gameRoundStartService.processReadyToPlay(code, principal.userIdentifier(), request.roundNo());
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
@@ -1,0 +1,33 @@
+package io.github.ascrew.monomatbe.domain.game.controller;
+
+import io.github.ascrew.monomatbe.domain.game.dto.ReadyToPlayRequest;
+import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class GameEventController {
+
+    private final GameRoundStartService gameRoundStartService;
+
+    @MessageMapping("/game/{code}/ready-to-play")
+    public void readyToPlay(
+            @DestinationVariable("code") String code,
+            @Payload ReadyToPlayRequest request,
+            CustomPrincipal principal) {
+        
+        if (principal == null || principal.userIdentifier() == null) {
+            log.warn("GameEventController: 인증 정보 없음 - code: {}", code);
+            return;
+        }
+
+        gameRoundStartService.processReadyToPlay(code, principal.userIdentifier(), request.roundNo());
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionController.java
@@ -21,6 +21,12 @@ public class GameSessionController {
     public ResponseEntity<CurrentRoundStatusResponse> getCurrentRoundStatus(
             @PathVariable("code") String code,
             CustomPrincipal principal) {
+        if (principal == null || principal.userIdentifier() == null) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.UNAUTHORIZED,
+                    "유효하지 않은 인증 정보입니다."
+            );
+        }
         CurrentRoundStatusResponse response = gameSessionQueryService.getCurrentRoundStatus(code, principal.userIdentifier());
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionController.java
@@ -1,0 +1,27 @@
+package io.github.ascrew.monomatbe.domain.game.controller;
+
+import io.github.ascrew.monomatbe.domain.game.dto.CurrentRoundStatusResponse;
+import io.github.ascrew.monomatbe.domain.game.service.GameSessionQueryService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/game")
+@RequiredArgsConstructor
+public class GameSessionController {
+
+    private final GameSessionQueryService gameSessionQueryService;
+
+    @GetMapping("/{code}/round/current")
+    public ResponseEntity<CurrentRoundStatusResponse> getCurrentRoundStatus(
+            @PathVariable("code") String code,
+            CustomPrincipal principal) {
+        CurrentRoundStatusResponse response = gameSessionQueryService.getCurrentRoundStatus(code, principal.userIdentifier());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/CurrentRoundStatusResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/CurrentRoundStatusResponse.java
@@ -1,0 +1,12 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CurrentRoundStatusResponse(
+        int roundNo,
+        String status,
+        int timeLimitSeconds,
+        Long serverStartedAt
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/ReadyToPlayRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/ReadyToPlayRequest.java
@@ -1,0 +1,6 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+public record ReadyToPlayRequest(
+        int roundNo
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundPlaybackStartedDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundPlaybackStartedDto.java
@@ -1,0 +1,12 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RoundPlaybackStartedDto(
+        String type,
+        int roundNo,
+        long serverStartedAt,
+        int durationSeconds
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
@@ -1,0 +1,92 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.RoundPlaybackStartedDto;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.constant.StompDestinations;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+public class GameRoundStartService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final RedisScript<String> readyToPlayScript;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+
+    public GameRoundStartService(
+            StringRedisTemplate redisTemplate,
+            SimpMessagingTemplate messagingTemplate,
+            @Qualifier("readyToPlayScript") RedisScript<String> readyToPlayScript) {
+        this.redisTemplate = redisTemplate;
+        this.messagingTemplate = messagingTemplate;
+        this.readyToPlayScript = readyToPlayScript;
+    }
+
+    public void scheduleForcePlaybackStart(String lobbyCode, int roundNo, int timeLimitSeconds) {
+        log.info("게임 세션 라운드 시작 예약 - code: {}, roundNo: {}, timeout: 10s", lobbyCode, roundNo);
+        scheduler.schedule(() -> forcePlaybackStart(lobbyCode, roundNo, timeLimitSeconds), 10, TimeUnit.SECONDS);
+    }
+
+    public void processReadyToPlay(String lobbyCode, String userIdentifier, int roundNo) {
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+        String readyKey = RedisKeys.gameSessionRoundReadyKey(lobbyCode, roundNo);
+        String participantsKey = RedisKeys.lobbyParticipantsKey(lobbyCode);
+        String playbackLockKey = RedisKeys.gameSessionPlaybackLockKey(lobbyCode, roundNo);
+
+        String result = redisTemplate.execute(
+                readyToPlayScript,
+                List.of(sessionKey, readyKey, participantsKey, playbackLockKey),
+                userIdentifier,
+                String.valueOf(roundNo),
+                "7200" // 2시간 TTL
+        );
+
+        log.info("라운드 재생 준비 처리 - code: {}, user: {}, roundNo: {}, result: {}", lobbyCode, userIdentifier, roundNo, result);
+
+        if ("ALL_READY".equals(result)) {
+            String timeLimitStr = (String) redisTemplate.opsForHash().get(sessionKey, "time_limit_seconds");
+            int timeLimitSeconds = timeLimitStr != null ? Integer.parseInt(timeLimitStr) : 30;
+            broadcastPlaybackStarted(lobbyCode, roundNo, timeLimitSeconds);
+        }
+    }
+
+    private void forcePlaybackStart(String lobbyCode, int roundNo, int timeLimitSeconds) {
+        String playbackLockKey = RedisKeys.gameSessionPlaybackLockKey(lobbyCode, roundNo);
+        Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(playbackLockKey, "1", Duration.ofHours(2));
+
+        if (Boolean.TRUE.equals(lockAcquired)) {
+            log.warn("라운드 준비 타임아웃 발생. 강제 재생 시작 - code: {}, roundNo: {}", lobbyCode, roundNo);
+            broadcastPlaybackStarted(lobbyCode, roundNo, timeLimitSeconds);
+        } else {
+            log.info("라운드 강제 재생 무시됨 (이미 시작됨) - code: {}, roundNo: {}", lobbyCode, roundNo);
+        }
+    }
+
+    private void broadcastPlaybackStarted(String lobbyCode, int roundNo, int durationSeconds) {
+        long serverStartedAt = System.currentTimeMillis();
+
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+        redisTemplate.opsForHash().put(sessionKey, "playback_started_at", String.valueOf(serverStartedAt));
+
+        RoundPlaybackStartedDto dto = RoundPlaybackStartedDto.builder()
+                .type("ROUND_PLAYBACK_STARTED")
+                .roundNo(roundNo)
+                .serverStartedAt(serverStartedAt)
+                .durationSeconds(durationSeconds)
+                .build();
+
+        messagingTemplate.convertAndSend(StompDestinations.subscribeGameRound(lobbyCode), dto);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
@@ -69,7 +69,7 @@ public class GameRoundStartService {
         Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(playbackLockKey, "1", Duration.ofHours(2));
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
-        String playbackStartedKey = "playback_started_at:" + roundNo;
+        String playbackStartedKey = RedisKeys.gameSessionRoundPlaybackStartedAtField(roundNo);
         String playbackStartedAtVal = (String) redisTemplate.opsForHash().get(sessionKey, playbackStartedKey);
 
         if (Boolean.TRUE.equals(lockAcquired)) {
@@ -87,17 +87,21 @@ public class GameRoundStartService {
         long serverStartedAt = System.currentTimeMillis();
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
-        String playbackStartedKey = "playback_started_at:" + roundNo;
-        redisTemplate.opsForHash().put(sessionKey, playbackStartedKey, String.valueOf(serverStartedAt));
+        String playbackStartedKey = RedisKeys.gameSessionRoundPlaybackStartedAtField(roundNo);
+        Boolean isSaved = redisTemplate.opsForHash().putIfAbsent(sessionKey, playbackStartedKey, String.valueOf(serverStartedAt));
 
-        RoundPlaybackStartedDto dto = RoundPlaybackStartedDto.builder()
-                .type(GameEventTypes.ROUND_PLAYBACK_STARTED)
-                .roundNo(roundNo)
-                .serverStartedAt(serverStartedAt)
-                .durationSeconds(durationSeconds)
-                .build();
+        if (Boolean.TRUE.equals(isSaved)) {
+            RoundPlaybackStartedDto dto = RoundPlaybackStartedDto.builder()
+                    .type(GameEventTypes.ROUND_PLAYBACK_STARTED)
+                    .roundNo(roundNo)
+                    .serverStartedAt(serverStartedAt)
+                    .durationSeconds(durationSeconds)
+                    .build();
 
-        messagingTemplate.convertAndSend(StompDestinations.subscribeGameRound(lobbyCode), dto);
+            messagingTemplate.convertAndSend(StompDestinations.subscribeGameRound(lobbyCode), dto);
+        } else {
+            log.info("이미 다른 스레드/서버에서 재생 시작 시각이 기록되어 브로드캐스트를 스킵합니다 - code: {}, roundNo: {}", lobbyCode, roundNo);
+        }
     }
 }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.game.service;
 
 import io.github.ascrew.monomatbe.domain.game.dto.RoundPlaybackStartedDto;
+import io.github.ascrew.monomatbe.global.constant.GameEventTypes;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import lombok.extern.slf4j.Slf4j;
@@ -8,13 +9,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -23,20 +23,22 @@ public class GameRoundStartService {
     private final StringRedisTemplate redisTemplate;
     private final SimpMessagingTemplate messagingTemplate;
     private final RedisScript<String> readyToPlayScript;
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+    private final TaskScheduler taskScheduler;
 
     public GameRoundStartService(
             StringRedisTemplate redisTemplate,
             SimpMessagingTemplate messagingTemplate,
-            @Qualifier("readyToPlayScript") RedisScript<String> readyToPlayScript) {
+            @Qualifier("readyToPlayScript") RedisScript<String> readyToPlayScript,
+            TaskScheduler taskScheduler) {
         this.redisTemplate = redisTemplate;
         this.messagingTemplate = messagingTemplate;
         this.readyToPlayScript = readyToPlayScript;
+        this.taskScheduler = taskScheduler;
     }
 
     public void scheduleForcePlaybackStart(String lobbyCode, int roundNo, int timeLimitSeconds) {
         log.info("게임 세션 라운드 시작 예약 - code: {}, roundNo: {}, timeout: 10s", lobbyCode, roundNo);
-        scheduler.schedule(() -> forcePlaybackStart(lobbyCode, roundNo, timeLimitSeconds), 10, TimeUnit.SECONDS);
+        taskScheduler.schedule(() -> forcePlaybackStart(lobbyCode, roundNo, timeLimitSeconds), Instant.now().plusSeconds(10));
     }
 
     public void processReadyToPlay(String lobbyCode, String userIdentifier, int roundNo) {
@@ -66,8 +68,15 @@ public class GameRoundStartService {
         String playbackLockKey = RedisKeys.gameSessionPlaybackLockKey(lobbyCode, roundNo);
         Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(playbackLockKey, "1", Duration.ofHours(2));
 
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+        String playbackStartedKey = "playback_started_at:" + roundNo;
+        String playbackStartedAtVal = (String) redisTemplate.opsForHash().get(sessionKey, playbackStartedKey);
+
         if (Boolean.TRUE.equals(lockAcquired)) {
             log.warn("라운드 준비 타임아웃 발생. 강제 재생 시작 - code: {}, roundNo: {}", lobbyCode, roundNo);
+            broadcastPlaybackStarted(lobbyCode, roundNo, timeLimitSeconds);
+        } else if (playbackStartedAtVal == null) {
+            log.warn("라운드 락은 획득되었으나 재생 시작 시간이 기록되지 않은 비정상 상태 감지. 강제 재생 시작으로 복구 - code: {}, roundNo: {}", lobbyCode, roundNo);
             broadcastPlaybackStarted(lobbyCode, roundNo, timeLimitSeconds);
         } else {
             log.info("라운드 강제 재생 무시됨 (이미 시작됨) - code: {}, roundNo: {}", lobbyCode, roundNo);
@@ -78,10 +87,11 @@ public class GameRoundStartService {
         long serverStartedAt = System.currentTimeMillis();
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
-        redisTemplate.opsForHash().put(sessionKey, "playback_started_at", String.valueOf(serverStartedAt));
+        String playbackStartedKey = "playback_started_at:" + roundNo;
+        redisTemplate.opsForHash().put(sessionKey, playbackStartedKey, String.valueOf(serverStartedAt));
 
         RoundPlaybackStartedDto dto = RoundPlaybackStartedDto.builder()
-                .type("ROUND_PLAYBACK_STARTED")
+                .type(GameEventTypes.ROUND_PLAYBACK_STARTED)
                 .roundNo(roundNo)
                 .serverStartedAt(serverStartedAt)
                 .durationSeconds(durationSeconds)
@@ -90,3 +100,4 @@ public class GameRoundStartService {
         messagingTemplate.convertAndSend(StompDestinations.subscribeGameRound(lobbyCode), dto);
     }
 }
+

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
@@ -25,7 +25,7 @@ public class GameSessionQueryService {
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
         
-        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of("current_round_no", "time_limit_seconds", "playback_started_at"));
+        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of("current_round_no", "time_limit_seconds"));
         
         if (hashValues.get(0) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "진행 중인 게임 세션이 없습니다.");
@@ -33,7 +33,10 @@ public class GameSessionQueryService {
 
         int roundNo = Integer.parseInt((String) hashValues.get(0));
         int timeLimitSeconds = hashValues.get(1) != null ? Integer.parseInt((String) hashValues.get(1)) : 30;
-        Long serverStartedAt = hashValues.get(2) != null ? Long.parseLong((String) hashValues.get(2)) : null;
+        
+        String playbackStartedKey = "playback_started_at:" + roundNo;
+        String playbackStartedAtStr = (String) redisTemplate.opsForHash().get(sessionKey, playbackStartedKey);
+        Long serverStartedAt = playbackStartedAtStr != null ? Long.parseLong(playbackStartedAtStr) : null;
 
         String playbackLockKey = RedisKeys.gameSessionPlaybackLockKey(lobbyCode, roundNo);
         boolean isPlaying = Boolean.TRUE.equals(redisTemplate.hasKey(playbackLockKey));

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
@@ -34,7 +34,7 @@ public class GameSessionQueryService {
         int roundNo = Integer.parseInt((String) hashValues.get(0));
         int timeLimitSeconds = hashValues.get(1) != null ? Integer.parseInt((String) hashValues.get(1)) : 30;
         
-        String playbackStartedKey = "playback_started_at:" + roundNo;
+        String playbackStartedKey = RedisKeys.gameSessionRoundPlaybackStartedAtField(roundNo);
         String playbackStartedAtStr = (String) redisTemplate.opsForHash().get(sessionKey, playbackStartedKey);
         Long serverStartedAt = playbackStartedAtStr != null ? Long.parseLong(playbackStartedAtStr) : null;
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
@@ -1,0 +1,48 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.CurrentRoundStatusResponse;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GameSessionQueryService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final LobbyRepository lobbyRepository;
+
+    public CurrentRoundStatusResponse getCurrentRoundStatus(String lobbyCode, String userIdentifier) {
+        if (!lobbyRepository.isParticipant(lobbyCode, userIdentifier)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "로비 참가자만 조회할 수 있습니다.");
+        }
+
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+        
+        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of("current_round_no", "time_limit_seconds", "playback_started_at"));
+        
+        if (hashValues.get(0) == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "진행 중인 게임 세션이 없습니다.");
+        }
+
+        int roundNo = Integer.parseInt((String) hashValues.get(0));
+        int timeLimitSeconds = hashValues.get(1) != null ? Integer.parseInt((String) hashValues.get(1)) : 30;
+        Long serverStartedAt = hashValues.get(2) != null ? Long.parseLong((String) hashValues.get(2)) : null;
+
+        String playbackLockKey = RedisKeys.gameSessionPlaybackLockKey(lobbyCode, roundNo);
+        boolean isPlaying = Boolean.TRUE.equals(redisTemplate.hasKey(playbackLockKey));
+
+        return CurrentRoundStatusResponse.builder()
+                .roundNo(roundNo)
+                .status(isPlaying ? "PLAYING" : "WAITING")
+                .timeLimitSeconds(timeLimitSeconds)
+                .serverStartedAt(serverStartedAt)
+                .build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartService.java
@@ -19,6 +19,9 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.lobby.StartLobbyResult;
+import io.github.ascrew.monomatbe.domain.game.service.GameRealtimeNotifier;
+import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
+import io.github.ascrew.monomatbe.domain.game.service.GameSessionCreateService;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
@@ -76,10 +79,11 @@ public class LobbyStartService {
 
     private final LobbyRepository lobbyRepository;
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
+    private final GameRealtimeNotifier gameRealtimeNotifier;
+    private final GameSessionCreateService gameSessionCreateService;
+    private final GameRoundStartService gameRoundStartService;
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final LobbyStartPolicy lobbyStartPolicy;
-    private final io.github.ascrew.monomatbe.domain.game.service.GameSessionCreateService gameSessionCreateService;
-    private final io.github.ascrew.monomatbe.domain.game.service.GameRealtimeNotifier gameRealtimeNotifier;
 
     /**
      * 로비 게임 시작 요청을 처리한다.
@@ -291,6 +295,7 @@ public class LobbyStartService {
 
                 try {
                     gameRealtimeNotifier.notifyRoundStart(code, firstRound);
+                    gameRoundStartService.scheduleForcePlaybackStart(code, firstRound.roundNo(), firstRound.timeLimitSeconds());
                 } catch (Exception e) {
                     log.error("[ALERT_REQUIRED] ROUND_START 발행 실패 - code: {}, requester: {}, roundNo: {}", code, requesterIdentifier, firstRound.roundNo(), e);
                 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/common/controller/SystemController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/common/controller/SystemController.java
@@ -1,0 +1,17 @@
+package io.github.ascrew.monomatbe.global.common.controller;
+
+import io.github.ascrew.monomatbe.global.common.dto.ServerTimeResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/system")
+public class SystemController {
+
+    @GetMapping("/time")
+    public ResponseEntity<ServerTimeResponse> getServerTime() {
+        return ResponseEntity.ok(new ServerTimeResponse(System.currentTimeMillis()));
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/common/dto/ServerTimeResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/common/dto/ServerTimeResponse.java
@@ -1,0 +1,4 @@
+package io.github.ascrew.monomatbe.global.common.dto;
+
+public record ServerTimeResponse(long serverTimeMillis) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -130,4 +130,12 @@ public class RedisScriptConfig {
         redisScript.setResultType(String.class);
         return redisScript;
     }
+
+    @Bean
+    public RedisScript<String> readyToPlayScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/ready_to_play.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/GameEventTypes.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/GameEventTypes.java
@@ -1,0 +1,8 @@
+package io.github.ascrew.monomatbe.global.constant;
+
+public final class GameEventTypes {
+    
+    public static final String ROUND_PLAYBACK_STARTED = "ROUND_PLAYBACK_STARTED";
+
+    private GameEventTypes() {}
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -553,4 +553,26 @@ public final class RedisKeys {
     public static String gameSessionPlayersKey(String lobbyCode) {
         return GAME_SESSION_PREFIX + lobbyCode + ":players";
     }
+
+    /**
+     * 특정 라운드의 재생 준비 완료된 유저 Set 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:ready"
+     */
+    public static String gameSessionRoundReadyKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":ready";
+    }
+
+    /**
+     * 특정 라운드의 재생 시작 중복 방지 SETNX 락 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:playback_lock"
+     */
+    public static String gameSessionPlaybackLockKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":playback_lock";
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -644,4 +644,14 @@ public final class RedisKeys {
     public static String gameSessionPlaybackLockKey(String lobbyCode, int roundNo) {
         return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":playback_lock";
     }
+
+    /**
+     * 특정 라운드의 재생 시작 시각 필드명을 반환합니다.
+     *
+     * @param roundNo 라운드 번호
+     * @return "playback_started_at:{roundNo}"
+     */
+    public static String gameSessionRoundPlaybackStartedAtField(int roundNo) {
+        return "playback_started_at:" + roundNo;
+    }
 }

--- a/src/main/resources/scripts/ready_to_play.lua
+++ b/src/main/resources/scripts/ready_to_play.lua
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- 라운드 준비 완료(ready-to-play) 원자적 처리 스크립트
+--
+-- [파라미터]
+-- KEYS[1] : sessionKey (예: game:session:{code})
+-- KEYS[2] : readyKey (예: game:session:{code}:round:{roundNo}:ready)
+-- KEYS[3] : participantsKey (예: lobby:{code}:participants)
+-- KEYS[4] : playbackLockKey (예: game:session:{code}:round:{roundNo}:playback_lock)
+--
+-- ARGV[1] : userIdentifier
+-- ARGV[2] : roundNo
+-- ARGV[3] : ttl (초)
+-- ============================================================================
+
+local sessionKey = KEYS[1]
+local readyKey = KEYS[2]
+local participantsKey = KEYS[3]
+local playbackLockKey = KEYS[4]
+
+local userIdentifier = ARGV[1]
+local roundNo = ARGV[2]
+local ttl = ARGV[3]
+
+-- 1. 유효성 검사
+if redis.call('EXISTS', sessionKey) == 0 then
+    return "ERROR_SESSION_NOT_FOUND"
+end
+if redis.call('HGET', sessionKey, 'current_round_no') ~= roundNo then
+    return "ERROR_INVALID_ROUND"
+end
+-- 게임 세션 참가자가 아니라도 현재 로비 참가자면 수용 (이탈 방어 목적)
+if redis.call('SISMEMBER', participantsKey, userIdentifier) == 0 then
+    return "ERROR_NOT_PARTICIPANT"
+end
+
+-- 2. 이미 재생 시작되었는지 확인
+if redis.call('EXISTS', playbackLockKey) == 1 then
+    return "ALREADY_STARTED"
+end
+
+-- 3. 준비 완료 세트에 추가
+redis.call('SADD', readyKey, userIdentifier)
+redis.call('EXPIRE', readyKey, ttl)
+
+local readyCount = redis.call('SCARD', readyKey)
+local totalCount = redis.call('SCARD', participantsKey)
+
+-- 4. 만약 인원이 충족되었다면 락 걸기
+if readyCount >= totalCount then
+    redis.call('SET', playbackLockKey, '1', 'EX', ttl)
+    return "ALL_READY"
+end
+
+return "WAITING"

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
@@ -1,0 +1,100 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.RoundPlaybackStartedDto;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GameRoundStartServiceTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+    @Mock
+    private RedisScript<String> readyToPlayScript;
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private GameRoundStartService gameRoundStartService;
+
+    private final String lobbyCode = "TEST12";
+    private final String userIdentifier = "user-1";
+    private final int roundNo = 1;
+
+    @BeforeEach
+    void setUp() {
+        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript);
+    }
+
+    @Test
+    @DisplayName("정상적으로 모두 준비 완료된 경우 (ALL_READY 반환)")
+    void processReadyToPlay_allReady() {
+        // given
+        when(redisTemplate.execute(eq(readyToPlayScript), anyList(), anyString(), anyString(), anyString()))
+                .thenReturn("ALL_READY");
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.get(anyString(), eq("time_limit_seconds"))).thenReturn("30");
+
+        // when
+        gameRoundStartService.processReadyToPlay(lobbyCode, userIdentifier, roundNo);
+
+        // then
+        ArgumentCaptor<RoundPlaybackStartedDto> captor = ArgumentCaptor.forClass(RoundPlaybackStartedDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + lobbyCode + "/round"), captor.capture());
+
+        RoundPlaybackStartedDto dto = captor.getValue();
+        assertThat(dto.type()).isEqualTo("ROUND_PLAYBACK_STARTED");
+        assertThat(dto.roundNo()).isEqualTo(roundNo);
+        assertThat(dto.durationSeconds()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("일부만 준비 완료된 경우 STOMP 발송하지 않음 (WAITING 반환)")
+    void processReadyToPlay_waiting() {
+        // given
+        when(redisTemplate.execute(eq(readyToPlayScript), anyList(), anyString(), anyString(), anyString()))
+                .thenReturn("WAITING");
+
+        // when
+        gameRoundStartService.processReadyToPlay(lobbyCode, userIdentifier, roundNo);
+
+        // then
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(RoundPlaybackStartedDto.class));
+    }
+
+    @Test
+    @DisplayName("참여자가 아닌 경우 에러 반환 시 STOMP 발송하지 않음")
+    void processReadyToPlay_notParticipant() {
+        // given
+        when(redisTemplate.execute(eq(readyToPlayScript), anyList(), anyString(), anyString(), anyString()))
+                .thenReturn("ERROR_NOT_PARTICIPANT");
+
+        // when
+        gameRoundStartService.processReadyToPlay(lobbyCode, userIdentifier, roundNo);
+
+        // then
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(RoundPlaybackStartedDto.class));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
@@ -58,6 +58,7 @@ class GameRoundStartServiceTest {
                 .thenReturn("ALL_READY");
         when(redisTemplate.opsForHash()).thenReturn(hashOperations);
         when(hashOperations.get(anyString(), eq("time_limit_seconds"))).thenReturn("30");
+        when(hashOperations.putIfAbsent(anyString(), anyString(), anyString())).thenReturn(true);
 
         // when
         gameRoundStartService.processReadyToPlay(lobbyCode, userIdentifier, roundNo);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
@@ -36,6 +36,8 @@ class GameRoundStartServiceTest {
     private HashOperations<String, Object, Object> hashOperations;
     @Mock
     private ValueOperations<String, String> valueOperations;
+    @Mock
+    private org.springframework.scheduling.TaskScheduler taskScheduler;
 
     private GameRoundStartService gameRoundStartService;
 
@@ -45,7 +47,7 @@ class GameRoundStartServiceTest {
 
     @BeforeEach
     void setUp() {
-        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript);
+        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript, taskScheduler);
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartServiceTest.java
@@ -29,7 +29,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-
+import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
+import io.github.ascrew.monomatbe.domain.game.service.GameSessionCreateService;
 @ExtendWith(MockitoExtension.class)
 class LobbyStartServiceTest {
 
@@ -44,24 +45,24 @@ class LobbyStartServiceTest {
     @Mock
     private GameRealtimeNotifier gameRealtimeNotifier;
     @Mock
-    private QuizMapJpaRepository quizMapJpaRepository;
+    private GameRoundStartService gameRoundStartService;
+    @Mock
+    private LobbyStartPolicy lobbyStartPolicy;
 
     private LobbyStartService lobbyStartService;
-    private LobbyStartPolicy lobbyStartPolicy;
 
     @BeforeEach
     void setUp() {
         TransactionSynchronizationManager.initSynchronization();
         
-        lobbyStartPolicy = new LobbyStartPolicy(quizMapJpaRepository);
-        
         lobbyStartService = new LobbyStartService(
                 lobbyRepository,
                 lobbyRealtimeNotifier,
-                gameLobbyJpaRepository,
-                lobbyStartPolicy,
+                gameRealtimeNotifier,
                 gameSessionCreateService,
-                gameRealtimeNotifier
+                gameRoundStartService,
+                gameLobbyJpaRepository,
+                lobbyStartPolicy
         );
     }
 
@@ -81,8 +82,8 @@ class LobbyStartServiceTest {
         QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).isDeleted(false).build();
         
         when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(code)).thenReturn(Optional.of(gameLobby));
+        when(lobbyStartPolicy.validateStartableMap(gameLobby)).thenReturn(quizMap);
         when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.Started(code));
         when(gameSessionCreateService.createGameSession(gameLobby, quizMap)).thenReturn(mock(RoundStartDto.class));
 
@@ -105,7 +106,8 @@ class LobbyStartServiceTest {
         GameLobby gameLobby = GameLobby.builder().inviteCode(code).mapId(null).roundCount(5).build();
         
         when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(code)).thenReturn(Optional.of(gameLobby));
+        when(lobbyStartPolicy.validateStartableMap(gameLobby)).thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.CONFLICT, "게임을 시작하려면 맵을 선택해야 합니다."));
 
         // when & then
         assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
@@ -125,8 +127,8 @@ class LobbyStartServiceTest {
         QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(3).isDeleted(false).build();
         
         when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(code)).thenReturn(Optional.of(gameLobby));
+        when(lobbyStartPolicy.validateStartableMap(gameLobby)).thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.CONFLICT, "맵의 문제 수가 설정된 라운드 수보다 적습니다."));
 
         // when & then
         assertThatThrownBy(() -> lobbyStartService.startLobbyGame(code, principal))
@@ -145,8 +147,8 @@ class LobbyStartServiceTest {
         QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).isDeleted(false).build();
         
         when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(code)).thenReturn(Optional.of(gameLobby));
+        when(lobbyStartPolicy.validateStartableMap(gameLobby)).thenReturn(quizMap);
         // 이미 진행 중인 로비이므로 LobbyNotWaiting 반환
         when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.LobbyNotWaiting(code));
 
@@ -168,8 +170,8 @@ class LobbyStartServiceTest {
         QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(10).build();
 
         when(lobbyRepository.findByInviteCode(code)).thenReturn(Optional.of(org.mockito.Mockito.mock(io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse.class)));
-        when(gameLobbyJpaRepository.findByInviteCode(code)).thenReturn(Optional.of(gameLobby));
-        when(quizMapJpaRepository.findById(1L)).thenReturn(Optional.of(quizMap));
+        when(gameLobbyJpaRepository.findByInviteCodeForUpdate(code)).thenReturn(Optional.of(gameLobby));
+        when(lobbyStartPolicy.validateStartableMap(gameLobby)).thenReturn(quizMap);
         when(lobbyRepository.executeStartLobbyProcess(code, "uId")).thenReturn(new StartLobbyResult.Started(code));
 
         when(gameSessionCreateService.createGameSession(gameLobby, quizMap))


### PR DESCRIPTION
## 📣 Related Issue

- #101 
- #103

## 📝 Summary

- **인게임 플레이어 준비 완료(ready-to-play) 핸드셰이크 구현**
  - 클라이언트의 YouTube IFrame API 준비 완료 상태를 수집하는 STOMP 메시지 핸들러 `/pub/game/{code}/ready-to-play` ([GameEventController](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java)) 추가.
  - 플레이어 준비 상태 관리 및 원자적 인원 충족 여부 판단을 위한 Redis Lua 스크립트 [ready_to_play.lua](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/resources/scripts/ready_to_play.lua) 작성 및 빈 등록 ([RedisScriptConfig](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java)).
  - 모든 플레이어가 준비 완료되면 비디오 재생 시작 STOMP 브로드캐스트 (`ROUND_PLAYBACK_STARTED` 이벤트) 전송.
- **재생 지연 방어용 강제 시작 타임아웃 타이머 적용**
  - 특정 플레이어의 로딩이 늦어지더라도 게임이 멈추지 않도록, 로비 시작 후 10초 후에 자동으로 발동하는 강제 재생 시작 스케줄러(`forcePlaybackStart`) 구현 ([GameRoundStartService](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java)).
  - 동시성 제어를 위해 Redis 락(`playback_lock`)을 활용하여, 10초 내 100% 준비 완료 시점과 강제 시작 타이머 중복 발송을 방어.
- **클라이언트-서버 간 정밀 시간 동기화(Time Synchronization) API 제공**
  - YouTube IFrame API의 재생 지점 보정(Seek Offset)에 사용될 수 있도록 서버 현재 시간 밀리초를 반환하는 `GET /api/system/time` ([SystemController](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/global/common/controller/SystemController.java)) 제공.
- **새로고침 및 중도 합류 대응용 현재 라운드 상태 API 제공**
  - 네트워크 단절이나 강제 새로고침 시 인게임 뷰 복구를 위한 `GET /api/game/{code}/round/current` ([GameSessionController](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionController.java)) 제공.
  - 현재 라운드 정보, 플레이 상태(`PLAYING`/`WAITING`), 재생 시작 시간 (`serverStartedAt`) 및 제한 시간을 함께 응답하여 뷰 복원을 지원.
- **테스트 및 문서화**
  - `docs/API.md`에 ready-to-play STOMP 및 REST API 계약을 갱신.
  - [GameRoundStartServiceTest](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java)를 추가하여 `ALL_READY` / `WAITING` / 에러 시나리오에 대한 단위 테스트 검증 완료.

## 🙏PR point

- **YouTube 플레이어 시간 보정 방식**:
  - `ROUND_PLAYBACK_STARTED` 이벤트나 `GET /api/game/{code}/round/current` API에서 응답받는 `serverStartedAt`(Long, 서버 기준 밀리초)을 사용합니다.
  - FE는 사전에 `GET /api/system/time`을 호출하여 `로컬 클라이언트 시간 - 서버 시간` 오프셋(Clock skew)을 계산해야 합니다.
  - `현재 서버 시간 = 현재 로컬 시간 - 오프셋`으로 보정하고, `경과 시간 = 현재 서버 시간 - serverStartedAt`을 계산하여 해당 초(seconds) 지점으로 유튜브 플레이어를 이동(`seekTo`)시켜야 모든 사용자가 초 단위 싱크를 맞출 수 있습니다.
- **강제 시작 시간(10초)**:
  - 현재 강제 시작 타임아웃은 방장이 게임 시작 버튼을 누르고 DB 상태가 변경된 시점부터 10초 후에 스케줄링됩니다.
  - 로비가 활성화될 때 `LobbyStartService`에서 `GameRoundStartService.scheduleForcePlaybackStart`를 호출하여 작동합니다.
- **Redis 키 네이밍 컨벤션**:
  - [RedisKeys](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java)에 인게임 세션 및 라운드 준비 상태 관리에 필요한 키 생성 규칙(`gameSessionRoundReadyKey`, `gameSessionPlaybackLockKey` 등)을 구조화하여 격리성을 유지했습니다.

## 📬 Reference