### PR TITLE
[Feat/#122] 신고 관리자 조회 및 처리 API 구현

### DIFF
--- a/docs/ADMIN_REPORT_API.md
+++ b/docs/ADMIN_REPORT_API.md
@@ -1,0 +1,294 @@
+# 관리자 신고 API
+
+## 개요
+
+관리자 권한을 가진 사용자가 접수된 신고를 조회하고 처리하는 API입니다.
+
+관리자 권한은 `users.role = ADMIN` 기준으로 판단합니다.  
+JWT Access Token에는 `userRole` claim이 포함되며, Spring Security에서는 `ROLE_ADMIN` 권한으로 변환됩니다.
+
+---
+
+## 공통 권한
+
+모든 관리자 신고 API는 다음 권한이 필요합니다.
+
+```text
+ROLE_ADMIN
+````
+
+일반 사용자 또는 게스트가 접근하면 `403 Forbidden`이 반환됩니다.
+
+---
+
+## 1. 신고 목록 조회
+
+```http
+GET /api/admin/reports
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+```
+
+### Query Parameters
+
+| 이름         | 타입     | 필수 | 설명                     |
+| ---------- | ------ | -: | ---------------------- |
+| targetType | string |  N | 신고 대상 타입               |
+| status     | string |  N | 신고 처리 상태               |
+| page       | number |  N | 0-based 페이지 번호. 기본값 0  |
+| size       | number |  N | 페이지 크기. 기본값 20, 최대 100 |
+
+### targetType
+
+| 값                  | 설명           |
+| ------------------ | ------------ |
+| LOBBY              | 로비 신고        |
+| LOBBY_USER         | 로비 내 사용자 신고  |
+| LOBBY_CHAT_MESSAGE | 로비 채팅 메시지 신고 |
+
+### status
+
+| 값         | 설명          |
+| --------- | ----------- |
+| PENDING   | 처리 대기       |
+| RESOLVED  | 유효 신고 처리 완료 |
+| DISMISSED | 기각          |
+
+### Request Example
+
+```http
+GET /api/admin/reports?targetType=LOBBY_CHAT_MESSAGE&status=PENDING&page=0&size=20
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+```
+
+### Response Example
+
+```json
+{
+  "items": [
+    {
+      "reportId": 1,
+      "reporterId": 10,
+      "reporterUsername": "reporter",
+      "lobbyId": 20,
+      "lobbyCode": "ABC123",
+      "lobbyTitle": "신고 테스트 로비",
+      "targetType": "LOBBY_CHAT_MESSAGE",
+      "targetId": 20,
+      "targetReference": "message-1",
+      "reason": "부적절한 채팅 메시지",
+      "status": "PENDING",
+      "createdAt": "2026-05-31T12:00:00",
+      "resolvedAt": null
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "hasNext": false
+}
+```
+
+### Error Responses
+
+| HTTP Status | 상황                                 |
+| ----------: | ---------------------------------- |
+|         400 | page가 음수이거나 size가 1~100 범위를 벗어난 경우 |
+|         401 | 인증되지 않은 요청                         |
+|         403 | 관리자 권한이 없는 요청                      |
+
+---
+
+## 2. 신고 상세 조회
+
+```http
+GET /api/admin/reports/{reportId}
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+```
+
+### Path Parameters
+
+| 이름       | 타입     | 설명    |
+| -------- | ------ | ----- |
+| reportId | number | 신고 ID |
+
+### Request Example
+
+```http
+GET /api/admin/reports/1
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+```
+
+### Response Example - 로비/유저 신고
+
+```json
+{
+  "reportId": 1,
+  "reporterId": 10,
+  "reporterUsername": "reporter",
+  "lobbyId": 20,
+  "lobbyCode": "ABC123",
+  "lobbyTitle": "신고 테스트 로비",
+  "targetType": "LOBBY_USER",
+  "targetId": 30,
+  "targetReference": null,
+  "reason": "부적절한 사용자",
+  "status": "PENDING",
+  "createdAt": "2026-05-31T12:00:00",
+  "resolvedAt": null,
+  "chatMessageSnapshot": null
+}
+```
+
+### Response Example - 채팅 메시지 신고
+
+```json
+{
+  "reportId": 2,
+  "reporterId": 10,
+  "reporterUsername": "reporter",
+  "lobbyId": 20,
+  "lobbyCode": "ABC123",
+  "lobbyTitle": "신고 테스트 로비",
+  "targetType": "LOBBY_CHAT_MESSAGE",
+  "targetId": 20,
+  "targetReference": "message-1",
+  "reason": "부적절한 채팅 메시지",
+  "status": "PENDING",
+  "createdAt": "2026-05-31T12:00:00",
+  "resolvedAt": null,
+  "chatMessageSnapshot": {
+    "snapshotId": 100,
+    "messageId": "message-1",
+    "senderIdentifier": "sender-uuid",
+    "senderId": 30,
+    "senderNickname": "sender",
+    "content": "신고 대상 메시지",
+    "messageType": "CHAT",
+    "sentAt": "2026-05-31T12:00:00",
+    "createdAt": "2026-05-31T12:01:00"
+  }
+}
+```
+
+### Error Responses
+
+| HTTP Status | 상황            |
+| ----------: | ------------- |
+|         401 | 인증되지 않은 요청    |
+|         403 | 관리자 권한이 없는 요청 |
+|         404 | 존재하지 않는 신고    |
+
+---
+
+## 3. 신고 처리 상태 변경
+
+```http
+PATCH /api/admin/reports/{reportId}/status
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+Content-Type: application/json
+```
+
+### Path Parameters
+
+| 이름       | 타입     | 설명    |
+| -------- | ------ | ----- |
+| reportId | number | 신고 ID |
+
+### Request Body
+
+| 이름     | 타입     | 필수 | 설명           |
+| ------ | ------ | -: | ------------ |
+| status | string |  Y | 변경할 신고 처리 상태 |
+
+### 허용 상태
+
+| 값         | 설명        |
+| --------- | --------- |
+| RESOLVED  | 유효 신고로 처리 |
+| DISMISSED | 신고 기각     |
+
+`PENDING`은 신고 접수 직후 상태이므로 관리자 처리 요청값으로 허용하지 않습니다.
+
+### Request Example - 처리 완료
+
+```http
+PATCH /api/admin/reports/1/status
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+Content-Type: application/json
+
+{
+  "status": "RESOLVED"
+}
+```
+
+### Request Example - 기각
+
+```http
+PATCH /api/admin/reports/1/status
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+Content-Type: application/json
+
+{
+  "status": "DISMISSED"
+}
+```
+
+### Response
+
+```http
+204 No Content
+```
+
+### Error Responses
+
+| HTTP Status | 상황                         |
+| ----------: | -------------------------- |
+|         400 | status가 누락되었거나 PENDING인 경우 |
+|         401 | 인증되지 않은 요청                 |
+|         403 | 관리자 권한이 없는 요청              |
+|         404 | 존재하지 않는 신고                 |
+|         409 | 이미 처리된 신고를 다시 처리하려는 경우     |
+
+---
+
+## 상태 전이 정책
+
+```text
+PENDING -> RESOLVED
+PENDING -> DISMISSED
+```
+
+아래 전이는 허용하지 않습니다.
+
+```text
+RESOLVED -> *
+DISMISSED -> *
+* -> PENDING
+```
+
+---
+
+## 수동 테스트 절차
+
+### 1. 관리자 권한 부여
+
+```sql
+UPDATE users
+SET role = 'ADMIN'
+WHERE id = {USER_ID};
+```
+
+### 2. 다시 로그인
+
+기존 Access Token에는 변경된 role이 반영되지 않습니다.
+관리자 권한을 부여한 뒤 반드시 다시 로그인해야 합니다.
+
+### 3. 관리자 API 호출
+
+```http
+GET /api/admin/reports
+Authorization: Bearer {ADMIN_ACCESS_TOKEN}
+```
+
+### 4. 일반 사용자 접근 차단 확인
+
+일반 사용자 Access Token으로 같은 API를 호출했을 때 `403 Forbidden`이 반환되어야 합니다.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1674,6 +1674,34 @@ SEND /app/lobby/{code}/kick
     "durationSeconds": 30
   }
   ```
+- **라운드 종료 및 결과 알림 (ROUND_END)**:
+  - **구독 경로**: `SUBSCRIBE /topic/game/{code}/round-end`
+  - **수신 메시지 (RoundMetadataDto)**:
+    ```json
+    {
+      "type": "ROUND_END",
+      "title": "곡 제목",
+      "artist": "가수명",
+      "answer": "대표 정답",
+      "thumbnailUrl": "https://img.youtube.com/vi/.../maxresdefault.jpg",
+      "rankings": [
+        {
+          "userIdentifier": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+          "nickname": "유저닉네임1",
+          "score": 140,
+          "rank": 1,
+          "scoreAdded": 140
+        },
+        {
+          "userIdentifier": "a9f8bb2c-4dd9-4b30-9fc9-9f7c7e0ee1fd",
+          "nickname": "유저닉네임2",
+          "score": 100,
+          "rank": 2,
+          "scoreAdded": 100
+        }
+      ]
+    }
+    ```
 
 #### 5) 인게임 전용 채팅 송신 및 브로드캐스트
 - **송신**: `SEND /app/game/{code}/chat`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,6 +148,8 @@ src/main/java/io/github/ascrew/monomatbe/
 │       │   ├── GameAnswerService.java              # 정답 검증 및 판별 비즈니스
 │       │   ├── GameParticipantResolver.java        # WebSocket 세션 참가자 검증
 │       │   ├── GameRealtimeNotifier.java           # 인게임 Pub/Sub 브로드캐스트
+│       │   ├── GameRoundEndService.java            # 라운드 종료 처리 및 점수 합산 반영 비즈니스
+│       │   ├── GameRoundProgressService.java       # 라운드 진행 관리 및 타이머/스케줄러 조정 서비스
 │       │   ├── GameRoundStartService.java          # 라운드 데이터 웜업 및 라운드 준비/재생 제어
 │       │   ├── GameSessionCreateService.java       # 게임 세션 및 라운드 초기 데이터 생성
 │       │   └── GameSessionQueryService.java        # 현재 게임 세션 및 라운드 상태 조회
@@ -839,8 +841,10 @@ GameRealtimeNotifier / LobbyRealtimeNotifier
 | `game:session:{lobbyCode}` | Hash | 인게임 세션 메타데이터 |
 | `game:session:{lobbyCode}:rounds` | List | 출제된 라운드 목록 |
 | `game:session:{lobbyCode}:players` | Hash | 인게임 플레이어 점수 |
-| `game:session:{lobbyCode}:round:{roundNo}:data` | Hash | 라운드 정답(JSON list), 비디오 제목, 아티스트 메타데이터 |
+| `game:session:{lobbyCode}:round:{roundNo}:data` | Hash | 라운드 정답(JSON list), 비디오 제목, 아티스트 메타데이터 및 최초 정답자 ID (`first_correct_user_id`) |
 | `game:session:{lobbyCode}:round:{roundNo}:correct_players` | Set | 해당 라운드에서 이미 정답을 맞춘 플레이어 목록 (스포일러 판정용) |
+| `game:session:{lobbyCode}:round:{roundNo}:correct_times` | Hash | 해당 라운드 정답 제출 시간 정보 |
+| `game:session:{lobbyCode}:round:{roundNo}:ended_lock` | String | 라운드 종료 중복 실행 방지 분산 락 |
 | `game:session:{lobbyCode}:round:{roundNo}:ready_players` | Set | 해당 라운드 시작 전 YouTube IFrame 준비 완료 신호를 보낸 플레이어 목록 |
 
 
@@ -1092,3 +1096,11 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 - **송신 규칙**: 사용자가 텍스트를 입력하고 전송할 때는 모두 `SEND /app/game/{code}/chat`으로 단일하게 송신합니다.
 - **개별 결과 수신**: 자신이 제출한 채팅이 정답에 해당할 경우, 서버는 일반 채팅 브로드캐스트를 중단(Drop)하고, 해당 사용자에게 `/user/queue/game/answers` 채널로 개별 정답 성공 통지(`ROUND_CORRECT`)를 보냅니다.
   - 이 통지에는 오타 허용으로 정답 처리되었는지를 알 수 있는 `isFuzzy` 필드가 포함되어 있으므로, FE는 이를 활용하여 사용자에게 "오타 허용 정답!" 같은 전용 연출을 표시할 수 있습니다.
+
+#### 3) 라운드 종료 결과 노출 및 랭킹 갱신 (핵심 계약)
+- **라운드 종료 수신**: FE는 `/topic/game/{code}/round-end` 채널을 구독하여 라운드 종료 이벤트를 수신합니다.
+  - 이 이벤트는 각 라운드의 제한 시간이 종료되거나 모든 플레이어가 정답을 입력했을 때 서버에 의해 자동으로 트리거됩니다.
+- **결과 노출 데이터**: 수신된 `RoundMetadataDto`에는 정답 곡 정보(`title`, `artist`, `answer`, `thumbnailUrl`)와 함께 플레이어들의 득점 및 실시간 순위 정보인 `rankings` 리스트가 포함되어 있습니다.
+- **랭킹 및 가점 연출**: `rankings` 리스트 내부의 각 객체는 `PlayerRankingDto` 타입으로, 플레이어의 현재 총점(`score`), 순위(`rank`), 그리고 해당 라운드에서 획득한 가점(`scoreAdded` - 1등 140점, 그 외 정답자 100점, 오답자 0점)을 가지고 있습니다. FE는 `scoreAdded`를 활용하여 "+140" 등 가점 애니메이션을 UI상에 연출하고 랭킹 리스트를 갱신합니다.
+- **자동 전환**: 라운드가 종료된 후 10초간 결과 화면을 노출한 뒤, 서버에 의해 자동으로 다음 라운드가 준비 상태(`ROUND_READY`)로 넘어가게 되므로 FE는 이에 맞춰 인게임 화면으로 복귀하여 비디오 재생 준비 신호를 다시 송신해야 합니다. 마지막 라운드인 경우에는 로비 및 게임 상태가 `FINISHED`로 변경되며 결과화면으로 자동 전환됩니다.
+

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/User.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/User.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
  *
  * 게스트/회원을 하나의 users 테이블로 통합 관리합니다.
  * 인증 방식(게스트/회원)은 userType으로 구분하고,
+ * 서비스 인가 권한은 role로 구분하며,
  * 공통 프로필 정보(닉네임, 상태, 생성일 등)는 이 엔티티에서 관리합니다.
  */
 @Getter
@@ -33,20 +34,29 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User {
 
+    private static final int USERNAME_MAX_LENGTH = 50;
+    private static final int USER_TYPE_MAX_LENGTH = 20;
+    private static final int USER_STATUS_MAX_LENGTH = 20;
+    private static final int USER_ROLE_MAX_LENGTH = 20;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "username", nullable = false, unique = true, length = 50)
+    @Column(name = "username", nullable = false, unique = true, length = USERNAME_MAX_LENGTH)
     private String username;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "user_type", nullable = false, length = 20)
+    @Column(name = "user_type", nullable = false, length = USER_TYPE_MAX_LENGTH)
     private UserType userType;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 20)
+    @Column(name = "status", nullable = false, length = USER_STATUS_MAX_LENGTH)
     private UserStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = USER_ROLE_MAX_LENGTH)
+    private UserRole role;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -68,6 +78,9 @@ public class User {
         }
         if (this.userType == null) {
             this.userType = UserType.GUEST;
+        }
+        if (this.role == null) {
+            this.role = UserRole.USER;
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/User.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/User.java
@@ -17,9 +17,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
- * 사용자 기본 엔티티.
+ * 사용자 기본 엔티티
  *
  * 게스트/회원을 하나의 users 테이블로 통합 관리합니다.
  * 인증 방식(게스트/회원)은 userType으로 구분하고,
@@ -69,7 +70,7 @@ public class User {
 
     @PrePersist
     public void prePersist() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
         this.createdAt = now;
         this.updatedAt = now;
 
@@ -86,7 +87,7 @@ public class User {
 
     @PreUpdate
     public void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now(ZoneOffset.UTC);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserRole.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserRole.java
@@ -1,0 +1,25 @@
+package io.github.ascrew.monomatbe.domain.auth.entity;
+
+/**
+ * 사용자 서비스 권한
+ *
+ * [역할]
+ * - USER  : 일반 사용자 권한
+ * - ADMIN : 운영자/관리자 권한
+ *
+ * [주의]
+ * userType은 게스트/정식 회원 같은 계정 유형을 의미하고,
+ * userRole은 서비스 내 인가 권한을 의미한다.
+ */
+public enum UserRole {
+
+    /**
+     * 일반 사용자
+     */
+    USER,
+
+    /**
+     * 관리자
+     */
+    ADMIN
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/GuestAuthService.java
@@ -98,6 +98,7 @@ public class GuestAuthService {
         TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(
                 savedUser.getId(),
                 savedUser.getUserType(),
+                savedUser.getRole(),
                 userIdentifier
         );
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/LoginAuthService.java
@@ -104,6 +104,7 @@ public class LoginAuthService {
         TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(
                 user.getId(),
                 userType,
+                user.getRole(),
                 userIdentifier
         );
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthService.java
@@ -75,7 +75,13 @@ public class RefreshAuthService {
             throw new AuthException(AuthErrorCode.AUTH_INVALID_REFRESH_TOKEN);
         }
 
-        TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(userId, userType, sessionId);
+        TokenWithExpiry accessToken = jwtTokenProvider.createAccessToken(
+                userId,
+                userType,
+                session.getUser().getRole(),
+                sessionId
+        );
+
         TokenWithExpiry rotatedRefreshToken = jwtTokenProvider.createRefreshToken(userId, userType, sessionId);
         String rotatedRefreshTokenHash = TokenHashUtils.sha256(rotatedRefreshToken.token());
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/PlayerRankingDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/PlayerRankingDto.java
@@ -1,0 +1,12 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PlayerRankingDto(
+        String userIdentifier,
+        String nickname,
+        int score,
+        int rank,
+        int scoreAdded
+) {}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
@@ -1,15 +1,20 @@
 package io.github.ascrew.monomatbe.domain.game.dto;
 
 import lombok.Builder;
+import java.util.List;
 
 /**
  * 라운드 종료 시 클라이언트(FE)에 공개할 메타데이터 DTO.
  */
 @Builder
 public record RoundMetadataDto(
+        String type,
         String title,
         String artist,
         String answer,
-        String thumbnailUrl
+        String thumbnailUrl,
+        List<PlayerRankingDto> rankings
 ) {
 }
+
+

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/GameSessionJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/GameSessionJpaRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface GameSessionJpaRepository extends JpaRepository<GameSession, Long> {
     Optional<GameSession> findTopByLobbyIdOrderByCreatedAtDesc(Long lobbyId);
+
+    @org.springframework.data.jpa.repository.Query("select s from GameSession s where s.lobby.inviteCode = :inviteCode and s.status != io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus.FINISHED")
+    Optional<GameSession> findActiveSessionByLobbyCode(@org.springframework.data.repository.query.Param("inviteCode") String inviteCode);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -39,6 +39,7 @@ public class GameAnswerService {
     private final ChatSenderProfileResolver chatSenderProfileResolver;
     private final JsonMapper jsonMapper;
     private final RedisScript<String> submitGameAnswerScript;
+    private final GameRoundEndService gameRoundEndService;
 
     /**
      * 인게임 전용 채팅 인입 시 정답 여부를 판별하여 처리합니다.
@@ -177,22 +178,25 @@ public class GameAnswerService {
             // 원자적 정답자 등록 및 상태 검증 (Lua Script 기동)
             String result = redisTemplate.execute(
                     submitGameAnswerScript,
-                    List.of(sessionKey, correctPlayersKey),
+                    List.of(sessionKey, correctPlayersKey, roundDataKey, RedisKeys.gameSessionRoundCorrectTimesKey(code, currentRoundNo)),
                     userIdentifier,
                     String.valueOf(currentRoundNo),
                     String.valueOf(System.currentTimeMillis())
             );
 
-            if ("CORRECT_FIRST".equals(result)) {
+            if ("CORRECT_FIRST_PLACE".equals(result) || "CORRECT".equals(result)) {
                 String nickname = getNickname(userIdentifier);
-                log.info("processGameChat: 정답 달성! - code: {}, user: {} ({}), fuzzy: {}", 
-                         code, userIdentifier, nickname, isFuzzy);
+                log.info("processGameChat: 정답 달성! - code: {}, user: {} ({}), result: {}, fuzzy: {}", 
+                         code, userIdentifier, nickname, result, isFuzzy);
 
                 // 정답 달성 시스템 공지 브로드캐스트
                 broadcastSystemMessage(code, nickname + "님이 정답을 맞췄습니다!");
 
                 // 정답 달성자 본인에게 개인 축하 응답 전송
                 sendDirectCorrectResponse(userIdentifier, currentRoundNo, isFuzzy);
+
+                // 모든 플레이어가 정답을 맞췄을 경우 라운드 즉시 조기 종료 트리거
+                checkAndTriggerEarlyRoundEnd(code, currentRoundNo, correctPlayersKey);
             } else if ("ALREADY_CORRECT".equals(result)) {
                 broadcastChatMessage(code, userIdentifier, messageDto.content());
             } else if ("TIMEOUT".equals(result) || "ROUND_NOT_STARTED".equals(result)) {
@@ -265,5 +269,20 @@ public class GameAnswerService {
                 || messageDto.content() == null
                 || messageDto.content().isBlank()
                 || messageDto.content().length() > 500;
+    }
+
+    private void checkAndTriggerEarlyRoundEnd(String code, int roundNo, String correctPlayersKey) {
+        try {
+            String playersKey = RedisKeys.gameSessionPlayersKey(code);
+            Long totalPlayers = redisTemplate.opsForHash().size(playersKey);
+            Long correctPlayers = redisTemplate.opsForSet().size(correctPlayersKey);
+
+            if (totalPlayers != null && correctPlayers != null && correctPlayers >= totalPlayers && totalPlayers > 0) {
+                log.info("checkAndTriggerEarlyRoundEnd: 모든 플레이어가 정답을 맞췄습니다. 라운드를 즉시 조기 종료합니다. - code: {}, roundNo: {}", code, roundNo);
+                gameRoundEndService.endRound(code, roundNo);
+            }
+        } catch (Exception e) {
+            log.error("checkAndTriggerEarlyRoundEnd: 조기 종료 트리거 처리 중 오류 발생 - code: {}, roundNo: {}", code, roundNo, e);
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -1,0 +1,250 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.domain.game.dto.PlayerRankingDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyPlayerNicknameResolver;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyRealtimeNotifier;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameRoundEndService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final GameSessionJpaRepository gameSessionJpaRepository;
+    private final GameSessionPlayerJpaRepository gameSessionPlayerJpaRepository;
+    private final GameLobbyJpaRepository gameLobbyJpaRepository;
+    private final MapItemJpaRepository mapItemJpaRepository;
+    private final UserSessionRepository userSessionRepository;
+    private final GuestSessionRepository guestSessionRepository;
+    private final LobbyPlayerNicknameResolver nicknameResolver;
+    private final GameRealtimeNotifier gameRealtimeNotifier;
+    private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
+    private final JsonMapper jsonMapper;
+    private final ApplicationContext applicationContext;
+
+    /**
+     * 특정 라운드를 종료하고 점수 계산 및 DB/Redis 업데이트를 수행합니다.
+     */
+    @Transactional
+    public void endRound(String lobbyCode, int roundNo) {
+        String endedLockKey = RedisKeys.gameSessionRoundEndedLockKey(lobbyCode, roundNo);
+        Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(endedLockKey, "1", Duration.ofMinutes(5));
+
+        if (Boolean.FALSE.equals(lockAcquired)) {
+            log.info("라운드 종료 무시됨 (이미 종료 처리됨) - code: {}, roundNo: {}", lobbyCode, roundNo);
+            return;
+        }
+
+        log.info("라운드 종료 처리 시작 - code: {}, roundNo: {}", lobbyCode, roundNo);
+
+        // 1. 게임 세션 및 플레이어 조회
+        GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
+                .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
+
+        List<GameSessionPlayer> dbPlayers = gameSessionPlayerJpaRepository.findAllByGameSessionId(gameSession.getId());
+
+        // 2. Redis에서 정답자 및 1등 정보 조회
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(lobbyCode, roundNo);
+        Set<String> correctPlayerIdentifiers = redisTemplate.opsForSet().members(correctPlayersKey);
+        if (correctPlayerIdentifiers == null) {
+            correctPlayerIdentifiers = Collections.emptySet();
+        }
+
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(lobbyCode, roundNo);
+        String firstCorrectIdentifier = (String) redisTemplate.opsForHash().get(roundDataKey, "first_correct_user_id");
+
+        // 3. userIdentifier -> User 매핑 정보 빌드
+        String playersKey = RedisKeys.gameSessionPlayersKey(lobbyCode);
+        Map<Object, Object> playersMap = redisTemplate.opsForHash().entries(playersKey);
+        Set<String> participantIdentifiers = playersMap.keySet().stream()
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> userIdToIdentifier = new HashMap<>();
+        userSessionRepository.findBySessionIdIn(participantIdentifiers)
+                .forEach(s -> userIdToIdentifier.put(s.getUser().getId(), s.getSessionId()));
+        guestSessionRepository.findByGuestTokenIn(participantIdentifiers)
+                .forEach(g -> userIdToIdentifier.put(g.getUser().getId(), g.getGuestToken()));
+
+        // 4. 각 플레이어별 득점 계산 및 반영
+        Map<String, Integer> scoreAddedMap = new HashMap<>();
+        for (GameSessionPlayer dbPlayer : dbPlayers) {
+            String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
+            if (identifier == null) {
+                continue;
+            }
+
+            int scoreAdded = 0;
+            if (correctPlayerIdentifiers.contains(identifier)) {
+                scoreAdded += 100; // 기본 점수
+                if (identifier.equals(firstCorrectIdentifier)) {
+                    scoreAdded += 40; // 1등 보너스
+                }
+            }
+
+            scoreAddedMap.put(identifier, scoreAdded);
+
+            if (scoreAdded > 0) {
+                dbPlayer.addScore(scoreAdded);
+                gameSessionPlayerJpaRepository.save(dbPlayer);
+            }
+        }
+
+        // 5. 실시간 랭킹 산정
+        Map<String, String> nicknameMap = nicknameResolver.resolveNicknameMap(participantIdentifiers);
+        List<PlayerTemp> tempPlayers = new ArrayList<>();
+        for (GameSessionPlayer dbPlayer : dbPlayers) {
+            String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
+            if (identifier == null) {
+                continue;
+            }
+            String nickname = nicknameMap.getOrDefault(identifier, nicknameResolver.fallbackNickname(identifier));
+            tempPlayers.add(new PlayerTemp(identifier, nickname, dbPlayer.getScore(), scoreAddedMap.getOrDefault(identifier, 0)));
+        }
+
+        // 점수 기준 내림차순 정렬
+        tempPlayers.sort((p1, p2) -> Integer.compare(p2.totalScore, p1.totalScore));
+
+        List<PlayerRankingDto> rankings = new ArrayList<>();
+        int currentRank = 1;
+        for (int i = 0; i < tempPlayers.size(); i++) {
+            PlayerTemp p = tempPlayers.get(i);
+            if (i > 0 && p.totalScore < tempPlayers.get(i - 1).totalScore) {
+                currentRank = i + 1;
+            }
+            rankings.add(PlayerRankingDto.builder()
+                    .userIdentifier(p.userIdentifier)
+                    .nickname(p.nickname)
+                    .score(p.totalScore)
+                    .rank(currentRank)
+                    .scoreAdded(p.scoreAdded)
+                    .build());
+        }
+
+        // 6. 라운드 종료 메타데이터 구성 (곡 정보)
+        String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+        String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, roundNo - 1);
+        String title = "";
+        String artist = "";
+        String representativeAnswer = "";
+        String thumbnailUrl = "";
+
+        if (mapItemIdStr != null) {
+            try {
+                Long mapItemId = Long.parseLong(mapItemIdStr);
+                MapItem mapItem = mapItemJpaRepository.findById(mapItemId).orElse(null);
+                if (mapItem != null) {
+                    title = mapItem.getTitle();
+                    artist = mapItem.getArtist();
+                    thumbnailUrl = mapItem.getThumbnailUrl();
+                    List<String> rawAnswers = jsonMapper.readValue(mapItem.getAnswers(), new TypeReference<List<String>>() {});
+                    representativeAnswer = rawAnswers.isEmpty() ? title : rawAnswers.get(0);
+                }
+            } catch (Exception e) {
+                log.error("라운드 종료 메타데이터 파싱 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+            }
+        }
+
+        RoundMetadataDto metadataDto = RoundMetadataDto.builder()
+                .type("ROUND_END")
+                .title(title)
+                .artist(artist)
+                .answer(representativeAnswer)
+                .thumbnailUrl(thumbnailUrl)
+                .rankings(rankings)
+                .build();
+
+        // 7. 다음 라운드 또는 게임 종료 전환
+        boolean isLastRound = roundNo >= gameSession.getTotalQuestionCount();
+
+        if (isLastRound) {
+            gameSession.finish();
+            gameSessionJpaRepository.save(gameSession);
+
+            GameLobby lobby = gameSession.getLobby();
+            lobby.changeStatus(LobbyStatus.FINISHED);
+            gameLobbyJpaRepository.save(lobby);
+
+            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "FINISHED");
+            redisTemplate.opsForHash().put(RedisKeys.lobbyKey(lobbyCode), "status", "FINISHED");
+        }
+
+        // 8. 트랜잭션 성공 후 STOMP 브로드캐스트 및 스케줄링 등록
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                log.info("라운드 종료 트랜잭션 커밋 완료 - Redis 점수 반영 및 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
+                
+                scoreAddedMap.forEach((identifier, scoreAdded) -> {
+                    if (scoreAdded > 0) {
+                        redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
+                    }
+                });
+
+                gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+
+                GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
+                if (isLastRound) {
+                    try {
+                        lobbyRealtimeNotifier.notifyLobbyInfoRefresh(lobbyCode, "SYSTEM");
+                    } catch (Exception e) {
+                        log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
+                    }
+                } else {
+                    progressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                }
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_ROLLED_BACK) {
+                    log.warn("라운드 종료 트랜잭션 롤백 감지 - 멱등 락 해제. code: {}, roundNo: {}", lobbyCode, roundNo);
+                    redisTemplate.delete(endedLockKey);
+                }
+            }
+        });
+    }
+
+    private static class PlayerTemp {
+        String userIdentifier;
+        String nickname;
+        int totalScore;
+        int scoreAdded;
+
+        PlayerTemp(String userIdentifier, String nickname, int totalScore, int scoreAdded) {
+            this.userIdentifier = userIdentifier;
+            this.nickname = nickname;
+            this.totalScore = totalScore;
+            this.scoreAdded = scoreAdded;
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
@@ -1,0 +1,126 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameRoundProgressService {
+
+    private final TaskScheduler taskScheduler;
+    private final StringRedisTemplate redisTemplate;
+    private final GameSessionJpaRepository gameSessionJpaRepository;
+    private final MapItemJpaRepository mapItemJpaRepository;
+    private final GameRealtimeNotifier gameRealtimeNotifier;
+    private final ApplicationContext applicationContext;
+
+    /**
+     * 라운드 종료 스케줄링을 등록합니다. (재생 시작 시점 기준 1.5초 완충 시간 포함)
+     */
+    public void scheduleRoundEnd(String lobbyCode, int roundNo, int timeLimitSeconds) {
+        long delayMillis = (timeLimitSeconds * 1000L) + 1500L;
+        log.info("라운드 종료 자동 태스크 예약 - code: {}, roundNo: {}, delay: {}ms", lobbyCode, roundNo, delayMillis);
+        
+        taskScheduler.schedule(() -> {
+            try {
+                GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
+                endService.endRound(lobbyCode, roundNo);
+            } catch (Exception e) {
+                log.error("자동 라운드 종료 처리 중 예외 발생 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+            }
+        }, Instant.now().plusMillis(delayMillis));
+    }
+
+    /**
+     * 다음 라운드 시작 스케줄링을 등록합니다. (결과 화면 노출 10초)
+     */
+    public void scheduleNextRound(String lobbyCode, int nextRoundNo) {
+        log.info("다음 라운드 시작 예약 - code: {}, nextRoundNo: {}, delay: 10s", lobbyCode, nextRoundNo);
+        
+        taskScheduler.schedule(() -> {
+            try {
+                GameRoundProgressService self = applicationContext.getBean(GameRoundProgressService.class);
+                self.startNextRound(lobbyCode, nextRoundNo);
+            } catch (Exception e) {
+                log.error("다음 라운드 시작 예약 처리 중 예외 발생 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
+            }
+        }, Instant.now().plusSeconds(10));
+    }
+
+    /**
+     * 다음 라운드 데이터를 로드하고 준비 신호(ROUND_READY)를 브로드캐스트합니다.
+     */
+    @Transactional
+    public void startNextRound(String lobbyCode, int nextRoundNo) {
+        log.info("다음 라운드 시작 처리 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+
+        // 1. 게임 세션 조회
+        GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
+                .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
+
+        // 2. DB 및 Redis 라운드 갱신
+        gameSession.nextRound();
+        gameSessionJpaRepository.save(gameSession);
+
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+        redisTemplate.opsForHash().put(sessionKey, "current_round_no", String.valueOf(nextRoundNo));
+        redisTemplate.opsForHash().put(sessionKey, "status", "READY");
+
+        // 3. 다음 라운드 MapItem 조회
+        String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+        String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, nextRoundNo - 1);
+        if (mapItemIdStr == null) {
+            throw new NoSuchElementException("다음 라운드의 문제 ID를 Redis에서 찾을 수 없습니다. roundNo: " + nextRoundNo);
+        }
+
+        Long mapItemId = Long.parseLong(mapItemIdStr);
+        MapItem mapItem = mapItemJpaRepository.findById(mapItemId)
+                .orElseThrow(() -> new NoSuchElementException("MapItem을 찾을 수 없습니다. id: " + mapItemId));
+
+        // 4. 다음 라운드 DTO 구성
+        long serverStartedAt = System.currentTimeMillis();
+        int effectiveEndTime = mapItem.getStartTime() + gameSession.getLobby().getTimeLimitSeconds();
+
+        RoundStartDto nextRoundDto = RoundStartDto.builder()
+                .type("ROUND_READY")
+                .videoId(mapItem.getVideoId())
+                .youtubeUrl(mapItem.getYoutubeUrl())
+                .startTime(mapItem.getStartTime())
+                .endTime(effectiveEndTime)
+                .timeLimitSeconds(gameSession.getLobby().getTimeLimitSeconds())
+                .roundNo(nextRoundNo)
+                .serverStartedAt(serverStartedAt)
+                .build();
+
+        // 5. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+                gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
+
+                GameRoundStartService startService = applicationContext.getBean(GameRoundStartService.class);
+                startService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+            }
+        });
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
@@ -6,6 +6,7 @@ import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -24,16 +25,19 @@ public class GameRoundStartService {
     private final SimpMessagingTemplate messagingTemplate;
     private final RedisScript<String> readyToPlayScript;
     private final TaskScheduler taskScheduler;
+    private final ApplicationContext applicationContext;
 
     public GameRoundStartService(
             StringRedisTemplate redisTemplate,
             SimpMessagingTemplate messagingTemplate,
             @Qualifier("readyToPlayScript") RedisScript<String> readyToPlayScript,
-            TaskScheduler taskScheduler) {
+            TaskScheduler taskScheduler,
+            ApplicationContext applicationContext) {
         this.redisTemplate = redisTemplate;
         this.messagingTemplate = messagingTemplate;
         this.readyToPlayScript = readyToPlayScript;
         this.taskScheduler = taskScheduler;
+        this.applicationContext = applicationContext;
     }
 
     public void scheduleForcePlaybackStart(String lobbyCode, int roundNo, int timeLimitSeconds) {
@@ -101,6 +105,14 @@ public class GameRoundStartService {
                     .build();
 
             messagingTemplate.convertAndSend(StompDestinations.subscribeGameRound(lobbyCode), dto);
+
+            // 라운드 종료 스케줄링 호출
+            try {
+                GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
+                progressService.scheduleRoundEnd(lobbyCode, roundNo, durationSeconds);
+            } catch (Exception e) {
+                log.error("라운드 종료 자동 스케줄링 예약 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+            }
         } else {
             log.info("이미 다른 스레드/서버에서 재생 시작 시각이 기록되어 브로드캐스트를 스킵합니다 - code: {}, roundNo: {}", lobbyCode, roundNo);
         }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -72,6 +72,14 @@ public class GameSessionCreateService {
         long serverStartedAt = System.currentTimeMillis();
         java.time.LocalDateTime startedAt = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(serverStartedAt), java.time.ZoneId.systemDefault());
 
+        // 0. 기존 미종료 활성 세션 정리 (정체 방지)
+        gameSessionJpaRepository.findActiveSessionByLobbyCode(code)
+                .ifPresent(oldSession -> {
+                    log.warn("미종료된 이전 게임 세션 발견 - 강제 FINISHED 처리. code: {}, oldSessionId: {}", code, oldSession.getId());
+                    oldSession.finish();
+                    gameSessionJpaRepository.save(oldSession);
+                });
+
         // 2. DB 세션 생성
         GameSession gameSession = GameSession.builder()
                 .lobby(lobby)

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportController.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.domain.report.controller;
 
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportDetailResponse;
 import io.github.ascrew.monomatbe.domain.report.dto.AdminReportPageResponse;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
@@ -11,19 +12,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 관리자 신고 REST API 컨트롤러
+ * 관리자 신고 REST API 컨트롤러.
  *
  * [책임]
  * - 신고 목록 조회
  * - 신고 상세 조회
  * - 신고 처리 상태 변경
- *
- * 이번 단계에서는 신고 목록 조회만 구현한다.
  */
 @Slf4j
 @Tag(name = "Admin Report", description = "관리자 신고 관리 API")
@@ -36,6 +36,10 @@ public class AdminReportController {
             "요청 수신: 관리자 신고 목록 조회 [GET /api/admin/reports] - targetType: {}, status: {}, page: {}, size: {}";
     private static final String LOG_GET_REPORTS_RESPONSE =
             "관리자 신고 목록 조회 완료 - count: {}, page: {}, size: {}, hasNext: {}";
+    private static final String LOG_GET_REPORT_DETAIL_REQUEST =
+            "요청 수신: 관리자 신고 상세 조회 [GET /api/admin/reports/{reportId}] - reportId: {}";
+    private static final String LOG_GET_REPORT_DETAIL_RESPONSE =
+            "관리자 신고 상세 조회 완료 - reportId: {}, status: {}";
 
     private final AdminReportQueryService adminReportQueryService;
 
@@ -85,6 +89,43 @@ public class AdminReportController {
                 response.page(),
                 response.size(),
                 response.hasNext()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 관리자 신고 상세 조회 API
+     *
+     * [권한]
+     * - ROLE_ADMIN 필요
+     *
+     * [응답]
+     * - 공통 신고 정보
+     * - 신고자 정보
+     * - 로비 맥락 정보
+     * - 채팅 메시지 신고인 경우 메시지 스냅샷
+     */
+    @Operation(
+            summary = "관리자 신고 상세 조회",
+            description = """
+                    관리자 권한으로 특정 신고의 상세 정보를 조회합니다.
+                    채팅 메시지 신고인 경우 신고 시점의 채팅 메시지 스냅샷을 함께 반환합니다.
+                    """
+    )
+    @GetMapping("/{reportId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<AdminReportDetailResponse> getReportDetail(
+            @PathVariable Long reportId
+    ) {
+        log.info(LOG_GET_REPORT_DETAIL_REQUEST, reportId);
+
+        AdminReportDetailResponse response = adminReportQueryService.getReportDetail(reportId);
+
+        log.info(
+                LOG_GET_REPORT_DETAIL_RESPONSE,
+                response.reportId(),
+                response.status()
         );
 
         return ResponseEntity.ok(response);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportController.java
@@ -1,0 +1,92 @@
+package io.github.ascrew.monomatbe.domain.report.controller;
+
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportPageResponse;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.service.AdminReportQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 신고 REST API 컨트롤러
+ *
+ * [책임]
+ * - 신고 목록 조회
+ * - 신고 상세 조회
+ * - 신고 처리 상태 변경
+ *
+ * 이번 단계에서는 신고 목록 조회만 구현한다.
+ */
+@Slf4j
+@Tag(name = "Admin Report", description = "관리자 신고 관리 API")
+@RestController
+@RequestMapping("/api/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private static final String LOG_GET_REPORTS_REQUEST =
+            "요청 수신: 관리자 신고 목록 조회 [GET /api/admin/reports] - targetType: {}, status: {}, page: {}, size: {}";
+    private static final String LOG_GET_REPORTS_RESPONSE =
+            "관리자 신고 목록 조회 완료 - count: {}, page: {}, size: {}, hasNext: {}";
+
+    private final AdminReportQueryService adminReportQueryService;
+
+    /**
+     * 관리자 신고 목록 조회 API.
+     *
+     * [권한]
+     * - ROLE_ADMIN 필요
+     *
+     * [필터]
+     * - targetType: LOBBY, LOBBY_USER, LOBBY_CHAT_MESSAGE
+     * - status: PENDING, RESOLVED, DISMISSED
+     */
+    @Operation(
+            summary = "관리자 신고 목록 조회",
+            description = """
+                    관리자 권한으로 신고 목록을 조회합니다.
+                    targetType과 status로 필터링할 수 있으며, page/size 기반 페이징을 지원합니다.
+                    """
+    )
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<AdminReportPageResponse> getReports(
+            @RequestParam(required = false) ReportTargetType targetType,
+            @RequestParam(required = false) ReportStatus status,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size
+    ) {
+        log.info(
+                LOG_GET_REPORTS_REQUEST,
+                targetType,
+                status,
+                page,
+                size
+        );
+
+        AdminReportPageResponse response = adminReportQueryService.getReports(
+                targetType,
+                status,
+                page,
+                size
+        );
+
+        log.info(
+                LOG_GET_REPORTS_RESPONSE,
+                response.items().size(),
+                response.page(),
+                response.size(),
+                response.hasNext()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportController.java
@@ -2,23 +2,28 @@ package io.github.ascrew.monomatbe.domain.report.controller;
 
 import io.github.ascrew.monomatbe.domain.report.dto.AdminReportDetailResponse;
 import io.github.ascrew.monomatbe.domain.report.dto.AdminReportPageResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportStatusUpdateRequest;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.service.AdminReportCommandService;
 import io.github.ascrew.monomatbe.domain.report.service.AdminReportQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 관리자 신고 REST API 컨트롤러.
+ * 관리자 신고 REST API 컨트롤러
  *
  * [책임]
  * - 신고 목록 조회
@@ -40,11 +45,16 @@ public class AdminReportController {
             "요청 수신: 관리자 신고 상세 조회 [GET /api/admin/reports/{reportId}] - reportId: {}";
     private static final String LOG_GET_REPORT_DETAIL_RESPONSE =
             "관리자 신고 상세 조회 완료 - reportId: {}, status: {}";
+    private static final String LOG_UPDATE_REPORT_STATUS_REQUEST =
+            "요청 수신: 관리자 신고 처리 상태 변경 [PATCH /api/admin/reports/{reportId}/status] - reportId: {}, status: {}";
+    private static final String LOG_UPDATE_REPORT_STATUS_RESPONSE =
+            "관리자 신고 처리 상태 변경 완료 - reportId: {}, status: {}";
 
     private final AdminReportQueryService adminReportQueryService;
+    private final AdminReportCommandService adminReportCommandService;
 
     /**
-     * 관리자 신고 목록 조회 API.
+     * 관리자 신고 목록 조회 API
      *
      * [권한]
      * - ROLE_ADMIN 필요
@@ -129,5 +139,51 @@ public class AdminReportController {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 관리자 신고 처리 상태 변경 API
+     *
+     * [권한]
+     * - ROLE_ADMIN 필요
+     *
+     * [허용 상태]
+     * - RESOLVED
+     * - DISMISSED
+     *
+     * [정책]
+     * 이미 처리된 신고는 다시 처리할 수 없다.
+     */
+    @Operation(
+            summary = "관리자 신고 처리 상태 변경",
+            description = """
+                    관리자 권한으로 PENDING 상태의 신고를 RESOLVED 또는 DISMISSED 상태로 변경합니다.
+                    이미 처리된 신고는 다시 처리할 수 없습니다.
+                    """
+    )
+    @PatchMapping("/{reportId}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> updateReportStatus(
+            @PathVariable Long reportId,
+            @Valid @RequestBody AdminReportStatusUpdateRequest request
+    ) {
+        log.info(
+                LOG_UPDATE_REPORT_STATUS_REQUEST,
+                reportId,
+                request.status()
+        );
+
+        adminReportCommandService.updateReportStatus(
+                reportId,
+                request.status()
+        );
+
+        log.info(
+                LOG_UPDATE_REPORT_STATUS_RESPONSE,
+                reportId,
+                request.status()
+        );
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportChatMessageSnapshotResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportChatMessageSnapshotResponse.java
@@ -1,0 +1,25 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 신고 상세 조회에서 사용하는 로비 채팅 메시지 스냅샷 응답 DTO
+ *
+ * [목적]
+ * Redis 최근 채팅 TTL 만료 후에도 운영자가 신고 당시의 메시지 원문과 발신자 정보를 확인할 수 있도록 한다.
+ */
+@Builder
+public record AdminReportChatMessageSnapshotResponse(
+        Long snapshotId,
+        String messageId,
+        String senderIdentifier,
+        Long senderId,
+        String senderNickname,
+        String content,
+        String messageType,
+        LocalDateTime sentAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportDetailResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportDetailResponse.java
@@ -1,0 +1,38 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 신고 상세 조회 응답 DTO
+ *
+ * [목적]
+ * 운영자가 신고 하나를 처리하기 전에 신고자, 신고 대상, 로비 맥락,
+ * 신고 사유, 처리 상태, 채팅 메시지 스냅샷을 확인할 수 있도록 한다.
+ */
+@Builder
+public record AdminReportDetailResponse(
+        Long reportId,
+
+        Long reporterId,
+        String reporterUsername,
+
+        Long lobbyId,
+        String lobbyCode,
+        String lobbyTitle,
+
+        ReportTargetType targetType,
+        Long targetId,
+        String targetReference,
+
+        String reason,
+        ReportStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime resolvedAt,
+
+        AdminReportChatMessageSnapshotResponse chatMessageSnapshot
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportListItemResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportListItemResponse.java
@@ -1,0 +1,36 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 신고 목록 아이템 응답 DTO
+ *
+ * [목적]
+ * 운영자가 신고 목록 화면에서 빠르게 판단할 수 있도록
+ * 신고 대상, 신고자, 로비 맥락, 처리 상태, 생성/처리 시각을 제공한다.
+ *
+ * [주의]
+ * 채팅 메시지 원문 같은 상세 정보는 목록 응답에 포함하지 않는다.
+ * 상세 조회 API에서 별도 제공한다.
+ */
+@Builder
+public record AdminReportListItemResponse(
+        Long reportId,
+        Long reporterId,
+        String reporterUsername,
+        Long lobbyId,
+        String lobbyCode,
+        String lobbyTitle,
+        ReportTargetType targetType,
+        Long targetId,
+        String targetReference,
+        String reason,
+        ReportStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime resolvedAt
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportPageResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportPageResponse.java
@@ -1,0 +1,37 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import java.util.List;
+
+/**
+ * 관리자 신고 목록 페이징 응답 DTO
+ *
+ * @param items   현재 페이지 신고 목록
+ * @param page    0-based 현재 페이지 번호
+ * @param size    요청한 페이지 크기
+ * @param hasNext 다음 페이지 존재 여부
+ */
+public record AdminReportPageResponse(
+        List<AdminReportListItemResponse> items,
+        int page,
+        int size,
+        boolean hasNext
+) {
+
+    public AdminReportPageResponse {
+        items = List.copyOf(items);
+    }
+
+    public static AdminReportPageResponse of(
+            List<AdminReportListItemResponse> items,
+            int page,
+            int size,
+            boolean hasNext
+    ) {
+        return new AdminReportPageResponse(
+                items,
+                page,
+                size,
+                hasNext
+        );
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportStatusUpdateRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/dto/AdminReportStatusUpdateRequest.java
@@ -1,0 +1,21 @@
+package io.github.ascrew.monomatbe.domain.report.dto;
+
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 관리자 신고 처리 상태 변경 요청 DTO
+ *
+ * [허용 상태]
+ * - RESOLVED  : 유효한 신고로 처리 완료
+ * - DISMISSED : 유효하지 않은 신고로 기각
+ *
+ * [주의]
+ * PENDING은 신고 접수 직후의 초기 상태이므로 관리자 처리 요청값으로 허용하지 않는다.
+ */
+public record AdminReportStatusUpdateRequest(
+
+        @NotNull(message = "변경할 신고 처리 상태는 필수입니다.")
+        ReportStatus status
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/event/ReportResolvedEvent.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/event/ReportResolvedEvent.java
@@ -1,0 +1,24 @@
+package io.github.ascrew.monomatbe.domain.report.event;
+
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+
+/**
+ * 관리자가 신고를 유효 신고로 처리했을 때 발행되는 이벤트
+ *
+ * [목적]
+ * 신고 승인과 실제 제재 처리를 느슨하게 분리한다.
+ * 이번 PR에서는 이벤트 발행까지만 수행하고,
+ * 계정 정지, 로비 폐쇄, 메시지 숨김 같은 실질 제재 listener는 후속 이슈에서 구현한다.
+ *
+ * [권장 listener 정책]
+ * 후속 listener는 @TransactionalEventListener(phase = AFTER_COMMIT) 기반으로 처리한다.
+ */
+public record ReportResolvedEvent(
+        Long reportId,
+        Long reporterId,
+        Long lobbyId,
+        ReportTargetType targetType,
+        Long targetId,
+        String targetReference
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/AdminReportSearchCondition.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/AdminReportSearchCondition.java
@@ -1,0 +1,18 @@
+package io.github.ascrew.monomatbe.domain.report.repository;
+
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+
+/**
+ * 관리자 신고 목록 조회 검색 조건
+ *
+ * [확장 목적]
+ * 현재는 targetType/status만 사용하지만,
+ * 향후 신고자 닉네임, 기간 검색, 키워드 검색 등이 추가되더라도
+ * Repository 메서드 조합을 늘리지 않고 단일 동적 쿼리로 처리하기 위한 조건 객체이다.
+ */
+public record AdminReportSearchCondition(
+        ReportTargetType targetType,
+        ReportStatus status
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/LobbyChatMessageReportSnapshotRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/LobbyChatMessageReportSnapshotRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 /**
  * 로비 채팅 메시지 신고 스냅샷 Repository
  *
@@ -25,6 +27,14 @@ public interface LobbyChatMessageReportSnapshotRepository
      * @return 존재 여부
      */
     boolean existsByReportId(Long reportId);
+
+    /**
+     * 특정 report에 연결된 채팅 메시지 스냅샷을 조회한다.
+     *
+     * @param reportId report.id
+     * @return 채팅 메시지 신고 스냅샷
+     */
+    Optional<LobbyChatMessageReportSnapshot> findByReportId(Long reportId);
 
     /**
      * 동일 사용자가 동일 로비에서 동일 채팅 메시지를 이미 PENDING 상태로 신고했는지 확인한다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
@@ -4,12 +4,14 @@ import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -109,8 +111,14 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
      *
      * 같은 신고를 여러 관리자가 동시에 처리하는 상황을 방지하기 위해
      * PESSIMISTIC_WRITE 락을 획득한다.
+     *
+     * 락 획득 대기 시간이 과도하게 길어질 경우 커넥션 풀이 고갈될 수 있으므로
+     * jakarta.persistence.lock.timeout 힌트로 최대 대기 시간을 제한한다.
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+            @QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")
+    })
     @Query("""
             select report
             from Report report

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
@@ -3,10 +3,12 @@ package io.github.ascrew.monomatbe.domain.report.repository;
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,6 +22,7 @@ import java.util.Optional;
  * - 동일 사용자의 동일 대상 PENDING 중복 신고 여부 확인
  * - 신고 누적 카운트 조회
  * - 관리자 신고 목록/상세 조회
+ * - 관리자 신고 처리 상태 변경용 비관적 락 조회
  *
  * [중복 신고 기준]
  * 동일 사용자가 같은 로비에서 같은 targetType/targetId에 대해
@@ -56,7 +59,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     );
 
     /**
-     * 관리자 신고 목록 조회.
+     * 관리자 신고 목록 조회
      *
      * reporter와 lobby는 목록 응답에 필요하므로 EntityGraph로 함께 로딩한다.
      */
@@ -97,4 +100,18 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             where report.id = :reportId
             """)
     Optional<Report> findDetailById(@Param("reportId") Long reportId);
+
+    /**
+     * 관리자 신고 처리 상태 변경용 조회
+     *
+     * 같은 신고를 여러 관리자가 동시에 처리하는 상황을 방지하기 위해
+     * PESSIMISTIC_WRITE 락을 획득한다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select report
+            from Report report
+            where report.id = :reportId
+            """)
+    Optional<Report> findByIdForUpdate(@Param("reportId") Long reportId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
@@ -5,9 +5,6 @@ import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -30,7 +27,7 @@ import java.util.Optional;
  * 동일 사용자가 같은 로비에서 같은 targetType/targetId에 대해
  * 아직 처리되지 않은 PENDING 신고를 이미 생성했다면 중복 신고로 본다.
  */
-public interface ReportRepository extends JpaRepository<Report, Long> {
+public interface ReportRepository extends JpaRepository<Report, Long>, ReportRepositoryCustom {
 
     /**
      * 동일 사용자의 동일 대상 미처리 신고 존재 여부를 확인한다.
@@ -58,38 +55,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     long countByLobbyIdAndStatus(
             Long lobbyId,
             ReportStatus status
-    );
-
-    /**
-     * 관리자 신고 목록 조회.
-     *
-     * AdminReportPageResponse는 totalCount/totalPages를 반환하지 않고 hasNext만 사용한다.
-     * 따라서 Page 대신 Slice를 사용해 불필요한 count query를 제거한다.
-     *
-     * reporter와 lobby는 목록 응답에 필요하므로 EntityGraph로 함께 로딩한다.
-     */
-    @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Slice<Report> findByTargetTypeAndStatus(
-            ReportTargetType targetType,
-            ReportStatus status,
-            Pageable pageable
-    );
-
-    @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Slice<Report> findByTargetType(
-            ReportTargetType targetType,
-            Pageable pageable
-    );
-
-    @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Slice<Report> findByStatus(
-            ReportStatus status,
-            Pageable pageable
-    );
-
-    @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Slice<Report> findAllBy(
-            Pageable pageable
     );
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
@@ -4,8 +4,8 @@ import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
 import jakarta.persistence.LockModeType;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -59,36 +59,39 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     );
 
     /**
-     * 관리자 신고 목록 조회
+     * 관리자 신고 목록 조회.
+     *
+     * AdminReportPageResponse는 totalCount/totalPages를 반환하지 않고 hasNext만 사용한다.
+     * 따라서 Page 대신 Slice를 사용해 불필요한 count query를 제거한다.
      *
      * reporter와 lobby는 목록 응답에 필요하므로 EntityGraph로 함께 로딩한다.
      */
     @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Page<Report> findByTargetTypeAndStatus(
+    Slice<Report> findByTargetTypeAndStatus(
             ReportTargetType targetType,
             ReportStatus status,
             Pageable pageable
     );
 
     @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Page<Report> findByTargetType(
+    Slice<Report> findByTargetType(
             ReportTargetType targetType,
             Pageable pageable
     );
 
     @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Page<Report> findByStatus(
+    Slice<Report> findByStatus(
             ReportStatus status,
             Pageable pageable
     );
 
     @EntityGraph(attributePaths = {"reporter", "lobby"})
-    Page<Report> findAllBy(
+    Slice<Report> findAllBy(
             Pageable pageable
     );
 
     /**
-     * 관리자 신고 상세 조회
+     * 관리자 신고 상세 조회.
      *
      * reporter와 lobby는 상세 응답에 필요하므로 fetch join으로 함께 조회한다.
      */
@@ -102,7 +105,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     Optional<Report> findDetailById(@Param("reportId") Long reportId);
 
     /**
-     * 관리자 신고 처리 상태 변경용 조회
+     * 관리자 신고 처리 상태 변경용 조회.
      *
      * 같은 신고를 여러 관리자가 동시에 처리하는 상황을 방지하기 위해
      * PESSIMISTIC_WRITE 락을 획득한다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
@@ -7,6 +7,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 /**
  * report 테이블 접근 JPA 리포지토리
@@ -15,7 +19,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * - 신고 저장
  * - 동일 사용자의 동일 대상 PENDING 중복 신고 여부 확인
  * - 신고 누적 카운트 조회
- * - 관리자 신고 목록 조회
+ * - 관리자 신고 목록/상세 조회
  *
  * [중복 신고 기준]
  * 동일 사용자가 같은 로비에서 같은 targetType/targetId에 대해
@@ -25,20 +29,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     /**
      * 동일 사용자의 동일 대상 미처리 신고 존재 여부를 확인한다.
-     *
-     * 로비 자체 신고:
-     * - reporterId = 신고자 users.id
-     * - lobbyId = 신고 대상 GAME_LOBBY.id
-     * - targetType = LOBBY
-     * - targetId = GAME_LOBBY.id
-     * - status = PENDING
-     *
-     * 로비 유저 신고:
-     * - reporterId = 신고자 users.id
-     * - lobbyId = 신고가 발생한 GAME_LOBBY.id
-     * - targetType = LOBBY_USER
-     * - targetId = 신고 대상 users.id
-     * - status = PENDING
      */
     boolean existsByReporterIdAndLobbyIdAndTargetTypeAndTargetIdAndStatus(
             Long reporterId,
@@ -50,10 +40,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     /**
      * 특정 신고 대상의 미처리 신고 누적 수를 조회한다.
-     *
-     * 예:
-     * - 특정 로비에 대한 PENDING 신고 수
-     * - 특정 유저에 대한 PENDING 신고 수
      */
     long countByTargetTypeAndTargetIdAndStatus(
             ReportTargetType targetType,
@@ -63,9 +49,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     /**
      * 특정 로비에서 발생한 미처리 신고 누적 수를 조회한다.
-     *
-     * 로비 자체 신고와 로비 유저 신고를 모두 포함해
-     * 해당 로비의 운영 위험도를 판단할 때 사용할 수 있다.
      */
     long countByLobbyIdAndStatus(
             Long lobbyId,
@@ -73,10 +56,9 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     );
 
     /**
-     * 관리자 신고 목록 조회
+     * 관리자 신고 목록 조회.
      *
-     * targetType/status가 null이면 해당 필터를 적용하지 않는다.
-     * reporter와 lobby는 목록 응답에 바로 필요하므로 EntityGraph로 함께 로딩한다.
+     * reporter와 lobby는 목록 응답에 필요하므로 EntityGraph로 함께 로딩한다.
      */
     @EntityGraph(attributePaths = {"reporter", "lobby"})
     Page<Report> findByTargetTypeAndStatus(
@@ -101,4 +83,18 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     Page<Report> findAllBy(
             Pageable pageable
     );
+
+    /**
+     * 관리자 신고 상세 조회
+     *
+     * reporter와 lobby는 상세 응답에 필요하므로 fetch join으로 함께 조회한다.
+     */
+    @Query("""
+            select report
+            from Report report
+            join fetch report.reporter
+            join fetch report.lobby
+            where report.id = :reportId
+            """)
+    Optional<Report> findDetailById(@Param("reportId") Long reportId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepository.java
@@ -3,6 +3,9 @@ package io.github.ascrew.monomatbe.domain.report.repository;
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -12,6 +15,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * - 신고 저장
  * - 동일 사용자의 동일 대상 PENDING 중복 신고 여부 확인
  * - 신고 누적 카운트 조회
+ * - 관리자 신고 목록 조회
  *
  * [중복 신고 기준]
  * 동일 사용자가 같은 로비에서 같은 targetType/targetId에 대해
@@ -66,5 +70,35 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     long countByLobbyIdAndStatus(
             Long lobbyId,
             ReportStatus status
+    );
+
+    /**
+     * 관리자 신고 목록 조회
+     *
+     * targetType/status가 null이면 해당 필터를 적용하지 않는다.
+     * reporter와 lobby는 목록 응답에 바로 필요하므로 EntityGraph로 함께 로딩한다.
+     */
+    @EntityGraph(attributePaths = {"reporter", "lobby"})
+    Page<Report> findByTargetTypeAndStatus(
+            ReportTargetType targetType,
+            ReportStatus status,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"reporter", "lobby"})
+    Page<Report> findByTargetType(
+            ReportTargetType targetType,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"reporter", "lobby"})
+    Page<Report> findByStatus(
+            ReportStatus status,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"reporter", "lobby"})
+    Page<Report> findAllBy(
+            Pageable pageable
     );
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepositoryCustom.java
@@ -1,0 +1,25 @@
+package io.github.ascrew.monomatbe.domain.report.repository;
+
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+/**
+ * 신고 Repository Custom Query 인터페이스
+ *
+ * Spring Data JPA 메서드 이름 조합 대신 동적 검색 조건을 처리한다.
+ */
+public interface ReportRepositoryCustom {
+
+    /**
+     * 관리자 신고 목록을 동적 조건으로 조회한다.
+     *
+     * @param condition 검색 조건
+     * @param pageable  페이징 정보
+     * @return count query 없는 Slice 결과
+     */
+    Slice<Report> searchAdminReports(
+            AdminReportSearchCondition condition,
+            Pageable pageable
+    );
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/repository/ReportRepositoryImpl.java
@@ -1,0 +1,105 @@
+package io.github.ascrew.monomatbe.domain.report.repository;
+
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 신고 Repository Custom Query 구현체.
+ *
+ * [설계 이유]
+ * 관리자 신고 목록 조회는 현재 targetType/status만 사용하지만,
+ * 운영자 검색 기능은 신고자 닉네임, 기간, 키워드 등으로 확장될 가능성이 높다.
+ *
+ * Spring Data JPA 메서드 이름 조합 방식은 필터가 늘어날수록
+ * 메서드 수가 기하급수적으로 증가하므로 Criteria API 기반 동적 쿼리로 처리한다.
+ *
+ * [페이징 정책]
+ * 응답 DTO는 totalCount/totalPages를 사용하지 않고 hasNext만 사용한다.
+ * 따라서 count query가 발생하는 Page 대신 limit + 1 방식의 Slice를 반환한다.
+ */
+@Repository
+public class ReportRepositoryImpl implements ReportRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Slice<Report> searchAdminReports(
+            AdminReportSearchCondition condition,
+            Pageable pageable
+    ) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Report> criteriaQuery = criteriaBuilder.createQuery(Report.class);
+        Root<Report> report = criteriaQuery.from(Report.class);
+
+        report.fetch("reporter", JoinType.INNER);
+        report.fetch("lobby", JoinType.INNER);
+
+        List<Predicate> predicates = buildPredicates(
+                condition,
+                criteriaBuilder,
+                report
+        );
+
+        criteriaQuery.select(report)
+                .where(predicates.toArray(Predicate[]::new))
+                .orderBy(criteriaBuilder.desc(report.get("createdAt")))
+                .distinct(true);
+
+        TypedQuery<Report> query = entityManager.createQuery(criteriaQuery);
+        query.setFirstResult((int) pageable.getOffset());
+        query.setMaxResults(pageable.getPageSize() + 1);
+
+        List<Report> results = query.getResultList();
+
+        boolean hasNext = results.size() > pageable.getPageSize();
+
+        if (hasNext) {
+            results = results.subList(0, pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(
+                results,
+                pageable,
+                hasNext
+        );
+    }
+
+    private List<Predicate> buildPredicates(
+            AdminReportSearchCondition condition,
+            CriteriaBuilder criteriaBuilder,
+            Root<Report> report
+    ) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (condition.targetType() != null) {
+            predicates.add(criteriaBuilder.equal(
+                    report.get("targetType"),
+                    condition.targetType()
+            ));
+        }
+
+        if (condition.status() != null) {
+            predicates.add(criteriaBuilder.equal(
+                    report.get("status"),
+                    condition.status()
+            ));
+        }
+
+        return predicates;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandService.java
@@ -1,0 +1,89 @@
+package io.github.ascrew.monomatbe.domain.report.service;
+
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 관리자 신고 처리 Command 서비스
+ *
+ * [책임]
+ * - 신고 처리 상태 변경
+ * - 이미 처리된 신고 재처리 방지
+ * - PENDING으로 되돌리는 잘못된 요청 차단
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminReportCommandService {
+
+    private static final String ERROR_REPORT_NOT_FOUND =
+            "존재하지 않는 신고입니다.";
+    private static final String ERROR_INVALID_TARGET_STATUS =
+            "신고 처리 상태는 RESOLVED 또는 DISMISSED만 지정할 수 있습니다.";
+    private static final String ERROR_REPORT_ALREADY_PROCESSED =
+            "이미 처리된 신고입니다.";
+
+    private final ReportRepository reportRepository;
+
+    /**
+     * 신고 처리 상태를 변경한다.
+     *
+     * [허용 전이]
+     * - PENDING -> RESOLVED
+     * - PENDING -> DISMISSED
+     *
+     * [차단 전이]
+     * - RESOLVED -> *
+     * - DISMISSED -> *
+     * - * -> PENDING
+     *
+     * @param reportId 신고 ID
+     * @param status   변경할 처리 상태
+     */
+    @Transactional
+    public void updateReportStatus(Long reportId, ReportStatus status) {
+        validateTargetStatus(status);
+
+        Report report = reportRepository.findByIdForUpdate(reportId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_REPORT_NOT_FOUND
+                ));
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_REPORT_ALREADY_PROCESSED
+            );
+        }
+
+        applyStatus(report, status);
+    }
+
+    private void validateTargetStatus(ReportStatus status) {
+        if (status == ReportStatus.RESOLVED || status == ReportStatus.DISMISSED) {
+            return;
+        }
+
+        throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                ERROR_INVALID_TARGET_STATUS
+        );
+    }
+
+    private void applyStatus(Report report, ReportStatus status) {
+        switch (status) {
+            case RESOLVED -> report.resolve();
+            case DISMISSED -> report.dismiss();
+            case PENDING -> throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    ERROR_INVALID_TARGET_STATUS
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandService.java
@@ -9,18 +9,21 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
- * 관리자 신고 처리 Command 서비스
+ * 관리자 신고 처리 Command 서비스.
  *
  * [책임]
  * - 신고 처리 상태 변경
  * - 이미 처리된 신고 재처리 방지
  * - PENDING으로 되돌리는 잘못된 요청 차단
  * - 유효 신고 처리 시 후속 제재 연계를 위한 이벤트 발행
+ *
+ * [이벤트 처리 정책]
+ * 서비스는 ReportResolvedEvent를 단순 발행한다.
+ * 실제 계정 제재, 로비 폐쇄, 메시지 숨김 등은 후속 listener에서
+ * @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)로 처리한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -86,7 +89,7 @@ public class AdminReportCommandService {
         switch (status) {
             case RESOLVED -> {
                 report.resolve();
-                publishReportResolvedEventAfterCommit(report);
+                publishReportResolvedEvent(report);
             }
             case DISMISSED -> report.dismiss();
             case PENDING -> throw new ResponseStatusException(
@@ -96,26 +99,14 @@ public class AdminReportCommandService {
         }
     }
 
-    private void publishReportResolvedEventAfterCommit(Report report) {
-        ReportResolvedEvent event = new ReportResolvedEvent(
+    private void publishReportResolvedEvent(Report report) {
+        eventPublisher.publishEvent(new ReportResolvedEvent(
                 report.getId(),
                 report.getReporter().getId(),
                 report.getLobby().getId(),
                 report.getTargetType(),
                 report.getTargetId(),
                 report.getTargetReference()
-        );
-
-        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            eventPublisher.publishEvent(event);
-            return;
-        }
-
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                eventPublisher.publishEvent(event);
-            }
-        });
+        ));
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandService.java
@@ -2,11 +2,15 @@ package io.github.ascrew.monomatbe.domain.report.service;
 
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.event.ReportResolvedEvent;
 import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -16,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
  * - 신고 처리 상태 변경
  * - 이미 처리된 신고 재처리 방지
  * - PENDING으로 되돌리는 잘못된 요청 차단
+ * - 유효 신고 처리 시 후속 제재 연계를 위한 이벤트 발행
  */
 @Service
 @RequiredArgsConstructor
@@ -29,6 +34,7 @@ public class AdminReportCommandService {
             "이미 처리된 신고입니다.";
 
     private final ReportRepository reportRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 신고 처리 상태를 변경한다.
@@ -78,12 +84,38 @@ public class AdminReportCommandService {
 
     private void applyStatus(Report report, ReportStatus status) {
         switch (status) {
-            case RESOLVED -> report.resolve();
+            case RESOLVED -> {
+                report.resolve();
+                publishReportResolvedEventAfterCommit(report);
+            }
             case DISMISSED -> report.dismiss();
             case PENDING -> throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     ERROR_INVALID_TARGET_STATUS
             );
         }
+    }
+
+    private void publishReportResolvedEventAfterCommit(Report report) {
+        ReportResolvedEvent event = new ReportResolvedEvent(
+                report.getId(),
+                report.getReporter().getId(),
+                report.getLobby().getId(),
+                report.getTargetType(),
+                report.getTargetId(),
+                report.getTargetReference()
+        );
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            eventPublisher.publishEvent(event);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                eventPublisher.publishEvent(event);
+            }
+        });
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
@@ -11,9 +11,9 @@ import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
 import io.github.ascrew.monomatbe.domain.report.repository.LobbyChatMessageReportSnapshotRepository;
 import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -72,9 +72,9 @@ public class AdminReportQueryService {
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        Page<Report> reportPage = findReports(targetType, status, pageable);
+        Slice<Report> reportSlice = findReports(targetType, status, pageable);
 
-        List<AdminReportListItemResponse> items = reportPage.getContent()
+        List<AdminReportListItemResponse> items = reportSlice.getContent()
                 .stream()
                 .map(this::toListItemResponse)
                 .toList();
@@ -83,7 +83,7 @@ public class AdminReportQueryService {
                 items,
                 resolvedPage,
                 resolvedSize,
-                reportPage.hasNext()
+                reportSlice.hasNext()
         );
     }
 
@@ -103,7 +103,7 @@ public class AdminReportQueryService {
         return toDetailResponse(report);
     }
 
-    private Page<Report> findReports(
+    private Slice<Report> findReports(
             ReportTargetType targetType,
             ReportStatus status,
             Pageable pageable

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
@@ -1,0 +1,143 @@
+package io.github.ascrew.monomatbe.domain.report.service;
+
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportListItemResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportPageResponse;
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+/**
+ * 관리자 신고 조회 서비스
+ *
+ * [책임]
+ * - 신고 목록 필터링
+ * - 페이징 파라미터 검증
+ * - 관리자 목록 응답 DTO 변환
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminReportQueryService {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private static final String ERROR_INVALID_PAGE =
+            "page는 0 이상이어야 합니다.";
+    private static final String ERROR_INVALID_SIZE =
+            "size는 1 이상 100 이하이어야 합니다.";
+
+    private final ReportRepository reportRepository;
+
+    /**
+     * 관리자 신고 목록을 조회한다.
+     *
+     * @param targetType 신고 대상 타입 필터. null이면 전체
+     * @param status     신고 처리 상태 필터. null이면 전체
+     * @param page       0-based 페이지 번호
+     * @param size       페이지 크기
+     * @return 신고 목록 페이징 응답
+     */
+    public AdminReportPageResponse getReports(
+            ReportTargetType targetType,
+            ReportStatus status,
+            Integer page,
+            Integer size
+    ) {
+        int resolvedPage = resolvePage(page);
+        int resolvedSize = resolveSize(size);
+
+        Pageable pageable = PageRequest.of(
+                resolvedPage,
+                resolvedSize,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<Report> reportPage = findReports(targetType, status, pageable);
+
+        List<AdminReportListItemResponse> items = reportPage.getContent()
+                .stream()
+                .map(this::toListItemResponse)
+                .toList();
+
+        return AdminReportPageResponse.of(
+                items,
+                resolvedPage,
+                resolvedSize,
+                reportPage.hasNext()
+        );
+    }
+
+    private Page<Report> findReports(
+            ReportTargetType targetType,
+            ReportStatus status,
+            Pageable pageable
+    ) {
+        if (targetType != null && status != null) {
+            return reportRepository.findByTargetTypeAndStatus(targetType, status, pageable);
+        }
+
+        if (targetType != null) {
+            return reportRepository.findByTargetType(targetType, pageable);
+        }
+
+        if (status != null) {
+            return reportRepository.findByStatus(status, pageable);
+        }
+
+        return reportRepository.findAllBy(pageable);
+    }
+
+    private int resolvePage(Integer page) {
+        if (page == null) {
+            return DEFAULT_PAGE;
+        }
+
+        if (page < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_PAGE);
+        }
+
+        return page;
+    }
+
+    private int resolveSize(Integer size) {
+        if (size == null) {
+            return DEFAULT_SIZE;
+        }
+
+        if (size < 1 || size > MAX_SIZE) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_SIZE);
+        }
+
+        return size;
+    }
+
+    private AdminReportListItemResponse toListItemResponse(Report report) {
+        return AdminReportListItemResponse.builder()
+                .reportId(report.getId())
+                .reporterId(report.getReporter().getId())
+                .reporterUsername(report.getReporter().getUsername())
+                .lobbyId(report.getLobby().getId())
+                .lobbyCode(report.getLobby().getInviteCode())
+                .lobbyTitle(report.getLobby().getTitle())
+                .targetType(report.getTargetType())
+                .targetId(report.getTargetId())
+                .targetReference(report.getTargetReference())
+                .reason(report.getReason())
+                .status(report.getStatus())
+                .createdAt(report.getCreatedAt())
+                .resolvedAt(report.getResolvedAt())
+                .build();
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
@@ -8,6 +8,7 @@ import io.github.ascrew.monomatbe.domain.report.entity.LobbyChatMessageReportSna
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.AdminReportSearchCondition;
 import io.github.ascrew.monomatbe.domain.report.repository.LobbyChatMessageReportSnapshotRepository;
 import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +52,9 @@ public class AdminReportQueryService {
     /**
      * 관리자 신고 목록을 조회한다.
      *
+     * 검색 조건은 AdminReportSearchCondition으로 묶어 Repository에 전달한다.
+     * 향후 조건이 늘어나도 Service의 if 분기와 Repository 메서드 조합을 늘리지 않는다.
+     *
      * @param targetType 신고 대상 타입 필터. null이면 전체
      * @param status     신고 처리 상태 필터. null이면 전체
      * @param page       0-based 페이지 번호
@@ -72,7 +76,15 @@ public class AdminReportQueryService {
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        Slice<Report> reportSlice = findReports(targetType, status, pageable);
+        AdminReportSearchCondition condition = new AdminReportSearchCondition(
+                targetType,
+                status
+        );
+
+        Slice<Report> reportSlice = reportRepository.searchAdminReports(
+                condition,
+                pageable
+        );
 
         List<AdminReportListItemResponse> items = reportSlice.getContent()
                 .stream()
@@ -101,26 +113,6 @@ public class AdminReportQueryService {
                 ));
 
         return toDetailResponse(report);
-    }
-
-    private Slice<Report> findReports(
-            ReportTargetType targetType,
-            ReportStatus status,
-            Pageable pageable
-    ) {
-        if (targetType != null && status != null) {
-            return reportRepository.findByTargetTypeAndStatus(targetType, status, pageable);
-        }
-
-        if (targetType != null) {
-            return reportRepository.findByTargetType(targetType, pageable);
-        }
-
-        if (status != null) {
-            return reportRepository.findByStatus(status, pageable);
-        }
-
-        return reportRepository.findAllBy(pageable);
     }
 
     private int resolvePage(Integer page) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryService.java
@@ -1,10 +1,14 @@
 package io.github.ascrew.monomatbe.domain.report.service;
 
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportChatMessageSnapshotResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportDetailResponse;
 import io.github.ascrew.monomatbe.domain.report.dto.AdminReportListItemResponse;
 import io.github.ascrew.monomatbe.domain.report.dto.AdminReportPageResponse;
+import io.github.ascrew.monomatbe.domain.report.entity.LobbyChatMessageReportSnapshot;
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.LobbyChatMessageReportSnapshotRepository;
 import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,12 +22,13 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 /**
- * 관리자 신고 조회 서비스
+ * 관리자 신고 조회 서비스.
  *
  * [책임]
  * - 신고 목록 필터링
+ * - 신고 상세 조회
  * - 페이징 파라미터 검증
- * - 관리자 목록 응답 DTO 변환
+ * - 관리자 응답 DTO 변환
  */
 @Service
 @RequiredArgsConstructor
@@ -37,8 +42,11 @@ public class AdminReportQueryService {
             "page는 0 이상이어야 합니다.";
     private static final String ERROR_INVALID_SIZE =
             "size는 1 이상 100 이하이어야 합니다.";
+    private static final String ERROR_REPORT_NOT_FOUND =
+            "존재하지 않는 신고입니다.";
 
     private final ReportRepository reportRepository;
+    private final LobbyChatMessageReportSnapshotRepository chatMessageReportSnapshotRepository;
 
     /**
      * 관리자 신고 목록을 조회한다.
@@ -77,6 +85,22 @@ public class AdminReportQueryService {
                 resolvedSize,
                 reportPage.hasNext()
         );
+    }
+
+    /**
+     * 관리자 신고 상세 정보를 조회한다.
+     *
+     * @param reportId 신고 ID
+     * @return 신고 상세 응답
+     */
+    public AdminReportDetailResponse getReportDetail(Long reportId) {
+        Report report = reportRepository.findDetailById(reportId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_REPORT_NOT_FOUND
+                ));
+
+        return toDetailResponse(report);
     }
 
     private Page<Report> findReports(
@@ -138,6 +162,51 @@ public class AdminReportQueryService {
                 .status(report.getStatus())
                 .createdAt(report.getCreatedAt())
                 .resolvedAt(report.getResolvedAt())
+                .build();
+    }
+
+    private AdminReportDetailResponse toDetailResponse(Report report) {
+        return AdminReportDetailResponse.builder()
+                .reportId(report.getId())
+                .reporterId(report.getReporter().getId())
+                .reporterUsername(report.getReporter().getUsername())
+                .lobbyId(report.getLobby().getId())
+                .lobbyCode(report.getLobby().getInviteCode())
+                .lobbyTitle(report.getLobby().getTitle())
+                .targetType(report.getTargetType())
+                .targetId(report.getTargetId())
+                .targetReference(report.getTargetReference())
+                .reason(report.getReason())
+                .status(report.getStatus())
+                .createdAt(report.getCreatedAt())
+                .resolvedAt(report.getResolvedAt())
+                .chatMessageSnapshot(resolveChatMessageSnapshot(report))
+                .build();
+    }
+
+    private AdminReportChatMessageSnapshotResponse resolveChatMessageSnapshot(Report report) {
+        if (report.getTargetType() != ReportTargetType.LOBBY_CHAT_MESSAGE) {
+            return null;
+        }
+
+        return chatMessageReportSnapshotRepository.findByReportId(report.getId())
+                .map(this::toChatMessageSnapshotResponse)
+                .orElse(null);
+    }
+
+    private AdminReportChatMessageSnapshotResponse toChatMessageSnapshotResponse(
+            LobbyChatMessageReportSnapshot snapshot
+    ) {
+        return AdminReportChatMessageSnapshotResponse.builder()
+                .snapshotId(snapshot.getId())
+                .messageId(snapshot.getMessageId())
+                .senderIdentifier(snapshot.getSenderIdentifier())
+                .senderId(snapshot.getSenderId())
+                .senderNickname(snapshot.getSenderNickname())
+                .content(snapshot.getContent())
+                .messageType(snapshot.getMessageType())
+                .sentAt(snapshot.getSentAt())
+                .createdAt(snapshot.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -759,4 +759,26 @@ public final class RedisKeys {
     public static String gameSessionRoundPlaybackStartedAtField(int roundNo) {
         return "playback_started_at:" + roundNo;
     }
+
+    /**
+     * 특정 라운드에서 정답을 맞춘 유저들의 제출 시각을 저장하는 Hash 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:correct_times"
+     */
+    public static String gameSessionRoundCorrectTimesKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":correct_times";
+    }
+
+    /**
+     * 특정 라운드의 종료 중복 방지 락 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:ended_lock"
+     */
+    public static String gameSessionRoundEndedLockKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":ended_lock";
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/CustomPrincipal.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/CustomPrincipal.java
@@ -1,17 +1,38 @@
 package io.github.ascrew.monomatbe.global.security.jwt;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 
 /**
  * JWT 파싱 후 SecurityContext에 저장되는 인증 주체 객체
  *
  * [설계 이유]
- * 컨트롤러에서 @AuthenticationPrincipal로 주입받아 userId (DB용)와 userIdentifier(Redis/WebSocket용)를 동시에 사용할 수 있도록한다.
+ * 컨트롤러에서 @AuthenticationPrincipal로 주입받아 userId (DB용)와 userIdentifier(Redis/WebSocket용)를
+ * 동시에 사용할 수 있도록 한다.
  * 두 식별자를 분리함으로써 DB와 Redis 각각 맞는 식별자를 사용할 수 있다.
+ *
+ * [권한]
+ * userType은 GUEST/REGISTERED 계정 유형이고,
+ * role은 USER/ADMIN 인가 권한이다.
  */
 public record CustomPrincipal(
-        Long userId,              // DB users.id (FK 참조용)
-        String userIdentifier,    // UUID (Redis/WebSocket 식별자)
-        UserType userType         // GUEST | REGISTERED
+        Long userId,
+        String userIdentifier,
+        UserType userType,
+        UserRole role
 ) {
+
+    /**
+     * 기존 테스트 및 일반 사용자 기본 생성 편의를 위한 보조 생성자.
+     *
+     * role을 명시하지 않는 경우 일반 사용자 권한(USER)으로 처리한다.
+     * 관리자 권한이 필요한 테스트나 실제 인증 필터에서는 4개 인자 생성자를 사용해야 한다.
+     */
+    public CustomPrincipal(
+            Long userId,
+            String userIdentifier,
+            UserType userType
+    ) {
+        this(userId, userIdentifier, userType, UserRole.USER);
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
@@ -31,9 +31,16 @@ import java.util.List;
  * [처리 흐름]
  * 1. Authorization 헤더에서 Bearer 토큰 추출
  * 2. JWT 파싱 및 서명 검증
- * 3. userId, userIdentifier, userType, userRole 클레임 추출
- * 4. 클레임 null 검증 — 하나라도 누락 시 인증 실패 처리
+ * 3. userId, userIdentifier, userType 클레임 추출
+ * 4. userRole 클레임 추출. 기존 토큰 호환을 위해 누락 시 USER로 처리
  * 5. CustomPrincipal 생성 후 SecurityContext 저장
+ *
+ * [하위호환성 정책]
+ * userRole claim은 #122에서 새로 추가된 claim이다.
+ * 배포 전 발급된 기존 Access Token에는 userRole이 없을 수 있으므로,
+ * 전환 기간 동안 userRole 누락 토큰은 USER 권한으로 처리한다.
+ *
+ * 잘못된 userRole 값은 위변조 또는 비정상 토큰으로 보고 인증 실패 처리한다.
  */
 @Slf4j
 @Component
@@ -87,7 +94,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long userId = Long.valueOf(claims.getSubject());
                 String userIdentifier = claims.get(JwtClaims.USER_IDENTIFIER, String.class);
                 UserType userType = UserType.valueOf(claims.get(JwtClaims.USER_TYPE, String.class));
-                UserRole userRole = UserRole.valueOf(claims.get(JwtClaims.USER_ROLE, String.class));
+                UserRole userRole = resolveUserRole(claims);
 
                 if (!isActiveSession(userIdentifier)) {
                     SecurityContextHolder.clearContext();
@@ -131,18 +138,39 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      * - subject        : userId
      * - userIdentifier : Redis/WebSocket 세션 식별자
      * - userType       : GUEST | REGISTERED
-     * - userRole       : USER | ADMIN
+     *
+     * [userRole 제외 이유]
+     * userRole은 #122에서 추가된 claim이므로 기존 발급 토큰에는 없을 수 있다.
+     * 누락 시 USER로 fallback 처리한다.
      */
     private boolean isValidClaims(Claims claims) {
         String subject = claims.getSubject();
         String userIdentifier = claims.get(JwtClaims.USER_IDENTIFIER, String.class);
         String userType = claims.get(JwtClaims.USER_TYPE, String.class);
-        String userRole = claims.get(JwtClaims.USER_ROLE, String.class);
 
         return subject != null && !subject.isBlank()
                 && userIdentifier != null
-                && userType != null
-                && userRole != null;
+                && userType != null;
+    }
+
+    /**
+     * userRole claim을 권한 enum으로 변환한다.
+     *
+     * [전환 기간 하위호환성]
+     * 기존 Access Token에는 userRole claim이 없으므로 USER로 간주한다.
+     *
+     * [보안]
+     * claim 값이 존재하지만 UserRole enum에 없는 값이면 IllegalArgumentException을 발생시켜
+     * 인증 실패로 처리한다.
+     */
+    private UserRole resolveUserRole(Claims claims) {
+        String userRole = claims.get(JwtClaims.USER_ROLE, String.class);
+
+        if (userRole == null || userRole.isBlank()) {
+            return UserRole.USER;
+        }
+
+        return UserRole.valueOf(userRole);
     }
 
     private String extractToken(HttpServletRequest request) {

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.global.security.jwt;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.jsonwebtoken.Claims;
@@ -30,30 +31,20 @@ import java.util.List;
  * [처리 흐름]
  * 1. Authorization 헤더에서 Bearer 토큰 추출
  * 2. JWT 파싱 및 서명 검증
- * 3. userId, userIdentifier, userType 클레임 추출 (JwtClaims 상수 사용)
+ * 3. userId, userIdentifier, userType, userRole 클레임 추출
  * 4. 클레임 null 검증 — 하나라도 누락 시 인증 실패 처리
  * 5. CustomPrincipal 생성 후 SecurityContext 저장
- *
- * [토큰 없는 요청 처리]
- * permitAll 경로는 토큰 없이 통과시킨다.
- * 경로별 접근 제어는 SecurityConfig의 authorizeHttpRequests에서 담당한다.
  */
 @Slf4j
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    // Authorization 헤더에 들어가는 토큰의 접두사 (공백 포함)
     private static final String BEARER_PREFIX = "Bearer ";
-    // 헤더 키 값
     private static final String HEADER_AUTHORIZATION = "Authorization";
 
-    // JWT 서명 검증에 사용할 암호화 키
     private final SecretKey secretKey;
     private final StringRedisTemplate redisTemplate;
 
-    /**
-     * 필터 생성자
-     * application.yml (또는 properties) 파일에서 'auth.jwt.secret' 값을 주입받아 SecretKey 객체로 초기화한다.     */
     public JwtAuthenticationFilter(
             @Value("${auth.jwt.secret}") String secret,
             StringRedisTemplate redisTemplate
@@ -70,11 +61,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        // 1. 요청 헤더에서 JWT 토큰 문자열을 추출
         String token = extractToken(request);
 
-        // 2. 토큰이 존재할 경우에만 검증 로직 수행
-        // 토큰이 없으면 그냥 다음 필터로 넘어감 -> permitAll이면 통과, 아니면 인가 예외 발생
         if (token != null) {
             try {
                 if (isBlacklistedAccessToken(token)) {
@@ -83,60 +71,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
 
-                // 3. JWT 문자열을 파싱하고 서명을 검증하여 Payload (클레임)를 가져옴
                 Claims claims = Jwts.parser()
-                        .verifyWith(secretKey) // 서버가 가진 secretKey로 서명 (Signature) 위변조 확인
+                        .verifyWith(secretKey)
                         .build()
-                        .parseSignedClaims(token) // 토큰 유휴성 (만료 시간 등) 검사 및 파싱
-                        .getPayload(); // 파싱된 데이터 (Claims) 추출
+                        .parseSignedClaims(token)
+                        .getPayload();
 
-                // 4. 클레임 추출 후 필수 데이터 null 검증
-                // subject, userIdentifier, userType 중 하나라도 누락되면
-                // 위변조 또는 잘못된 토큰으로 간주하여 인증 실패 처리
                 if (!isValidClaims(claims)) {
                     log.warn("JWT 클레임 누락 또는 유효하지 않음 - 인증 거부");
-                    SecurityContextHolder.clearContext(); // 비정상 토큰이므로 현재 스레드의 시큐리티 컨텍스트 초기화
-                    filterChain.doFilter(request, response); // 다음 필터로 넘김 (인증되지 않은 상태로 진행됨)
+                    SecurityContextHolder.clearContext();
+                    filterChain.doFilter(request, response);
                     return;
                 }
 
-                // 5. 토큰 클레임에서 사용자 정보 추출
                 Long userId = Long.valueOf(claims.getSubject());
                 String userIdentifier = claims.get(JwtClaims.USER_IDENTIFIER, String.class);
-                UserType userType = UserType.valueOf(
-                        claims.get(JwtClaims.USER_TYPE, String.class));
+                UserType userType = UserType.valueOf(claims.get(JwtClaims.USER_TYPE, String.class));
+                UserRole userRole = UserRole.valueOf(claims.get(JwtClaims.USER_ROLE, String.class));
+
                 if (!isActiveSession(userIdentifier)) {
                     SecurityContextHolder.clearContext();
                     filterChain.doFilter(request, response);
                     return;
                 }
 
-                // 6. 인증된 사용자를 표현하는 커스텀 Principal 객체 생성
-                CustomPrincipal principal = new CustomPrincipal(userId, userIdentifier, userType);
+                CustomPrincipal principal = new CustomPrincipal(
+                        userId,
+                        userIdentifier,
+                        userType,
+                        userRole
+                );
 
-                // 7. 스프링 시큐리티의 Authentication 객체 (UsernamePasswordAuthenticationToken) 생성
-                // 비밀번호 (Credentials)는 이미 JWT로 인증이 끝났으므로 null 처리
-                // 사용자의 권한 (Role) 목록을 SimpleGrantedAuthority로 감싸서 전달
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(
                                 principal,
                                 null,
                                 List.of(new SimpleGrantedAuthority(
-                                        JwtClaims.ROLE_PREFIX + userType.name()))
+                                        JwtClaims.ROLE_PREFIX + userRole.name()))
                         );
 
-                // 8. 최종적으로 SecurityContext에 인증 객체를 저장하여 전역에서 사용 가능하게 함
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
             } catch (JwtException e) {
-                // 토큰 만료, 서명 불일치, 형식 오류
                 log.warn("JWT 검증 실패: {}", e.getMessage());
-                SecurityContextHolder.clearContext(); // 안전을 위해 컨텍스트 초기화
-
-                // JwtException 외 예외도 인증 실패로 동일 처리
-                // Long.valueOf(null)   → NumberFormatException (IllegalArgumentException 하위)
-                // UserType.valueOf(null) → IllegalArgumentException
-                // claims.get() null 참조 → NullPointerException
+                SecurityContextHolder.clearContext();
             } catch (IllegalArgumentException | NullPointerException e) {
                 log.warn("JWT 클레임 파싱 실패 - 인증 거부: {}", e.getMessage());
                 SecurityContextHolder.clearContext();
@@ -147,37 +125,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 인증에 필요한 클레임이 모두 존재하고 유효한지 검증한다.
+     * 인증에 필요한 Access Token 클레임이 모두 존재하고 유효한지 검증한다.
      *
      * [검증 항목]
-     * - subject        : userId (null 또는 빈 문자열이면 유효하지 않음)
-     * - userIdentifier : UUID 식별자 (null이면 유효하지 않음)
-     * - userType       : 사용자 유형 (null이면 유효하지 않음)
-     *
-     * @param claims JWT 파싱 후 추출된 클레임
-     * @return 모든 필수 클레임이 존재하면 true, 하나라도 누락이면 false
+     * - subject        : userId
+     * - userIdentifier : Redis/WebSocket 세션 식별자
+     * - userType       : GUEST | REGISTERED
+     * - userRole       : USER | ADMIN
      */
     private boolean isValidClaims(Claims claims) {
         String subject = claims.getSubject();
         String userIdentifier = claims.get(JwtClaims.USER_IDENTIFIER, String.class);
         String userType = claims.get(JwtClaims.USER_TYPE, String.class);
+        String userRole = claims.get(JwtClaims.USER_ROLE, String.class);
 
         return subject != null && !subject.isBlank()
                 && userIdentifier != null
-                && userType != null;
+                && userType != null
+                && userRole != null;
     }
 
-    /**
-     * Authorization 헤더에서 Bearer 토큰을 추출한다.
-     * 헤더가 없거나 형식이 맞지 않으면 null을 반환한다.
-     */
     private String extractToken(HttpServletRequest request) {
         String header = request.getHeader(HEADER_AUTHORIZATION);
-        // 헤더에 값이 있고, "Bearer "로 시작하는지 확인
+
         if (header != null && header.startsWith(BEARER_PREFIX)) {
-            // "Bearer " 이후의 문자열 (실제 토큰)만 잘라서 반환
             return header.substring(BEARER_PREFIX.length());
         }
+
         return null;
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtClaims.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtClaims.java
@@ -7,21 +7,23 @@ package io.github.ascrew.monomatbe.global.security.jwt;
  * - JwtTokenProvider (발급)와 JwtAuthenticationFilter (검증)가 동일한 클레임 키를 사용해야 한다.
  * - 문자열 리터럴이 각자 하드코딩하면 오타 시 런타임에서야 발견되므로 상수로 통일하여 컴파일 타임에 감지되도록 한다.
  */
-
 public final class JwtClaims {
 
-    private JwtClaims() {}
+    private JwtClaims() {
+    }
 
-        // 게스트/회원 공통 UUID 식별자 클레임 키
-        public static final String USER_IDENTIFIER = "userIdentifier";
+    // 게스트/회원 공통 UUID 식별자 클레임 키
+    public static final String USER_IDENTIFIER = "userIdentifier";
 
-        // 사용자 유형 클레임 키 (GUEST | REGISTERED)
-        public static final String USER_TYPE = "userType";
+    // 사용자 유형 클레임 키 (GUEST | REGISTERED)
+    public static final String USER_TYPE = "userType";
 
-        // Refresh Token의 세션 ID 클레임 키
-        public static final String SESSION_ID = "sessionId";
+    // 사용자 권한 클레임 키 (USER | ADMIN)
+    public static final String USER_ROLE = "userRole";
 
-        // Spring Security 권한 접두사
-        public static final String ROLE_PREFIX = "ROLE_";
+    // Refresh Token의 세션 ID 클레임 키
+    public static final String SESSION_ID = "sessionId";
 
+    // Spring Security 권한 접두사
+    public static final String ROLE_PREFIX = "ROLE_";
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/jwt/JwtTokenProvider.java
@@ -1,9 +1,10 @@
 package io.github.ascrew.monomatbe.global.security.jwt;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,7 +19,7 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * JWT Access/Refresh 토큰 발급 컴포넌트.
+ * JWT Access/Refresh 토큰 발급 컴포넌트
  *
  * [입력값 검증 원칙]
  * 토큰에 포함되는 모든 클레임은 발급 시점에 검증한다.
@@ -30,14 +31,12 @@ import java.util.Map;
 @Component
 public class JwtTokenProvider {
 
-    // =========================================================
-    // 에러 메시지 상수
-    // =========================================================
-
     private static final String ERROR_USER_ID_NULL =
             "토큰 발급 실패: userId는 null일 수 없습니다.";
     private static final String ERROR_USER_TYPE_NULL =
             "토큰 발급 실패: userType은 null일 수 없습니다.";
+    private static final String ERROR_USER_ROLE_NULL =
+            "토큰 발급 실패: userRole은 null일 수 없습니다.";
     private static final String ERROR_USER_IDENTIFIER_BLANK =
             "토큰 발급 실패: userIdentifier는 null이거나 빈 값일 수 없습니다.";
     private static final String ERROR_SESSION_ID_BLANK =
@@ -74,21 +73,15 @@ public class JwtTokenProvider {
      * - subject        : userId (DB PK)
      * - userIdentifier : UUID (Redis/WebSocket 식별자)
      * - userType       : GUEST | REGISTERED
-     *
-     * [입력값 검증]
-     * userIdentifier가 null이거나 빈 문자열이면 IllegalArgumentException을 던진다.
-     * 잘못된 클레임이 포함된 토큰이 발급되어 JwtAuthenticationFilter의
-     * isValidClaims()에서 인증 실패로 처리되는 상황을 발급 시점에 차단한다.
-     *
-     * @param userId         DB users.id (subject 클레임)
-     * @param userType       사용자 유형 (GUEST | REGISTERED)
-     * @param userIdentifier Redis/WebSocket 식별자 (UUID)
-     * @return 발급된 토큰과 만료시각
-     * @throws IllegalArgumentException userIdentifier가 null이거나 빈 값인 경우
+     * - userRole       : USER | ADMIN
      */
-    public TokenWithExpiry createAccessToken(Long userId, UserType userType, String userIdentifier) {
-        // 발급 시점 입력값 검증
-        validateCommonClaims(userId, userType);
+    public TokenWithExpiry createAccessToken(
+            Long userId,
+            UserType userType,
+            UserRole userRole,
+            String userIdentifier
+    ) {
+        validateCommonClaims(userId, userType, userRole);
         if (!StringUtils.hasText(userIdentifier)) {
             throw new IllegalArgumentException(ERROR_USER_IDENTIFIER_BLANK);
         }
@@ -100,6 +93,7 @@ public class JwtTokenProvider {
                 .subject(String.valueOf(userId))
                 .claims(Map.of(
                         JwtClaims.USER_TYPE, userType.name(),
+                        JwtClaims.USER_ROLE, userRole.name(),
                         JwtClaims.USER_IDENTIFIER, userIdentifier
                 ))
                 .issuedAt(Date.from(now))
@@ -118,19 +112,11 @@ public class JwtTokenProvider {
      * - userType  : GUEST | REGISTERED
      * - sessionId : UUID (Redis refresh key와 동일 식별자)
      *
-     * [입력값 검증]
-     * sessionId가 null이거나 빈 문자열이면 IllegalArgumentException을 던진다.
-     * 유효하지 않은 sessionId로 Refresh Token이 발급되면
-     * Redis에 저장된 토큰과 불일치가 발생하여 갱신이 불가능해진다.
-     *
-     * @param userId    DB users.id (subject 클레임)
-     * @param userType  사용자 유형 (GUEST | REGISTERED)
-     * @param sessionId Redis refresh key 식별자 (UUID)
-     * @return 발급된 토큰과 만료시각
-     * @throws IllegalArgumentException sessionId가 null이거나 빈 값인 경우
+     * [주의]
+     * Refresh Token에는 userRole을 넣지 않는다.
+     * 권한 변경 후 access token 재발급 시점에는 DB UserSession.user.role 기준으로 최신 권한을 반영한다.
      */
     public TokenWithExpiry createRefreshToken(Long userId, UserType userType, String sessionId) {
-        // 발급 시점 입력값 검증
         validateCommonClaims(userId, userType);
         if (!StringUtils.hasText(sessionId)) {
             throw new IllegalArgumentException(ERROR_SESSION_ID_BLANK);
@@ -176,25 +162,19 @@ public class JwtTokenProvider {
         return remaining.isNegative() ? Duration.ZERO : remaining;
     }
 
-    // =========================================================
-    // private 메서드
-    // =========================================================
-
-    /**
-     * Access/Refresh 토큰 발급 시 공통으로 검증하는 클레임을 확인한다.
-     *
-     * [검증 항목]
-     * - userId    : null이면 subject 클레임을 구성할 수 없음
-     * - userType  : null이면 권한 클레임을 구성할 수 없음
-     *
-     * @throws IllegalArgumentException userId 또는 userType이 null인 경우
-     */
     private void validateCommonClaims(Long userId, UserType userType) {
         if (userId == null) {
             throw new IllegalArgumentException(ERROR_USER_ID_NULL);
         }
         if (userType == null) {
             throw new IllegalArgumentException(ERROR_USER_TYPE_NULL);
+        }
+    }
+
+    private void validateCommonClaims(Long userId, UserType userType, UserRole userRole) {
+        validateCommonClaims(userId, userType);
+        if (userRole == null) {
+            throw new IllegalArgumentException(ERROR_USER_ROLE_NULL);
         }
     }
 }

--- a/src/main/resources/db/migration/V13__add_role_to_users.sql
+++ b/src/main/resources/db/migration/V13__add_role_to_users.sql
@@ -3,18 +3,5 @@
 -- users 테이블에 서비스 권한(role) 컬럼 추가
 -- ============================================================================
 
-SET @sql = (
-    SELECT IF(
-                   COUNT(*) = 0,
-                   'ALTER TABLE users ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT ''USER'' COMMENT ''서비스 권한: USER, ADMIN''',
-                   'SELECT 1'
-           )
-    FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE()
-      AND TABLE_NAME = 'users'
-      AND COLUMN_NAME = 'role'
-);
-
-PREPARE v13_stmt FROM @sql;
-EXECUTE v13_stmt;
-DEALLOCATE PREPARE v13_stmt;
+ALTER TABLE users
+    ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER';

--- a/src/main/resources/db/migration/V13__add_role_to_users.sql
+++ b/src/main/resources/db/migration/V13__add_role_to_users.sql
@@ -3,6 +3,18 @@
 -- users 테이블에 서비스 권한(role) 컬럼 추가
 -- ============================================================================
 
-ALTER TABLE users
-    ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER'
-    COMMENT '서비스 권한: USER, ADMIN';
+SET @sql = (
+    SELECT IF(
+                   COUNT(*) = 0,
+                   'ALTER TABLE users ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT ''USER'' COMMENT ''서비스 권한: USER, ADMIN''',
+                   'SELECT 1'
+           )
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'users'
+      AND COLUMN_NAME = 'role'
+);
+
+PREPARE v13_stmt FROM @sql;
+EXECUTE v13_stmt;
+DEALLOCATE PREPARE v13_stmt;

--- a/src/main/resources/db/migration/V13__add_role_to_users.sql
+++ b/src/main/resources/db/migration/V13__add_role_to_users.sql
@@ -1,0 +1,8 @@
+-- ============================================================================
+-- V13__add_role_to_users.sql
+-- users 테이블에 서비스 권한(role) 컬럼 추가
+-- ============================================================================
+
+ALTER TABLE users
+    ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER'
+    COMMENT '서비스 권한: USER, ADMIN';

--- a/src/main/resources/scripts/submit_game_answer.lua
+++ b/src/main/resources/scripts/submit_game_answer.lua
@@ -1,5 +1,7 @@
 local sessionKey = KEYS[1]
 local correctPlayersKey = KEYS[2]
+local roundDataKey = KEYS[3]
+local correctTimesKey = KEYS[4]
 
 local userIdentifier = ARGV[1]
 local requestRoundNo = tonumber(ARGV[2])
@@ -44,6 +46,15 @@ if isMember == 1 then
     return 'ALREADY_CORRECT'
 end
 
--- 5. 정답자 등록
+-- 5. 정답 시간 기록 및 정답자 등록
+redis.call('HSET', correctTimesKey, userIdentifier, tostring(nowMillis))
 redis.call('SADD', correctPlayersKey, userIdentifier)
-return 'CORRECT_FIRST'
+
+-- 6. 최초 정답자(1등) 여부 판별 (HSETNX)
+local isFirst = redis.call('HSETNX', roundDataKey, 'first_correct_user_id', userIdentifier)
+if isFirst == 1 then
+    return 'CORRECT_FIRST_PLACE'
+else
+    return 'CORRECT'
+end
+

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RefreshAuthServiceTest.java
@@ -2,6 +2,7 @@ package io.github.ascrew.monomatbe.domain.auth.service;
 
 import io.github.ascrew.monomatbe.domain.auth.dto.RefreshTokenResponse;
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
@@ -111,7 +112,7 @@ class RefreshAuthServiceTest {
                 Instant.now().plusSeconds(3600)
         );
 
-        when(jwtTokenProvider.createAccessToken(userId, UserType.REGISTERED, sessionId))
+        when(jwtTokenProvider.createAccessToken(userId, UserType.REGISTERED, UserRole.USER, sessionId))
                 .thenReturn(accessToken);
         when(jwtTokenProvider.createRefreshToken(userId, UserType.REGISTERED, sessionId))
                 .thenReturn(refreshToken);
@@ -298,6 +299,7 @@ class RefreshAuthServiceTest {
                         .username("tester")
                         .userType(UserType.REGISTERED)
                         .status(UserStatus.ACTIVE)
+                        .role(UserRole.USER)
                         .build())
                 .sessionId(sessionId)
                 .sessionToken(sessionToken)

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -82,6 +82,7 @@ class GameChatAnswerIntegrationTest {
         redisTemplate.delete(RedisKeys.gameSessionKey(LOBBY_CODE));
         redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1));
     }
 
     private void givenGameSession(String status, int currentRoundNo, int timeLimit, Long playbackStartedAt) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -1,0 +1,239 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyPlayerNicknameResolver;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyRealtimeNotifier;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=none"
+})
+class GameRoundProgressIntegrationTest {
+
+    private static final String LOBBY_CODE = "PROGRESS12";
+    private static final String USER_ID_1 = "player-1-uuid";
+    private static final String USER_ID_2 = "player-2-uuid";
+    private static final String USER_ID_3 = "player-3-uuid";
+
+    @Autowired
+    private GameRoundEndService gameRoundEndService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private GameSessionJpaRepository gameSessionJpaRepository;
+
+    @MockitoBean
+    private GameSessionPlayerJpaRepository gameSessionPlayerJpaRepository;
+
+    @MockitoBean
+    private GameLobbyJpaRepository gameLobbyJpaRepository;
+
+    @MockitoBean
+    private MapItemJpaRepository mapItemJpaRepository;
+
+    @MockitoBean
+    private UserSessionRepository userSessionRepository;
+
+    @MockitoBean
+    private GuestSessionRepository guestSessionRepository;
+
+    @MockitoBean
+    private LobbyPlayerNicknameResolver nicknameResolver;
+
+    @MockitoBean
+    private GameRealtimeNotifier gameRealtimeNotifier;
+
+    @MockitoBean
+    private LobbyRealtimeNotifier lobbyRealtimeNotifier;
+
+    private GameLobby lobby;
+    private GameSession gameSession;
+    private List<GameSessionPlayer> players;
+
+    @BeforeEach
+    void setUp() {
+        lobby = mock(GameLobby.class);
+        when(lobby.getInviteCode()).thenReturn(LOBBY_CODE);
+        when(lobby.getTimeLimitSeconds()).thenReturn(30);
+
+        gameSession = GameSession.builder()
+                .id(1L)
+                .lobby(lobby)
+                .currentRoundNo(1)
+                .totalQuestionCount(3)
+                .status(GameSessionStatus.READY)
+                .build();
+
+        when(gameSessionJpaRepository.findActiveSessionByLobbyCode(LOBBY_CODE))
+                .thenReturn(Optional.of(gameSession));
+
+        User user1 = mock(User.class);
+        when(user1.getId()).thenReturn(101L);
+        User user2 = mock(User.class);
+        when(user2.getId()).thenReturn(102L);
+        User user3 = mock(User.class);
+        when(user3.getId()).thenReturn(103L);
+
+        GameSessionPlayer p1 = GameSessionPlayer.builder().id(1L).gameSession(gameSession).user(user1).score(0).build();
+        GameSessionPlayer p2 = GameSessionPlayer.builder().id(2L).gameSession(gameSession).user(user2).score(0).build();
+        GameSessionPlayer p3 = GameSessionPlayer.builder().id(3L).gameSession(gameSession).user(user3).score(0).build();
+        players = List.of(p1, p2, p3);
+
+        when(gameSessionPlayerJpaRepository.findAllByGameSessionId(1L)).thenReturn(players);
+
+        // Redis keys initialization
+        String playersKey = RedisKeys.gameSessionPlayersKey(LOBBY_CODE);
+        redisTemplate.opsForHash().put(playersKey, USER_ID_1, "0");
+        redisTemplate.opsForHash().put(playersKey, USER_ID_2, "0");
+        redisTemplate.opsForHash().put(playersKey, USER_ID_3, "0");
+
+        // User sessions mocks
+        UserSession s1 = mock(UserSession.class);
+        when(s1.getUser()).thenReturn(user1);
+        when(s1.getSessionId()).thenReturn(USER_ID_1);
+
+        UserSession s2 = mock(UserSession.class);
+        when(s2.getUser()).thenReturn(user2);
+        when(s2.getSessionId()).thenReturn(USER_ID_2);
+
+        UserSession s3 = mock(UserSession.class);
+        when(s3.getUser()).thenReturn(user3);
+        when(s3.getSessionId()).thenReturn(USER_ID_3);
+
+        when(userSessionRepository.findBySessionIdIn(any())).thenReturn(List.of(s1, s2, s3));
+        when(guestSessionRepository.findByGuestTokenIn(any())).thenReturn(Collections.emptyList());
+
+        // Nicknames mock
+        Map<String, String> nicknames = new HashMap<>();
+        nicknames.put(USER_ID_1, "유저1");
+        nicknames.put(USER_ID_2, "유저2");
+        nicknames.put(USER_ID_3, "유저3");
+        when(nicknameResolver.resolveNicknameMap(any())).thenReturn(nicknames);
+
+        // MapItem mock
+        MapItem mapItem = mock(MapItem.class);
+        when(mapItem.getTitle()).thenReturn("Test Song");
+        when(mapItem.getArtist()).thenReturn("Test Artist");
+        when(mapItem.getThumbnailUrl()).thenReturn("http://test.com/thumb.jpg");
+        when(mapItem.getAnswers()).thenReturn("[\"test answer\"]");
+        when(mapItemJpaRepository.findById(anyLong())).thenReturn(Optional.of(mapItem));
+
+        String roundsKey = RedisKeys.gameSessionRoundsKey(LOBBY_CODE);
+        redisTemplate.opsForList().rightPushAll(roundsKey, "1001", "1002", "1003");
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(RedisKeys.gameSessionPlayersKey(LOBBY_CODE));
+        redisTemplate.delete(RedisKeys.gameSessionRoundsKey(LOBBY_CODE));
+        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 3));
+        redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 3));
+        redisTemplate.delete(RedisKeys.gameSessionKey(LOBBY_CODE));
+    }
+
+    @Test
+    @DisplayName("라운드 종료 시 정답자들에게 기본 100점, 1등에게 추가 40점이 정상 부여된다")
+    void endRoundCalculatesCorrectScores() {
+        // given
+        // 1번 플레이어가 1등, 2번 플레이어는 2등 정답, 3번 플레이어는 오답(제출 안함)
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1);
+        redisTemplate.opsForSet().add(correctPlayersKey, USER_ID_1, USER_ID_2);
+
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1);
+        redisTemplate.opsForHash().put(roundDataKey, "first_correct_user_id", USER_ID_1);
+
+        String correctTimesKey = RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1);
+        redisTemplate.opsForHash().put(correctTimesKey, USER_ID_1, String.valueOf(System.currentTimeMillis() - 5000));
+        redisTemplate.opsForHash().put(correctTimesKey, USER_ID_2, String.valueOf(System.currentTimeMillis() - 2000));
+
+        // when
+        gameRoundEndService.endRound(LOBBY_CODE, 1);
+
+        // then
+        // 1등(USER_ID_1) -> 140점 득점
+        // 2등(USER_ID_2) -> 100점 득점
+        // 3등(USER_ID_3) -> 0점 득점
+        assertThat(players.get(0).getScore()).isEqualTo(140);
+        assertThat(players.get(1).getScore()).isEqualTo(100);
+        assertThat(players.get(2).getScore()).isEqualTo(0);
+
+        // Redis players score check
+        String playersKey = RedisKeys.gameSessionPlayersKey(LOBBY_CODE);
+        assertThat(redisTemplate.opsForHash().get(playersKey, USER_ID_1)).isEqualTo("140");
+        assertThat(redisTemplate.opsForHash().get(playersKey, USER_ID_2)).isEqualTo("100");
+        assertThat(redisTemplate.opsForHash().get(playersKey, USER_ID_3)).isEqualTo("0");
+
+        // Event publish check
+        verify(gameRealtimeNotifier, times(1)).notifyRoundEnd(eq(LOBBY_CODE), any(RoundMetadataDto.class));
+    }
+
+    @Test
+    @DisplayName("마지막 라운드 종료 시 게임 세션 및 로비가 FINISHED 상태로 전환된다")
+    void lastRoundTransitionsToFinished() {
+        // given
+        gameSession = GameSession.builder()
+                .id(1L)
+                .lobby(lobby)
+                .currentRoundNo(3)
+                .totalQuestionCount(3)
+                .status(GameSessionStatus.READY)
+                .build();
+        when(gameSessionJpaRepository.findActiveSessionByLobbyCode(LOBBY_CODE)).thenReturn(Optional.of(gameSession));
+
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 3);
+        redisTemplate.opsForHash().put(roundDataKey, "first_correct_user_id", USER_ID_1);
+
+        // when
+        gameRoundEndService.endRound(LOBBY_CODE, 3);
+
+        // then
+        assertThat(gameSession.getStatus()).isEqualTo(GameSessionStatus.FINISHED);
+        verify(lobby).changeStatus(LobbyStatus.FINISHED);
+        verify(gameLobbyJpaRepository).save(lobby);
+
+        assertThat(redisTemplate.opsForHash().get(RedisKeys.gameSessionKey(LOBBY_CODE), "status")).isEqualTo("FINISHED");
+        assertThat(redisTemplate.opsForHash().get(RedisKeys.lobbyKey(LOBBY_CODE), "status")).isEqualTo("FINISHED");
+
+        verify(lobbyRealtimeNotifier, times(1)).notifyLobbyInfoRefresh(eq(LOBBY_CODE), eq("SYSTEM"));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
@@ -15,6 +15,8 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import org.springframework.context.ApplicationContext;
+
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +40,8 @@ class GameRoundStartServiceTest {
     private ValueOperations<String, String> valueOperations;
     @Mock
     private org.springframework.scheduling.TaskScheduler taskScheduler;
+    @Mock
+    private ApplicationContext applicationContext;
 
     private GameRoundStartService gameRoundStartService;
 
@@ -47,7 +51,7 @@ class GameRoundStartServiceTest {
 
     @BeforeEach
     void setUp() {
-        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript, taskScheduler);
+        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript, taskScheduler, applicationContext);
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/controller/AdminReportControllerTest.java
@@ -1,0 +1,163 @@
+package io.github.ascrew.monomatbe.domain.report.controller;
+
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportDetailResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportListItemResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportPageResponse;
+import io.github.ascrew.monomatbe.domain.report.dto.AdminReportStatusUpdateRequest;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.service.AdminReportCommandService;
+import io.github.ascrew.monomatbe.domain.report.service.AdminReportQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AdminReportControllerTest {
+
+    private static final Long REPORT_ID = 1L;
+
+    @Mock
+    private AdminReportQueryService adminReportQueryService;
+
+    @Mock
+    private AdminReportCommandService adminReportCommandService;
+
+    private AdminReportController adminReportController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        adminReportController = new AdminReportController(
+                adminReportQueryService,
+                adminReportCommandService
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 신고 목록 조회 요청을 QueryService로 위임하고 200을 반환한다")
+    void getReports_delegatesToQueryService() {
+        // given
+        AdminReportPageResponse expected = AdminReportPageResponse.of(
+                List.of(listItemResponse()),
+                0,
+                20,
+                false
+        );
+
+        when(adminReportQueryService.getReports(
+                ReportTargetType.LOBBY_USER,
+                ReportStatus.PENDING,
+                0,
+                20
+        )).thenReturn(expected);
+
+        // when
+        var response = adminReportController.getReports(
+                ReportTargetType.LOBBY_USER,
+                ReportStatus.PENDING,
+                0,
+                20
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expected);
+
+        verify(adminReportQueryService).getReports(
+                ReportTargetType.LOBBY_USER,
+                ReportStatus.PENDING,
+                0,
+                20
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 신고 상세 조회 요청을 QueryService로 위임하고 200을 반환한다")
+    void getReportDetail_delegatesToQueryService() {
+        // given
+        AdminReportDetailResponse expected = detailResponse();
+
+        when(adminReportQueryService.getReportDetail(REPORT_ID))
+                .thenReturn(expected);
+
+        // when
+        var response = adminReportController.getReportDetail(REPORT_ID);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expected);
+
+        verify(adminReportQueryService).getReportDetail(REPORT_ID);
+    }
+
+    @Test
+    @DisplayName("관리자 신고 처리 상태 변경 요청을 CommandService로 위임하고 204를 반환한다")
+    void updateReportStatus_delegatesToCommandService() {
+        // given
+        AdminReportStatusUpdateRequest request =
+                new AdminReportStatusUpdateRequest(ReportStatus.RESOLVED);
+
+        // when
+        var response = adminReportController.updateReportStatus(
+                REPORT_ID,
+                request
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+
+        verify(adminReportCommandService).updateReportStatus(
+                REPORT_ID,
+                ReportStatus.RESOLVED
+        );
+    }
+
+    private AdminReportListItemResponse listItemResponse() {
+        return AdminReportListItemResponse.builder()
+                .reportId(REPORT_ID)
+                .reporterId(10L)
+                .reporterUsername("reporter")
+                .lobbyId(20L)
+                .lobbyCode("ABC123")
+                .lobbyTitle("신고 테스트 로비")
+                .targetType(ReportTargetType.LOBBY_USER)
+                .targetId(30L)
+                .targetReference(null)
+                .reason("부적절한 사용자")
+                .status(ReportStatus.PENDING)
+                .createdAt(LocalDateTime.of(2026, 5, 31, 12, 0))
+                .resolvedAt(null)
+                .build();
+    }
+
+    private AdminReportDetailResponse detailResponse() {
+        return AdminReportDetailResponse.builder()
+                .reportId(REPORT_ID)
+                .reporterId(10L)
+                .reporterUsername("reporter")
+                .lobbyId(20L)
+                .lobbyCode("ABC123")
+                .lobbyTitle("신고 테스트 로비")
+                .targetType(ReportTargetType.LOBBY_USER)
+                .targetId(30L)
+                .targetReference(null)
+                .reason("부적절한 사용자")
+                .status(ReportStatus.PENDING)
+                .createdAt(LocalDateTime.of(2026, 5, 31, 12, 0))
+                .resolvedAt(null)
+                .chatMessageSnapshot(null)
+                .build();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandServiceTest.java
@@ -8,12 +8,15 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.event.ReportResolvedEvent;
 import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -22,6 +25,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AdminReportCommandServiceTest {
@@ -31,6 +36,9 @@ class AdminReportCommandServiceTest {
     @Mock
     private ReportRepository reportRepository;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     private AdminReportCommandService adminReportCommandService;
 
     @BeforeEach
@@ -38,12 +46,13 @@ class AdminReportCommandServiceTest {
         MockitoAnnotations.openMocks(this);
 
         adminReportCommandService = new AdminReportCommandService(
-                reportRepository
+                reportRepository,
+                eventPublisher
         );
     }
 
     @Test
-    @DisplayName("PENDING 신고를 RESOLVED 상태로 처리한다")
+    @DisplayName("PENDING 신고를 RESOLVED 상태로 처리하고 ReportResolvedEvent를 발행한다")
     void updateReportStatus_resolved() {
         // given
         Report report = report(ReportStatus.PENDING);
@@ -60,6 +69,20 @@ class AdminReportCommandServiceTest {
         // then
         assertThat(report.getStatus()).isEqualTo(ReportStatus.RESOLVED);
         assertThat(report.getResolvedAt()).isNotNull();
+
+        ArgumentCaptor<ReportResolvedEvent> eventCaptor =
+                ArgumentCaptor.forClass(ReportResolvedEvent.class);
+
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        ReportResolvedEvent event = eventCaptor.getValue();
+
+        assertThat(event.reportId()).isEqualTo(REPORT_ID);
+        assertThat(event.reporterId()).isEqualTo(10L);
+        assertThat(event.lobbyId()).isEqualTo(20L);
+        assertThat(event.targetType()).isEqualTo(ReportTargetType.LOBBY);
+        assertThat(event.targetId()).isEqualTo(20L);
+        assertThat(event.targetReference()).isNull();
     }
 
     @Test
@@ -80,6 +103,8 @@ class AdminReportCommandServiceTest {
         // then
         assertThat(report.getStatus()).isEqualTo(ReportStatus.DISMISSED);
         assertThat(report.getResolvedAt()).isNotNull();
+
+        verify(eventPublisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportCommandServiceTest.java
@@ -1,0 +1,171 @@
+package io.github.ascrew.monomatbe.domain.report.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+class AdminReportCommandServiceTest {
+
+    private static final Long REPORT_ID = 1L;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    private AdminReportCommandService adminReportCommandService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        adminReportCommandService = new AdminReportCommandService(
+                reportRepository
+        );
+    }
+
+    @Test
+    @DisplayName("PENDING 신고를 RESOLVED 상태로 처리한다")
+    void updateReportStatus_resolved() {
+        // given
+        Report report = report(ReportStatus.PENDING);
+
+        when(reportRepository.findByIdForUpdate(REPORT_ID))
+                .thenReturn(Optional.of(report));
+
+        // when
+        adminReportCommandService.updateReportStatus(
+                REPORT_ID,
+                ReportStatus.RESOLVED
+        );
+
+        // then
+        assertThat(report.getStatus()).isEqualTo(ReportStatus.RESOLVED);
+        assertThat(report.getResolvedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("PENDING 신고를 DISMISSED 상태로 처리한다")
+    void updateReportStatus_dismissed() {
+        // given
+        Report report = report(ReportStatus.PENDING);
+
+        when(reportRepository.findByIdForUpdate(REPORT_ID))
+                .thenReturn(Optional.of(report));
+
+        // when
+        adminReportCommandService.updateReportStatus(
+                REPORT_ID,
+                ReportStatus.DISMISSED
+        );
+
+        // then
+        assertThat(report.getStatus()).isEqualTo(ReportStatus.DISMISSED);
+        assertThat(report.getResolvedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("PENDING으로 상태 변경 요청 시 400 예외를 던진다")
+    void updateReportStatus_pending_throwsBadRequest() {
+        assertThatThrownBy(() -> adminReportCommandService.updateReportStatus(
+                REPORT_ID,
+                ReportStatus.PENDING
+        ))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("statusCode")
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 신고 처리 시 404 예외를 던진다")
+    void updateReportStatus_notFound_throwsNotFound() {
+        // given
+        when(reportRepository.findByIdForUpdate(REPORT_ID))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminReportCommandService.updateReportStatus(
+                REPORT_ID,
+                ReportStatus.RESOLVED
+        ))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("statusCode")
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이미 처리된 신고를 다시 처리하면 409 예외를 던진다")
+    void updateReportStatus_alreadyProcessed_throwsConflict() {
+        // given
+        Report report = report(ReportStatus.RESOLVED);
+
+        when(reportRepository.findByIdForUpdate(REPORT_ID))
+                .thenReturn(Optional.of(report));
+
+        // when & then
+        assertThatThrownBy(() -> adminReportCommandService.updateReportStatus(
+                REPORT_ID,
+                ReportStatus.DISMISSED
+        ))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("statusCode")
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    private Report report(ReportStatus status) {
+        return Report.builder()
+                .id(REPORT_ID)
+                .reporter(user())
+                .lobby(lobby())
+                .targetType(ReportTargetType.LOBBY)
+                .targetId(20L)
+                .reason("신고 사유")
+                .status(status)
+                .createdAt(LocalDateTime.of(2026, 5, 31, 12, 0))
+                .resolvedAt(status == ReportStatus.PENDING
+                        ? null
+                        : LocalDateTime.of(2026, 5, 31, 12, 10))
+                .build();
+    }
+
+    private User user() {
+        return User.builder()
+                .id(10L)
+                .username("reporter")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+    }
+
+    private GameLobby lobby() {
+        return GameLobby.builder()
+                .id(20L)
+                .host(user())
+                .inviteCode("ABC123")
+                .title("신고 테스트 로비")
+                .maxPlayers(8)
+                .questionCount(10)
+                .timeLimitSeconds(30)
+                .isPrivate(false)
+                .build();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryServiceTest.java
@@ -9,15 +9,17 @@ import io.github.ascrew.monomatbe.domain.report.entity.LobbyChatMessageReportSna
 import io.github.ascrew.monomatbe.domain.report.entity.Report;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
 import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.AdminReportSearchCondition;
 import io.github.ascrew.monomatbe.domain.report.repository.LobbyChatMessageReportSnapshotRepository;
 import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -28,7 +30,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +56,7 @@ class AdminReportQueryServiceTest {
     }
 
     @Test
-    @DisplayName("targetType과 status가 모두 있으면 두 조건으로 신고 목록을 조회한다")
+    @DisplayName("targetType과 status 조건을 검색 조건 객체로 묶어 신고 목록을 조회한다")
     void getReports_withTargetTypeAndStatus() {
         // given
         Report report = report(
@@ -65,9 +66,8 @@ class AdminReportQueryServiceTest {
                 ReportStatus.PENDING
         );
 
-        when(reportRepository.findByTargetTypeAndStatus(
-                eq(ReportTargetType.LOBBY_USER),
-                eq(ReportStatus.PENDING),
+        when(reportRepository.searchAdminReports(
+                any(AdminReportSearchCondition.class),
                 any(Pageable.class)
         )).thenReturn(new SliceImpl<>(List.of(report)));
 
@@ -90,15 +90,22 @@ class AdminReportQueryServiceTest {
         assertThat(item.targetType()).isEqualTo(ReportTargetType.LOBBY_USER);
         assertThat(item.status()).isEqualTo(ReportStatus.PENDING);
 
-        verify(reportRepository).findByTargetTypeAndStatus(
-                eq(ReportTargetType.LOBBY_USER),
-                eq(ReportStatus.PENDING),
+        ArgumentCaptor<AdminReportSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(AdminReportSearchCondition.class);
+
+        verify(reportRepository).searchAdminReports(
+                conditionCaptor.capture(),
                 any(Pageable.class)
         );
+
+        AdminReportSearchCondition condition = conditionCaptor.getValue();
+
+        assertThat(condition.targetType()).isEqualTo(ReportTargetType.LOBBY_USER);
+        assertThat(condition.status()).isEqualTo(ReportStatus.PENDING);
     }
 
     @Test
-    @DisplayName("필터가 없으면 전체 신고 목록을 조회한다")
+    @DisplayName("필터가 없으면 null 조건 객체로 전체 신고 목록을 조회한다")
     void getReports_withoutFilters() {
         // given
         Report report = report(
@@ -108,8 +115,10 @@ class AdminReportQueryServiceTest {
                 ReportStatus.PENDING
         );
 
-        when(reportRepository.findAllBy(any(Pageable.class)))
-                .thenReturn(new SliceImpl<>(List.of(report)));
+        when(reportRepository.searchAdminReports(
+                any(AdminReportSearchCondition.class),
+                any(Pageable.class)
+        )).thenReturn(new SliceImpl<>(List.of(report)));
 
         // when
         var response = adminReportQueryService.getReports(
@@ -124,7 +133,18 @@ class AdminReportQueryServiceTest {
         assertThat(response.page()).isEqualTo(0);
         assertThat(response.size()).isEqualTo(20);
 
-        verify(reportRepository).findAllBy(any(Pageable.class));
+        ArgumentCaptor<AdminReportSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(AdminReportSearchCondition.class);
+
+        verify(reportRepository).searchAdminReports(
+                conditionCaptor.capture(),
+                any(Pageable.class)
+        );
+
+        AdminReportSearchCondition condition = conditionCaptor.getValue();
+
+        assertThat(condition.targetType()).isNull();
+        assertThat(condition.status()).isNull();
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryServiceTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -69,7 +69,7 @@ class AdminReportQueryServiceTest {
                 eq(ReportTargetType.LOBBY_USER),
                 eq(ReportStatus.PENDING),
                 any(Pageable.class)
-        )).thenReturn(new PageImpl<>(List.of(report)));
+        )).thenReturn(new SliceImpl<>(List.of(report)));
 
         // when
         var response = adminReportQueryService.getReports(
@@ -109,7 +109,7 @@ class AdminReportQueryServiceTest {
         );
 
         when(reportRepository.findAllBy(any(Pageable.class)))
-                .thenReturn(new PageImpl<>(List.of(report)));
+                .thenReturn(new SliceImpl<>(List.of(report)));
 
         // when
         var response = adminReportQueryService.getReports(

--- a/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/report/service/AdminReportQueryServiceTest.java
@@ -1,0 +1,280 @@
+package io.github.ascrew.monomatbe.domain.report.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.report.entity.LobbyChatMessageReportSnapshot;
+import io.github.ascrew.monomatbe.domain.report.entity.Report;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportStatus;
+import io.github.ascrew.monomatbe.domain.report.entity.ReportTargetType;
+import io.github.ascrew.monomatbe.domain.report.repository.LobbyChatMessageReportSnapshotRepository;
+import io.github.ascrew.monomatbe.domain.report.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AdminReportQueryServiceTest {
+
+    private static final Long REPORT_ID = 1L;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private LobbyChatMessageReportSnapshotRepository chatMessageReportSnapshotRepository;
+
+    private AdminReportQueryService adminReportQueryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        adminReportQueryService = new AdminReportQueryService(
+                reportRepository,
+                chatMessageReportSnapshotRepository
+        );
+    }
+
+    @Test
+    @DisplayName("targetType과 status가 모두 있으면 두 조건으로 신고 목록을 조회한다")
+    void getReports_withTargetTypeAndStatus() {
+        // given
+        Report report = report(
+                ReportTargetType.LOBBY_USER,
+                30L,
+                null,
+                ReportStatus.PENDING
+        );
+
+        when(reportRepository.findByTargetTypeAndStatus(
+                eq(ReportTargetType.LOBBY_USER),
+                eq(ReportStatus.PENDING),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(report)));
+
+        // when
+        var response = adminReportQueryService.getReports(
+                ReportTargetType.LOBBY_USER,
+                ReportStatus.PENDING,
+                0,
+                20
+        );
+
+        // then
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.page()).isEqualTo(0);
+        assertThat(response.size()).isEqualTo(20);
+        assertThat(response.hasNext()).isFalse();
+
+        var item = response.items().getFirst();
+        assertThat(item.reportId()).isEqualTo(REPORT_ID);
+        assertThat(item.targetType()).isEqualTo(ReportTargetType.LOBBY_USER);
+        assertThat(item.status()).isEqualTo(ReportStatus.PENDING);
+
+        verify(reportRepository).findByTargetTypeAndStatus(
+                eq(ReportTargetType.LOBBY_USER),
+                eq(ReportStatus.PENDING),
+                any(Pageable.class)
+        );
+    }
+
+    @Test
+    @DisplayName("필터가 없으면 전체 신고 목록을 조회한다")
+    void getReports_withoutFilters() {
+        // given
+        Report report = report(
+                ReportTargetType.LOBBY,
+                20L,
+                null,
+                ReportStatus.PENDING
+        );
+
+        when(reportRepository.findAllBy(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(report)));
+
+        // when
+        var response = adminReportQueryService.getReports(
+                null,
+                null,
+                null,
+                null
+        );
+
+        // then
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.page()).isEqualTo(0);
+        assertThat(response.size()).isEqualTo(20);
+
+        verify(reportRepository).findAllBy(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("page가 음수이면 400 예외를 던진다")
+    void getReports_negativePage_throwsBadRequest() {
+        assertThatThrownBy(() -> adminReportQueryService.getReports(
+                null,
+                null,
+                -1,
+                20
+        ))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("statusCode")
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("size가 허용 범위를 벗어나면 400 예외를 던진다")
+    void getReports_invalidSize_throwsBadRequest() {
+        assertThatThrownBy(() -> adminReportQueryService.getReports(
+                null,
+                null,
+                0,
+                101
+        ))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("statusCode")
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("신고 상세 조회 시 공통 신고 정보를 반환한다")
+    void getReportDetail_returnsDetail() {
+        // given
+        Report report = report(
+                ReportTargetType.LOBBY_USER,
+                30L,
+                null,
+                ReportStatus.PENDING
+        );
+
+        when(reportRepository.findDetailById(REPORT_ID))
+                .thenReturn(Optional.of(report));
+
+        // when
+        var response = adminReportQueryService.getReportDetail(REPORT_ID);
+
+        // then
+        assertThat(response.reportId()).isEqualTo(REPORT_ID);
+        assertThat(response.reporterId()).isEqualTo(10L);
+        assertThat(response.lobbyId()).isEqualTo(20L);
+        assertThat(response.targetType()).isEqualTo(ReportTargetType.LOBBY_USER);
+        assertThat(response.status()).isEqualTo(ReportStatus.PENDING);
+        assertThat(response.chatMessageSnapshot()).isNull();
+    }
+
+    @Test
+    @DisplayName("채팅 메시지 신고 상세 조회 시 스냅샷을 함께 반환한다")
+    void getReportDetail_chatMessageReport_returnsSnapshot() {
+        // given
+        Report report = report(
+                ReportTargetType.LOBBY_CHAT_MESSAGE,
+                20L,
+                "message-1",
+                ReportStatus.PENDING
+        );
+
+        LobbyChatMessageReportSnapshot snapshot = LobbyChatMessageReportSnapshot.builder()
+                .id(100L)
+                .report(report)
+                .messageId("message-1")
+                .senderIdentifier("sender-uuid")
+                .senderId(30L)
+                .senderNickname("sender")
+                .content("신고 대상 메시지")
+                .messageType("CHAT")
+                .sentAt(LocalDateTime.of(2026, 5, 31, 12, 0))
+                .createdAt(LocalDateTime.of(2026, 5, 31, 12, 1))
+                .build();
+
+        when(reportRepository.findDetailById(REPORT_ID))
+                .thenReturn(Optional.of(report));
+        when(chatMessageReportSnapshotRepository.findByReportId(REPORT_ID))
+                .thenReturn(Optional.of(snapshot));
+
+        // when
+        var response = adminReportQueryService.getReportDetail(REPORT_ID);
+
+        // then
+        assertThat(response.reportId()).isEqualTo(REPORT_ID);
+        assertThat(response.chatMessageSnapshot()).isNotNull();
+        assertThat(response.chatMessageSnapshot().snapshotId()).isEqualTo(100L);
+        assertThat(response.chatMessageSnapshot().messageId()).isEqualTo("message-1");
+        assertThat(response.chatMessageSnapshot().content()).isEqualTo("신고 대상 메시지");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 신고 상세 조회 시 404 예외를 던진다")
+    void getReportDetail_notFound_throwsNotFound() {
+        // given
+        when(reportRepository.findDetailById(REPORT_ID))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminReportQueryService.getReportDetail(REPORT_ID))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("statusCode")
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    private Report report(
+            ReportTargetType targetType,
+            Long targetId,
+            String targetReference,
+            ReportStatus status
+    ) {
+        return Report.builder()
+                .id(REPORT_ID)
+                .reporter(reporter())
+                .lobby(lobby())
+                .targetType(targetType)
+                .targetId(targetId)
+                .targetReference(targetReference)
+                .reason("신고 사유")
+                .status(status)
+                .createdAt(LocalDateTime.of(2026, 5, 31, 12, 0))
+                .resolvedAt(null)
+                .build();
+    }
+
+    private User reporter() {
+        return User.builder()
+                .id(10L)
+                .username("reporter")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+    }
+
+    private GameLobby lobby() {
+        return GameLobby.builder()
+                .id(20L)
+                .host(reporter())
+                .inviteCode("ABC123")
+                .title("신고 테스트 로비")
+                .maxPlayers(8)
+                .questionCount(10)
+                .timeLimitSeconds(30)
+                .isPrivate(false)
+                .build();
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,229 @@
+package io.github.ascrew.monomatbe.global.security.jwt;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String SECRET =
+            "01234567890123456789012345678901";
+    private static final Long USER_ID = 1L;
+    private static final String USER_IDENTIFIER =
+            "11111111-1111-1111-1111-111111111111";
+
+    private StringRedisTemplate redisTemplate;
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        jwtAuthenticationFilter = new JwtAuthenticationFilter(
+                SECRET,
+                redisTemplate
+        );
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("userRole claim이 없는 기존 Access Token은 ROLE_USER로 인증된다")
+    void doFilterInternal_withoutUserRoleClaim_authenticatesAsUser()
+            throws ServletException, IOException {
+        // given
+        String token = createAccessTokenWithoutUserRole();
+
+        when(redisTemplate.hasKey(RedisKeys.accessTokenBlacklistKey(TokenHashUtils.sha256(token))))
+                .thenReturn(false);
+        when(redisTemplate.hasKey(RedisKeys.activeSessionKey(USER_IDENTIFIER)))
+                .thenReturn(true);
+
+        MockHttpServletRequest request = authenticatedRequest(token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        // when
+        jwtAuthenticationFilter.doFilter(
+                request,
+                response,
+                filterChain
+        );
+
+        // then
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.getAuthorities())
+                .extracting("authority")
+                .containsExactly("ROLE_USER");
+
+        assertThat(authentication.getPrincipal())
+                .isInstanceOf(CustomPrincipal.class);
+
+        CustomPrincipal principal = (CustomPrincipal) authentication.getPrincipal();
+
+        assertThat(principal.userId()).isEqualTo(USER_ID);
+        assertThat(principal.userIdentifier()).isEqualTo(USER_IDENTIFIER);
+        assertThat(principal.userType()).isEqualTo(UserType.REGISTERED);
+        assertThat(principal.role()).isEqualTo(UserRole.USER);
+    }
+
+    @Test
+    @DisplayName("userRole=ADMIN Access Token은 ROLE_ADMIN으로 인증된다")
+    void doFilterInternal_withAdminUserRoleClaim_authenticatesAsAdmin()
+            throws ServletException, IOException {
+        // given
+        String token = createAccessTokenWithUserRole(UserRole.ADMIN.name());
+
+        when(redisTemplate.hasKey(RedisKeys.accessTokenBlacklistKey(TokenHashUtils.sha256(token))))
+                .thenReturn(false);
+        when(redisTemplate.hasKey(RedisKeys.activeSessionKey(USER_IDENTIFIER)))
+                .thenReturn(true);
+
+        MockHttpServletRequest request = authenticatedRequest(token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        // when
+        jwtAuthenticationFilter.doFilter(
+                request,
+                response,
+                filterChain
+        );
+
+        // then
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.getAuthorities())
+                .extracting("authority")
+                .containsExactly("ROLE_ADMIN");
+
+        CustomPrincipal principal = (CustomPrincipal) authentication.getPrincipal();
+
+        assertThat(principal.role()).isEqualTo(UserRole.ADMIN);
+    }
+
+    @Test
+    @DisplayName("userRole claim 값이 잘못되면 인증되지 않는다")
+    void doFilterInternal_invalidUserRoleClaim_doesNotAuthenticate()
+            throws ServletException, IOException {
+        // given
+        String token = createAccessTokenWithUserRole("SUPER_ADMIN");
+
+        when(redisTemplate.hasKey(RedisKeys.accessTokenBlacklistKey(TokenHashUtils.sha256(token))))
+                .thenReturn(false);
+
+        MockHttpServletRequest request = authenticatedRequest(token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        // when
+        jwtAuthenticationFilter.doFilter(
+                request,
+                response,
+                filterChain
+        );
+
+        // then
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        assertThat(authentication).isNull();
+    }
+
+    @Test
+    @DisplayName("active session이 Redis에 없으면 인증되지 않는다")
+    void doFilterInternal_inactiveSession_doesNotAuthenticate()
+            throws ServletException, IOException {
+        // given
+        String token = createAccessTokenWithUserRole(UserRole.USER.name());
+
+        when(redisTemplate.hasKey(RedisKeys.accessTokenBlacklistKey(TokenHashUtils.sha256(token))))
+                .thenReturn(false);
+        when(redisTemplate.hasKey(RedisKeys.activeSessionKey(USER_IDENTIFIER)))
+                .thenReturn(false);
+
+        MockHttpServletRequest request = authenticatedRequest(token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        // when
+        jwtAuthenticationFilter.doFilter(
+                request,
+                response,
+                filterChain
+        );
+
+        // then
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        assertThat(authentication).isNull();
+    }
+
+    private MockHttpServletRequest authenticatedRequest(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        return request;
+    }
+
+    private String createAccessTokenWithoutUserRole() {
+        return createToken(Map.of(
+                JwtClaims.USER_IDENTIFIER, USER_IDENTIFIER,
+                JwtClaims.USER_TYPE, UserType.REGISTERED.name()
+        ));
+    }
+
+    private String createAccessTokenWithUserRole(String userRole) {
+        return createToken(Map.of(
+                JwtClaims.USER_IDENTIFIER, USER_IDENTIFIER,
+                JwtClaims.USER_TYPE, UserType.REGISTERED.name(),
+                JwtClaims.USER_ROLE, userRole
+        ));
+    }
+
+    private String createToken(Map<String, Object> claims) {
+        Instant now = Instant.now();
+        SecretKey secretKey = Keys.hmacShaKeyFor(
+                SECRET.getBytes(StandardCharsets.UTF_8)
+        );
+
+        return Jwts.builder()
+                .subject(String.valueOf(USER_ID))
+                .claims(claims)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(600)))
+                .signWith(secretKey)
+                .compact();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #122

## 📝 Summary

- 사용자 서비스 권한 구분을 위한 `UserRole` enum과 `users.role` 컬럼을 추가했습니다.
- JWT Access Token에 `userRole` claim을 추가하고, Spring Security 권한을 `ROLE_USER`, `ROLE_ADMIN` 기반으로 반영했습니다.
- 관리자 신고 목록 조회 API를 구현했습니다.
  - `GET /api/admin/reports`
  - `targetType`, `status`, `page`, `size` 필터 지원
- 관리자 신고 상세 조회 API를 구현했습니다.
  - `GET /api/admin/reports/{reportId}`
  - 채팅 메시지 신고인 경우 신고 시점의 메시지 스냅샷을 함께 반환
- 관리자 신고 처리 상태 변경 API를 구현했습니다.
  - `PATCH /api/admin/reports/{reportId}/status`
  - `PENDING -> RESOLVED`
  - `PENDING -> DISMISSED`
- 이미 처리된 신고의 재처리를 방지하도록 `PESSIMISTIC_WRITE` 락 기반 조회를 추가했습니다.
- 관리자 신고 API 단위 테스트를 추가했습니다.
- Swagger와 함께 사용할 수 있는 관리자 신고 API 수동 테스트 HTML을 추가했습니다.

## 🙏PR point

- `userType`은 `GUEST/REGISTERED` 계정 유형으로 유지하고, `role`은 `USER/ADMIN` 인가 권한으로 분리했습니다.
- `userRole` claim은 이번 PR에서 새로 추가되었습니다.
- 배포 전 발급된 기존 Access Token에는 `userRole`이 없을 수 있으므로, 전환 기간 동안 누락 시 `USER` 권한으로 fallback 처리합니다.
따라서 기존 일반 사용자 토큰은 계속 보호 API에 접근할 수 있습니다.
단, 관리자 API 접근에는 `ROLE_ADMIN`이 필요하므로 관리자 권한을 부여받은 사용자는 다시 로그인해 `userRole=ADMIN`이 포함된 Access Token을 발급받아야 합니다.- 관리자 API는 `@PreAuthorize("hasRole('ADMIN')")` 기준으로 접근을 제한합니다.
- `V13__add_role_to_users.sql`은 로컬 DB에 이미 `role` 컬럼이 존재하는 경우를 고려해 멱등 처리했습니다.
- 신고 처리 상태 변경은 `PENDING` 상태에서만 가능합니다.
  - `PENDING -> RESOLVED`
  - `PENDING -> DISMISSED`
- `RESOLVED`, `DISMISSED` 상태의 신고는 다시 처리할 수 없으며, 재처리 요청 시 `409 Conflict`를 반환합니다.
- 채팅 메시지 신고 상세 조회 시 Redis TTL 만료 이후에도 운영자가 신고 원문을 확인할 수 있도록 `LobbyChatMessageReportSnapshot` 정보를 함께 반환합니다.
- 기존 `AdminAccessValidator`는 develop에 남아 있지만, 이번 관리자 신고 API는 `UserRole.ADMIN` 기반의 `ROLE_ADMIN` 권한 정책을 사용합니다.

## 📬 Reference

