### PR TITLE
[Feat/#104] 라운드 정답 제출 및 정답 판별 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,4 +72,10 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperty "file.encoding", "UTF-8"
 }
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -1486,6 +1486,123 @@ SEND /app/lobby/{code}/kick
 
 ---
 
+## 🎮 인게임 (In-Game API)
+
+인게임 세션 생성 이후 라운드 준비, IFrame 재생 동기화 및 단일 대화창 정답 판단에 사용되는 REST 및 STOMP API 규격입니다.
+
+### REST API
+
+#### 1) 서버 현재 시간 조회 (Clock Skew 보정용)
+- **URL**: `GET /api/system/time`
+- **설명**: YouTube IFrame API 재생 시간의 초 단위 동기화(Clock skew 보정)를 위해 서버 기준 밀리초를 조회합니다.
+- **응답 (Response)**:
+  ```json
+  {
+    "serverTime": 1716500000000
+  }
+  ```
+
+#### 2) 현재 라운드 정보 조회 (새로고침 및 중도 합류용)
+- **URL**: `GET /api/game/{code}/round/current`
+- **설명**: 사용자가 게임 중간에 강제 새로고침을 하거나 세션이 일시 단절되었다 복구되었을 때, 뷰 복원을 지원하기 위해 현재 진행 중인 라운드의 세부 정보 및 재생 개시 시각을 반환합니다.
+- **응답 (Response)**:
+  ```json
+  {
+    "status": "PLAYING", // READY, PLAYING, FINISHED
+    "currentRoundNo": 1,
+    "timeLimitSeconds": 30,
+    "playbackStartedAt": 1716500000000 // 아직 재생 전인 경우 null
+  }
+  ```
+
+---
+
+### STOMP API
+
+#### 3) 유튜브 IFrame 로딩 완료 (Ready To Play) 송신
+- **Destination**: `SEND /app/game/{code}/ready-to-play`
+- **설명**: 클라이언트가 비디오 로드 완료 및 준비 상태를 서버에 전송합니다. 모든 참가자가 해당 신호를 보내거나, 10초 타임아웃이 지나면 실제 라운드 비디오 재생이 트리거됩니다.
+- **Body**:
+  ```json
+  {
+    "roundNo": 1
+  }
+  ```
+
+#### 4) 인게임 라운드 시작 및 비디오 재생 이벤트 구독
+- **Destination**: `SUBSCRIBE /topic/game/{code}/round`
+- **설명**: 새로운 라운드가 준비되거나, 모든 참가자가 준비를 완료하여 비디오 재생을 개시할 때 전파되는 이벤트를 수신합니다.
+- **라운드 준비 알림 (ROUND_READY)**:
+  ```json
+  {
+    "type": "ROUND_READY",
+    "videoId": "dQw4w9WgXcQ",
+    "youtubeUrl": "https://youtube.com/watch?v=dQw4w9WgXcQ",
+    "startTime": 10,
+    "endTime": 40,
+    "timeLimitSeconds": 30,
+    "roundNo": 1,
+    "serverStartedAt": 1716500000000
+  }
+  ```
+  *(정답, 힌트 등은 스포일러 방지를 위해 ROUND_READY 시점에는 일절 포함되지 않습니다)*
+- **재생 개시 알림 (ROUND_PLAYBACK_STARTED)**:
+  ```json
+  {
+    "type": "ROUND_PLAYBACK_STARTED",
+    "roundNo": 1,
+    "serverStartedAt": 1716500000000,
+    "durationSeconds": 30
+  }
+  ```
+
+#### 5) 인게임 전용 채팅 송신 및 브로드캐스트
+- **송신**: `SEND /app/game/{code}/chat`
+- **Body**:
+  ```json
+  {
+    "roundNo": 1,
+    "content": "제출할 채팅 혹은 정답"
+  }
+  ```
+- **구독 (수신)**: `SUBSCRIBE /topic/game/{code}/chat`
+  - **일반 채팅 및 오답 수신 (CHAT)**:
+    ```json
+    {
+      "type": "CHAT",
+      "roomId": "GAME12",
+      "sender": "닉네임",
+      "content": "가나다라마",
+      "timestamp": "2026-05-30T21:46:52"
+    }
+    ```
+    *(정답을 이미 맞춘 사람이 채팅에 정답을 포함할 경우, 스포일러 방지를 위해 본문 content가 "***" 로 마스킹 처리되어 브로드캐스트됩니다)*
+  - **최초 정답 공지 (SYSTEM)**: 미정답자였던 사용자가 정답을 입력하면 본문은 차단되고 전체 사용자에게 시스템 정답 공지가 브로드캐스트됩니다.
+    ```json
+    {
+      "type": "SYSTEM",
+      "roomId": "GAME12",
+      "sender": "SYSTEM",
+      "content": "닉네임님이 정답을 맞췄습니다!",
+      "timestamp": "2026-05-30T21:46:52"
+    }
+    ```
+
+#### 6) 정답 성공 개별 통지 구독
+- **Destination**: `SUBSCRIBE /user/queue/game/answers`
+- **설명**: 자신이 제출한 채팅이 정답으로 승인되었을 때, 개별 축하 메시지 및 오타 허용(Fuzzy Match) 여부를 직접 통지 받습니다.
+- **Response**:
+  ```json
+  {
+    "type": "ROUND_CORRECT",
+    "roundNo": 1,
+    "isFuzzy": true, // 오타 허용으로 맞춘 경우 true, 완전 일치일 시 false
+    "message": "오타 허용 정답입니다!"
+  }
+  ```
+
+---
+
 ## 에러 응답
 
 ### STOMP ERROR 프레임
@@ -1609,4 +1726,3 @@ REST join 성공 후에도 다음 상황에서는 WebSocket SUBSCRIBE가 실패�
 | 맵 아이템(문제) CRUD     | `GET/POST/PUT/DELETE /api/maps/{mapId}/items` |
 | YouTube URL 유효성 검증 | `POST /api/youtube/validate`                  |
 | 로비 맵 변경            | `PATCH /api/lobbies/{inviteCode}/map`         |
-| 인게임 WebSocket      | `/app/game/{code}/**`                         |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,12 +123,37 @@ src/main/java/io/github/ascrew/monomatbe/
 │   │   ├── repository/
 │   │   └── service/
 │   │
-│   └── game/                                       # 인게임 도메인
+│   └── game/                                       # 인게임 플레이 도메인
 │       ├── controller/
+│       │   ├── GameEventController.java            # 인게임 WebSocket 엔드포인트
+│       │   └── GameSessionController.java          # 인게임 REST 엔드포인트
 │       ├── dto/
+│       │   ├── CurrentRoundStatusResponse.java
+│       │   ├── GameChatMessageDto.java
+│       │   ├── ReadyToPlayRequest.java
+│       │   ├── RoundCorrectResponse.java
+│       │   ├── RoundMetadataDto.java
+│       │   ├── RoundPlaybackStartedDto.java
+│       │   └── RoundStartDto.java
 │       ├── entity/
+│       │   ├── GameSession.java
+│       │   └── GameSessionPlayer.java
+│       ├── exception/
+│       │   ├── GameSessionAlreadyExistsException.java
+│       │   └── NotEnoughMapItemsException.java
 │       ├── repository/
-│       └── service/
+│       │   ├── GameSessionJpaRepository.java
+│       │   └── GameSessionPlayerJpaRepository.java
+│       ├── service/
+│       │   ├── GameAnswerService.java              # 정답 검증 및 판별 비즈니스
+│       │   ├── GameParticipantResolver.java        # WebSocket 세션 참가자 검증
+│       │   ├── GameRealtimeNotifier.java           # 인게임 Pub/Sub 브로드캐스트
+│       │   ├── GameRoundStartService.java          # 라운드 데이터 웜업 및 라운드 준비/재생 제어
+│       │   ├── GameSessionCreateService.java       # 게임 세션 및 라운드 초기 데이터 생성
+│       │   └── GameSessionQueryService.java        # 현재 게임 세션 및 라운드 상태 조회
+│       └── support/
+│           ├── FuzzyMatcher.java                   # 오타 허용 임계거리 판단 정책
+│           └── LevenshteinDistance.java            # Levenshtein Distance 계산 (공간 복잡도 O(min(M, N)))
 │
 └── global/                                         # 전역 인프라 레이어
     ├── config/
@@ -213,6 +238,17 @@ LobbyCreateService
             ▼
 LobbyRepositoryImpl
     └── Redis 저장에 필요한 mapId, mapTitle, mapCategory만 사용
+```
+
+또한, 인게임 플레이 중에 이루어지는 채팅 및 정답 제출은 대기실/로비를 다루는 `chat` 도메인과의 순환 의존을 방지하기 위해 완전히 격리되어 있습니다. 인게임 채팅 엔드포인트 `/app/game/{code}/chat`은 `game` 도메인의 `GameEventController`가 수용하여 `GameAnswerService`로 직접 제어를 위임합니다.
+
+```text
+GameEventController (인게임 채팅 송신 수용)
+     │
+     ▼
+GameAnswerService (정답 여부 검증 및 라우팅)
+     ├── (최초 정답자) -> Redis 정답자 Set 등록 및 SYSTEM 공지 발행 + 개별 성공 통지(/user/queue/game/answers)
+     └── (오답 및 정답자 채팅) -> CHAT 타입 브로드캐스트 (스포일러 방지를 위해 정답 키워드 포함 시 *** 마스킹)
 ```
 
 ---
@@ -442,6 +478,77 @@ KICK:
   "content": "target-user-identifier님이 강퇴되었습니다.",
   "timestamp": "2026-05-26T12:00:00"
 }
+```
+
+### 인게임 메시지 및 동기화 흐름
+
+#### 1. 인게임 준비 및 YouTube IFrame 동기화 흐름 (#103)
+게임 세션 시작 혹은 다음 라운드 진행 시, 비디오가 정확히 동기화되어 모든 사용자에게 동시에 재생될 수 있도록 2단계 동기화가 이루어집니다.
+
+```text
+클라이언트 (방장/참가자)                               서버
+      │                                                │
+      │ 1. [ROUND_READY] 브로드캐스트 수신              │
+      │    (videoId, startTime, endTime, limit)        │
+      │    - 스포일러 방지를 위해 정답/메타 생략       │
+      │    - YouTube IFrame API 로딩 및 버퍼링 시작    │
+      │◄───────────────────────────────────────────────┤
+      │                                                │
+      │ 2. YouTube IFrame 로딩 완료 (ready-to-play)     │
+      │    SEND /app/game/{code}/ready-to-play         │
+      ├───────────────────────────────────────────────►│ 1. ready count 증가 (Redis Set)
+      │                                                │ 2. 모든 세션의 준비 완료 취합 또는
+      │                                                │    10초 타임아웃 발생 감지
+      │                                                │ 3. 재생 시작 조건 충족 시
+      │                                                │
+      │ 3. [ROUND_PLAYBACK_STARTED] 브로드캐스트 수신   │
+      │    (roundNo, serverStartedAt, duration)        │
+      │◄───────────────────────────────────────────────┤
+      │                                                │
+      │ 4. 재생 시간 보정 및 강제 재생                 │
+      │    - (현재 서버시간 - serverStartedAt) 만큼       │
+      │      seekTo() 후 playVideo() 수행              │
+      ▼                                                ▼
+```
+
+#### 2. 단일 채팅창 기반 인게임 정답 제출 및 판별 흐름 (#104)
+사용자는 단일 채팅창에서 일반 채팅 대화와 정답 제출을 동시에 수행합니다. 시스템은 사용자가 아직 정답을 맞추지 못했을 경우 정답 여부를 판별하여 처리합니다.
+
+```text
+클라이언트 (미정답자)                                 서버
+      │                                                │
+      │ 1. 채팅/정답 입력 (SEND /app/game/{code}/chat)   │
+      ├───────────────────────────────────────────────►│ 1. 사용자가 이미 정답을 맞춘 상태인지 확인 (Redis Set)
+      │                                                │ 2. (미정답자일 시) 정답 여부 대소문자/공백 제거 비교
+      │                                                │ 3. Fuzzy Match(Levenshtein Distance)로 오타 판단
+      │                                                │
+      │                    [정답인 경우]               │
+      │                    - 일반 채팅 브로드캐스트 차단
+      │                    - Redis 정답자 Set 등록
+      │                    - 전체 공지 브로드캐스트 (SYSTEM 타입)
+      │                      "/topic/game/{code}/chat"
+      │◄───────────────────────────────────────────────┤
+      │                                                │
+      │                    - 개별 정답 성공 통지 (ROUND_CORRECT)
+      │                      "/user/queue/game/answers"
+      │◄───────────────────────────────────────────────┤
+      │                                                │
+      │                    [오답/일반채팅인 경우]      │
+      │                    - 일반 채팅 브로드캐스트 (CHAT 타입)
+      │                      "/topic/game/{code}/chat"
+      │◄───────────────────────────────────────────────┤
+```
+
+```text
+클라이언트 (이미 정답을 맞춘 사람)                     서버
+      │                                                │
+      │ 1. 채팅 입력 (SEND /app/game/{code}/chat)       │
+      ├───────────────────────────────────────────────►│ 1. 사용자가 이미 정답을 맞춘 상태인지 확인 (Redis Set)
+      │                                                │ 2. 입력된 채팅 본문에 정답 키워드가 포함되는지 확인
+      │                                                │ 3. (스포일러 방지) 정답 포함 시 본문 "***" 마스킹
+      │                                                │
+      │ 2. 마스킹된 일반 채팅 수신 (CHAT 타입)        │
+      │◄───────────────────────────────────────────────┤
 ```
 
 ---
@@ -732,6 +839,10 @@ GameRealtimeNotifier / LobbyRealtimeNotifier
 | `game:session:{lobbyCode}` | Hash | 인게임 세션 메타데이터 |
 | `game:session:{lobbyCode}:rounds` | List | 출제된 라운드 목록 |
 | `game:session:{lobbyCode}:players` | Hash | 인게임 플레이어 점수 |
+| `game:session:{lobbyCode}:round:{roundNo}:data` | Hash | 라운드 정답(JSON list), 비디오 제목, 아티스트 메타데이터 |
+| `game:session:{lobbyCode}:round:{roundNo}:correct_players` | Set | 해당 라운드에서 이미 정답을 맞춘 플레이어 목록 (스포일러 판정용) |
+| `game:session:{lobbyCode}:round:{roundNo}:ready_players` | Set | 해당 라운드 시작 전 YouTube IFrame 준비 완료 신호를 보낸 플레이어 목록 |
+
 
 ### `lobby:{code}` Hash 구조
 
@@ -751,6 +862,24 @@ GameRealtimeNotifier / LobbyRealtimeNotifier
 
 `map_id`, `map_title`, `map_category`는 로비 생성 시 `mapId`가 전달된 경우에만 저장합니다.  
 맵이 선택되지 않은 로비는 위 세 필드를 저장하지 않습니다.
+
+### `game:session:{lobbyCode}` Hash 구조
+
+| 필드 | 설명 |
+| --- | --- |
+| `lobby_code` | 게임 로비 초대 코드 |
+| `status` | 인게임 상태 (`READY`, `PLAYING`, `FINISHED`) |
+| `current_round_no` | 현재 진행 중인 라운드 번호 (1-based) |
+| `time_limit_seconds` | 라운드별 재생 시간 제한 |
+| `playback_started_at` | 현재 라운드의 비디오 재생 개시 시각 (Clock sync용, 아직 재생 전이면 null) |
+
+### `game:session:{lobbyCode}:round:{roundNo}:data` Hash 구조
+
+| 필드 | 설명 |
+| --- | --- |
+| `answers` | JSON 직렬화된 정답 목록 문자열 (예: `["곡제목1", "곡제목2"]`) |
+| `title` | 정답 공개용 곡 공식 타이틀 |
+| `artist` | 정답 공개용 가수명 |
 
 ---
 
@@ -947,3 +1076,19 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 | `action` | 화면 이동/재연결/재시도 정책 |
 | `recoverable` | 같은 화면에서 재시도 가능한지 판단 |
 | `message` | 사용자에게 표시할 문구 |
+
+### 인게임 플레이 및 동기화
+
+#### 1) 유튜브 IFrame API 동기화 및 Clock Skew 보정
+- FE는 인게임 화면 진입 시 `GET /api/system/time`을 호출하여 서버와 클라이언트 간의 **시간차(Clock Skew)**를 계산하고 보관해야 합니다.
+- 라운드가 시작되어 `ROUND_READY` 수신 후 YouTube 비디오 로드가 완료되면 즉시 `SEND /app/game/{code}/ready-to-play`를 전송해야 합니다. (전체 준비가 완료되지 않아 대기하는 동안 비디오는 재생하지 않고 정지 또는 일시정지 상태여야 함)
+- 모든 유저의 준비 완료 혹은 타임아웃으로 `ROUND_PLAYBACK_STARTED` 메시지를 받으면, FE는 즉시 비디오를 재생해야 합니다.
+- **재생 지점 보정**: 네트워크 딜레이 등으로 인해 메시지 수신 시점이 비디오 시작 타임라인보다 늦을 수 있으므로, `(현재 서버 기준 밀리초 - serverStartedAt)` 만큼 비디오를 앞으로 감기(`seekTo`)한 후 재생(`playVideo`)하여 정확히 1초 미만의 싱크차를 맞춥니다.
+
+#### 2) 단일 채팅창 연동 및 스포일러 방지 필터링
+- **수신 분기**: 인게임 채팅 채널 `/topic/game/{code}/chat`을 구독하고, 수신된 메시지의 `type`을 확인합니다:
+  - `CHAT`: 일반 사용자의 채팅 내용입니다. 본문 `content`가 `"***"`로 왔다면 이는 **정답을 맞춘 사용자가 정답 키워드를 누설하지 않도록 서버에서 마스킹한 스포일러 방지 본문**이므로, 그대로 화면에 출력합니다.
+  - `SYSTEM`: 누군가 새로 정답을 맞췄을 때 브로드캐스트되는 공지입니다. (예: `"닉네임님이 정답을 맞췄습니다!"`)
+- **송신 규칙**: 사용자가 텍스트를 입력하고 전송할 때는 모두 `SEND /app/game/{code}/chat`으로 단일하게 송신합니다.
+- **개별 결과 수신**: 자신이 제출한 채팅이 정답에 해당할 경우, 서버는 일반 채팅 브로드캐스트를 중단(Drop)하고, 해당 사용자에게 `/user/queue/game/answers` 채널로 개별 정답 성공 통지(`ROUND_CORRECT`)를 보냅니다.
+  - 이 통지에는 오타 허용으로 정답 처리되었는지를 알 수 있는 `isFuzzy` 필드가 포함되어 있으므로, FE는 이를 활용하여 사용자에게 "오타 허용 정답!" 같은 전용 연출을 표시할 수 있습니다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
@@ -1,8 +1,11 @@
 package io.github.ascrew.monomatbe.domain.game.controller;
 
+import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
 import io.github.ascrew.monomatbe.domain.game.dto.ReadyToPlayRequest;
+import io.github.ascrew.monomatbe.domain.game.service.GameAnswerService;
 import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Controller;
 public class GameEventController {
 
     private final GameRoundStartService gameRoundStartService;
+    private final GameAnswerService gameAnswerService;
 
     @MessageMapping("/game/{code}/ready-to-play")
     public void readyToPlay(
@@ -34,5 +38,19 @@ public class GameEventController {
         }
 
         gameRoundStartService.processReadyToPlay(code, principal.userIdentifier(), request.roundNo());
+    }
+
+    @MessageMapping("/game/{code}/chat")
+    public void handleGameChat(
+            @DestinationVariable("code") String code,
+            @Payload @Valid GameChatMessageDto messageDto,
+            CustomPrincipal principal) {
+
+        if (principal == null || principal.userIdentifier() == null) {
+            log.warn("GameEventController: 인증 정보 없음 - code: {}", code);
+            return;
+        }
+
+        gameAnswerService.processGameChat(code, principal.userIdentifier(), messageDto);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/GameChatMessageDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/GameChatMessageDto.java
@@ -1,0 +1,18 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 인게임 전용 채팅 송신 DTO.
+ * 라운드 번호를 포함하여 만료된 이전 라운드 정답 제출을 방지합니다.
+ */
+public record GameChatMessageDto(
+        @NotNull(message = "라운드 번호는 필수입니다.")
+        Integer roundNo,
+
+        @NotBlank(message = "메시지 내용은 비어있을 수 없습니다.")
+        @Size(max = 500, message = "메시지는 최대 500자까지 전송 가능합니다.")
+        String content
+) {}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundCorrectResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundCorrectResponse.java
@@ -1,0 +1,14 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import lombok.Builder;
+
+/**
+ * 정답을 맞춘 플레이어에게 개인적으로 전송할 성공 응답 DTO.
+ */
+@Builder
+public record RoundCorrectResponse(
+        String type, // "ROUND_CORRECT"
+        Integer roundNo,
+        boolean isFuzzy,
+        String message
+) {}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -1,7 +1,7 @@
 package io.github.ascrew.monomatbe.domain.game.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.ascrew.monomatbe.domain.chat.service.ChatSenderProfile;
+import io.github.ascrew.monomatbe.domain.chat.service.ChatSenderProfileResolver;
 import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundCorrectResponse;
 import io.github.ascrew.monomatbe.domain.game.support.FuzzyMatcher;
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -33,7 +35,8 @@ public class GameAnswerService {
     private final SimpMessagingTemplate messagingTemplate;
     private final LobbyRepository lobbyRepository;
     private final LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ChatSenderProfileResolver chatSenderProfileResolver;
+    private final JsonMapper jsonMapper;
 
     /**
      * 인게임 전용 채팅 인입 시 정답 여부를 판별하여 처리합니다.
@@ -100,7 +103,7 @@ public class GameAnswerService {
         List<String> rawAnswers = Collections.emptyList();
         if (answersJson != null) {
             try {
-                rawAnswers = objectMapper.readValue(answersJson, new TypeReference<List<String>>() {});
+                rawAnswers = jsonMapper.readValue(answersJson, new TypeReference<List<String>>() {});
             } catch (Exception e) {
                 log.error("processGameChat: 정답 캐시 역직렬화 실패 - key: {}", roundDataKey, e);
             }
@@ -113,7 +116,7 @@ public class GameAnswerService {
             for (String rawAnswer : rawAnswers) {
                 String normalizedTarget = AnswerNormalizer.normalize(rawAnswer);
                 String normalizedAnswer = AnswerNormalizer.normalize(content);
-                if (FuzzyMatcher.isMatch(normalizedAnswer, normalizedTarget)) {
+                if (normalizedAnswer.contains(normalizedTarget) || FuzzyMatcher.isMatch(normalizedAnswer, normalizedTarget)) {
                     content = "***";
                     break;
                 }
@@ -197,7 +200,14 @@ public class GameAnswerService {
     }
 
     private String getNickname(String userIdentifier) {
-        Map<String, String> resolved = lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(userIdentifier));
-        return resolved.getOrDefault(userIdentifier, lobbyPlayerNicknameResolver.fallbackNickname(userIdentifier));
+        try {
+            ChatSenderProfile profile = chatSenderProfileResolver.resolve(userIdentifier);
+            if (profile != null && profile.getNickname() != null) {
+                return profile.getNickname();
+            }
+        } catch (Exception e) {
+            log.warn("getNickname: 캐시 프로필 조회 실패. userIdentifier: {}", userIdentifier, e);
+        }
+        return lobbyPlayerNicknameResolver.fallbackNickname(userIdentifier);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -13,6 +13,7 @@ import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import tools.jackson.core.type.TypeReference;
@@ -37,6 +38,7 @@ public class GameAnswerService {
     private final LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver;
     private final ChatSenderProfileResolver chatSenderProfileResolver;
     private final JsonMapper jsonMapper;
+    private final RedisScript<String> submitGameAnswerScript;
 
     /**
      * 인게임 전용 채팅 인입 시 정답 여부를 판별하여 처리합니다.
@@ -46,6 +48,11 @@ public class GameAnswerService {
      * @param messageDto 인게임 채팅 DTO
      */
     public void processGameChat(String code, String userIdentifier, GameChatMessageDto messageDto) {
+        if (isInvalidMessage(messageDto)) {
+            log.warn("processGameChat: 잘못된 게임 채팅 요청 - code: {}, user: {}", code, userIdentifier);
+            return;
+        }
+
         // 1. 기본 검증
         if (!lobbyRepository.existsByCode(code)) {
             log.warn("processGameChat: 존재하지 않는 로비 - code: {}", code);
@@ -83,19 +90,18 @@ public class GameAnswerService {
             return;
         }
 
-        // 2. 시간 초과 검증 (지연 완충 시간 1.5초 고려)
+        // 2. 시간 초과 사전 검증 (지연 완충 시간 1.5초 고려)
         String playbackStartedAtStr = (String) values.get(3);
         String timeLimitStr = (String) values.get(2);
         int timeLimitSeconds = timeLimitStr != null ? Integer.parseInt(timeLimitStr) : 30;
+        boolean isTimeout = false;
 
         if (playbackStartedAtStr != null) {
             long playbackStartedAt = Long.parseLong(playbackStartedAtStr);
             long limitTimeMillis = playbackStartedAt + (timeLimitSeconds * 1000L) + 1500L;
             if (System.currentTimeMillis() > limitTimeMillis) {
                 log.info("processGameChat: 제출 시간 초과 - code: {}, user: {}", code, userIdentifier);
-                // 만료된 제출은 일반 채팅 브로드캐스트로 무조건 내보냄
-                broadcastChatMessage(code, userIdentifier, messageDto.content());
-                return;
+                isTimeout = true;
             }
         }
 
@@ -115,7 +121,7 @@ public class GameAnswerService {
             }
         }
 
-        // 5. 정답자 대화 처리 (스포일러 트롤링 필터 적용)
+        // 5. 이미 정답을 맞춘 사용자 대화 처리 (스포일러 트롤링 필터 적용)
         if (Boolean.TRUE.equals(isAlreadyCorrect)) {
             String content = messageDto.content();
             String normalizedAnswer = AnswerNormalizer.normalize(content);
@@ -132,7 +138,23 @@ public class GameAnswerService {
             return;
         }
 
-        // 6. 미정답자의 정답 여부 판단
+        // 6. 만료 제출인 경우 정답 판별 없이 일반 대화 송출 (스포일러 마스킹 적용)
+        if (isTimeout) {
+            String content = messageDto.content();
+            String normalizedAnswer = AnswerNormalizer.normalize(content);
+            if (!normalizedAnswer.isEmpty()) {
+                for (String normalizedTarget : normalizedAnswers) {
+                    if (normalizedAnswer.contains(normalizedTarget) || FuzzyMatcher.isMatch(normalizedAnswer, normalizedTarget)) {
+                        content = "***";
+                        break;
+                    }
+                }
+            }
+            broadcastChatMessage(code, userIdentifier, content);
+            return;
+        }
+
+        // 7. 미정답자의 정답 여부 판단
         boolean isCorrect = false;
         boolean isFuzzy = false;
 
@@ -146,16 +168,22 @@ public class GameAnswerService {
                 } else if (FuzzyMatcher.isMatch(normalizedUserAnswer, normalizedTarget)) {
                     isCorrect = true;
                     isFuzzy = true;
-                    // Fuzzy 매칭이 되어도 계속 더 가까운 매칭을 찾을 수 있으므로 루프를 유지하되 우선 true 처리
                 }
             }
         }
 
-        // 7. 결과 분기 처리
+        // 8. 결과 분기 처리
         if (isCorrect) {
-            // 정답자 추가 (SADD의 리턴값이 1일 때만 최초 정답 달성으로 취급)
-            Long addedCount = redisTemplate.opsForSet().add(correctPlayersKey, userIdentifier);
-            if (addedCount != null && addedCount == 1) {
+            // 원자적 정답자 등록 및 상태 검증 (Lua Script 기동)
+            String result = redisTemplate.execute(
+                    submitGameAnswerScript,
+                    List.of(sessionKey, correctPlayersKey),
+                    userIdentifier,
+                    String.valueOf(currentRoundNo),
+                    String.valueOf(System.currentTimeMillis())
+            );
+
+            if ("CORRECT_FIRST".equals(result)) {
                 String nickname = getNickname(userIdentifier);
                 log.info("processGameChat: 정답 달성! - code: {}, user: {} ({}), fuzzy: {}", 
                          code, userIdentifier, nickname, isFuzzy);
@@ -165,6 +193,20 @@ public class GameAnswerService {
 
                 // 정답 달성자 본인에게 개인 축하 응답 전송
                 sendDirectCorrectResponse(userIdentifier, currentRoundNo, isFuzzy);
+            } else if ("ALREADY_CORRECT".equals(result)) {
+                broadcastChatMessage(code, userIdentifier, messageDto.content());
+            } else if ("TIMEOUT".equals(result)) {
+                log.info("processGameChat: Lua 검증 기준 제출 시간 초과 - code: {}, user: {}", code, userIdentifier);
+                String content = messageDto.content();
+                for (String normalizedTarget : normalizedAnswers) {
+                    if (normalizedUserAnswer.contains(normalizedTarget) || FuzzyMatcher.isMatch(normalizedUserAnswer, normalizedTarget)) {
+                        content = "***";
+                        break;
+                    }
+                }
+                broadcastChatMessage(code, userIdentifier, content);
+            } else {
+                log.warn("processGameChat: Lua 검증 실패 - result: {}, code: {}, user: {}", result, code, userIdentifier);
             }
         } else {
             // 오답인 경우 일반 채팅으로 전송
@@ -215,5 +257,13 @@ public class GameAnswerService {
             log.warn("getNickname: 캐시 프로필 조회 실패. userIdentifier: {}", userIdentifier, e);
         }
         return lobbyPlayerNicknameResolver.fallbackNickname(userIdentifier);
+    }
+
+    private boolean isInvalidMessage(GameChatMessageDto messageDto) {
+        return messageDto == null
+                || messageDto.roundNo() == null
+                || messageDto.content() == null
+                || messageDto.content().isBlank()
+                || messageDto.content().length() > 500;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -57,19 +57,25 @@ public class GameAnswerService {
         }
 
         String sessionKey = RedisKeys.gameSessionKey(code);
-        Map<Object, Object> sessionMeta = redisTemplate.opsForHash().entries(sessionKey);
-        if (sessionMeta.isEmpty()) {
+        List<Object> fields = List.of(
+                "status",
+                "current_round_no",
+                "time_limit_seconds",
+                RedisKeys.gameSessionRoundPlaybackStartedAtField(messageDto.roundNo())
+        );
+        List<Object> values = redisTemplate.opsForHash().multiGet(sessionKey, fields);
+        if (values == null || values.get(0) == null) {
             log.warn("processGameChat: 활성화된 게임 세션이 없음 - code: {}", code);
             return;
         }
 
-        String status = (String) sessionMeta.get("status");
+        String status = (String) values.get(0);
         if (!"PLAYING".equals(status)) {
             log.warn("processGameChat: 게임 진행 중이 아님 (status: {}) - code: {}", status, code);
             return;
         }
 
-        String currentRoundNoStr = (String) sessionMeta.get("current_round_no");
+        String currentRoundNoStr = (String) values.get(1);
         int currentRoundNo = currentRoundNoStr != null ? Integer.parseInt(currentRoundNoStr) : 1;
         if (messageDto.roundNo() != currentRoundNo) {
             log.warn("processGameChat: 라운드 번호 불일치 - code: {}, expected: {}, actual: {}", 
@@ -78,8 +84,8 @@ public class GameAnswerService {
         }
 
         // 2. 시간 초과 검증 (지연 완충 시간 1.5초 고려)
-        String playbackStartedAtStr = (String) sessionMeta.get(RedisKeys.gameSessionRoundPlaybackStartedAtField(currentRoundNo));
-        String timeLimitStr = (String) sessionMeta.get("time_limit_seconds");
+        String playbackStartedAtStr = (String) values.get(3);
+        String timeLimitStr = (String) values.get(2);
         int timeLimitSeconds = timeLimitStr != null ? Integer.parseInt(timeLimitStr) : 30;
 
         if (playbackStartedAtStr != null) {
@@ -99,11 +105,11 @@ public class GameAnswerService {
 
         // 4. 캐싱된 문제 정답 로드
         String roundDataKey = RedisKeys.gameSessionRoundDataKey(code, currentRoundNo);
-        String answersJson = (String) redisTemplate.opsForHash().get(roundDataKey, "answers");
-        List<String> rawAnswers = Collections.emptyList();
-        if (answersJson != null) {
+        String normalizedAnswersJson = (String) redisTemplate.opsForHash().get(roundDataKey, "normalized_answers");
+        List<String> normalizedAnswers = Collections.emptyList();
+        if (normalizedAnswersJson != null) {
             try {
-                rawAnswers = jsonMapper.readValue(answersJson, new TypeReference<List<String>>() {});
+                normalizedAnswers = jsonMapper.readValue(normalizedAnswersJson, new TypeReference<List<String>>() {});
             } catch (Exception e) {
                 log.error("processGameChat: 정답 캐시 역직렬화 실패 - key: {}", roundDataKey, e);
             }
@@ -112,13 +118,14 @@ public class GameAnswerService {
         // 5. 정답자 대화 처리 (스포일러 트롤링 필터 적용)
         if (Boolean.TRUE.equals(isAlreadyCorrect)) {
             String content = messageDto.content();
-            // 정답을 맞춘 유저의 채팅 중 정답과 100% 일치하거나 오타 매칭이 되는 부분은 마스킹 처리하여 스포일러 방지
-            for (String rawAnswer : rawAnswers) {
-                String normalizedTarget = AnswerNormalizer.normalize(rawAnswer);
-                String normalizedAnswer = AnswerNormalizer.normalize(content);
-                if (normalizedAnswer.contains(normalizedTarget) || FuzzyMatcher.isMatch(normalizedAnswer, normalizedTarget)) {
-                    content = "***";
-                    break;
+            String normalizedAnswer = AnswerNormalizer.normalize(content);
+            if (!normalizedAnswer.isEmpty()) {
+                // 정답을 맞춘 유저의 채팅 중 정답과 100% 일치하거나 오타 매칭이 되는 부분은 마스킹 처리하여 스포일러 방지
+                for (String normalizedTarget : normalizedAnswers) {
+                    if (normalizedAnswer.contains(normalizedTarget) || FuzzyMatcher.isMatch(normalizedAnswer, normalizedTarget)) {
+                        content = "***";
+                        break;
+                    }
                 }
             }
             broadcastChatMessage(code, userIdentifier, content);
@@ -131,8 +138,7 @@ public class GameAnswerService {
 
         String normalizedUserAnswer = AnswerNormalizer.normalize(messageDto.content());
         if (!normalizedUserAnswer.isEmpty()) {
-            for (String rawAnswer : rawAnswers) {
-                String normalizedTarget = AnswerNormalizer.normalize(rawAnswer);
+            for (String normalizedTarget : normalizedAnswers) {
                 if (normalizedUserAnswer.equals(normalizedTarget)) {
                     isCorrect = true;
                     isFuzzy = false;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -1,0 +1,203 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundCorrectResponse;
+import io.github.ascrew.monomatbe.domain.game.support.FuzzyMatcher;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyPlayerNicknameResolver;
+import io.github.ascrew.monomatbe.domain.map.support.AnswerNormalizer;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 인게임 채팅 인입 시 정답을 판별하고 알림 및 일반 대화 브로드캐스트의 흐름을 처리하는 서비스.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameAnswerService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final LobbyRepository lobbyRepository;
+    private final LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 인게임 전용 채팅 인입 시 정답 여부를 판별하여 처리합니다.
+     *
+     * @param code 로비 초대 코드
+     * @param userIdentifier 발신자 식별자
+     * @param messageDto 인게임 채팅 DTO
+     */
+    public void processGameChat(String code, String userIdentifier, GameChatMessageDto messageDto) {
+        // 1. 기본 검증
+        if (!lobbyRepository.existsByCode(code)) {
+            log.warn("processGameChat: 존재하지 않는 로비 - code: {}", code);
+            return;
+        }
+        if (!lobbyRepository.isParticipant(code, userIdentifier)) {
+            log.warn("processGameChat: 로비 참여자가 아님 - code: {}, user: {}", code, userIdentifier);
+            return;
+        }
+
+        String sessionKey = RedisKeys.gameSessionKey(code);
+        Map<Object, Object> sessionMeta = redisTemplate.opsForHash().entries(sessionKey);
+        if (sessionMeta.isEmpty()) {
+            log.warn("processGameChat: 활성화된 게임 세션이 없음 - code: {}", code);
+            return;
+        }
+
+        String status = (String) sessionMeta.get("status");
+        if (!"PLAYING".equals(status)) {
+            log.warn("processGameChat: 게임 진행 중이 아님 (status: {}) - code: {}", status, code);
+            return;
+        }
+
+        String currentRoundNoStr = (String) sessionMeta.get("current_round_no");
+        int currentRoundNo = currentRoundNoStr != null ? Integer.parseInt(currentRoundNoStr) : 1;
+        if (messageDto.roundNo() != currentRoundNo) {
+            log.warn("processGameChat: 라운드 번호 불일치 - code: {}, expected: {}, actual: {}", 
+                     code, currentRoundNo, messageDto.roundNo());
+            return;
+        }
+
+        // 2. 시간 초과 검증 (지연 완충 시간 1.5초 고려)
+        String playbackStartedAtStr = (String) sessionMeta.get(RedisKeys.gameSessionRoundPlaybackStartedAtField(currentRoundNo));
+        String timeLimitStr = (String) sessionMeta.get("time_limit_seconds");
+        int timeLimitSeconds = timeLimitStr != null ? Integer.parseInt(timeLimitStr) : 30;
+
+        if (playbackStartedAtStr != null) {
+            long playbackStartedAt = Long.parseLong(playbackStartedAtStr);
+            long limitTimeMillis = playbackStartedAt + (timeLimitSeconds * 1000L) + 1500L;
+            if (System.currentTimeMillis() > limitTimeMillis) {
+                log.info("processGameChat: 제출 시간 초과 - code: {}, user: {}", code, userIdentifier);
+                // 만료된 제출은 일반 채팅 브로드캐스트로 무조건 내보냄
+                broadcastChatMessage(code, userIdentifier, messageDto.content());
+                return;
+            }
+        }
+
+        // 3. 정답자 데이터 로드
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(code, currentRoundNo);
+        Boolean isAlreadyCorrect = redisTemplate.opsForSet().isMember(correctPlayersKey, userIdentifier);
+
+        // 4. 캐싱된 문제 정답 로드
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(code, currentRoundNo);
+        String answersJson = (String) redisTemplate.opsForHash().get(roundDataKey, "answers");
+        List<String> rawAnswers = Collections.emptyList();
+        if (answersJson != null) {
+            try {
+                rawAnswers = objectMapper.readValue(answersJson, new TypeReference<List<String>>() {});
+            } catch (Exception e) {
+                log.error("processGameChat: 정답 캐시 역직렬화 실패 - key: {}", roundDataKey, e);
+            }
+        }
+
+        // 5. 정답자 대화 처리 (스포일러 트롤링 필터 적용)
+        if (Boolean.TRUE.equals(isAlreadyCorrect)) {
+            String content = messageDto.content();
+            // 정답을 맞춘 유저의 채팅 중 정답과 100% 일치하거나 오타 매칭이 되는 부분은 마스킹 처리하여 스포일러 방지
+            for (String rawAnswer : rawAnswers) {
+                String normalizedTarget = AnswerNormalizer.normalize(rawAnswer);
+                String normalizedAnswer = AnswerNormalizer.normalize(content);
+                if (FuzzyMatcher.isMatch(normalizedAnswer, normalizedTarget)) {
+                    content = "***";
+                    break;
+                }
+            }
+            broadcastChatMessage(code, userIdentifier, content);
+            return;
+        }
+
+        // 6. 미정답자의 정답 여부 판단
+        boolean isCorrect = false;
+        boolean isFuzzy = false;
+
+        String normalizedUserAnswer = AnswerNormalizer.normalize(messageDto.content());
+        if (!normalizedUserAnswer.isEmpty()) {
+            for (String rawAnswer : rawAnswers) {
+                String normalizedTarget = AnswerNormalizer.normalize(rawAnswer);
+                if (normalizedUserAnswer.equals(normalizedTarget)) {
+                    isCorrect = true;
+                    isFuzzy = false;
+                    break;
+                } else if (FuzzyMatcher.isMatch(normalizedUserAnswer, normalizedTarget)) {
+                    isCorrect = true;
+                    isFuzzy = true;
+                    // Fuzzy 매칭이 되어도 계속 더 가까운 매칭을 찾을 수 있으므로 루프를 유지하되 우선 true 처리
+                }
+            }
+        }
+
+        // 7. 결과 분기 처리
+        if (isCorrect) {
+            // 정답자 추가 (SADD의 리턴값이 1일 때만 최초 정답 달성으로 취급)
+            Long addedCount = redisTemplate.opsForSet().add(correctPlayersKey, userIdentifier);
+            if (addedCount != null && addedCount == 1) {
+                String nickname = getNickname(userIdentifier);
+                log.info("processGameChat: 정답 달성! - code: {}, user: {} ({}), fuzzy: {}", 
+                         code, userIdentifier, nickname, isFuzzy);
+
+                // 정답 달성 시스템 공지 브로드캐스트
+                broadcastSystemMessage(code, nickname + "님이 정답을 맞췄습니다!");
+
+                // 정답 달성자 본인에게 개인 축하 응답 전송
+                sendDirectCorrectResponse(userIdentifier, currentRoundNo, isFuzzy);
+            }
+        } else {
+            // 오답인 경우 일반 채팅으로 전송
+            broadcastChatMessage(code, userIdentifier, messageDto.content());
+        }
+    }
+
+    private void broadcastChatMessage(String code, String userIdentifier, String content) {
+        String nickname = getNickname(userIdentifier);
+        ChatMessageDto chatMessage = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.CHAT)
+                .roomId(code)
+                .sender(nickname)
+                .content(content)
+                .timestamp(LocalDateTime.now().toString())
+                .build();
+        messagingTemplate.convertAndSend("/topic/game/" + code + "/chat", chatMessage);
+    }
+
+    private void broadcastSystemMessage(String code, String content) {
+        ChatMessageDto systemMessage = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.SYSTEM)
+                .roomId(code)
+                .sender("SYSTEM")
+                .content(content)
+                .timestamp(LocalDateTime.now().toString())
+                .build();
+        messagingTemplate.convertAndSend("/topic/game/" + code + "/chat", systemMessage);
+    }
+
+    private void sendDirectCorrectResponse(String userIdentifier, int roundNo, boolean isFuzzy) {
+        RoundCorrectResponse response = RoundCorrectResponse.builder()
+                .type("ROUND_CORRECT")
+                .roundNo(roundNo)
+                .isFuzzy(isFuzzy)
+                .message(isFuzzy ? "오타 허용 정답입니다!" : "완벽한 정답입니다!")
+                .build();
+        messagingTemplate.convertAndSendToUser(userIdentifier, "/queue/game/answers", response);
+    }
+
+    private String getNickname(String userIdentifier) {
+        Map<String, String> resolved = lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(userIdentifier));
+        return resolved.getOrDefault(userIdentifier, lobbyPlayerNicknameResolver.fallbackNickname(userIdentifier));
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -195,8 +195,8 @@ public class GameAnswerService {
                 sendDirectCorrectResponse(userIdentifier, currentRoundNo, isFuzzy);
             } else if ("ALREADY_CORRECT".equals(result)) {
                 broadcastChatMessage(code, userIdentifier, messageDto.content());
-            } else if ("TIMEOUT".equals(result)) {
-                log.info("processGameChat: Lua 검증 기준 제출 시간 초과 - code: {}, user: {}", code, userIdentifier);
+            } else if ("TIMEOUT".equals(result) || "ROUND_NOT_STARTED".equals(result)) {
+                log.info("processGameChat: Lua 검증 기준 제출 시간 초과 또는 미시작 (result: {}) - code: {}, user: {}", result, code, userIdentifier);
                 String content = messageDto.content();
                 for (String normalizedTarget : normalizedAnswers) {
                     if (normalizedUserAnswer.contains(normalizedTarget) || FuzzyMatcher.isMatch(normalizedUserAnswer, normalizedTarget)) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
@@ -91,6 +91,8 @@ public class GameRoundStartService {
         Boolean isSaved = redisTemplate.opsForHash().putIfAbsent(sessionKey, playbackStartedKey, String.valueOf(serverStartedAt));
 
         if (Boolean.TRUE.equals(isSaved)) {
+            redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
+
             RoundPlaybackStartedDto dto = RoundPlaybackStartedDto.builder()
                     .type(GameEventTypes.ROUND_PLAYBACK_STARTED)
                     .roundNo(roundNo)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -21,6 +21,9 @@ import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+import io.github.ascrew.monomatbe.domain.map.support.AnswerNormalizer;
 
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +49,7 @@ public class GameSessionCreateService {
     private final GameParticipantResolver gameParticipantResolver;
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<String> initGameSessionScript;
+    private final JsonMapper jsonMapper;
 
     /**
      * 로비 게임 시작 시 호출되어 게임 세션을 초기화한다.
@@ -129,7 +133,21 @@ public class GameSessionCreateService {
             int roundNo = i + 1;
             String roundDataKey = RedisKeys.gameSessionRoundDataKey(code, roundNo);
             java.util.Map<String, String> roundData = new java.util.HashMap<>();
-            roundData.put("answers", item.getAnswers()); // 이미 JSON List 포맷 문자열
+            roundData.put("answers", item.getAnswers());
+            
+            // 정규화된 정답 목록 캐싱 추가
+            try {
+                List<String> rawAnswers = jsonMapper.readValue(item.getAnswers(), new TypeReference<List<String>>() {});
+                List<String> normalizedAnswers = rawAnswers.stream()
+                        .map(AnswerNormalizer::normalize)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+                roundData.put("normalized_answers", jsonMapper.writeValueAsString(normalizedAnswers));
+            } catch (Exception e) {
+                log.error("createGameSession: 정답 데이터 정규화 캐싱 실패 - item id: {}", item.getId(), e);
+                roundData.put("normalized_answers", "[]");
+            }
+
             roundData.put("title", item.getTitle() == null ? "" : item.getTitle());
             roundData.put("artist", item.getArtist() == null ? "" : item.getArtist());
             redisTemplate.opsForHash().putAll(roundDataKey, roundData);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -123,6 +123,19 @@ public class GameSessionCreateService {
             throw new IllegalStateException("게임 세션 Redis 초기화 실패: " + result);
         }
 
+        // 4-1. 라운드별 문제 데이터 Redis 캐싱
+        for (int i = 0; i < selectedItems.size(); i++) {
+            MapItem item = selectedItems.get(i);
+            int roundNo = i + 1;
+            String roundDataKey = RedisKeys.gameSessionRoundDataKey(code, roundNo);
+            java.util.Map<String, String> roundData = new java.util.HashMap<>();
+            roundData.put("answers", item.getAnswers()); // 이미 JSON List 포맷 문자열
+            roundData.put("title", item.getTitle() == null ? "" : item.getTitle());
+            roundData.put("artist", item.getArtist() == null ? "" : item.getArtist());
+            redisTemplate.opsForHash().putAll(roundDataKey, roundData);
+            redisTemplate.expire(roundDataKey, java.time.Duration.ofSeconds(7200));
+        }
+
         log.info("게임 세션 생성 완료 - 로비 코드: {}, 문제 갯수: {}, 참여자 수: {}",
                  code, lobby.getQuestionCount(), participantIdentifiers.size());
 
@@ -132,6 +145,10 @@ public class GameSessionCreateService {
                 if (status == STATUS_ROLLED_BACK) {
                     log.warn("DB 트랜잭션 롤백 감지 - Redis 세션 잔여 데이터 정리. code: {}", code);
                     redisTemplate.delete(List.of(sessionKey, roundsKey, playersKey));
+                    for (int i = 1; i <= lobby.getQuestionCount(); i++) {
+                        redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(code, i));
+                        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(code, i));
+                    }
                 }
             }
         });

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcher.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcher.java
@@ -12,23 +12,41 @@ public final class FuzzyMatcher {
      *
      * [정책]
      * - 1~2글자: 오타 비허용 (임계 거리 0)
-     * - 3~5글자: 임계 거리 1 허용
+     * - 5글자 이하이면서 ASCII 영문/숫자로만 이루어진 정답: 오타 비허용 (임계 거리 0)
+     * - 3~5글자 (그 외): 임계 거리 1 허용
      * - 6~9글자: 임계 거리 2 허용
      * - 10글자 이상: 임계 거리 3 허용
      *
-     * @param targetLength 정규화된 정답 후보 문자열의 길이
+     * @param normalizedTarget 정규화된 정답 후보 문자열
      * @return 허용할 수 있는 최대 Levenshtein Distance
      */
-    public static int getThreshold(int targetLength) {
-        if (targetLength <= 2) {
+    public static int getThreshold(String normalizedTarget) {
+        int length = normalizedTarget.length();
+
+        if (length <= 2) {
             return 0;
-        } else if (targetLength <= 5) {
-            return 1;
-        } else if (targetLength <= 9) {
-            return 2;
-        } else {
-            return 3;
         }
+
+        if (isAsciiAlphaNumeric(normalizedTarget) && length <= 5) {
+            return 0;
+        }
+
+        if (length <= 5) {
+            return 1;
+        }
+
+        if (length <= 9) {
+            return 2;
+        }
+
+        return 3;
+    }
+
+    private static boolean isAsciiAlphaNumeric(String value) {
+        return value.chars().allMatch(ch ->
+                (ch >= 'a' && ch <= 'z') ||
+                (ch >= '0' && ch <= '9')
+        );
     }
 
     /**
@@ -46,12 +64,12 @@ public final class FuzzyMatcher {
             return true;
         }
 
-        int targetLength = normalizedTarget.length();
-        int threshold = getThreshold(targetLength);
+        int threshold = getThreshold(normalizedTarget);
         if (threshold == 0) {
             return false;
         }
 
+        int targetLength = normalizedTarget.length();
         // 사용자가 적은 답안이 타겟보다 너무 길거나 짧으면 Levenshtein 연산 필요 없이 탈락시킬 수 있는 조기 최적화
         if (Math.abs(normalizedAnswer.length() - targetLength) > threshold) {
             return false;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcher.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcher.java
@@ -1,0 +1,63 @@
+package io.github.ascrew.monomatbe.domain.game.support;
+
+/**
+ * 정답 글자 수 비례 오타 허용 임계 거리 판단 및 매칭을 수용하는 매처 유틸리티.
+ */
+public final class FuzzyMatcher {
+
+    private FuzzyMatcher() {}
+
+    /**
+     * 정답 후보의 글자 수에 따른 오타 허용 여부와 최대 임계 거리를 반환합니다.
+     *
+     * [정책]
+     * - 1~2글자: 오타 비허용 (임계 거리 0)
+     * - 3~5글자: 임계 거리 1 허용
+     * - 6~9글자: 임계 거리 2 허용
+     * - 10글자 이상: 임계 거리 3 허용
+     *
+     * @param targetLength 정규화된 정답 후보 문자열의 길이
+     * @return 허용할 수 있는 최대 Levenshtein Distance
+     */
+    public static int getThreshold(int targetLength) {
+        if (targetLength <= 2) {
+            return 0;
+        } else if (targetLength <= 5) {
+            return 1;
+        } else if (targetLength <= 9) {
+            return 2;
+        } else {
+            return 3;
+        }
+    }
+
+    /**
+     * 사용자가 제출한 답안이 정답 후보와 오타 매칭을 포함해 만족하는지 판단합니다.
+     *
+     * @param normalizedAnswer 사용자가 제출한 정규화 완료된 답안 (공백 제거, 소문자화 됨)
+     * @param normalizedTarget 정답 후보군 중 정규화 완료된 정답 (공백 제거, 소문자화 됨)
+     * @return 정답 여부
+     */
+    public static boolean isMatch(String normalizedAnswer, String normalizedTarget) {
+        if (normalizedAnswer == null || normalizedTarget == null) {
+            return false;
+        }
+        if (normalizedAnswer.equals(normalizedTarget)) {
+            return true;
+        }
+
+        int targetLength = normalizedTarget.length();
+        int threshold = getThreshold(targetLength);
+        if (threshold == 0) {
+            return false;
+        }
+
+        // 사용자가 적은 답안이 타겟보다 너무 길거나 짧으면 Levenshtein 연산 필요 없이 탈락시킬 수 있는 조기 최적화
+        if (Math.abs(normalizedAnswer.length() - targetLength) > threshold) {
+            return false;
+        }
+
+        int distance = LevenshteinDistance.calculate(normalizedAnswer, normalizedTarget);
+        return distance <= threshold;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/support/LevenshteinDistance.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/support/LevenshteinDistance.java
@@ -1,0 +1,56 @@
+package io.github.ascrew.monomatbe.domain.game.support;
+
+/**
+ * 두 문자열 간의 편집 거리(Levenshtein Distance)를 계산하는 유틸리티 클래스.
+ * DP 2차원 배열을 1차원 배열로 압축하여 가상 스레드 환경에서 메모리 및 GC 부하를 최소화합니다.
+ */
+public final class LevenshteinDistance {
+
+    private LevenshteinDistance() {}
+
+    /**
+     * s1과 s2 사이의 Levenshtein Distance를 계산합니다.
+     *
+     * @param s1 비교할 문자열 1 (null 불가)
+     * @param s2 비교할 문자열 2 (null 불가)
+     * @return 두 문자열 간의 최소 편집 횟수
+     */
+    public static int calculate(String s1, String s2) {
+        if (s1 == null || s2 == null) {
+            throw new IllegalArgumentException("문자열은 null일 수 없습니다.");
+        }
+        if (s1.equals(s2)) {
+            return 0;
+        }
+
+        int len1 = s1.length();
+        int len2 = s2.length();
+
+        if (len1 == 0) return len2;
+        if (len2 == 0) return len1;
+
+        // 짧은 쪽을 열(columns)로 삼아 메모리 공간 사용을 min(len1, len2)로 줄임
+        String shorter = len1 < len2 ? s1 : s2;
+        String longer = len1 < len2 ? s2 : s1;
+
+        int[] dp = new int[shorter.length() + 1];
+        for (int i = 0; i <= shorter.length(); i++) {
+            dp[i] = i;
+        }
+
+        for (int i = 1; i <= longer.length(); i++) {
+            int previousDiagonal = dp[0];
+            dp[0] = i;
+            for (int j = 1; j <= shorter.length(); j++) {
+                int temp = dp[j];
+                if (longer.charAt(i - 1) == shorter.charAt(j - 1)) {
+                    dp[j] = previousDiagonal;
+                } else {
+                    dp[j] = Math.min(Math.min(dp[j - 1], dp[j]), previousDiagonal) + 1;
+                }
+                previousDiagonal = temp;
+            }
+        }
+        return dp[shorter.length()];
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/support/AnswerNormalizer.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/support/AnswerNormalizer.java
@@ -4,11 +4,13 @@ import java.text.Normalizer;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * 정답 정규화 유틸
  *
  * [정책] 정답은 저장·비교 모두 동일한 정규화를 거친다.
+ *   - 유튜브 메타데이터 제거 (괄호 내용 [MV], (Official) 등 및 official, video, mv 등의 키워드 제거)
  *   - 유니코드 NFC 통일 (한글 조합형/호환 문자 차이 제거)
  *   - 모든 공백 제거 (일반 공백 + 비분리 공백 U+00A0 + 전각 공백 U+3000 등)
  *   - 쉼표 제거 (ASCII ',' + 전각 '，')
@@ -21,7 +23,22 @@ import java.util.List;
  */
 public final class AnswerNormalizer {
 
+    private static final Pattern METADATA_PATTERN = Pattern.compile(
+            "\\[[^\\]]*\\]|\\([^\\)]*\\)|(?i)(official\\s+video|official\\s+audio|official\\s+mv|official\\s+music\\s+video|official|mv|audio)",
+            Pattern.UNICODE_CHARACTER_CLASS
+    );
+
     private AnswerNormalizer() {}
+
+    /**
+     * 원본 문자열에서 대괄호/소괄호 안의 메타데이터 및 YouTube 관련 키워드를 제거하고 공백을 정돈합니다.
+     */
+    public static String cleanMetadata(String raw) {
+        if (raw == null) {
+            return "";
+        }
+        return METADATA_PATTERN.matcher(raw).replaceAll("").trim();
+    }
 
     /**
      * 단일 정답 문자열을 정규화한다.
@@ -34,7 +51,8 @@ public final class AnswerNormalizer {
             return "";
         }
 
-        String nfc = Normalizer.normalize(raw, Normalizer.Form.NFC);
+        String cleaned = cleanMetadata(raw);
+        String nfc = Normalizer.normalize(cleaned, Normalizer.Form.NFC);
         StringBuilder builder = new StringBuilder(nfc.length());
         nfc.codePoints().forEach(cp -> {
             if (Character.isWhitespace(cp) || Character.isSpaceChar(cp)) {

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -154,4 +154,12 @@ public class RedisScriptConfig {
         redisScript.setResultType(String.class);
         return redisScript;
     }
+
+    @Bean
+    public RedisScript<String> submitGameAnswerScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/submit_game_answer.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -673,6 +673,28 @@ public final class RedisKeys {
     }
 
     /**
+     * 특정 라운드의 캐싱된 문제 데이터 Hash 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:data"
+     */
+    public static String gameSessionRoundDataKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":data";
+    }
+
+    /**
+     * 특정 라운드에서 정답을 맞춘 유저 식별자 Set 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:correct_players"
+     */
+    public static String gameSessionRoundCorrectPlayersKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":correct_players";
+    }
+
+    /**
      * 특정 라운드의 재생 시작 시각 필드명을 반환합니다.
      *
      * @param roundNo 라운드 번호

--- a/src/main/resources/scripts/submit_game_answer.lua
+++ b/src/main/resources/scripts/submit_game_answer.lua
@@ -1,0 +1,45 @@
+local sessionKey = KEYS[1]
+local correctPlayersKey = KEYS[2]
+
+local userIdentifier = ARGV[1]
+local requestRoundNo = tonumber(ARGV[2])
+local nowMillis = tonumber(ARGV[3])
+
+-- 1. 게임 세션 존재 여부 및 status 검증
+local status = redis.call('HGET', sessionKey, 'status')
+if not status then
+    return 'NOT_FOUND'
+end
+if status ~= 'PLAYING' then
+    return 'NOT_PLAYING'
+end
+
+-- 2. 라운드 일치 여부 검증
+local currentRoundNo = tonumber(redis.call('HGET', sessionKey, 'current_round_no'))
+if currentRoundNo ~= requestRoundNo then
+    return 'WRONG_ROUND'
+end
+
+-- 3. 시간 초과 검증 (지연 완충 시간 1.5초 고려)
+local playbackStartedKey = 'playback_started_at_round_' .. requestRoundNo
+local playbackStartedAtStr = redis.call('HGET', sessionKey, playbackStartedKey)
+local timeLimitStr = redis.call('HGET', sessionKey, 'time_limit_seconds')
+
+if playbackStartedAtStr and timeLimitStr then
+    local playbackStartedAt = tonumber(playbackStartedAtStr)
+    local timeLimitSeconds = tonumber(timeLimitStr)
+    local limitTimeMillis = playbackStartedAt + (timeLimitSeconds * 1000) + 1500
+    if nowMillis > limitTimeMillis then
+        return 'TIMEOUT'
+    end
+end
+
+-- 4. 중복 정답 여부 검증
+local isMember = redis.call('SISMEMBER', correctPlayersKey, userIdentifier)
+if isMember == 1 then
+    return 'ALREADY_CORRECT'
+end
+
+-- 5. 정답자 등록
+redis.call('SADD', correctPlayersKey, userIdentifier)
+return 'CORRECT_FIRST'

--- a/src/main/resources/scripts/submit_game_answer.lua
+++ b/src/main/resources/scripts/submit_game_answer.lua
@@ -21,17 +21,21 @@ if currentRoundNo ~= requestRoundNo then
 end
 
 -- 3. 시간 초과 검증 (지연 완충 시간 1.5초 고려)
-local playbackStartedKey = 'playback_started_at_round_' .. requestRoundNo
+-- Java RedisKeys.gameSessionRoundPlaybackStartedAtField() 계약과 일치하는 필드명 사용
+local playbackStartedKey = 'playback_started_at:' .. requestRoundNo
 local playbackStartedAtStr = redis.call('HGET', sessionKey, playbackStartedKey)
 local timeLimitStr = redis.call('HGET', sessionKey, 'time_limit_seconds')
 
-if playbackStartedAtStr and timeLimitStr then
-    local playbackStartedAt = tonumber(playbackStartedAtStr)
-    local timeLimitSeconds = tonumber(timeLimitStr)
-    local limitTimeMillis = playbackStartedAt + (timeLimitSeconds * 1000) + 1500
-    if nowMillis > limitTimeMillis then
-        return 'TIMEOUT'
-    end
+-- 라운드 재생 시작 시간이나 제한 시간 설정이 아직 기록되지 않은 경우 정답 제출 거부
+if not playbackStartedAtStr or not timeLimitStr then
+    return 'ROUND_NOT_STARTED'
+end
+
+local playbackStartedAt = tonumber(playbackStartedAtStr)
+local timeLimitSeconds = tonumber(timeLimitStr)
+local limitTimeMillis = playbackStartedAt + (timeLimitSeconds * 1000) + 1500
+if nowMillis > limitTimeMillis then
+    return 'TIMEOUT'
 end
 
 -- 4. 중복 정답 여부 검증

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -93,9 +93,10 @@ class GameChatAnswerIntegrationTest {
             redisTemplate.opsForHash().put(sessionKey, RedisKeys.gameSessionRoundPlaybackStartedAtField(currentRoundNo), String.valueOf(playbackStartedAt));
         }
 
-        // 정답 데이터 설정 (answers는 JSON List 문자열)
+        // 정답 데이터 설정 (answers 및 normalized_answers)
         String roundDataKey = RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, currentRoundNo);
         redisTemplate.opsForHash().put(roundDataKey, "answers", "[\"dynamite\",\"다이너마이트\"]");
+        redisTemplate.opsForHash().put(roundDataKey, "normalized_answers", "[\"dynamite\",\"다이너마이트\"]");
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -214,8 +214,8 @@ class GameChatAnswerIntegrationTest {
     }
 
     @Test
-    @DisplayName("제한 시간이 지나서 들어온 정답 제출은 오답처럼 일반 채팅으로 송출된다")
-    void timeoutAnswerBroadcastsAsNormalChat() {
+    @DisplayName("제한 시간이 지나서 들어온 정답 제출은 정답일 경우 ***로 마스킹 처리되어 일반 채팅으로 송출된다")
+    void timeoutAnswerWithCorrectWordIsMasked() {
         // given (현재 시간 대비 32초 전 재생 시작하여 제한시간 30초 만료됨)
         long startedAt = System.currentTimeMillis() - (32 * 1000L);
         givenGameSession("PLAYING", 1, 30, startedAt);
@@ -230,9 +230,48 @@ class GameChatAnswerIntegrationTest {
         
         ChatMessageDto broadcasted = chatCaptor.getValue();
         assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
-        assertThat(broadcasted.getContent()).isEqualTo("다이너마이트"); // 만료되었으므로 정답 처리 없이 텍스트 노출
+        assertThat(broadcasted.getContent()).isEqualTo("***"); // 만료된 정답 제출은 스포일러 방지를 위해 마스킹 처리됨
+
+        Boolean isCorrect = redisTemplate.opsForSet().isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
+        assertThat(isCorrect).isFalse(); // 정답 처리는 되지 않음
+    }
+
+    @Test
+    @DisplayName("제한 시간이 지나서 들어온 일반 채팅(오답)은 마스킹 없이 그대로 송출된다")
+    void timeoutAnswerWithWrongWordIsBroadcastedAsIs() {
+        // given
+        long startedAt = System.currentTimeMillis() - (32 * 1000L);
+        givenGameSession("PLAYING", 1, 30, startedAt);
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "그냥 일반 채팅");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto broadcasted = chatCaptor.getValue();
+        assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(broadcasted.getContent()).isEqualTo("그냥 일반 채팅");
 
         Boolean isCorrect = redisTemplate.opsForSet().isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
         assertThat(isCorrect).isFalse();
+    }
+
+    @Test
+    @DisplayName("Java RedisKeys 필드명 포맷과 Lua 스크립트 내부 하드코딩 필드명이 일치하는지 검증한다")
+    void validateJavaAndLuaRedisFieldContract() throws java.io.IOException {
+        // Given
+        String expectedFieldPrefix = "playback_started_at:";
+        int testRoundNo = 5;
+        String javaGeneratedField = RedisKeys.gameSessionRoundPlaybackStartedAtField(testRoundNo);
+        assertThat(javaGeneratedField).isEqualTo(expectedFieldPrefix + testRoundNo);
+
+        // Lua 파일 내에서 해당 패턴이 존재하는지 검증
+        org.springframework.core.io.ClassPathResource resource = new org.springframework.core.io.ClassPathResource("scripts/submit_game_answer.lua");
+        String luaContent = new String(resource.getInputStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        
+        assertThat(luaContent).contains("'playback_started_at:'");
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -1,0 +1,204 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundCorrectResponse;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyPlayerNicknameResolver;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=none"
+})
+class GameChatAnswerIntegrationTest {
+
+    private static final String LOBBY_CODE = "GAME12";
+    private static final String USER_ID = "test-user-id";
+    private static final String NICKNAME = "테스트유저";
+
+    @Autowired
+    private GameAnswerService gameAnswerService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private SimpMessagingTemplate messagingTemplate;
+
+    @MockitoBean
+    private LobbyRepository lobbyRepository;
+
+    @MockitoBean
+    private LobbyPlayerNicknameResolver nicknameResolver;
+
+    @BeforeEach
+    void setUp() {
+        // Mock 기본 셋팅
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        when(lobbyRepository.isParticipant(LOBBY_CODE, USER_ID)).thenReturn(true);
+        
+        Map<String, String> nicknameMap = new HashMap<>();
+        nicknameMap.put(USER_ID, NICKNAME);
+        when(nicknameResolver.resolveNicknameMap(any())).thenReturn(nicknameMap);
+        when(nicknameResolver.fallbackNickname(USER_ID)).thenReturn(NICKNAME);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 임시 Redis Key 데이터 정리
+        redisTemplate.delete(RedisKeys.gameSessionKey(LOBBY_CODE));
+        redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1));
+    }
+
+    private void givenGameSession(String status, int currentRoundNo, int timeLimit, Long playbackStartedAt) {
+        String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
+        redisTemplate.opsForHash().put(sessionKey, "status", status);
+        redisTemplate.opsForHash().put(sessionKey, "current_round_no", String.valueOf(currentRoundNo));
+        redisTemplate.opsForHash().put(sessionKey, "time_limit_seconds", String.valueOf(timeLimit));
+        if (playbackStartedAt != null) {
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.gameSessionRoundPlaybackStartedAtField(currentRoundNo), String.valueOf(playbackStartedAt));
+        }
+
+        // 정답 데이터 설정 (answers는 JSON List 문자열)
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, currentRoundNo);
+        redisTemplate.opsForHash().put(roundDataKey, "answers", "[\"dynamite\",\"다이너마이트\"]");
+    }
+
+    @Test
+    @DisplayName("오답을 입력하면 일반 대화 채널로 브로드캐스트된다")
+    void wrongAnswerBroadcastsAsNormalChat() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "hello bts");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto broadcasted = chatCaptor.getValue();
+        assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(broadcasted.getSender()).isEqualTo(NICKNAME);
+        assertThat(broadcasted.getContent()).isEqualTo("hello bts");
+        
+        // 정답자 추가되지 않음
+        Boolean isCorrect = redisTemplate.opsForSet().isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
+        assertThat(isCorrect).isFalse();
+    }
+
+    @Test
+    @DisplayName("정답을 입력하면 원래 텍스트는 차단되고, 맞춘 사람 추가 및 시스템 축하 메시지가 전파된다")
+    void correctAnswerBlocksTextAndBroadcastsSystemAlert() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "다이너마이트 [MV]"); // 메타데이터 정규화 포함
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        // 1. 시스템 정답 공지 브로드캐스트 발생 검증
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto broadcasted = chatCaptor.getValue();
+        assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.SYSTEM);
+        assertThat(broadcasted.getContent()).contains(NICKNAME + "님이 정답을 맞췄습니다!");
+
+        // 2. 정답자 본인에게 개인 축하 메시지 수신 검증
+        verify(messagingTemplate).convertAndSendToUser(eq(USER_ID), eq("/queue/game/answers"), any(RoundCorrectResponse.class));
+
+        // 3. Redis Set에 정답자로 등록 검증
+        Boolean isCorrect = redisTemplate.opsForSet().isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
+        assertThat(isCorrect).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 정답을 맞춘 사용자가 대화할 경우 정답 유무 검사 없이 일반 대화로 송출된다")
+    void correctPlayerNormalChatBroadcastsDirectly() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        // 정답자로 등록 처리
+        redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "노래 진짜 좋네요!");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto broadcasted = chatCaptor.getValue();
+        assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(broadcasted.getContent()).isEqualTo("노래 진짜 좋네요!");
+    }
+
+    @Test
+    @DisplayName("이미 정답을 맞춘 사용자가 정답 키워드를 한번 더 도배(스포일러 트롤링)하려 하면 *** 로 마스킹 처리된다")
+    void correctPlayerSpoilerFilteredWithMasking() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        // 정답자로 등록 처리
+        redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "다이너마이트");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto broadcasted = chatCaptor.getValue();
+        assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(broadcasted.getContent()).isEqualTo("***"); // 정답 문자 스포일러 차단
+    }
+
+    @Test
+    @DisplayName("제한 시간이 지나서 들어온 정답 제출은 오답처럼 일반 채팅으로 송출된다")
+    void timeoutAnswerBroadcastsAsNormalChat() {
+        // given (현재 시간 대비 32초 전 재생 시작하여 제한시간 30초 만료됨)
+        long startedAt = System.currentTimeMillis() - (32 * 1000L);
+        givenGameSession("PLAYING", 1, 30, startedAt);
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "다이너마이트");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto broadcasted = chatCaptor.getValue();
+        assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(broadcasted.getContent()).isEqualTo("다이너마이트"); // 만료되었으므로 정답 처리 없이 텍스트 노출
+
+        Boolean isCorrect = redisTemplate.opsForSet().isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
+        assertThat(isCorrect).isFalse();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.github.ascrew.monomatbe.domain.game.service;
 
+import io.github.ascrew.monomatbe.domain.chat.service.ChatSenderProfile;
+import io.github.ascrew.monomatbe.domain.chat.service.ChatSenderProfileResolver;
 import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundCorrectResponse;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
@@ -52,6 +54,9 @@ class GameChatAnswerIntegrationTest {
     @MockitoBean
     private LobbyPlayerNicknameResolver nicknameResolver;
 
+    @MockitoBean
+    private ChatSenderProfileResolver chatSenderProfileResolver;
+
     @BeforeEach
     void setUp() {
         // Mock 기본 셋팅
@@ -62,6 +67,13 @@ class GameChatAnswerIntegrationTest {
         nicknameMap.put(USER_ID, NICKNAME);
         when(nicknameResolver.resolveNicknameMap(any())).thenReturn(nicknameMap);
         when(nicknameResolver.fallbackNickname(USER_ID)).thenReturn(NICKNAME);
+
+        ChatSenderProfile profile = ChatSenderProfile.builder()
+                .userIdentifier(USER_ID)
+                .userId(1L)
+                .nickname(NICKNAME)
+                .build();
+        when(chatSenderProfileResolver.resolve(USER_ID)).thenReturn(profile);
     }
 
     @AfterEach
@@ -177,6 +189,27 @@ class GameChatAnswerIntegrationTest {
         ChatMessageDto broadcasted = chatCaptor.getValue();
         assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
         assertThat(broadcasted.getContent()).isEqualTo("***"); // 정답 문자 스포일러 차단
+    }
+
+    @Test
+    @DisplayName("이미 정답을 맞춘 사용자의 메시지에 정답 키워드가 포함(부분 스포일러)되어 있으면 *** 로 마스킹 처리된다")
+    void correctPlayerSubstringSpoilerFilteredWithMasking() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        // 정답자로 등록 처리
+        redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "정답은 다이너마이트 입니다!");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto broadcasted = chatCaptor.getValue();
+        assertThat(broadcasted.getType()).isEqualTo(ChatMessageDto.MessageType.CHAT);
+        assertThat(broadcasted.getContent()).isEqualTo("***"); // 포함된 정답 스포일러 차단
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -54,6 +55,8 @@ class GameSessionCreateServiceTest {
     private StringRedisTemplate redisTemplate;
     @Mock
     private RedisScript<String> initGameSessionScript;
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
 
     @InjectMocks
     private GameSessionCreateService gameSessionCreateService;
@@ -114,6 +117,7 @@ class GameSessionCreateServiceTest {
                 anyString(),
                 anyString()
         )).thenReturn("OK");
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
 
         // when
         RoundStartDto result = gameSessionCreateService.createGameSession(lobby, quizMap);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -57,6 +58,8 @@ class GameSessionCreateServiceTest {
     private RedisScript<String> initGameSessionScript;
     @Mock
     private HashOperations<String, Object, Object> hashOperations;
+    @Mock
+    private JsonMapper jsonMapper;
 
     @InjectMocks
     private GameSessionCreateService gameSessionCreateService;
@@ -106,6 +109,15 @@ class GameSessionCreateServiceTest {
                 .thenReturn(List.of("uId"));
         when(gameParticipantResolver.resolveUsers(List.of("uId")))
                 .thenReturn(List.of(user));
+        
+        try {
+            when(jsonMapper.readValue(eq("[\"정답\"]"), any(tools.jackson.core.type.TypeReference.class)))
+                    .thenReturn(List.of("정답"));
+            when(jsonMapper.writeValueAsString(any()))
+                    .thenReturn("[\"정답\"]");
+        } catch (Exception e) {
+            // ignore for mock
+        }
         
         when(redisTemplate.execute(
                 eq(initGameSessionScript),

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcherTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcherTest.java
@@ -1,0 +1,62 @@
+package io.github.ascrew.monomatbe.domain.game.support;
+
+import io.github.ascrew.monomatbe.domain.map.support.AnswerNormalizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FuzzyMatcherTest {
+
+    @Test
+    @DisplayName("정답 후보 길이에 따른 허용 임계 거리(Threshold) 반환 테스트")
+    void getThresholdTest() {
+        // 1~2글자: 0
+        assertThat(FuzzyMatcher.getThreshold(1)).isZero();
+        assertThat(FuzzyMatcher.getThreshold(2)).isZero();
+
+        // 3~5글자: 1
+        assertThat(FuzzyMatcher.getThreshold(3)).isEqualTo(1);
+        assertThat(FuzzyMatcher.getThreshold(5)).isEqualTo(1);
+
+        // 6~9글자: 2
+        assertThat(FuzzyMatcher.getThreshold(6)).isEqualTo(2);
+        assertThat(FuzzyMatcher.getThreshold(9)).isEqualTo(2);
+
+        // 10글자 이상: 3
+        assertThat(FuzzyMatcher.getThreshold(10)).isEqualTo(3);
+        assertThat(FuzzyMatcher.getThreshold(15)).isEqualTo(3);
+    }
+
+    private boolean isMatchNormalized(String answer, String target) {
+        return FuzzyMatcher.isMatch(AnswerNormalizer.normalize(answer), AnswerNormalizer.normalize(target));
+    }
+
+    @Test
+    @DisplayName("FuzzyMatch 판별 성공 및 실패 케이스 테스트")
+    void isMatchTest() {
+        // 1. 짧은 글자 (1~2글자) -> 오타 허용 없음
+        assertThat(isMatchNormalized("가나", "가나")).isTrue();
+        assertThat(isMatchNormalized("가다", "가나")).isFalse();
+
+        // 2. 중간 글자 (3~5글자, 임계치 1) -> 1글자 차이 허용
+        assertThat(isMatchNormalized("bts", "bts")).isTrue();
+        assertThat(isMatchNormalized("bts", "bta")).isTrue(); // 3글자, 1글자 차이 허용
+        assertThat(isMatchNormalized("bts", "baa")).isFalse(); // 2글자 차이 불가
+
+        // 3. 긴 글자 (6~9글자, 임계치 2) -> 2글자 차이 허용
+        assertThat(isMatchNormalized("다이너마이트", "다이너마이트")).isTrue();
+        assertThat(isMatchNormalized("다이너마이트", "다이너마이")).isTrue(); // 1글자 삭제 허용
+        assertThat(isMatchNormalized("다이너마이트", "다이나마이그")).isTrue(); // 2글자 변경 허용 (다이'나'마이'그')
+        assertThat(isMatchNormalized("다이너마이트", "다이아바이그")).isFalse(); // 3글자 변경 불가 (너->아, 마->바, 트->그)
+
+        // 4. 매우 긴 글자 (10글자 이상, 임계치 3)
+        String target = "permissiontodance"; // 17글자
+        assertThat(isMatchNormalized("permissiontodance", "permissiontodance")).isTrue();
+        assertThat(isMatchNormalized("permissiontodanc", "permissiontodance")).isTrue(); // 1글자 차이
+        assertThat(isMatchNormalized("permisiontodanse", "permissiontodance")).isTrue(); // 2글자 차이 (m 하나, c->s)
+        assertThat(isMatchNormalized("permisontodanse", "permissiontodance")).isTrue(); // 3글자 차이 (m 하나, i 누락, c->s)
+        assertThat(isMatchNormalized("permisontodanseee", "permissiontodance")).isFalse(); // 4글자 차이 불가
+    }
+}
+

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcherTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/support/FuzzyMatcherTest.java
@@ -12,20 +12,23 @@ class FuzzyMatcherTest {
     @DisplayName("정답 후보 길이에 따른 허용 임계 거리(Threshold) 반환 테스트")
     void getThresholdTest() {
         // 1~2글자: 0
-        assertThat(FuzzyMatcher.getThreshold(1)).isZero();
-        assertThat(FuzzyMatcher.getThreshold(2)).isZero();
+        assertThat(FuzzyMatcher.getThreshold("가")).isZero();
+        assertThat(FuzzyMatcher.getThreshold("가나")).isZero();
 
-        // 3~5글자: 1
-        assertThat(FuzzyMatcher.getThreshold(3)).isEqualTo(1);
-        assertThat(FuzzyMatcher.getThreshold(5)).isEqualTo(1);
+        // 5글자 이하 ASCII 영문/숫자: 0
+        assertThat(FuzzyMatcher.getThreshold("bts")).isZero();
+        assertThat(FuzzyMatcher.getThreshold("ive")).isZero();
+
+        // 3~5글자 (그 외): 1
+        assertThat(FuzzyMatcher.getThreshold("가나다")).isEqualTo(1);
+        assertThat(FuzzyMatcher.getThreshold("가나다라마")).isEqualTo(1);
 
         // 6~9글자: 2
-        assertThat(FuzzyMatcher.getThreshold(6)).isEqualTo(2);
-        assertThat(FuzzyMatcher.getThreshold(9)).isEqualTo(2);
+        assertThat(FuzzyMatcher.getThreshold("가나다라마바")).isEqualTo(2);
+        assertThat(FuzzyMatcher.getThreshold("가나다라마바사아자")).isEqualTo(2);
 
         // 10글자 이상: 3
-        assertThat(FuzzyMatcher.getThreshold(10)).isEqualTo(3);
-        assertThat(FuzzyMatcher.getThreshold(15)).isEqualTo(3);
+        assertThat(FuzzyMatcher.getThreshold("가나다라마바사아자차카")).isEqualTo(3);
     }
 
     private boolean isMatchNormalized(String answer, String target) {
@@ -39,10 +42,11 @@ class FuzzyMatcherTest {
         assertThat(isMatchNormalized("가나", "가나")).isTrue();
         assertThat(isMatchNormalized("가다", "가나")).isFalse();
 
-        // 2. 중간 글자 (3~5글자, 임계치 1) -> 1글자 차이 허용
+        // 2. 중간 글자 (3~5글자, 임계치 1) -> 한글 등은 허용, ASCII 영문은 5자 이하 비허용
         assertThat(isMatchNormalized("bts", "bts")).isTrue();
-        assertThat(isMatchNormalized("bts", "bta")).isTrue(); // 3글자, 1글자 차이 허용
-        assertThat(isMatchNormalized("bts", "baa")).isFalse(); // 2글자 차이 불가
+        assertThat(isMatchNormalized("bts", "bta")).isFalse(); // ASCII 5자 이하이므로 1글자 차이 비허용
+        assertThat(isMatchNormalized("가나다", "가나라")).isTrue(); // 한글 3자이므로 1글자 차이 허용
+        assertThat(isMatchNormalized("가나다", "가라마")).isFalse(); // 2글자 차이 불가
 
         // 3. 긴 글자 (6~9글자, 임계치 2) -> 2글자 차이 허용
         assertThat(isMatchNormalized("다이너마이트", "다이너마이트")).isTrue();

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/support/LevenshteinDistanceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/support/LevenshteinDistanceTest.java
@@ -1,0 +1,36 @@
+package io.github.ascrew.monomatbe.domain.game.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LevenshteinDistanceTest {
+
+    @Test
+    @DisplayName("Levenshtein Distance 기본 계산 검증")
+    void calculateTest() {
+        // 완전 일치
+        assertThat(LevenshteinDistance.calculate("abc", "abc")).isZero();
+
+        // 1 문자 삽입/삭제/대체
+        assertThat(LevenshteinDistance.calculate("abc", "ab")).isEqualTo(1); // 삭제
+        assertThat(LevenshteinDistance.calculate("abc", "abcd")).isEqualTo(1); // 삽입
+        assertThat(LevenshteinDistance.calculate("abc", "axc")).isEqualTo(1); // 대체
+
+        // 다중 변경
+        assertThat(LevenshteinDistance.calculate("kitten", "sitting")).isEqualTo(3);
+        assertThat(LevenshteinDistance.calculate("한글테스트", "한글텍스트")).isEqualTo(1);
+        assertThat(LevenshteinDistance.calculate("가나다라마", "가마바사")).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("Null 입력 시 예외 발생 검증")
+    void calculateNullValidation() {
+        assertThatThrownBy(() -> LevenshteinDistance.calculate(null, "abc"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> LevenshteinDistance.calculate("abc", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/support/AnswerNormalizerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/support/AnswerNormalizerTest.java
@@ -1,8 +1,8 @@
 package io.github.ascrew.monomatbe.domain.map.support;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,72 +10,60 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AnswerNormalizerTest {
 
     @Test
-    void normalize_removesAllWhitespaceTrimAndInternal() {
-        assertThat(AnswerNormalizer.normalize("데이 식스")).isEqualTo("데이식스");
-        assertThat(AnswerNormalizer.normalize("  Bruno Mars ")).isEqualTo("brunomars");
+    @DisplayName("유튜브 메타데이터 정제 테스트 (cleanMetadata)")
+    void cleanMetadataTest() {
+        // Given
+        String raw1 = "Dynamite [MV]";
+        String raw2 = "Butter (Official Video)";
+        String raw3 = "Permission To Dance (Official Music Video)";
+        String raw4 = "Life Goes On mv";
+        String raw5 = "Stay Gold [Official]";
+
+        // When & Then
+        assertThat(AnswerNormalizer.cleanMetadata(raw1)).isEqualTo("Dynamite");
+        assertThat(AnswerNormalizer.cleanMetadata(raw2)).isEqualTo("Butter");
+        assertThat(AnswerNormalizer.cleanMetadata(raw3)).isEqualTo("Permission To Dance");
+        assertThat(AnswerNormalizer.cleanMetadata(raw4)).isEqualTo("Life Goes On");
+        assertThat(AnswerNormalizer.cleanMetadata(raw5)).isEqualTo("Stay Gold");
     }
 
     @Test
-    void normalize_lowercasesAscii() {
-        assertThat(AnswerNormalizer.normalize("IU")).isEqualTo("iu");
-        assertThat(AnswerNormalizer.normalize("BTS")).isEqualTo("bts");
+    @DisplayName("단일 정답 문자열 전체 정규화 테스트 (normalize)")
+    void normalizeTest() {
+        // Given
+        String raw1 = " Dynamite [MV] ";
+        String raw2 = "Butter, (Official Video)";
+        String raw3 = "가나다라， 마바사";
+
+        // When & Then
+        // 1. Dynamite [MV] -> Dynamite -> dynamite (공백제거 및 소문자화)
+        assertThat(AnswerNormalizer.normalize(raw1)).isEqualTo("dynamite");
+
+        // 2. Butter, (Official Video) -> Butter, -> butter (쉼표제거, 공백제거)
+        assertThat(AnswerNormalizer.normalize(raw2)).isEqualTo("butter");
+
+        // 3. 가나다라， 마바사 -> 가나다라마바사 (전각쉼표제거, 공백제거)
+        assertThat(AnswerNormalizer.normalize(raw3)).isEqualTo("가나다라마바사");
     }
 
     @Test
-    void normalize_removesCommas() {
-        assertThat(AnswerNormalizer.normalize("a,b,c")).isEqualTo("abc");
-        assertThat(AnswerNormalizer.normalize("가，나")).isEqualTo("가나");
-    }
+    @DisplayName("정답 리스트 전체 정규화 및 중복제거 테스트 (normalizeList)")
+    void normalizeListTest() {
+        // Given
+        List<String> rawList = List.of(
+                "Dynamite [MV]",
+                "dynamite",
+                " Butter (Official) ",
+                "butter",
+                ""
+        );
 
-    @Test
-    void normalize_removesFullWidthAndNonBreakingSpaces() {
-        assertThat(AnswerNormalizer.normalize("브루노　마스")).isEqualTo("브루노마스");
-        assertThat(AnswerNormalizer.normalize("브루노 마스")).isEqualTo("브루노마스");
-    }
+        // When
+        List<String> result = AnswerNormalizer.normalizeList(rawList);
 
-    @Test
-    void normalize_appliesNfc() {
-        // 분해형(NFD) 한글 자모가 조합형(NFC)으로 통일되어야 한다.
-        String nfd = "가"; // ㄱ + ㅏ → "가"
-        String decomposed = new String(new int[]{0x1100, 0x1161}, 0, 2); // 초성 ㄱ + 중성 ㅏ
-        String composed = new String(Character.toChars(0xAC00)); // U+AC00 "가"
-        assertThat(AnswerNormalizer.normalize(decomposed)).isEqualTo(composed);
-    }
-
-    @Test
-    void normalize_nullOrBlankBecomesEmpty() {
-        assertThat(AnswerNormalizer.normalize(null)).isEmpty();
-        assertThat(AnswerNormalizer.normalize("   ")).isEmpty();
-        assertThat(AnswerNormalizer.normalize(",")).isEmpty();
-    }
-
-    @Test
-    void normalize_isIdempotent() {
-        String once = AnswerNormalizer.normalize("  Bruno Mars ");
-        assertThat(AnswerNormalizer.normalize(once)).isEqualTo(once);
-    }
-
-    @Test
-    void normalizeList_dedupsAfterNormalizationPreservingOrder() {
-        List<String> result = AnswerNormalizer.normalizeList(List.of("IU", "i u"));
-        assertThat(result).containsExactly("iu");
-    }
-
-    @Test
-    void normalizeList_preservesFirstOccurrenceOrder() {
-        List<String> result = AnswerNormalizer.normalizeList(List.of("좋은날", "Good Day", "좋은 날"));
-        // "좋은날"과 "좋은 날"은 dedup, "Good Day"→"goodday". 첫 등장 순서 보존.
-        assertThat(result).containsExactly("좋은날", "goodday");
-    }
-
-    @Test
-    void normalizeList_dropsBlankAndNullElements() {
-        List<String> result = AnswerNormalizer.normalizeList(Arrays.asList("정답", "  ", null, ","));
-        assertThat(result).containsExactly("정답");
-    }
-
-    @Test
-    void normalizeList_nullInputReturnsEmpty() {
-        assertThat(AnswerNormalizer.normalizeList(null)).isEmpty();
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo("dynamite");
+        assertThat(result.get(1)).isEqualTo("butter");
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #101 
- #104 

## 📝 Summary

- **단일 채팅창 기반 인게임 전용 채팅 및 정답 검증 구현**:
  - 인게임 전용 채팅 및 정답 제출 엔드포인트(`SEND /app/game/{code}/chat`)와 브로드캐스트 채널(`SUBSCRIBE /topic/game/{code}/chat`)을 구축했습니다.
  - 사용자별 정답 상태를 관리하기 위해 Redis Set(`game:session:{code}:round:{roundNo}:correct_players`) 캐시를 활용해 중복 정답 판정을 방지합니다.
- **스포일러 방지 마스킹 및 실시간 라우팅**:
  - 미정답자가 정답을 맞추면 본문 노출을 차단하고 `SYSTEM` 공지로 전파하며, `/user/queue/game/answers`로 개별 정답 성공 통지(`ROUND_CORRECT`)를 보냅니다.
  - 이미 정답을 맞춘 사용자가 대화창에 정답 키워드를 노출할 경우, 본문을 `***`로 마스킹 처리하여 `CHAT` 타입으로 브로드캐스트함으로써 스포일러를 방지합니다.
  - 정답과 완전 일치하는 경우뿐만 아니라, `정답은 XXX임`과 같이 **정답을 부분적으로 포함(substring match)하는 문장**까지 검지하여 스포일러 트롤링을 사전에 완벽히 차단하도록 보완했습니다.
- **오타 허용(Fuzzy Match) 판별기 도입**:
  - 글자수 대비 오타 허용 임계 거리를 매칭하는 `FuzzyMatcher` 정책과 1차원 공간 최적화 Levenshtein Distance 알고리즘(`LevenshteinDistance`)을 적용했습니다.
- **닉네임 조회 캐시 최적화**:
  - 인게임 채팅의 높은 QPS를 감안하여, 매번 닉네임을 외부 저장소(DB/Redis)에서 개별적으로 Resolve하던 로직을 기존 Redis 캐싱 기반의 `ChatSenderProfileResolver`를 사용하는 방식으로 전환하여 핫패스의 부하를 최소화했습니다.
- **JsonMapper DI 주입**:
  - `GameAnswerService` 내부에서 스프링 전역 직렬화/역직렬화 설정을 무시하고 `new ObjectMapper()`를 직접 생성하여 사용하던 하드코딩 문제를 해결하고, 생성자 주입 방식으로 스프링 컨텍스트의 `JsonMapper` 빈(`tools.jackson.databind.json.JsonMapper`)을 주입받아 사용하도록 리팩토링하여 프로젝트 내 일관된 직/역직렬화 정합성을 확보했습니다.
- **Redis 역직렬화 실패 예외 처리 정책**:
  - 정답 캐시 데이터가 훼손되어 JSON 역직렬화에 실패하더라도, 전체 게임 프로세스가 중단(Crash)되지 않도록 예외 처리를 격리하고 빈 리스트(`Collections.emptyList()`)로 대체함으로써 오답 처리가 정상적으로 이루어지도록 디그레이드(Degrade) 정책을 견고히 다듬었습니다.
- **WebSocket 인게임 채팅 Hot Path 성능 최적화**:
  - QPS가 높은 인게임 채팅 처리 로직의 부하를 획기적으로 낮췄습니다.
    - **HMGET 도입**: Redis 메타데이터 조회 시 `HGETALL` 대신 필요한 필드만 최소한으로 쿼리하는 `HMGET`을 사용하여 데이터 전송 오버헤드와 Redis 부하를 줄였습니다.
    - **정규화 정답 사전 캐싱**: 채팅 시마다 발생하던 Jackson 파싱 및 정규화(`AnswerNormalizer.normalize`) 연산을 단 1회로 단축하고자 게임 세션 생성 시점(`GameSessionCreateService`)에 정규화 완료된 답안 목록(`normalized_answers`)을 미리 JSON 문자열로 캐싱해 두도록 최적화했습니다.
    - **매칭 루프 조기 탈출(Cheap Filter)**: 정답 판별 시 1차 Perfect Match 검증을 수행해 100% 일치할 경우 O(1) 수준으로 검증을 즉시 끝내고, 일치하지 않는 경우에만 2차로 비싼 Levenshtein Distance DP 연산(`FuzzyMatcher.isMatch`)을 돌려 CPU/GC 자원을 아꼈습니다.
- **DTO 방어적 검증 추가**:
  - WebSocket 인터페이스 혹은 예외 처리 누락 등으로 `roundNo`나 `content`가 null/blank로 서비스 계층에 들어왔을 때 발생할 수 있는 NPE를 원천 예방하고자 `isInvalidMessage` 방어 필터를 추가했습니다.
- **짧은 영문/숫자 약어 Fuzzy 제한 **:
  - 3~5글자 한글은 오타 1글자를 허용하되, `BTS`, `IU`, `IVE`와 같이 영문/숫자(ASCII)로만 구성된 5글자 이하 짧은 단어는 오타 허용 임계 거리를 0으로 강제하는 예외 필터를 구현하여 퀴즈의 변별력을 확보하고 관련 테스트 케이스를 최신화했습니다.
- **Lua Script 기반 원자적 정답자 등록 처리**:
  - *기존 Java단 개별 Redis 쿼리에 따른 동시성 상태 정합성 위배(Race Condition)를 해결하기 위해, 게임 플레이 여부, 라운드 번호 검증, 시간 제한, 정답자 중복 등록 및 최초 등록 처리를 Redis 상에서 단일 트랜잭션으로 원자화하는 `submit_game_answer.lua` 스크립트를 적용했습니다.
- **만료 제출 스포일러 마스킹**:
  - **제한 시간이 초과되어 일반 대화로 전송되는 만료 채팅에서도 정답 단어 포함 여부를 필터링해 `***`로 마스킹 전송함으로써, 찰나의 순간에 발생하는 스포일러 트롤링을 차단했습니다.
- **Redis Lua 스크립트 계약 불일치 해결 & 미시작 정답 제출 차단**:
  - Java `RedisKeys`의 필드명 생성 포맷(`playback_started_at:roundNo`)과 Lua 내부의 하드코딩 리터럴이 맞지 않았던 불일치를 수정하고, 두 시스템 간 계약 동기화를 자동으로 체크하는 통합 테스트(`validateJavaAndLuaRedisFieldContract`)를 구현해 검증을 자동화했습니다.
  - 라운드가 완전히 시작(재생 시작 시각 설정)되기 전에 발생한 정답 제출에 대해 검증을 우회하여 정답으로 인정하던 공정성 보안 결함을 차단하도록 Lua 스크립트와 Java 서비스 계층에 `ROUND_NOT_STARTED` 예외 처리를 추가했습니다.

## 🙏PR point

- **도메인 결합성 분리**:
  - 인게임 채팅은 대기실 로비 채팅(`chat` 도메인)과의 순환 의존을 배제하기 위해 `game` 도메인 내 `GameEventController` 및 `GameAnswerService`가 독자적으로 수용하여 처리합니다.
- **GC 및 메모리 효율성 극대화**:
  - 정답 검증 시 호출되는 `LevenshteinDistance` 알고리즘은 2차원 배열 대신 1차원 배열 2개만을 사용하는 O(min(M, N)) 공간 복잡도로 설계하여 잦은 가비지 컬렉션(GC) 부하를 방지했습니다.
  - 정답 판별 및 동시성 제어 시 DB I/O를 일으키지 않고 Redis의 캐싱 데이터 구조 및 분산 Set을 기반으로 0-DB I/O 원자적 비즈니스를 수행하도록 고안했습니다.
- **트랜잭션 커밋 완료 후 브로드캐스트**:
  - 게임 시작 및 라운드 상태 변경 단계에서 DB 트랜잭션이 완전히 커밋 완료된 시점(`afterCompletion`)에만 WebSocket 실시간 이벤트를 전송하도록 `TransactionSynchronizationManager`를 명시적으로 결합했습니다.
- **프론트엔드 연동 계약**:
  - FE는 비디오 동기화를 위해 `ROUND_PLAYBACK_STARTED` 메시지의 `serverStartedAt` 시점과 `GET /api/system/time`으로 계산한 Clock Skew 값을 기반으로 재생 지점을 강제 보정(`seekTo`)해야 합니다.
  - 스포일러 방지를 위해 이미 정답을 맞춘 사람이 보낸 문맥 내의 정답은 서버 단에서 마스킹되어 내려갑니다.

## 📬 Reference