### PR TITLE
[Feat/#105] 라운드 점수 계산 및 실시간 랭킹 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1674,6 +1674,34 @@ SEND /app/lobby/{code}/kick
     "durationSeconds": 30
   }
   ```
+- **라운드 종료 및 결과 알림 (ROUND_END)**:
+  - **구독 경로**: `SUBSCRIBE /topic/game/{code}/round-end`
+  - **수신 메시지 (RoundMetadataDto)**:
+    ```json
+    {
+      "type": "ROUND_END",
+      "title": "곡 제목",
+      "artist": "가수명",
+      "answer": "대표 정답",
+      "thumbnailUrl": "https://img.youtube.com/vi/.../maxresdefault.jpg",
+      "rankings": [
+        {
+          "userIdentifier": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+          "nickname": "유저닉네임1",
+          "score": 140,
+          "rank": 1,
+          "scoreAdded": 140
+        },
+        {
+          "userIdentifier": "a9f8bb2c-4dd9-4b30-9fc9-9f7c7e0ee1fd",
+          "nickname": "유저닉네임2",
+          "score": 100,
+          "rank": 2,
+          "scoreAdded": 100
+        }
+      ]
+    }
+    ```
 
 #### 5) 인게임 전용 채팅 송신 및 브로드캐스트
 - **송신**: `SEND /app/game/{code}/chat`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,6 +148,8 @@ src/main/java/io/github/ascrew/monomatbe/
 │       │   ├── GameAnswerService.java              # 정답 검증 및 판별 비즈니스
 │       │   ├── GameParticipantResolver.java        # WebSocket 세션 참가자 검증
 │       │   ├── GameRealtimeNotifier.java           # 인게임 Pub/Sub 브로드캐스트
+│       │   ├── GameRoundEndService.java            # 라운드 종료 처리 및 점수 합산 반영 비즈니스
+│       │   ├── GameRoundProgressService.java       # 라운드 진행 관리 및 타이머/스케줄러 조정 서비스
 │       │   ├── GameRoundStartService.java          # 라운드 데이터 웜업 및 라운드 준비/재생 제어
 │       │   ├── GameSessionCreateService.java       # 게임 세션 및 라운드 초기 데이터 생성
 │       │   └── GameSessionQueryService.java        # 현재 게임 세션 및 라운드 상태 조회
@@ -839,8 +841,10 @@ GameRealtimeNotifier / LobbyRealtimeNotifier
 | `game:session:{lobbyCode}` | Hash | 인게임 세션 메타데이터 |
 | `game:session:{lobbyCode}:rounds` | List | 출제된 라운드 목록 |
 | `game:session:{lobbyCode}:players` | Hash | 인게임 플레이어 점수 |
-| `game:session:{lobbyCode}:round:{roundNo}:data` | Hash | 라운드 정답(JSON list), 비디오 제목, 아티스트 메타데이터 |
+| `game:session:{lobbyCode}:round:{roundNo}:data` | Hash | 라운드 정답(JSON list), 비디오 제목, 아티스트 메타데이터 및 최초 정답자 ID (`first_correct_user_id`) |
 | `game:session:{lobbyCode}:round:{roundNo}:correct_players` | Set | 해당 라운드에서 이미 정답을 맞춘 플레이어 목록 (스포일러 판정용) |
+| `game:session:{lobbyCode}:round:{roundNo}:correct_times` | Hash | 해당 라운드 정답 제출 시간 정보 |
+| `game:session:{lobbyCode}:round:{roundNo}:ended_lock` | String | 라운드 종료 중복 실행 방지 분산 락 |
 | `game:session:{lobbyCode}:round:{roundNo}:ready_players` | Set | 해당 라운드 시작 전 YouTube IFrame 준비 완료 신호를 보낸 플레이어 목록 |
 
 
@@ -1092,3 +1096,11 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 - **송신 규칙**: 사용자가 텍스트를 입력하고 전송할 때는 모두 `SEND /app/game/{code}/chat`으로 단일하게 송신합니다.
 - **개별 결과 수신**: 자신이 제출한 채팅이 정답에 해당할 경우, 서버는 일반 채팅 브로드캐스트를 중단(Drop)하고, 해당 사용자에게 `/user/queue/game/answers` 채널로 개별 정답 성공 통지(`ROUND_CORRECT`)를 보냅니다.
   - 이 통지에는 오타 허용으로 정답 처리되었는지를 알 수 있는 `isFuzzy` 필드가 포함되어 있으므로, FE는 이를 활용하여 사용자에게 "오타 허용 정답!" 같은 전용 연출을 표시할 수 있습니다.
+
+#### 3) 라운드 종료 결과 노출 및 랭킹 갱신 (핵심 계약)
+- **라운드 종료 수신**: FE는 `/topic/game/{code}/round-end` 채널을 구독하여 라운드 종료 이벤트를 수신합니다.
+  - 이 이벤트는 각 라운드의 제한 시간이 종료되거나 모든 플레이어가 정답을 입력했을 때 서버에 의해 자동으로 트리거됩니다.
+- **결과 노출 데이터**: 수신된 `RoundMetadataDto`에는 정답 곡 정보(`title`, `artist`, `answer`, `thumbnailUrl`)와 함께 플레이어들의 득점 및 실시간 순위 정보인 `rankings` 리스트가 포함되어 있습니다.
+- **랭킹 및 가점 연출**: `rankings` 리스트 내부의 각 객체는 `PlayerRankingDto` 타입으로, 플레이어의 현재 총점(`score`), 순위(`rank`), 그리고 해당 라운드에서 획득한 가점(`scoreAdded` - 1등 140점, 그 외 정답자 100점, 오답자 0점)을 가지고 있습니다. FE는 `scoreAdded`를 활용하여 "+140" 등 가점 애니메이션을 UI상에 연출하고 랭킹 리스트를 갱신합니다.
+- **자동 전환**: 라운드가 종료된 후 10초간 결과 화면을 노출한 뒤, 서버에 의해 자동으로 다음 라운드가 준비 상태(`ROUND_READY`)로 넘어가게 되므로 FE는 이에 맞춰 인게임 화면으로 복귀하여 비디오 재생 준비 신호를 다시 송신해야 합니다. 마지막 라운드인 경우에는 로비 및 게임 상태가 `FINISHED`로 변경되며 결과화면으로 자동 전환됩니다.
+

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/PlayerRankingDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/PlayerRankingDto.java
@@ -1,0 +1,12 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PlayerRankingDto(
+        String userIdentifier,
+        String nickname,
+        int score,
+        int rank,
+        int scoreAdded
+) {}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
@@ -1,15 +1,20 @@
 package io.github.ascrew.monomatbe.domain.game.dto;
 
 import lombok.Builder;
+import java.util.List;
 
 /**
  * 라운드 종료 시 클라이언트(FE)에 공개할 메타데이터 DTO.
  */
 @Builder
 public record RoundMetadataDto(
+        String type,
         String title,
         String artist,
         String answer,
-        String thumbnailUrl
+        String thumbnailUrl,
+        List<PlayerRankingDto> rankings
 ) {
 }
+
+

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/GameSessionJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/GameSessionJpaRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface GameSessionJpaRepository extends JpaRepository<GameSession, Long> {
     Optional<GameSession> findTopByLobbyIdOrderByCreatedAtDesc(Long lobbyId);
+
+    @org.springframework.data.jpa.repository.Query("select s from GameSession s where s.lobby.inviteCode = :inviteCode and s.status != io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus.FINISHED")
+    Optional<GameSession> findActiveSessionByLobbyCode(@org.springframework.data.repository.query.Param("inviteCode") String inviteCode);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -177,16 +177,16 @@ public class GameAnswerService {
             // 원자적 정답자 등록 및 상태 검증 (Lua Script 기동)
             String result = redisTemplate.execute(
                     submitGameAnswerScript,
-                    List.of(sessionKey, correctPlayersKey),
+                    List.of(sessionKey, correctPlayersKey, roundDataKey, RedisKeys.gameSessionRoundCorrectTimesKey(code, currentRoundNo)),
                     userIdentifier,
                     String.valueOf(currentRoundNo),
                     String.valueOf(System.currentTimeMillis())
             );
 
-            if ("CORRECT_FIRST".equals(result)) {
+            if ("CORRECT_FIRST_PLACE".equals(result) || "CORRECT".equals(result)) {
                 String nickname = getNickname(userIdentifier);
-                log.info("processGameChat: 정답 달성! - code: {}, user: {} ({}), fuzzy: {}", 
-                         code, userIdentifier, nickname, isFuzzy);
+                log.info("processGameChat: 정답 달성! - code: {}, user: {} ({}), result: {}, fuzzy: {}", 
+                         code, userIdentifier, nickname, result, isFuzzy);
 
                 // 정답 달성 시스템 공지 브로드캐스트
                 broadcastSystemMessage(code, nickname + "님이 정답을 맞췄습니다!");

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -39,6 +39,7 @@ public class GameAnswerService {
     private final ChatSenderProfileResolver chatSenderProfileResolver;
     private final JsonMapper jsonMapper;
     private final RedisScript<String> submitGameAnswerScript;
+    private final GameRoundEndService gameRoundEndService;
 
     /**
      * 인게임 전용 채팅 인입 시 정답 여부를 판별하여 처리합니다.
@@ -193,6 +194,9 @@ public class GameAnswerService {
 
                 // 정답 달성자 본인에게 개인 축하 응답 전송
                 sendDirectCorrectResponse(userIdentifier, currentRoundNo, isFuzzy);
+
+                // 모든 플레이어가 정답을 맞췄을 경우 라운드 즉시 조기 종료 트리거
+                checkAndTriggerEarlyRoundEnd(code, currentRoundNo, correctPlayersKey);
             } else if ("ALREADY_CORRECT".equals(result)) {
                 broadcastChatMessage(code, userIdentifier, messageDto.content());
             } else if ("TIMEOUT".equals(result) || "ROUND_NOT_STARTED".equals(result)) {
@@ -265,5 +269,20 @@ public class GameAnswerService {
                 || messageDto.content() == null
                 || messageDto.content().isBlank()
                 || messageDto.content().length() > 500;
+    }
+
+    private void checkAndTriggerEarlyRoundEnd(String code, int roundNo, String correctPlayersKey) {
+        try {
+            String playersKey = RedisKeys.gameSessionPlayersKey(code);
+            Long totalPlayers = redisTemplate.opsForHash().size(playersKey);
+            Long correctPlayers = redisTemplate.opsForSet().size(correctPlayersKey);
+
+            if (totalPlayers != null && correctPlayers != null && correctPlayers >= totalPlayers && totalPlayers > 0) {
+                log.info("checkAndTriggerEarlyRoundEnd: 모든 플레이어가 정답을 맞췄습니다. 라운드를 즉시 조기 종료합니다. - code: {}, roundNo: {}", code, roundNo);
+                gameRoundEndService.endRound(code, roundNo);
+            }
+        } catch (Exception e) {
+            log.error("checkAndTriggerEarlyRoundEnd: 조기 종료 트리거 처리 중 오류 발생 - code: {}, roundNo: {}", code, roundNo, e);
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -116,7 +116,6 @@ public class GameRoundEndService {
             if (scoreAdded > 0) {
                 dbPlayer.addScore(scoreAdded);
                 gameSessionPlayerJpaRepository.save(dbPlayer);
-                redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
             }
         }
 
@@ -203,7 +202,14 @@ public class GameRoundEndService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                log.info("라운드 종료 트랜잭션 커밋 완료 - 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
+                log.info("라운드 종료 트랜잭션 커밋 완료 - Redis 점수 반영 및 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
+                
+                scoreAddedMap.forEach((identifier, scoreAdded) -> {
+                    if (scoreAdded > 0) {
+                        redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
+                    }
+                });
+
                 gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
 
                 GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
@@ -215,6 +221,14 @@ public class GameRoundEndService {
                     }
                 } else {
                     progressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                }
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_ROLLED_BACK) {
+                    log.warn("라운드 종료 트랜잭션 롤백 감지 - 멱등 락 해제. code: {}, roundNo: {}", lobbyCode, roundNo);
+                    redisTemplate.delete(endedLockKey);
                 }
             }
         });

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -1,0 +1,236 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.domain.game.dto.PlayerRankingDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyPlayerNicknameResolver;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyRealtimeNotifier;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameRoundEndService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final GameSessionJpaRepository gameSessionJpaRepository;
+    private final GameSessionPlayerJpaRepository gameSessionPlayerJpaRepository;
+    private final GameLobbyJpaRepository gameLobbyJpaRepository;
+    private final MapItemJpaRepository mapItemJpaRepository;
+    private final UserSessionRepository userSessionRepository;
+    private final GuestSessionRepository guestSessionRepository;
+    private final LobbyPlayerNicknameResolver nicknameResolver;
+    private final GameRealtimeNotifier gameRealtimeNotifier;
+    private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
+    private final JsonMapper jsonMapper;
+    private final ApplicationContext applicationContext;
+
+    /**
+     * 특정 라운드를 종료하고 점수 계산 및 DB/Redis 업데이트를 수행합니다.
+     */
+    @Transactional
+    public void endRound(String lobbyCode, int roundNo) {
+        String endedLockKey = RedisKeys.gameSessionRoundEndedLockKey(lobbyCode, roundNo);
+        Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(endedLockKey, "1", Duration.ofMinutes(5));
+
+        if (Boolean.FALSE.equals(lockAcquired)) {
+            log.info("라운드 종료 무시됨 (이미 종료 처리됨) - code: {}, roundNo: {}", lobbyCode, roundNo);
+            return;
+        }
+
+        log.info("라운드 종료 처리 시작 - code: {}, roundNo: {}", lobbyCode, roundNo);
+
+        // 1. 게임 세션 및 플레이어 조회
+        GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
+                .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
+
+        List<GameSessionPlayer> dbPlayers = gameSessionPlayerJpaRepository.findAllByGameSessionId(gameSession.getId());
+
+        // 2. Redis에서 정답자 및 1등 정보 조회
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(lobbyCode, roundNo);
+        Set<String> correctPlayerIdentifiers = redisTemplate.opsForSet().members(correctPlayersKey);
+        if (correctPlayerIdentifiers == null) {
+            correctPlayerIdentifiers = Collections.emptySet();
+        }
+
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(lobbyCode, roundNo);
+        String firstCorrectIdentifier = (String) redisTemplate.opsForHash().get(roundDataKey, "first_correct_user_id");
+
+        // 3. userIdentifier -> User 매핑 정보 빌드
+        String playersKey = RedisKeys.gameSessionPlayersKey(lobbyCode);
+        Map<Object, Object> playersMap = redisTemplate.opsForHash().entries(playersKey);
+        Set<String> participantIdentifiers = playersMap.keySet().stream()
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> userIdToIdentifier = new HashMap<>();
+        userSessionRepository.findBySessionIdIn(participantIdentifiers)
+                .forEach(s -> userIdToIdentifier.put(s.getUser().getId(), s.getSessionId()));
+        guestSessionRepository.findByGuestTokenIn(participantIdentifiers)
+                .forEach(g -> userIdToIdentifier.put(g.getUser().getId(), g.getGuestToken()));
+
+        // 4. 각 플레이어별 득점 계산 및 반영
+        Map<String, Integer> scoreAddedMap = new HashMap<>();
+        for (GameSessionPlayer dbPlayer : dbPlayers) {
+            String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
+            if (identifier == null) {
+                continue;
+            }
+
+            int scoreAdded = 0;
+            if (correctPlayerIdentifiers.contains(identifier)) {
+                scoreAdded += 100; // 기본 점수
+                if (identifier.equals(firstCorrectIdentifier)) {
+                    scoreAdded += 40; // 1등 보너스
+                }
+            }
+
+            scoreAddedMap.put(identifier, scoreAdded);
+
+            if (scoreAdded > 0) {
+                dbPlayer.addScore(scoreAdded);
+                gameSessionPlayerJpaRepository.save(dbPlayer);
+                redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
+            }
+        }
+
+        // 5. 실시간 랭킹 산정
+        Map<String, String> nicknameMap = nicknameResolver.resolveNicknameMap(participantIdentifiers);
+        List<PlayerTemp> tempPlayers = new ArrayList<>();
+        for (GameSessionPlayer dbPlayer : dbPlayers) {
+            String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
+            if (identifier == null) {
+                continue;
+            }
+            String nickname = nicknameMap.getOrDefault(identifier, nicknameResolver.fallbackNickname(identifier));
+            tempPlayers.add(new PlayerTemp(identifier, nickname, dbPlayer.getScore(), scoreAddedMap.getOrDefault(identifier, 0)));
+        }
+
+        // 점수 기준 내림차순 정렬
+        tempPlayers.sort((p1, p2) -> Integer.compare(p2.totalScore, p1.totalScore));
+
+        List<PlayerRankingDto> rankings = new ArrayList<>();
+        int currentRank = 1;
+        for (int i = 0; i < tempPlayers.size(); i++) {
+            PlayerTemp p = tempPlayers.get(i);
+            if (i > 0 && p.totalScore < tempPlayers.get(i - 1).totalScore) {
+                currentRank = i + 1;
+            }
+            rankings.add(PlayerRankingDto.builder()
+                    .userIdentifier(p.userIdentifier)
+                    .nickname(p.nickname)
+                    .score(p.totalScore)
+                    .rank(currentRank)
+                    .scoreAdded(p.scoreAdded)
+                    .build());
+        }
+
+        // 6. 라운드 종료 메타데이터 구성 (곡 정보)
+        String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+        String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, roundNo - 1);
+        String title = "";
+        String artist = "";
+        String representativeAnswer = "";
+        String thumbnailUrl = "";
+
+        if (mapItemIdStr != null) {
+            try {
+                Long mapItemId = Long.parseLong(mapItemIdStr);
+                MapItem mapItem = mapItemJpaRepository.findById(mapItemId).orElse(null);
+                if (mapItem != null) {
+                    title = mapItem.getTitle();
+                    artist = mapItem.getArtist();
+                    thumbnailUrl = mapItem.getThumbnailUrl();
+                    List<String> rawAnswers = jsonMapper.readValue(mapItem.getAnswers(), new TypeReference<List<String>>() {});
+                    representativeAnswer = rawAnswers.isEmpty() ? title : rawAnswers.get(0);
+                }
+            } catch (Exception e) {
+                log.error("라운드 종료 메타데이터 파싱 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+            }
+        }
+
+        RoundMetadataDto metadataDto = RoundMetadataDto.builder()
+                .type("ROUND_END")
+                .title(title)
+                .artist(artist)
+                .answer(representativeAnswer)
+                .thumbnailUrl(thumbnailUrl)
+                .rankings(rankings)
+                .build();
+
+        // 7. 다음 라운드 또는 게임 종료 전환
+        boolean isLastRound = roundNo >= gameSession.getTotalQuestionCount();
+
+        if (isLastRound) {
+            gameSession.finish();
+            gameSessionJpaRepository.save(gameSession);
+
+            GameLobby lobby = gameSession.getLobby();
+            lobby.changeStatus(LobbyStatus.FINISHED);
+            gameLobbyJpaRepository.save(lobby);
+
+            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "FINISHED");
+            redisTemplate.opsForHash().put(RedisKeys.lobbyKey(lobbyCode), "status", "FINISHED");
+        }
+
+        // 8. 트랜잭션 성공 후 STOMP 브로드캐스트 및 스케줄링 등록
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                log.info("라운드 종료 트랜잭션 커밋 완료 - 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
+                gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+
+                GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
+                if (isLastRound) {
+                    try {
+                        lobbyRealtimeNotifier.notifyLobbyInfoRefresh(lobbyCode, "SYSTEM");
+                    } catch (Exception e) {
+                        log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
+                    }
+                } else {
+                    progressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                }
+            }
+        });
+    }
+
+    private static class PlayerTemp {
+        String userIdentifier;
+        String nickname;
+        int totalScore;
+        int scoreAdded;
+
+        PlayerTemp(String userIdentifier, String nickname, int totalScore, int scoreAdded) {
+            this.userIdentifier = userIdentifier;
+            this.nickname = nickname;
+            this.totalScore = totalScore;
+            this.scoreAdded = scoreAdded;
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
@@ -1,0 +1,126 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameRoundProgressService {
+
+    private final TaskScheduler taskScheduler;
+    private final StringRedisTemplate redisTemplate;
+    private final GameSessionJpaRepository gameSessionJpaRepository;
+    private final MapItemJpaRepository mapItemJpaRepository;
+    private final GameRealtimeNotifier gameRealtimeNotifier;
+    private final ApplicationContext applicationContext;
+
+    /**
+     * 라운드 종료 스케줄링을 등록합니다. (재생 시작 시점 기준 1.5초 완충 시간 포함)
+     */
+    public void scheduleRoundEnd(String lobbyCode, int roundNo, int timeLimitSeconds) {
+        long delayMillis = (timeLimitSeconds * 1000L) + 1500L;
+        log.info("라운드 종료 자동 태스크 예약 - code: {}, roundNo: {}, delay: {}ms", lobbyCode, roundNo, delayMillis);
+        
+        taskScheduler.schedule(() -> {
+            try {
+                GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
+                endService.endRound(lobbyCode, roundNo);
+            } catch (Exception e) {
+                log.error("자동 라운드 종료 처리 중 예외 발생 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+            }
+        }, Instant.now().plusMillis(delayMillis));
+    }
+
+    /**
+     * 다음 라운드 시작 스케줄링을 등록합니다. (결과 화면 노출 10초)
+     */
+    public void scheduleNextRound(String lobbyCode, int nextRoundNo) {
+        log.info("다음 라운드 시작 예약 - code: {}, nextRoundNo: {}, delay: 10s", lobbyCode, nextRoundNo);
+        
+        taskScheduler.schedule(() -> {
+            try {
+                GameRoundProgressService self = applicationContext.getBean(GameRoundProgressService.class);
+                self.startNextRound(lobbyCode, nextRoundNo);
+            } catch (Exception e) {
+                log.error("다음 라운드 시작 예약 처리 중 예외 발생 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
+            }
+        }, Instant.now().plusSeconds(10));
+    }
+
+    /**
+     * 다음 라운드 데이터를 로드하고 준비 신호(ROUND_READY)를 브로드캐스트합니다.
+     */
+    @Transactional
+    public void startNextRound(String lobbyCode, int nextRoundNo) {
+        log.info("다음 라운드 시작 처리 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+
+        // 1. 게임 세션 조회
+        GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
+                .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
+
+        // 2. DB 및 Redis 라운드 갱신
+        gameSession.nextRound();
+        gameSessionJpaRepository.save(gameSession);
+
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+        redisTemplate.opsForHash().put(sessionKey, "current_round_no", String.valueOf(nextRoundNo));
+        redisTemplate.opsForHash().put(sessionKey, "status", "READY");
+
+        // 3. 다음 라운드 MapItem 조회
+        String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+        String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, nextRoundNo - 1);
+        if (mapItemIdStr == null) {
+            throw new NoSuchElementException("다음 라운드의 문제 ID를 Redis에서 찾을 수 없습니다. roundNo: " + nextRoundNo);
+        }
+
+        Long mapItemId = Long.parseLong(mapItemIdStr);
+        MapItem mapItem = mapItemJpaRepository.findById(mapItemId)
+                .orElseThrow(() -> new NoSuchElementException("MapItem을 찾을 수 없습니다. id: " + mapItemId));
+
+        // 4. 다음 라운드 DTO 구성
+        long serverStartedAt = System.currentTimeMillis();
+        int effectiveEndTime = mapItem.getStartTime() + gameSession.getLobby().getTimeLimitSeconds();
+
+        RoundStartDto nextRoundDto = RoundStartDto.builder()
+                .type("ROUND_READY")
+                .videoId(mapItem.getVideoId())
+                .youtubeUrl(mapItem.getYoutubeUrl())
+                .startTime(mapItem.getStartTime())
+                .endTime(effectiveEndTime)
+                .timeLimitSeconds(gameSession.getLobby().getTimeLimitSeconds())
+                .roundNo(nextRoundNo)
+                .serverStartedAt(serverStartedAt)
+                .build();
+
+        // 5. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+                gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
+
+                GameRoundStartService startService = applicationContext.getBean(GameRoundStartService.class);
+                startService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+            }
+        });
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
@@ -6,6 +6,7 @@ import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -24,16 +25,19 @@ public class GameRoundStartService {
     private final SimpMessagingTemplate messagingTemplate;
     private final RedisScript<String> readyToPlayScript;
     private final TaskScheduler taskScheduler;
+    private final ApplicationContext applicationContext;
 
     public GameRoundStartService(
             StringRedisTemplate redisTemplate,
             SimpMessagingTemplate messagingTemplate,
             @Qualifier("readyToPlayScript") RedisScript<String> readyToPlayScript,
-            TaskScheduler taskScheduler) {
+            TaskScheduler taskScheduler,
+            ApplicationContext applicationContext) {
         this.redisTemplate = redisTemplate;
         this.messagingTemplate = messagingTemplate;
         this.readyToPlayScript = readyToPlayScript;
         this.taskScheduler = taskScheduler;
+        this.applicationContext = applicationContext;
     }
 
     public void scheduleForcePlaybackStart(String lobbyCode, int roundNo, int timeLimitSeconds) {
@@ -101,6 +105,14 @@ public class GameRoundStartService {
                     .build();
 
             messagingTemplate.convertAndSend(StompDestinations.subscribeGameRound(lobbyCode), dto);
+
+            // 라운드 종료 스케줄링 호출
+            try {
+                GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
+                progressService.scheduleRoundEnd(lobbyCode, roundNo, durationSeconds);
+            } catch (Exception e) {
+                log.error("라운드 종료 자동 스케줄링 예약 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+            }
         } else {
             log.info("이미 다른 스레드/서버에서 재생 시작 시각이 기록되어 브로드캐스트를 스킵합니다 - code: {}, roundNo: {}", lobbyCode, roundNo);
         }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -72,6 +72,14 @@ public class GameSessionCreateService {
         long serverStartedAt = System.currentTimeMillis();
         java.time.LocalDateTime startedAt = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(serverStartedAt), java.time.ZoneId.systemDefault());
 
+        // 0. 기존 미종료 활성 세션 정리 (정체 방지)
+        gameSessionJpaRepository.findActiveSessionByLobbyCode(code)
+                .ifPresent(oldSession -> {
+                    log.warn("미종료된 이전 게임 세션 발견 - 강제 FINISHED 처리. code: {}, oldSessionId: {}", code, oldSession.getId());
+                    oldSession.finish();
+                    gameSessionJpaRepository.save(oldSession);
+                });
+
         // 2. DB 세션 생성
         GameSession gameSession = GameSession.builder()
                 .lobby(lobby)

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -759,4 +759,26 @@ public final class RedisKeys {
     public static String gameSessionRoundPlaybackStartedAtField(int roundNo) {
         return "playback_started_at:" + roundNo;
     }
+
+    /**
+     * 특정 라운드에서 정답을 맞춘 유저들의 제출 시각을 저장하는 Hash 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:correct_times"
+     */
+    public static String gameSessionRoundCorrectTimesKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":correct_times";
+    }
+
+    /**
+     * 특정 라운드의 종료 중복 방지 락 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:ended_lock"
+     */
+    public static String gameSessionRoundEndedLockKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":ended_lock";
+    }
 }

--- a/src/main/resources/scripts/submit_game_answer.lua
+++ b/src/main/resources/scripts/submit_game_answer.lua
@@ -1,5 +1,7 @@
 local sessionKey = KEYS[1]
 local correctPlayersKey = KEYS[2]
+local roundDataKey = KEYS[3]
+local correctTimesKey = KEYS[4]
 
 local userIdentifier = ARGV[1]
 local requestRoundNo = tonumber(ARGV[2])
@@ -44,6 +46,15 @@ if isMember == 1 then
     return 'ALREADY_CORRECT'
 end
 
--- 5. 정답자 등록
+-- 5. 정답 시간 기록 및 정답자 등록
+redis.call('HSET', correctTimesKey, userIdentifier, tostring(nowMillis))
 redis.call('SADD', correctPlayersKey, userIdentifier)
-return 'CORRECT_FIRST'
+
+-- 6. 최초 정답자(1등) 여부 판별 (HSETNX)
+local isFirst = redis.call('HSETNX', roundDataKey, 'first_correct_user_id', userIdentifier)
+if isFirst == 1 then
+    return 'CORRECT_FIRST_PLACE'
+else
+    return 'CORRECT'
+end
+

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -82,6 +82,7 @@ class GameChatAnswerIntegrationTest {
         redisTemplate.delete(RedisKeys.gameSessionKey(LOBBY_CODE));
         redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1));
     }
 
     private void givenGameSession(String status, int currentRoundNo, int timeLimit, Long playbackStartedAt) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -1,0 +1,239 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyPlayerNicknameResolver;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyRealtimeNotifier;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=none"
+})
+class GameRoundProgressIntegrationTest {
+
+    private static final String LOBBY_CODE = "PROGRESS12";
+    private static final String USER_ID_1 = "player-1-uuid";
+    private static final String USER_ID_2 = "player-2-uuid";
+    private static final String USER_ID_3 = "player-3-uuid";
+
+    @Autowired
+    private GameRoundEndService gameRoundEndService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private GameSessionJpaRepository gameSessionJpaRepository;
+
+    @MockitoBean
+    private GameSessionPlayerJpaRepository gameSessionPlayerJpaRepository;
+
+    @MockitoBean
+    private GameLobbyJpaRepository gameLobbyJpaRepository;
+
+    @MockitoBean
+    private MapItemJpaRepository mapItemJpaRepository;
+
+    @MockitoBean
+    private UserSessionRepository userSessionRepository;
+
+    @MockitoBean
+    private GuestSessionRepository guestSessionRepository;
+
+    @MockitoBean
+    private LobbyPlayerNicknameResolver nicknameResolver;
+
+    @MockitoBean
+    private GameRealtimeNotifier gameRealtimeNotifier;
+
+    @MockitoBean
+    private LobbyRealtimeNotifier lobbyRealtimeNotifier;
+
+    private GameLobby lobby;
+    private GameSession gameSession;
+    private List<GameSessionPlayer> players;
+
+    @BeforeEach
+    void setUp() {
+        lobby = mock(GameLobby.class);
+        when(lobby.getInviteCode()).thenReturn(LOBBY_CODE);
+        when(lobby.getTimeLimitSeconds()).thenReturn(30);
+
+        gameSession = GameSession.builder()
+                .id(1L)
+                .lobby(lobby)
+                .currentRoundNo(1)
+                .totalQuestionCount(3)
+                .status(GameSessionStatus.READY)
+                .build();
+
+        when(gameSessionJpaRepository.findActiveSessionByLobbyCode(LOBBY_CODE))
+                .thenReturn(Optional.of(gameSession));
+
+        User user1 = mock(User.class);
+        when(user1.getId()).thenReturn(101L);
+        User user2 = mock(User.class);
+        when(user2.getId()).thenReturn(102L);
+        User user3 = mock(User.class);
+        when(user3.getId()).thenReturn(103L);
+
+        GameSessionPlayer p1 = GameSessionPlayer.builder().id(1L).gameSession(gameSession).user(user1).score(0).build();
+        GameSessionPlayer p2 = GameSessionPlayer.builder().id(2L).gameSession(gameSession).user(user2).score(0).build();
+        GameSessionPlayer p3 = GameSessionPlayer.builder().id(3L).gameSession(gameSession).user(user3).score(0).build();
+        players = List.of(p1, p2, p3);
+
+        when(gameSessionPlayerJpaRepository.findAllByGameSessionId(1L)).thenReturn(players);
+
+        // Redis keys initialization
+        String playersKey = RedisKeys.gameSessionPlayersKey(LOBBY_CODE);
+        redisTemplate.opsForHash().put(playersKey, USER_ID_1, "0");
+        redisTemplate.opsForHash().put(playersKey, USER_ID_2, "0");
+        redisTemplate.opsForHash().put(playersKey, USER_ID_3, "0");
+
+        // User sessions mocks
+        UserSession s1 = mock(UserSession.class);
+        when(s1.getUser()).thenReturn(user1);
+        when(s1.getSessionId()).thenReturn(USER_ID_1);
+
+        UserSession s2 = mock(UserSession.class);
+        when(s2.getUser()).thenReturn(user2);
+        when(s2.getSessionId()).thenReturn(USER_ID_2);
+
+        UserSession s3 = mock(UserSession.class);
+        when(s3.getUser()).thenReturn(user3);
+        when(s3.getSessionId()).thenReturn(USER_ID_3);
+
+        when(userSessionRepository.findBySessionIdIn(any())).thenReturn(List.of(s1, s2, s3));
+        when(guestSessionRepository.findByGuestTokenIn(any())).thenReturn(Collections.emptyList());
+
+        // Nicknames mock
+        Map<String, String> nicknames = new HashMap<>();
+        nicknames.put(USER_ID_1, "유저1");
+        nicknames.put(USER_ID_2, "유저2");
+        nicknames.put(USER_ID_3, "유저3");
+        when(nicknameResolver.resolveNicknameMap(any())).thenReturn(nicknames);
+
+        // MapItem mock
+        MapItem mapItem = mock(MapItem.class);
+        when(mapItem.getTitle()).thenReturn("Test Song");
+        when(mapItem.getArtist()).thenReturn("Test Artist");
+        when(mapItem.getThumbnailUrl()).thenReturn("http://test.com/thumb.jpg");
+        when(mapItem.getAnswers()).thenReturn("[\"test answer\"]");
+        when(mapItemJpaRepository.findById(anyLong())).thenReturn(Optional.of(mapItem));
+
+        String roundsKey = RedisKeys.gameSessionRoundsKey(LOBBY_CODE);
+        redisTemplate.opsForList().rightPushAll(roundsKey, "1001", "1002", "1003");
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(RedisKeys.gameSessionPlayersKey(LOBBY_CODE));
+        redisTemplate.delete(RedisKeys.gameSessionRoundsKey(LOBBY_CODE));
+        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 3));
+        redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 3));
+        redisTemplate.delete(RedisKeys.gameSessionKey(LOBBY_CODE));
+    }
+
+    @Test
+    @DisplayName("라운드 종료 시 정답자들에게 기본 100점, 1등에게 추가 40점이 정상 부여된다")
+    void endRoundCalculatesCorrectScores() {
+        // given
+        // 1번 플레이어가 1등, 2번 플레이어는 2등 정답, 3번 플레이어는 오답(제출 안함)
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1);
+        redisTemplate.opsForSet().add(correctPlayersKey, USER_ID_1, USER_ID_2);
+
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1);
+        redisTemplate.opsForHash().put(roundDataKey, "first_correct_user_id", USER_ID_1);
+
+        String correctTimesKey = RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1);
+        redisTemplate.opsForHash().put(correctTimesKey, USER_ID_1, String.valueOf(System.currentTimeMillis() - 5000));
+        redisTemplate.opsForHash().put(correctTimesKey, USER_ID_2, String.valueOf(System.currentTimeMillis() - 2000));
+
+        // when
+        gameRoundEndService.endRound(LOBBY_CODE, 1);
+
+        // then
+        // 1등(USER_ID_1) -> 140점 득점
+        // 2등(USER_ID_2) -> 100점 득점
+        // 3등(USER_ID_3) -> 0점 득점
+        assertThat(players.get(0).getScore()).isEqualTo(140);
+        assertThat(players.get(1).getScore()).isEqualTo(100);
+        assertThat(players.get(2).getScore()).isEqualTo(0);
+
+        // Redis players score check
+        String playersKey = RedisKeys.gameSessionPlayersKey(LOBBY_CODE);
+        assertThat(redisTemplate.opsForHash().get(playersKey, USER_ID_1)).isEqualTo("140");
+        assertThat(redisTemplate.opsForHash().get(playersKey, USER_ID_2)).isEqualTo("100");
+        assertThat(redisTemplate.opsForHash().get(playersKey, USER_ID_3)).isEqualTo("0");
+
+        // Event publish check
+        verify(gameRealtimeNotifier, times(1)).notifyRoundEnd(eq(LOBBY_CODE), any(RoundMetadataDto.class));
+    }
+
+    @Test
+    @DisplayName("마지막 라운드 종료 시 게임 세션 및 로비가 FINISHED 상태로 전환된다")
+    void lastRoundTransitionsToFinished() {
+        // given
+        gameSession = GameSession.builder()
+                .id(1L)
+                .lobby(lobby)
+                .currentRoundNo(3)
+                .totalQuestionCount(3)
+                .status(GameSessionStatus.READY)
+                .build();
+        when(gameSessionJpaRepository.findActiveSessionByLobbyCode(LOBBY_CODE)).thenReturn(Optional.of(gameSession));
+
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 3);
+        redisTemplate.opsForHash().put(roundDataKey, "first_correct_user_id", USER_ID_1);
+
+        // when
+        gameRoundEndService.endRound(LOBBY_CODE, 3);
+
+        // then
+        assertThat(gameSession.getStatus()).isEqualTo(GameSessionStatus.FINISHED);
+        verify(lobby).changeStatus(LobbyStatus.FINISHED);
+        verify(gameLobbyJpaRepository).save(lobby);
+
+        assertThat(redisTemplate.opsForHash().get(RedisKeys.gameSessionKey(LOBBY_CODE), "status")).isEqualTo("FINISHED");
+        assertThat(redisTemplate.opsForHash().get(RedisKeys.lobbyKey(LOBBY_CODE), "status")).isEqualTo("FINISHED");
+
+        verify(lobbyRealtimeNotifier, times(1)).notifyLobbyInfoRefresh(eq(LOBBY_CODE), eq("SYSTEM"));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
@@ -15,6 +15,8 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import org.springframework.context.ApplicationContext;
+
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +40,8 @@ class GameRoundStartServiceTest {
     private ValueOperations<String, String> valueOperations;
     @Mock
     private org.springframework.scheduling.TaskScheduler taskScheduler;
+    @Mock
+    private ApplicationContext applicationContext;
 
     private GameRoundStartService gameRoundStartService;
 
@@ -47,7 +51,7 @@ class GameRoundStartServiceTest {
 
     @BeforeEach
     void setUp() {
-        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript, taskScheduler);
+        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript, taskScheduler, applicationContext);
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

- #101 
- #105 

## 📝 Summary

- **하이브리드 점수 산정 구현**:
  - 정답을 맞춘 플레이어에게 기본 점수 100점을 부여하며, 최초 정답자(1등)에게는 보너스 40점을 추가로 부여하는 로직을 [GameRoundEndService](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java)에 구현했습니다. (사용자 피드백을 반영하여 시간 비례 보너스는 제외되었습니다)
- **Redis Lua 스크립트를 통한 원자적 1등 판별 및 시간 기록**:
  - 다수의 유저가 거의 동시에 정답을 제출하는 레이스 컨디션을 방지하기 위해, [submit_game_answer.lua](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/resources/scripts/submit_game_answer.lua) 내부에서 `HSETNX`로 `first_correct_user_id`를 선점하여 원자적으로 1등을 가려내도록 수정했습니다.
  - 플레이어별 정답 제출 시간을 `game:session:{code}:round:{roundNo}:correct_times` Hash 키에 epoch milliseconds 형태로 기록합니다.
- **실시간 랭킹 산정 및 공동 순위(경쟁 순위) 적용**:
  - 라운드 종료 시 플레이어들의 점수를 내림차순 정렬하고, 동점자가 존재할 경우 동일한 순위를 부여한 뒤 다음 사람의 순위를 건너뛰는 공동 순위(예: 1, 2, 2, 4) 정책을 구현했습니다.
  - 랭킹 데이터는 신규 레코드 DTO인 [PlayerRankingDto](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/PlayerRankingDto.java) 및 [RoundMetadataDto](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java)에 적재되어 클라이언트로 전파됩니다.
- **라운드 종료 및 다음 라운드/게임 종료 자동 스케줄링**:
  - 라운드 재생 시작 시 제한시간 + 1.5초 완충 시각 뒤 강제로 라운드를 자동 종료하도록 예약하는 비동기 스케줄링과 라운드 종료 후 10초 대기 화면 노출 후 다음 라운드를 개시(`ROUND_READY` 전파)하는 복합 스케줄러를 [GameRoundProgressService](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java)로 이관했습니다.
  - 마지막 라운드 도달 시 게임 세션 및 로비 상태를 `FINISHED`로 원자적으로 전환하고 결과를 브로드캐스트합니다.
- **트랜잭션 격리 및 멱등성 락 도입**:
  - DB 트랜잭션이 성공적으로 최종 커밋된 직후(`afterCommit`)에만 외부 웹소켓 전송 및 타이머 스케줄링이 활성화되도록 `TransactionSynchronizationManager`를 결합하여 일관성을 확보했습니다.
  - 분산 환경에서의 라운드 종료 중복 처리를 차단하기 위해 `ended_lock` 키로 분산 멱등 락(5분)을 잡고 동작합니다.
- **트랜잭션 격리 및 Redis 점수 동기화**:
  - DB 업데이트와 Redis 누적 점수 동기화의 원자성을 보장하기 위해 Redis 점수 반영(`opsForHash().increment`)을 DB 트랜잭션 성공 후인 `afterCommit` 단계에서 브로드캐스트와 함께 실행하도록 구현했습니다.
  - 트랜잭션 실패(롤백) 시에는 선점했던 `ended_lock` 키를 `afterCompletion` 단계에서 즉시 제거(해제)하도록 예외 복구 루틴을 적용했습니다.
- **조기 종료 트리거 구현**:
  - 인메모리 타이머의 유실 가능성을 차단하고 플레이어 흐름을 최적화하기 위해, 라운드 도중 모든 참여자가 정답을 완료할 경우 남은 제한 시간과 관계없이 라운드를 즉시 강제 종료하는 조기 종료 트리거를 [GameAnswerService](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java)에 구현했습니다.
- **세션 정체 및 중복 활성화 방어**:
  - 이전 게임 세션이 비정상적으로 잔류하여 발생할 수 있는 `NonUniqueResultException`을 원천 방지하고자, 새로운 게임 세션을 기동할 때 기존 활성 세션을 멱등적으로 찾아 강제 종결(`FINISHED`) 처리하는 라이프사이클 복구 루틴을 [GameSessionCreateService](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java)에 결합했습니다.

## 🙏PR point

- **Lua 스크립트 실행 파라미터 구조**:
  - [GameAnswerService](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java)가 Lua 호출 시 4개의 KEYS(`sessionKey`, `correctPlayersKey`, `roundDataKey`, `correctTimesKey`)를 넘깁니다. 클러스터 환경을 고려하여 모든 키는 명시적 파라미터 구조를 지켰습니다.
- **동점자 랭킹 처리 로직**:
  - [GameRoundEndService](file:///C:/Users/Junki/IdeaProjects/Monomat-BE/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java#L135-152)에서 유저들을 정렬한 뒤 점수가 이전 인덱스의 유저 점수와 동일하면 순위를 유지하고, 점수가 낮을 때만 `i + 1`로 동적 할당하여 경쟁 순위 알고리즘을 정상 보장하도록 설계했습니다.
- **트랜잭션의 부수 효과 제어**:
  - 타이머 스케줄링(`TaskScheduler`)과 웹소켓 브로드캐스트(`messagingTemplate`)는 DB 롤백 발생 시 함께 롤백될 수 없는 외부 인프라스트럭처이므로, 반드시 `TransactionSynchronizationManager.registerSynchronization`을 통해 DB 커밋 후에 실행되도록 구조적 안정성을 더했습니다.
- **분산 락을 통한 안정성**:
  - `GameRoundEndService.endRound()` 초입에서 Redis `setIfAbsent`를 활용해 중복 종료 시도가 들어올 경우 멱등적으로 무시하여 분산 환경에서의 상태 오염을 사전에 막아둡니다.
- **Redis 점수 동기화 원자성 및 예외 대응**:
  - DB 점수와 Redis 점수가 어긋나는 것을 방지하고자 Redis 점수 증액 연산도 `afterCommit` 으로 완전 이관하였으며, 롤백 발생 시 멱등 락(`ended_lock`)을 안전하게 해제하도록 `afterCompletion` 콜백을 구성했습니다.
- **인메모리 스케줄러 보완을 위한 조기 종료 트리거**:
  - 네트워크 단절이나 타이머 오작동 리스크를 완화하기 위해 모든 사용자가 정답을 제출하면 타이머 대기 없이 즉시 종료되는 트리거를 도입했습니다.
- **세션 라이프사이클 멱등성 보장**:
  - 로비 내 미종료 세션 잔류 시 새로운 게임 시작 단계에서 세션이 중복 인입되어 쿼리 오류가 나는 현상을 막기 위해 기존 미종료 세션을 강제로 폐기/FINISHED 처리하는 안전장치를 추가했습니다.

## 📬 Reference