### PR TITLE
[Feat/#149] 로비 목록 응답에 방장 닉네임 추가

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -753,7 +753,7 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available&page=0&siz
 | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `code`                 | String  | 로비 초대 코드                                                                                                |
 | `hostId`               | String  | 방장 사용자 식별자                                                                                              |
-| `hostNickname`         | String  | 방장 닉네임. 정식 회원·게스트 모두 내려옵니다. 세션 만료 등으로 닉네임을 찾지 못하면 `Unknown-xxxxxx` 형태의 fallback 값을 내려줍니다.                  |
+| `hostNickname`         | String  | 방장 닉네임. 정식 회원·게스트 모두 내려옵니다. 세션 만료 등으로 닉네임을 찾지 못하면 `Unknown-xxxxxx` 형태의 fallback 값을 내려줍니다. 이때 `xxxxxx`는 식별자의 SHA-256 해시 앞 6자리(비가역)이며 세션/토큰 원문을 포함하지 않습니다. |
 | `title`                | String  | 로비 제목                                                                                                   |
 | `mapId`                | Long    | 선택된 맵 ID. 미선택 시 `null`                                                                                  |
 | `mapTitle`             | String  | 선택된 맵 제목. 미선택 시 `null`                                                                                  |

--- a/docs/API.md
+++ b/docs/API.md
@@ -753,7 +753,7 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available&page=0&siz
 | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `code`                 | String  | 로비 초대 코드                                                                                                |
 | `hostId`               | String  | 방장 사용자 식별자                                                                                              |
-| `hostNickname`         | String  | 방장 닉네임. 정식 회원·게스트 모두 내려옵니다. 세션 만료 등으로 닉네임을 찾지 못하면 `Unknown-xxxxxx` 형태의 fallback 값을 내려줍니다. 이때 `xxxxxx`는 식별자의 SHA-256 해시 앞 6자리(비가역)이며 세션/토큰 원문을 포함하지 않습니다. |
+| `hostNickname`         | String  | 방장 닉네임. **항상 값이 존재하며 `null`이 아닙니다**(실제 닉네임 또는 fallback). 정식 회원·게스트 모두 내려옵니다. 세션 만료 등으로 닉네임을 찾지 못하면 `Unknown-xxxxxx` 형태의 fallback 값을 내려줍니다. 이때 `xxxxxx`는 식별자의 SHA-256 해시 앞 6자리(비가역)이며 세션/토큰 원문을 포함하지 않습니다. |
 | `title`                | String  | 로비 제목                                                                                                   |
 | `mapId`                | Long    | 선택된 맵 ID. 미선택 시 `null`                                                                                  |
 | `mapTitle`             | String  | 선택된 맵 제목. 미선택 시 `null`                                                                                  |

--- a/docs/API.md
+++ b/docs/API.md
@@ -706,6 +706,7 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available&page=0&siz
     {
       "code": "ABC123",
       "hostId": "f8f6aa1b-3dd8-4b20-8ec8-9f7c7e0dd0fc",
+      "hostNickname": "모노유저",
       "title": "K-POP 퀴즈방",
       "mapId": 1,
       "mapTitle": "K-POP 2세대",
@@ -719,6 +720,7 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available&page=0&siz
     {
       "code": "DEF456",
       "hostId": "b17f7ee0-614f-4f5f-b770-83f6d4b85f4a",
+      "hostNickname": "게스트1234",
       "title": "진행 중인 POP 퀴즈방",
       "mapId": 3,
       "mapTitle": "POP 히트곡",
@@ -751,6 +753,7 @@ GET /api/lobbies?keyword=애니&mapCategory=J-POP&sort=most_available&page=0&siz
 | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `code`                 | String  | 로비 초대 코드                                                                                                |
 | `hostId`               | String  | 방장 사용자 식별자                                                                                              |
+| `hostNickname`         | String  | 방장 닉네임. 정식 회원·게스트 모두 내려옵니다. 세션 만료 등으로 닉네임을 찾지 못하면 `Unknown-xxxxxx` 형태의 fallback 값을 내려줍니다.                  |
 | `title`                | String  | 로비 제목                                                                                                   |
 | `mapId`                | Long    | 선택된 맵 ID. 미선택 시 `null`                                                                                  |
 | `mapTitle`             | String  | 선택된 맵 제목. 미선택 시 `null`                                                                                  |

--- a/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatSenderProfileCacheEvictor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/chat/service/ChatSenderProfileCacheEvictor.java
@@ -12,19 +12,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
- * 채팅 발신자 프로필 캐시 무효화 컴포넌트
+ * 사용자 표시 정보(닉네임) 캐시 무효화 컴포넌트
  *
  * [책임]
- * - 닉네임 변경 등 사용자 표시 정보가 변경된 경우 Redis에 저장된 채팅 발신자 프로필 캐시를 제거한다.
- * - ChatSenderProfileResolver가 생성하는 Redis cache key 정책을 한 곳에서 관리한다.
+ * - 닉네임 변경 등 사용자 표시 정보가 변경된 경우, userIdentifier 기준으로 캐싱된
+ *   사용자 표시 정보 캐시를 Redis에서 제거한다.
+ * - 무효화 대상은 두 종류다.
+ *   1) 채팅 발신자 프로필 캐시 (chat:sender-profile:{userIdentifier})
+ *   2) 로비 목록/상세 닉네임 캐시 (user:nickname:{sha256(userIdentifier)})
+ * - 두 캐시 모두 userIdentifier 기준이라 식별자 조회를 한 번만 수행하고 함께 무효화한다.
  *
  * [사용 시점]
  * - 사용자 닉네임 변경 트랜잭션이 성공한 뒤 호출한다.
  * - 트랜잭션 내부에서 호출하는 경우, DB 변경 롤백 가능성을 고려해 afterCommit에서 호출하는 편이 더 안전하다.
  *
- * [무효화 대상]
+ * [무효화 대상 식별자]
  * - 회원: ACTIVE user_sessions.session_id 기반 cache key
  * - 게스트: guest_sessions.guest_token 기반 cache key
  */
@@ -51,7 +56,10 @@ public class ChatSenderProfileCacheEvictor {
     }
 
     /**
-     * 사용자 ID에 연결된 모든 채팅 발신자 프로필 캐시를 제거한다.
+     * 사용자 ID에 연결된 모든 사용자 표시 정보 캐시를 제거한다.
+     *
+     * 각 userIdentifier마다 채팅 발신자 프로필 캐시와 로비 닉네임 캐시 키를 함께 만들어
+     * 한 번의 batch 삭제로 무효화한다.
      *
      * @param userId 사용자 ID
      */
@@ -69,7 +77,10 @@ public class ChatSenderProfileCacheEvictor {
 
         List<String> cacheKeys = userIdentifiers.stream()
                 .filter(userIdentifier -> userIdentifier != null && !userIdentifier.isBlank())
-                .map(RedisKeys::chatSenderProfileKey)
+                .flatMap(userIdentifier -> Stream.of(
+                        RedisKeys.chatSenderProfileKey(userIdentifier),
+                        RedisKeys.userNicknameKey(userIdentifier)
+                ))
                 .toList();
 
         if (cacheKeys.isEmpty()) {
@@ -96,7 +107,7 @@ public class ChatSenderProfileCacheEvictor {
             redisTemplate.delete(cacheKeys);
         } catch (RuntimeException e) {
             log.warn(
-                    "채팅 발신자 프로필 캐시 일괄 무효화 실패. userId: {}, targetCount: {}",
+                    "사용자 표시 정보 캐시 일괄 무효화 실패. userId: {}, targetCount: {}",
                     userId,
                     cacheKeys.size(),
                     e

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/config/LobbyNicknameCacheProperties.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/config/LobbyNicknameCacheProperties.java
@@ -1,0 +1,38 @@
+package io.github.ascrew.monomatbe.domain.lobby.config;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+/**
+ * 로비 방장 닉네임 캐시 정책 설정
+ *
+ * 로비 목록(GET /api/lobbies)은 호출 빈도가 높아 매 요청마다 닉네임을 DB로 조회하면
+ * latency spike와 DB 커넥션 병목으로 증폭될 수 있다. userIdentifier 기준 닉네임을
+ * 짧은 TTL로 캐싱하므로, 그 TTL을 설정값으로 관리한다.
+ */
+@Validated
+@Component
+@ConfigurationProperties(prefix = "monomat.lobby.nickname-cache")
+public class LobbyNicknameCacheProperties {
+
+    /**
+     * 닉네임 캐시 TTL.
+     *
+     * 짧게 둘수록 닉네임 변경이 빠르게 반영되지만 DB 조회 빈도가 늘어난다.
+     * 닉네임 변경 즉시성이 요구되지 않으므로 분 단위의 짧은 TTL을 기본값으로 둔다.
+     */
+    @NotNull
+    private Duration ttl = Duration.ofMinutes(10);
+
+    public Duration getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryController.java
@@ -12,8 +12,8 @@
 package io.github.ascrew.monomatbe.domain.lobby.controller;
 
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyListItemResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPageResponse;
-import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyQueryService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
@@ -129,7 +129,7 @@ public class LobbyQueryController {
                     """
     )
     @GetMapping
-    public ResponseEntity<LobbyPageResponse<LobbyRedisDto>> getPublicLobbies(
+    public ResponseEntity<LobbyPageResponse<LobbyListItemResponse>> getPublicLobbies(
             @Parameter(description = "로비 제목 검색어")
             @RequestParam(required = false) String keyword,
 
@@ -162,7 +162,7 @@ public class LobbyQueryController {
                 size
         );
 
-        LobbyPageResponse<LobbyRedisDto> response = lobbyQueryService.getPublicLobbyPage(condition);
+        LobbyPageResponse<LobbyListItemResponse> response = lobbyQueryService.getPublicLobbyPage(condition);
 
         log.info(
                 LOG_GET_PUBLIC_LOBBIES_RESPONSE,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyListItemResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyListItemResponse.java
@@ -1,0 +1,71 @@
+/*
+ * 공개 로비 목록 응답의 단일 로비 아이템 DTO
+ *
+ * [설계 이유]
+ * Redis Hash 매핑 전용 LobbyRedisDto와 API 응답 계약을 분리한다.
+ * 방장 닉네임(hostNickname)은 Redis에 저장되지 않고 Auth 도메인 조회로 채워지는
+ * enriched 값이므로, Redis 매핑 DTO에 두지 않고 응답 전용 DTO에만 둔다.
+ */
+package io.github.ascrew.monomatbe.domain.lobby.dto;
+
+/**
+ * 공개 로비 목록의 각 로비 아이템 응답 DTO
+ *
+ * @param code                 로비 초대 코드 (6자리 고유 코드)
+ * @param hostId               현재 방장의 사용자 식별자 (userIdentifier)
+ * @param hostNickname         방장 닉네임. 정식 회원/게스트 모두 내려오며, 조회 실패 시 fallback 값
+ * @param title                로비 제목
+ * @param mapId                선택된 맵 세트 ID (미선택 시 null)
+ * @param mapTitle             선택된 맵 제목 (미선택 시 null)
+ * @param mapCategory          선택된 맵의 카테고리 (미선택 시 null)
+ * @param maxPlayers           최대 참여 가능 인원
+ * @param currentPlayers       현재 참여 인원 수
+ * @param isPrivate            공개(false) / 비공개(true) 여부
+ * @param status               로비 상태 (WAITING, PLAYING)
+ * @param questionCount        문제 수
+ * @param timeLimitSeconds     제한 시간(초)
+ * @param createdAtEpochMillis 로비 생성 시각 (epoch millis, null 가능)
+ */
+public record LobbyListItemResponse(
+        String code,
+        String hostId,
+        String hostNickname,
+        String title,
+        Long mapId,
+        String mapTitle,
+        String mapCategory,
+        Integer maxPlayers,
+        Integer currentPlayers,
+        Boolean isPrivate,
+        String status,
+        Integer questionCount,
+        Integer timeLimitSeconds,
+        Long createdAtEpochMillis
+) {
+
+    /**
+     * Redis 조회 DTO와 별도로 조회한 방장 닉네임을 합쳐 응답 아이템을 생성한다.
+     *
+     * @param dto          Redis에서 조회한 로비 정보
+     * @param hostNickname 별도 조회한 방장 닉네임 (fallback 포함)
+     * @return 닉네임이 채워진 로비 목록 아이템 응답
+     */
+    public static LobbyListItemResponse of(LobbyRedisDto dto, String hostNickname) {
+        return new LobbyListItemResponse(
+                dto.getCode(),
+                dto.getHostId(),
+                hostNickname,
+                dto.getTitle(),
+                dto.getMapId(),
+                dto.getMapTitle(),
+                dto.getMapCategory(),
+                dto.getMaxPlayers(),
+                dto.getCurrentPlayers(),
+                dto.getIsPrivate(),
+                dto.getStatus(),
+                dto.getQuestionCount(),
+                dto.getTimeLimitSeconds(),
+                dto.getCreatedAtEpochMillis()
+        );
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyListItemResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyListItemResponse.java
@@ -12,7 +12,6 @@ package io.github.ascrew.monomatbe.domain.lobby.dto;
  * 공개 로비 목록의 각 로비 아이템 응답 DTO
  *
  * @param code                 로비 초대 코드 (6자리 고유 코드)
- * @param hostId               현재 방장의 사용자 식별자 (userIdentifier)
  * @param hostNickname         방장 닉네임. 정식 회원/게스트 모두 내려오며, 조회 실패 시 fallback 값
  * @param title                로비 제목
  * @param mapId                선택된 맵 세트 ID (미선택 시 null)
@@ -28,7 +27,6 @@ package io.github.ascrew.monomatbe.domain.lobby.dto;
  */
 public record LobbyListItemResponse(
         String code,
-        String hostId,
         String hostNickname,
         String title,
         Long mapId,
@@ -53,7 +51,6 @@ public record LobbyListItemResponse(
     public static LobbyListItemResponse of(LobbyRedisDto dto, String hostNickname) {
         return new LobbyListItemResponse(
                 dto.getCode(),
-                dto.getHostId(),
                 hostNickname,
                 dto.getTitle(),
                 dto.getMapId(),

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
+import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +26,9 @@ public class LobbyPlayerNicknameResolver {
 
     private static final String UNKNOWN_NICKNAME_PREFIX = "Unknown-";
 
+    /** fallback 표시값에 사용할 식별자 해시 앞자리 길이 (SHA-256 hex 기준) */
+    private static final int HASH_SUFFIX_LENGTH = 6;
+
     private final UserNicknameLookupService userNicknameLookupService;
 
     /**
@@ -43,18 +47,22 @@ public class LobbyPlayerNicknameResolver {
      * [fallback 정책]
      * Redis participants에는 남아 있지만 DB 세션이 이미 정리된 경우,
      * 상세 조회 전체를 실패시키면 대기실 UI가 깨진다.
-     * 따라서 식별자 일부를 포함한 안전한 표시값으로 내려준다.
+     * 따라서 닉네임 대신 안전한 표시값을 내려준다.
+     *
+     * [보안 — 식별자 원문 미노출]
+     * userIdentifier는 세션 ID 또는 게스트 토큰이므로 원문(일부 포함)을 응답에 노출하면 안 된다.
+     * 특히 로비 목록은 호출 빈도가 높고 노출 범위가 넓다.
+     * 따라서 식별자의 SHA-256 해시 앞 6자리(비가역)만 사용해 표시값을 만든다.
+     * 결정적이므로 같은 식별자는 항상 같은 fallback 값으로 표시된다.
      */
     public String fallbackNickname(String userIdentifier) {
         if (userIdentifier == null || userIdentifier.isBlank()) {
             return UNKNOWN_NICKNAME_PREFIX + "user";
         }
 
-        String compact = userIdentifier.replace("-", "");
-        String suffix = compact.length() <= 6
-                ? compact
-                : compact.substring(0, 6);
+        String hashSuffix = TokenHashUtils.sha256(userIdentifier)
+                .substring(0, HASH_SUFFIX_LENGTH);
 
-        return UNKNOWN_NICKNAME_PREFIX + suffix;
+        return UNKNOWN_NICKNAME_PREFIX + hashSuffix;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
@@ -1,12 +1,16 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
+import io.github.ascrew.monomatbe.domain.lobby.config.LobbyNicknameCacheProperties;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.RedisStringCommands;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -37,7 +41,8 @@ import java.util.Map;
  *   상위 계층에서 fallbackNickname()으로 처리한다.
  * - 캐싱으로 인해 닉네임 변경이 최대 TTL만큼 로비 목록/상세에 지연 반영될 수 있다.
  *   닉네임 변경 즉시성이 요구되지 않으므로 이를 수용한다.
- * - 식별자 원문은 캐시 키(user:nickname:{userIdentifier})에만 사용되며 응답에 노출되지 않는다.
+ * - 캐시 키는 식별자 원문이 아니라 SHA-256 해시(user:nickname:{sha256(userIdentifier)})로 만들어,
+ *   Redis 키/모니터링/SCAN 어디에도 세션·토큰 원문이 노출되지 않는다.
  *
  * [장애 정책]
  * 캐시 조회/저장 실패만으로 목록 API를 실패시키지 않는다.
@@ -53,20 +58,9 @@ public class LobbyPlayerNicknameResolver {
     /** fallback 표시값에 사용할 식별자 해시 앞자리 길이 (SHA-256 hex 기준) */
     private static final int HASH_SUFFIX_LENGTH = 6;
 
-    /** TTL 프로퍼티가 비정상이거나 미주입된 경우 사용할 기본 캐시 TTL */
-    private static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(10);
-
     private final StringRedisTemplate redisTemplate;
     private final UserNicknameLookupService userNicknameLookupService;
-
-    /**
-     * 닉네임 캐시 TTL.
-     *
-     * Spring Context 밖에서 생성되는 단위 테스트에서는 @Value가 주입되지 않을 수 있으므로
-     * effectiveCacheTtl()에서 null/zero/negative를 DEFAULT_CACHE_TTL로 보정한다.
-     */
-    @Value("${monomat.lobby.nickname-cache.ttl:PT10M}")
-    private Duration cacheTtl;
+    private final LobbyNicknameCacheProperties nicknameCacheProperties;
 
     /**
      * 여러 userIdentifier에 대응되는 닉네임을 한 번에 조회한다.
@@ -154,42 +148,44 @@ public class LobbyPlayerNicknameResolver {
     /**
      * DB에서 새로 조회된 닉네임만 캐시에 저장한다.
      *
+     * [batch 저장]
+     * 식별자 수만큼 개별 SET을 날리면 서버↔Redis RTT가 누적되어 캐시가 또 다른 병목이 된다.
+     * 따라서 executePipelined로 SET(+TTL)을 한 번에 묶어 round-trip을 줄인다.
+     *
+     * [장애 정책]
      * 저장 실패는 목록 응답에 영향을 주지 않도록 무시하고 로그만 남긴다.
+     * 로그에는 식별자 원문 대신 대상 개수만 남겨 식별자 노출을 막는다.
      */
     private void writeToCache(Map<String, String> loadedNicknames) {
         if (loadedNicknames.isEmpty()) {
             return;
         }
 
-        Duration ttl = effectiveCacheTtl();
+        Duration ttl = nicknameCacheProperties.getTtl();
 
-        loadedNicknames.forEach((userIdentifier, nickname) -> {
-            if (nickname == null || nickname.isBlank()) {
-                return;
-            }
-
-            try {
-                redisTemplate.opsForValue().set(
-                        RedisKeys.userNicknameKey(userIdentifier),
-                        nickname,
-                        ttl
-                );
-            } catch (RuntimeException e) {
-                log.warn(
-                        "닉네임 캐시 저장 실패 - 목록 응답은 계속 진행. userIdentifier: {}",
-                        userIdentifier,
-                        e
-                );
-            }
-        });
-    }
-
-    private Duration effectiveCacheTtl() {
-        if (cacheTtl == null || cacheTtl.isZero() || cacheTtl.isNegative()) {
-            return DEFAULT_CACHE_TTL;
+        try {
+            redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+                StringRedisConnection stringConnection = (StringRedisConnection) connection;
+                loadedNicknames.forEach((userIdentifier, nickname) -> {
+                    if (nickname == null || nickname.isBlank()) {
+                        return;
+                    }
+                    stringConnection.set(
+                            RedisKeys.userNicknameKey(userIdentifier),
+                            nickname,
+                            Expiration.from(ttl),
+                            RedisStringCommands.SetOption.upsert()
+                    );
+                });
+                return null;
+            });
+        } catch (RuntimeException e) {
+            log.warn(
+                    "닉네임 캐시 batch 저장 실패 - 목록 응답은 계속 진행. targetCount: {}",
+                    loadedNicknames.size(),
+                    e
+            );
         }
-
-        return cacheTtl;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
@@ -1,11 +1,19 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -17,9 +25,25 @@ import java.util.Map;
  * Auth 도메인의 내부 구현이므로 UserNicknameLookupService에 위임한다.
  *
  * [역할]
- * - Auth 도메인 서비스에서 userIdentifier -> nickname Map을 조회한다.
+ * - userIdentifier -> nickname Map을 Cache -> DB 순으로 조회한다.
  * - 조회되지 않은 사용자를 위한 fallback nickname을 제공한다.
+ *
+ * [캐시 정책]
+ * 로비 목록(GET /api/lobbies)은 호출 빈도가 높아 매 요청마다 닉네임을 DB로 조회하면
+ * latency spike와 DB 커넥션 병목으로 증폭될 수 있다. 따라서 userIdentifier 기준 닉네임을
+ * Redis에 짧은 TTL로 캐싱하고, cache miss인 식별자만 Auth 도메인 서비스로 조회한다.
+ *
+ * - 정상 조회된 닉네임만 캐싱한다. 세션 만료 등으로 닉네임이 없는 식별자는 negative 캐싱하지 않고,
+ *   상위 계층에서 fallbackNickname()으로 처리한다.
+ * - 캐싱으로 인해 닉네임 변경이 최대 TTL만큼 로비 목록/상세에 지연 반영될 수 있다.
+ *   닉네임 변경 즉시성이 요구되지 않으므로 이를 수용한다.
+ * - 식별자 원문은 캐시 키(user:nickname:{userIdentifier})에만 사용되며 응답에 노출되지 않는다.
+ *
+ * [장애 정책]
+ * 캐시 조회/저장 실패만으로 목록 API를 실패시키지 않는다.
+ * 캐시 조회 실패 시 전부 miss로 간주해 DB 경로로 진행하고, 저장 실패는 무시한다.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LobbyPlayerNicknameResolver {
@@ -29,16 +53,143 @@ public class LobbyPlayerNicknameResolver {
     /** fallback 표시값에 사용할 식별자 해시 앞자리 길이 (SHA-256 hex 기준) */
     private static final int HASH_SUFFIX_LENGTH = 6;
 
+    /** TTL 프로퍼티가 비정상이거나 미주입된 경우 사용할 기본 캐시 TTL */
+    private static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(10);
+
+    private final StringRedisTemplate redisTemplate;
     private final UserNicknameLookupService userNicknameLookupService;
 
     /**
+     * 닉네임 캐시 TTL.
+     *
+     * Spring Context 밖에서 생성되는 단위 테스트에서는 @Value가 주입되지 않을 수 있으므로
+     * effectiveCacheTtl()에서 null/zero/negative를 DEFAULT_CACHE_TTL로 보정한다.
+     */
+    @Value("${monomat.lobby.nickname-cache.ttl:PT10M}")
+    private Duration cacheTtl;
+
+    /**
      * 여러 userIdentifier에 대응되는 닉네임을 한 번에 조회한다.
+     *
+     * [조회 순서]
+     * 1. Redis 캐시에서 batch(MGET)로 적중분을 먼저 조회한다.
+     * 2. cache miss인 식별자만 Auth 도메인 서비스로 DB 조회한다.
+     * 3. DB에서 새로 얻은 닉네임만 캐시에 저장한다.
      *
      * @param userIdentifiers 로비 참여자 userIdentifier 목록
      * @return userIdentifier -> nickname Map
      */
     public Map<String, String> resolveNicknameMap(Collection<String> userIdentifiers) {
-        return userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers);
+        if (userIdentifiers == null || userIdentifiers.isEmpty()) {
+            return Map.of();
+        }
+
+        List<String> distinctIdentifiers = userIdentifiers.stream()
+                .filter(identifier -> identifier != null && !identifier.isBlank())
+                .distinct()
+                .toList();
+
+        if (distinctIdentifiers.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, String> nicknameMap = new HashMap<>();
+
+        List<String> missedIdentifiers = readFromCache(distinctIdentifiers, nicknameMap);
+
+        if (!missedIdentifiers.isEmpty()) {
+            Map<String, String> loaded =
+                    userNicknameLookupService.findNicknameMapByUserIdentifiers(missedIdentifiers);
+
+            nicknameMap.putAll(loaded);
+            writeToCache(loaded);
+        }
+
+        return nicknameMap;
+    }
+
+    /**
+     * 캐시에서 닉네임 적중분을 조회해 resultMap에 채우고, cache miss인 식별자 목록을 반환한다.
+     *
+     * 캐시 조회가 실패하면 전부 miss로 간주해 입력 식별자를 그대로 반환한다.
+     */
+    private List<String> readFromCache(
+            List<String> distinctIdentifiers,
+            Map<String, String> resultMap
+    ) {
+        List<String> keys = distinctIdentifiers.stream()
+                .map(RedisKeys::userNicknameKey)
+                .toList();
+
+        try {
+            List<String> cachedNicknames = redisTemplate.opsForValue().multiGet(keys);
+
+            if (cachedNicknames == null) {
+                return distinctIdentifiers;
+            }
+
+            List<String> missedIdentifiers = new ArrayList<>();
+
+            for (int i = 0; i < distinctIdentifiers.size(); i++) {
+                String cached = i < cachedNicknames.size() ? cachedNicknames.get(i) : null;
+
+                if (cached != null && !cached.isBlank()) {
+                    resultMap.put(distinctIdentifiers.get(i), cached);
+                } else {
+                    missedIdentifiers.add(distinctIdentifiers.get(i));
+                }
+            }
+
+            return missedIdentifiers;
+        } catch (RuntimeException e) {
+            log.warn(
+                    "닉네임 캐시 조회 실패 - 전부 DB fallback 사용. targetCount: {}",
+                    distinctIdentifiers.size(),
+                    e
+            );
+            return distinctIdentifiers;
+        }
+    }
+
+    /**
+     * DB에서 새로 조회된 닉네임만 캐시에 저장한다.
+     *
+     * 저장 실패는 목록 응답에 영향을 주지 않도록 무시하고 로그만 남긴다.
+     */
+    private void writeToCache(Map<String, String> loadedNicknames) {
+        if (loadedNicknames.isEmpty()) {
+            return;
+        }
+
+        Duration ttl = effectiveCacheTtl();
+
+        loadedNicknames.forEach((userIdentifier, nickname) -> {
+            if (nickname == null || nickname.isBlank()) {
+                return;
+            }
+
+            try {
+                redisTemplate.opsForValue().set(
+                        RedisKeys.userNicknameKey(userIdentifier),
+                        nickname,
+                        ttl
+                );
+            } catch (RuntimeException e) {
+                log.warn(
+                        "닉네임 캐시 저장 실패 - 목록 응답은 계속 진행. userIdentifier: {}",
+                        userIdentifier,
+                        e
+                );
+            }
+        });
+    }
+
+    private Duration effectiveCacheTtl() {
+        if (cacheTtl == null || cacheTtl.isZero() || cacheTtl.isNegative()) {
+            return DEFAULT_CACHE_TTL;
+        }
+
+        return cacheTtl;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -20,6 +20,7 @@ package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyListItemResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPageRequest;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPageResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
@@ -133,7 +134,7 @@ public class LobbyQueryService {
      * @return 페이징된 공개 로비 목록 응답
      */
     @Transactional(readOnly = true)
-    public LobbyPageResponse<LobbyRedisDto> getPublicLobbyPage(LobbySearchCondition condition) {
+    public LobbyPageResponse<LobbyListItemResponse> getPublicLobbyPage(LobbySearchCondition condition) {
         if (canUseSortIndex(condition)) {
             return getPublicLobbyPageBySortIndex(condition);
         }
@@ -196,7 +197,7 @@ public class LobbyQueryService {
      * page offset 이전에 존재하는 stale code까지 완전히 보정하지는 않는다.
      * 다만 요청 중 만난 stale code는 Repository에서 제거하므로 반복 조회할수록 정합성이 회복된다.
      */
-    private LobbyPageResponse<LobbyRedisDto> getPublicLobbyPageBySortIndex(
+    private LobbyPageResponse<LobbyListItemResponse> getPublicLobbyPageBySortIndex(
             LobbySearchCondition condition
     ) {
         LobbyPageRequest pageRequest = condition.pageRequest();
@@ -279,7 +280,7 @@ public class LobbyQueryService {
                 : collectedItems;
 
         return LobbyPageResponse.of(
-                pageItems,
+                toListItemResponses(pageItems),
                 pageRequest,
                 hasNext
         );
@@ -310,7 +311,7 @@ public class LobbyQueryService {
      * 요청 page가 전체 목록 범위를 넘어가면 빈 items를 반환한다.
      * page 값 자체는 유효한 0 이상 값이므로 400으로 보지 않는다.
      */
-    private LobbyPageResponse<LobbyRedisDto> toPageResponse(
+    private LobbyPageResponse<LobbyListItemResponse> toPageResponse(
             List<LobbyRedisDto> sortedLobbies,
             LobbyPageRequest pageRequest
     ) {
@@ -338,10 +339,57 @@ public class LobbyQueryService {
         boolean hasNext = endExclusive < sortedLobbies.size();
 
         return LobbyPageResponse.of(
-                pageItems,
+                toListItemResponses(pageItems),
                 pageRequest,
                 hasNext
         );
+    }
+
+    /**
+     * 페이지 단위 로비 목록에 방장 닉네임을 채워 응답 DTO로 변환한다.
+     *
+     * [N+1 방지]
+     * 페이지 내 모든 hostId를 한 번에 모아 닉네임 Map을 단 1회 조회한다.
+     * 닉네임 조회는 게스트/회원 각각 IN 쿼리 1회로 batch 처리된다.
+     *
+     * [fallback]
+     * 세션 만료 등으로 닉네임을 찾지 못하면 로비 상세 조회와 동일하게
+     * LobbyPlayerNicknameResolver.fallbackNickname()으로 안전한 표시값을 내려준다.
+     */
+    private List<LobbyListItemResponse> toListItemResponses(List<LobbyRedisDto> pageItems) {
+        if (pageItems.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> hostIds = pageItems.stream()
+                .map(LobbyRedisDto::getHostId)
+                .filter(hostId -> hostId != null && !hostId.isBlank())
+                .distinct()
+                .toList();
+
+        Map<String, String> hostNicknameMap = hostIds.isEmpty()
+                ? Map.of()
+                : lobbyPlayerNicknameResolver.resolveNicknameMap(hostIds);
+
+        return pageItems.stream()
+                .map(lobby -> LobbyListItemResponse.of(
+                        lobby,
+                        resolveHostNickname(lobby.getHostId(), hostNicknameMap)
+                ))
+                .toList();
+    }
+
+    /**
+     * 방장 hostId에 대응하는 닉네임을 반환한다.
+     *
+     * 조회된 닉네임이 없거나 비어 있으면 fallback 표시값을 사용한다.
+     */
+    private String resolveHostNickname(String hostId, Map<String, String> hostNicknameMap) {
+        String nickname = hostNicknameMap.get(hostId);
+        if (nickname == null || nickname.isBlank()) {
+            return lobbyPlayerNicknameResolver.fallbackNickname(hostId);
+        }
+        return nickname;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -46,6 +46,9 @@ public final class RedisKeys {
     /** 채팅 발신자 프로필 캐시 키 접두사 */
     private static final String CHAT_SENDER_PROFILE_PREFIX = "chat:sender-profile:";
 
+    /** userIdentifier 기준 닉네임 캐시 키 접두사 */
+    private static final String USER_NICKNAME_PREFIX = "user:nickname:";
+
     /** 로비 채팅 메시지 신고 중복 방지 lock 키 접두사 */
     private static final String LOBBY_CHAT_MESSAGE_REPORT_LOCK_PREFIX = "lock:report:lobby-chat-message:";
 
@@ -383,6 +386,26 @@ public final class RedisKeys {
      */
     public static String chatSenderProfileKey(String userIdentifier) {
         return CHAT_SENDER_PROFILE_PREFIX + userIdentifier;
+    }
+
+    /**
+     * userIdentifier 기준 닉네임 캐시 키를 반환한다.
+     *
+     * 저장 구조:
+     * - Key   : user:nickname:{userIdentifier}
+     * - Type  : String
+     * - Value : 사용자 표시 닉네임 (plain string)
+     *
+     * [사용 목적]
+     * 로비 목록(GET /api/lobbies)은 호출 빈도가 높아 매 요청마다 회원/게스트 닉네임을
+     * DB IN 쿼리로 조회하면 latency spike와 DB 커넥션 병목으로 증폭될 수 있다.
+     * userIdentifier 기준 닉네임 스냅샷을 짧은 TTL로 캐싱해 cache miss만 DB로 조회한다.
+     *
+     * @param userIdentifier 사용자 식별자
+     * @return 닉네임 캐시 키
+     */
+    public static String userNicknameKey(String userIdentifier) {
+        return USER_NICKNAME_PREFIX + userIdentifier;
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -13,6 +13,8 @@
  */
 package io.github.ascrew.monomatbe.global.constant;
 
+import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
+
 public final class RedisKeys {
 
     // 인스턴스화 방지
@@ -405,7 +407,9 @@ public final class RedisKeys {
      * @return 닉네임 캐시 키
      */
     public static String userNicknameKey(String userIdentifier) {
-        return USER_NICKNAME_PREFIX + userIdentifier;
+        // 세션/게스트 토큰 성격의 식별자 원문을 Redis 키에 노출하지 않도록 SHA-256 해시를 사용한다.
+        // (운영자/모니터링/SCAN 과정의 식별자 노출 방지, 키 길이 고정)
+        return USER_NICKNAME_PREFIX + TokenHashUtils.sha256(userIdentifier);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,10 @@ youtube.oembed.request-timeout=${YOUTUBE_OEMBED_REQUEST_TIMEOUT:5s}
 chat.lobby.recent-messages.max-size=${LOBBY_RECENT_CHAT_MAX_SIZE:50}
 chat.lobby.recent-messages.ttl=${LOBBY_RECENT_CHAT_TTL:2h}
 
+# 로비 목록/상세 닉네임 캐시 TTL (Spring Boot Duration 형식: 10m, 5m, 30m 등)
+# 호출 빈도 높은 GET /api/lobbies에서 닉네임 DB 조회를 줄이기 위한 cache-aside TTL
+monomat.lobby.nickname-cache.ttl=${LOBBY_NICKNAME_CACHE_TTL:10m}
+
 # 신고 정책
 # lobby-review-threshold: 특정 로비의 PENDING 신고 수가 이 값 이상이면 관리자 검토 대상
 # auto-private-enabled: true일 경우 후속 정책에서 자동 비공개 전환 후보로 판단 가능

--- a/src/test/java/io/github/ascrew/monomatbe/domain/chat/service/ChatSenderProfileCacheEvictorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/chat/service/ChatSenderProfileCacheEvictorTest.java
@@ -1,0 +1,94 @@
+package io.github.ascrew.monomatbe.domain.chat.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
+import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 사용자 표시 정보 캐시 무효화 컴포넌트 검증.
+ *
+ * evictByUserId는 userIdentifier 조회를 한 번만 수행하고,
+ * 각 식별자에 대해 채팅 발신자 프로필 캐시와 로비 닉네임 캐시를 함께 무효화해야 한다.
+ */
+class ChatSenderProfileCacheEvictorTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String SESSION_ID = "session-id";
+    private static final String GUEST_TOKEN = "guest-token";
+
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+    private final UserSessionRepository userSessionRepository = mock(UserSessionRepository.class);
+    private final GuestSessionRepository guestSessionRepository = mock(GuestSessionRepository.class);
+
+    private final ChatSenderProfileCacheEvictor evictor = new ChatSenderProfileCacheEvictor(
+            redisTemplate,
+            userSessionRepository,
+            guestSessionRepository
+    );
+
+    @Test
+    @DisplayName("evictByUserId는 각 식별자의 채팅 발신자 프로필 캐시와 로비 닉네임 캐시를 함께 삭제한다")
+    void evictByUserId_deletesBothChatProfileAndNicknameCaches() {
+        // given
+        when(userSessionRepository.findSessionIdsByUserIdAndStatus(USER_ID, UserSessionStatus.ACTIVE))
+                .thenReturn(List.of(SESSION_ID));
+        when(guestSessionRepository.findGuestTokensByUserId(USER_ID))
+                .thenReturn(List.of(GUEST_TOKEN));
+
+        // when
+        evictor.evictByUserId(USER_ID);
+
+        // then
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(redisTemplate).delete(captor.capture());
+
+        assertThat(captor.getValue()).containsExactlyInAnyOrder(
+                RedisKeys.chatSenderProfileKey(SESSION_ID),
+                RedisKeys.userNicknameKey(SESSION_ID),
+                RedisKeys.chatSenderProfileKey(GUEST_TOKEN),
+                RedisKeys.userNicknameKey(GUEST_TOKEN)
+        );
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 캐시를 삭제하지 않는다")
+    void evictByUserId_doesNothingWhenUserIdIsNull() {
+        // when
+        evictor.evictByUserId(null);
+
+        // then
+        verify(redisTemplate, never()).delete(anyCollection());
+    }
+
+    @Test
+    @DisplayName("연결된 식별자가 없으면 캐시를 삭제하지 않는다")
+    void evictByUserId_doesNothingWhenNoIdentifiers() {
+        // given
+        when(userSessionRepository.findSessionIdsByUserIdAndStatus(USER_ID, UserSessionStatus.ACTIVE))
+                .thenReturn(List.of());
+        when(guestSessionRepository.findGuestTokensByUserId(USER_ID))
+                .thenReturn(List.of());
+
+        // when
+        evictor.evictByUserId(USER_ID);
+
+        // then
+        verify(redisTemplate, never()).delete(anyCollection());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryControllerMockMvcTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryControllerMockMvcTest.java
@@ -1,0 +1,105 @@
+package io.github.ascrew.monomatbe.domain.lobby.controller;
+
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyListItemResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPageResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyQueryService;
+import io.github.ascrew.monomatbe.global.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * GET /api/lobbies 응답의 실제 JSON 직렬화 계약을 고정하는 MockMvc 테스트.
+ *
+ * [목적]
+ * 응답 타입이 LobbyPageResponse&lt;LobbyRedisDto&gt; -&gt; LobbyPageResponse&lt;LobbyListItemResponse&gt;로
+ * 바뀌고 hostNickname이 추가되었다. 이 변경이 기존 필드명/직렬화(특히 isPrivate)와 페이지 메타를
+ * 깨지 않는지 실제 JSON 기준으로 회귀 방지한다.
+ *
+ * [보안 필터]
+ * 직렬화 계약 검증이 목적이므로 addFilters = false로 보안 필터 체인을 우회한다.
+ * (/api/lobbies는 prod에서 인증이 필요한 엔드포인트다)
+ */
+@WebMvcTest(LobbyQueryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class LobbyQueryControllerMockMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LobbyQueryService lobbyQueryService;
+
+    /*
+     * JwtAuthenticationFilter는 @Component Filter라 @WebMvcTest 슬라이스에 포함되지만
+     * StringRedisTemplate 등 인프라 빈을 요구한다. addFilters = false로 필터는 적용하지 않으므로,
+     * 컨텍스트 로드를 위해 mock으로 대체한다.
+     */
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    @DisplayName("GET /api/lobbies 응답 item에 hostNickname이 포함되고 기존 필드/페이지 메타가 동일하게 직렬화된다")
+    void getPublicLobbies_serializesHostNicknameAndLegacyFields() throws Exception {
+        // given
+        LobbyListItemResponse item = new LobbyListItemResponse(
+                "ABC123",
+                "host-uuid",
+                "모노유저",
+                "K-POP 퀴즈방",
+                10L,
+                "아이돌 명곡",
+                "K-POP",
+                8,
+                3,
+                false,
+                "WAITING",
+                15,
+                30,
+                1710000000000L
+        );
+        LobbyPageResponse<LobbyListItemResponse> response =
+                new LobbyPageResponse<>(List.of(item), 0, 6, true);
+
+        when(lobbyQueryService.getPublicLobbyPage(any(LobbySearchCondition.class)))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/lobbies"))
+                .andExpect(status().isOk())
+                // 신규 필드
+                .andExpect(jsonPath("$.items[0].hostNickname").value("모노유저"))
+                // 기존 필드 회귀 가드 (필드명/값 동일)
+                .andExpect(jsonPath("$.items[0].code").value("ABC123"))
+                .andExpect(jsonPath("$.items[0].hostId").value("host-uuid"))
+                .andExpect(jsonPath("$.items[0].title").value("K-POP 퀴즈방"))
+                .andExpect(jsonPath("$.items[0].mapId").value(10))
+                .andExpect(jsonPath("$.items[0].mapTitle").value("아이돌 명곡"))
+                .andExpect(jsonPath("$.items[0].mapCategory").value("K-POP"))
+                .andExpect(jsonPath("$.items[0].maxPlayers").value(8))
+                .andExpect(jsonPath("$.items[0].currentPlayers").value(3))
+                // Boolean 필드명이 "isPrivate"로 직렬화되는지 고정
+                .andExpect(jsonPath("$.items[0].isPrivate").value(false))
+                .andExpect(jsonPath("$.items[0].status").value("WAITING"))
+                .andExpect(jsonPath("$.items[0].questionCount").value(15))
+                .andExpect(jsonPath("$.items[0].timeLimitSeconds").value(30))
+                .andExpect(jsonPath("$.items[0].createdAtEpochMillis").value(1710000000000L))
+                // 페이지 메타
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(6))
+                .andExpect(jsonPath("$.hasNext").value(true));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryControllerMockMvcTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyQueryControllerMockMvcTest.java
@@ -57,7 +57,6 @@ class LobbyQueryControllerMockMvcTest {
         // given
         LobbyListItemResponse item = new LobbyListItemResponse(
                 "ABC123",
-                "host-uuid",
                 "모노유저",
                 "K-POP 퀴즈방",
                 10L,
@@ -84,7 +83,8 @@ class LobbyQueryControllerMockMvcTest {
                 .andExpect(jsonPath("$.items[0].hostNickname").value("모노유저"))
                 // 기존 필드 회귀 가드 (필드명/값 동일)
                 .andExpect(jsonPath("$.items[0].code").value("ABC123"))
-                .andExpect(jsonPath("$.items[0].hostId").value("host-uuid"))
+                // hostId(userIdentifier)는 공개 목록 응답에서 노출되지 않아야 한다
+                .andExpect(jsonPath("$.items[0].hostId").doesNotExist())
                 .andExpect(jsonPath("$.items[0].title").value("K-POP 퀴즈방"))
                 .andExpect(jsonPath("$.items[0].mapId").value(10))
                 .andExpect(jsonPath("$.items[0].mapTitle").value("아이돌 명곡"))

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
@@ -1,15 +1,25 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,26 +27,40 @@ import static org.mockito.Mockito.when;
  * LobbyPlayerNicknameResolver의 로비 응답용 닉네임 변환 정책을 검증한다.
  *
  * [검증 범위]
- * - Auth 도메인 닉네임 조회 서비스로 위임하는지
+ * - Cache -> DB(miss only) 계층 조회
+ * - 캐시 적중분은 DB 조회 대상에서 제외
+ * - 캐시 조회 실패 시 DB fallback
+ * - DB 조회 결과 캐싱
  * - fallback nickname 생성 정책
  */
 class LobbyPlayerNicknameResolverTest {
 
     private final UserNicknameLookupService userNicknameLookupService = mock(UserNicknameLookupService.class);
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+
+    @SuppressWarnings("unchecked")
+    private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
 
     private final LobbyPlayerNicknameResolver resolver = new LobbyPlayerNicknameResolver(
+            redisTemplate,
             userNicknameLookupService
     );
 
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
     @Test
-    @DisplayName("resolveNicknameMap은 UserNicknameLookupService에 조회를 위임한다")
-    void resolveNicknameMap_delegatesToUserNicknameLookupService() {
+    @DisplayName("전부 캐시 미스면 DB로 위임 조회한 뒤 결과를 캐싱한다")
+    void resolveNicknameMap_allCacheMiss_delegatesToDbAndCaches() {
         // given
         List<String> userIdentifiers = List.of(
                 "guest-identifier",
                 "registered-identifier"
         );
 
+        when(valueOperations.multiGet(any())).thenReturn(Arrays.asList(null, null));
         when(userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers))
                 .thenReturn(Map.of(
                         "guest-identifier", "게스트닉네임",
@@ -53,6 +77,105 @@ class LobbyPlayerNicknameResolverTest {
                 .hasSize(2);
 
         verify(userNicknameLookupService).findNicknameMapByUserIdentifiers(userIdentifiers);
+        verify(valueOperations).set(
+                eq(RedisKeys.userNicknameKey("guest-identifier")),
+                eq("게스트닉네임"),
+                any(Duration.class)
+        );
+        verify(valueOperations).set(
+                eq(RedisKeys.userNicknameKey("registered-identifier")),
+                eq("회원닉네임"),
+                any(Duration.class)
+        );
+    }
+
+    @Test
+    @DisplayName("캐시 적중분은 DB 조회 대상에서 제외하고 미스인 식별자만 위임한다")
+    void resolveNicknameMap_partialHit_onlyMissDelegated() {
+        // given
+        List<String> userIdentifiers = List.of(
+                "cached-identifier",
+                "missed-identifier"
+        );
+
+        // multiGet은 keys 순서와 정렬된 결과를 반환한다.
+        when(valueOperations.multiGet(any())).thenReturn(Arrays.asList("캐시닉네임", null));
+        when(userNicknameLookupService.findNicknameMapByUserIdentifiers(List.of("missed-identifier")))
+                .thenReturn(Map.of("missed-identifier", "DB닉네임"));
+
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("cached-identifier", "캐시닉네임")
+                .containsEntry("missed-identifier", "DB닉네임")
+                .hasSize(2);
+
+        verify(userNicknameLookupService).findNicknameMapByUserIdentifiers(List.of("missed-identifier"));
+        // 적중분은 다시 캐싱하지 않는다.
+        verify(valueOperations, never()).set(
+                eq(RedisKeys.userNicknameKey("cached-identifier")),
+                anyString(),
+                any(Duration.class)
+        );
+    }
+
+    @Test
+    @DisplayName("전부 캐시 적중이면 DB 조회를 호출하지 않는다")
+    void resolveNicknameMap_allHit_skipsDb() {
+        // given
+        List<String> userIdentifiers = List.of("a", "b");
+        when(valueOperations.multiGet(any())).thenReturn(Arrays.asList("닉a", "닉b"));
+
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("a", "닉a")
+                .containsEntry("b", "닉b")
+                .hasSize(2);
+
+        verify(userNicknameLookupService, never()).findNicknameMapByUserIdentifiers(any());
+        verify(valueOperations, never()).set(anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("캐시 조회가 예외를 던지면 전부 DB fallback으로 조회한다")
+    void resolveNicknameMap_cacheFailure_fallsBackToDb() {
+        // given
+        List<String> userIdentifiers = List.of("guest-identifier", "registered-identifier");
+
+        when(valueOperations.multiGet(any())).thenThrow(new RuntimeException("redis down"));
+        when(userNicknameLookupService.findNicknameMapByUserIdentifiers(userIdentifiers))
+                .thenReturn(Map.of(
+                        "guest-identifier", "게스트닉네임",
+                        "registered-identifier", "회원닉네임"
+                ));
+
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(userIdentifiers);
+
+        // then
+        assertThat(result)
+                .containsEntry("guest-identifier", "게스트닉네임")
+                .containsEntry("registered-identifier", "회원닉네임")
+                .hasSize(2);
+
+        verify(userNicknameLookupService).findNicknameMapByUserIdentifiers(userIdentifiers);
+    }
+
+    @Test
+    @DisplayName("blank/null 식별자만 있으면 빈 맵을 반환하고 캐시/DB를 조회하지 않는다")
+    void resolveNicknameMap_blankIdentifiers_returnsEmpty() {
+        // when
+        Map<String, String> result = resolver.resolveNicknameMap(Arrays.asList(null, "", "   "));
+
+        // then
+        assertThat(result).isEmpty();
+        verify(valueOperations, never()).multiGet(any());
+        verify(userNicknameLookupService, never()).findNicknameMapByUserIdentifiers(any());
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
@@ -1,22 +1,25 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
+import io.github.ascrew.monomatbe.domain.lobby.config.LobbyNicknameCacheProperties;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.types.Expiration;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -43,12 +46,27 @@ class LobbyPlayerNicknameResolverTest {
 
     private final LobbyPlayerNicknameResolver resolver = new LobbyPlayerNicknameResolver(
             redisTemplate,
-            userNicknameLookupService
+            userNicknameLookupService,
+            new LobbyNicknameCacheProperties()
     );
 
     @BeforeEach
     void setUp() {
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    /**
+     * writeToCache의 executePipelined 콜백을 캡처해 mock StringRedisConnection에 실행시킨 뒤,
+     * batch SET이 어떤 키로 호출되었는지 검증할 수 있도록 connection을 반환한다.
+     */
+    @SuppressWarnings("unchecked")
+    private StringRedisConnection capturePipelineWrites() {
+        ArgumentCaptor<RedisCallback<Object>> captor = ArgumentCaptor.forClass(RedisCallback.class);
+        verify(redisTemplate).executePipelined(captor.capture());
+
+        StringRedisConnection connection = mock(StringRedisConnection.class);
+        captor.getValue().doInRedis(connection);
+        return connection;
     }
 
     @Test
@@ -77,15 +95,20 @@ class LobbyPlayerNicknameResolverTest {
                 .hasSize(2);
 
         verify(userNicknameLookupService).findNicknameMapByUserIdentifiers(userIdentifiers);
-        verify(valueOperations).set(
+
+        // 캐시 write는 executePipelined batch로 묶여 실행된다.
+        StringRedisConnection connection = capturePipelineWrites();
+        verify(connection).set(
                 eq(RedisKeys.userNicknameKey("guest-identifier")),
                 eq("게스트닉네임"),
-                any(Duration.class)
+                any(Expiration.class),
+                any()
         );
-        verify(valueOperations).set(
+        verify(connection).set(
                 eq(RedisKeys.userNicknameKey("registered-identifier")),
                 eq("회원닉네임"),
-                any(Duration.class)
+                any(Expiration.class),
+                any()
         );
     }
 
@@ -113,11 +136,20 @@ class LobbyPlayerNicknameResolverTest {
                 .hasSize(2);
 
         verify(userNicknameLookupService).findNicknameMapByUserIdentifiers(List.of("missed-identifier"));
-        // 적중분은 다시 캐싱하지 않는다.
-        verify(valueOperations, never()).set(
+
+        // miss 식별자만 batch SET되고, 적중분은 다시 캐싱하지 않는다.
+        StringRedisConnection connection = capturePipelineWrites();
+        verify(connection).set(
+                eq(RedisKeys.userNicknameKey("missed-identifier")),
+                eq("DB닉네임"),
+                any(Expiration.class),
+                any()
+        );
+        verify(connection, never()).set(
                 eq(RedisKeys.userNicknameKey("cached-identifier")),
-                anyString(),
-                any(Duration.class)
+                any(),
+                any(Expiration.class),
+                any()
         );
     }
 
@@ -138,7 +170,7 @@ class LobbyPlayerNicknameResolverTest {
                 .hasSize(2);
 
         verify(userNicknameLookupService, never()).findNicknameMapByUserIdentifiers(any());
-        verify(valueOperations, never()).set(anyString(), anyString(), any(Duration.class));
+        verify(redisTemplate, never()).executePipelined(any(RedisCallback.class));
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolverTest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.auth.service.UserNicknameLookupService;
+import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -63,12 +64,29 @@ class LobbyPlayerNicknameResolverTest {
     }
 
     @Test
-    @DisplayName("fallbackNickname은 식별자의 하이픈을 제거한 앞 6자리를 suffix로 사용한다")
-    void fallbackNickname_returnsPrefixWithIdentifierSuffix() {
+    @DisplayName("fallbackNickname은 식별자의 SHA-256 해시 앞 6자리를 suffix로 사용한다")
+    void fallbackNickname_usesHashedSuffix() {
         String userIdentifier = "11111111-2222-3333-4444-555555555555";
 
         String result = resolver.fallbackNickname(userIdentifier);
 
-        assertThat(result).isEqualTo("Unknown-111111");
+        String expectedSuffix = TokenHashUtils.sha256(userIdentifier).substring(0, 6);
+        assertThat(result).isEqualTo("Unknown-" + expectedSuffix);
+    }
+
+    @Test
+    @DisplayName("fallbackNickname은 식별자 원문 fragment를 노출하지 않고 비가역 해시 포맷을 사용한다")
+    void fallbackNickname_doesNotExposeRawIdentifier() {
+        String userIdentifier = "11111111-2222-3333-4444-555555555555";
+
+        String result = resolver.fallbackNickname(userIdentifier);
+
+        // 식별자 원문(하이픈 제거 앞자리 포함)을 그대로 포함하면 안 된다.
+        assertThat(result)
+                .doesNotContain("111111")
+                .matches("Unknown-[0-9a-f]{6}");
+
+        // 결정적: 같은 식별자는 항상 같은 fallback 값으로 표시된다.
+        assertThat(resolver.fallbackNickname(userIdentifier)).isEqualTo(result);
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -3,6 +3,7 @@ package io.github.ascrew.monomatbe.domain.lobby.service;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.lobby.dto.JoinLobbyResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyDetailResponse;
+import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyListItemResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyPlayerResponse;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyRedisDto;
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
@@ -19,11 +20,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -256,7 +259,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("MID-1", "OLD");
         assertThat(result.page()).isEqualTo(1);
         assertThat(result.size()).isEqualTo(2);
@@ -288,7 +291,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("LOBBY-5", "LOBBY-4");
         assertThat(result.hasNext()).isTrue();
     }
@@ -317,6 +320,86 @@ class LobbyQueryServiceTest {
         assertThat(result.page()).isEqualTo(10);
         assertThat(result.size()).isEqualTo(20);
         assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("공개 로비 목록 페이징 조회는 정식 회원/게스트 방장 닉네임을 각각 채워 응답한다")
+    void getPublicLobbyPage_fillsHostNicknameForMemberAndGuestHosts() {
+        // given
+        String memberHostId = "member-session-id";
+        String guestHostId = "guest-token-id";
+
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobbyWithHost("ROOM-1", memberHostId, 2000L),
+                lobbyWithHost("ROOM-2", guestHostId, 1000L)
+        ));
+
+        /*
+         * 방장 닉네임 조회는 페이지 내 hostId 전체를 한 번에 넘긴다.
+         * 게스트/회원 식별자가 섞여 있어도 동일한 Map 조회로 닉네임이 채워져야 한다.
+         */
+        when(lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(memberHostId, guestHostId)))
+                .thenReturn(Map.of(
+                        memberHostId, "정식회원닉",
+                        guestHostId, "게스트닉"
+                ));
+
+        LobbySearchCondition condition = LobbySearchCondition.of(
+                null,
+                null,
+                "latest",
+                0,
+                20
+        );
+
+        // when
+        var result = lobbyQueryService.getPublicLobbyPage(condition);
+
+        // then
+        assertThat(result.items())
+                .extracting(
+                        LobbyListItemResponse::code,
+                        LobbyListItemResponse::hostId,
+                        LobbyListItemResponse::hostNickname
+                )
+                .containsExactly(
+                        tuple("ROOM-1", memberHostId, "정식회원닉"),
+                        tuple("ROOM-2", guestHostId, "게스트닉")
+                );
+
+        // N+1 방지: 페이지 내 방장 닉네임은 단 1회 조회로 처리한다.
+        verify(lobbyPlayerNicknameResolver, times(1)).resolveNicknameMap(any());
+    }
+
+    @Test
+    @DisplayName("방장 닉네임을 찾지 못하면 fallback 닉네임을 hostNickname으로 내려준다")
+    void getPublicLobbyPage_usesFallbackNicknameWhenHostNicknameMissing() {
+        // given
+        String hostId = "missing-host-id";
+
+        when(lobbyRepository.getPublicLobbies()).thenReturn(List.of(
+                lobbyWithHost("ROOM-1", hostId, 1000L)
+        ));
+        when(lobbyPlayerNicknameResolver.resolveNicknameMap(List.of(hostId)))
+                .thenReturn(Map.of());
+        when(lobbyPlayerNicknameResolver.fallbackNickname(hostId))
+                .thenReturn("Unknown-missin");
+
+        LobbySearchCondition condition = LobbySearchCondition.of(
+                null,
+                null,
+                "latest",
+                0,
+                20
+        );
+
+        // when
+        var result = lobbyQueryService.getPublicLobbyPage(condition);
+
+        // then
+        assertThat(result.items())
+                .extracting(LobbyListItemResponse::hostNickname)
+                .containsExactly("Unknown-missin");
     }
 
     @Test
@@ -594,7 +677,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("NEW", "MID");
         assertThat(result.page()).isEqualTo(0);
         assertThat(result.size()).isEqualTo(2);
@@ -628,7 +711,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("MATCHED");
 
         verify(lobbyRepository, never()).getPublicLobbyCodesByLatestIndex(anyLong(), anyInt());
@@ -658,7 +741,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("KPOP");
 
         verify(lobbyRepository, never()).getPublicLobbyCodesByLatestIndex(anyLong(), anyInt());
@@ -688,7 +771,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("NEW", "OLD");
 
         verify(lobbyRepository, never()).getPublicLobbyCodesByLatestIndex(anyLong(), anyInt());
@@ -739,7 +822,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("NEW", "MID");
         assertThat(result.hasNext()).isTrue();
 
@@ -777,7 +860,7 @@ class LobbyQueryServiceTest {
 
         // then
         assertThat(result.items())
-                .extracting(LobbyRedisDto::getCode)
+                .extracting(LobbyListItemResponse::code)
                 .containsExactly("ONLY");
         assertThat(result.hasNext()).isFalse();
     }
@@ -840,6 +923,34 @@ class LobbyQueryServiceTest {
                 .maxPlayers(maxPlayers)
                 .isPrivate(isPrivate)
                 .status(status.name())
+                .createdAtEpochMillis(createdAtEpochMillis)
+                .build();
+    }
+
+    /**
+     * 방장 닉네임 검증 테스트용 로비 DTO를 생성한다.
+     *
+     * [의도]
+     * 기존 lobby() fixture는 hostId를 고정값으로 채우기 때문에
+     * 회원/게스트 방장별 닉네임 매핑을 구분해 검증할 수 없다.
+     * 따라서 hostId를 직접 지정할 수 있는 fixture를 둔다.
+     */
+    private LobbyRedisDto lobbyWithHost(
+            String code,
+            String hostId,
+            Long createdAtEpochMillis
+    ) {
+        return LobbyRedisDto.builder()
+                .code(code)
+                .hostId(hostId)
+                .title("로비 " + code)
+                .mapId(1L)
+                .mapTitle("테스트 맵")
+                .mapCategory("K-POP")
+                .currentPlayers(2)
+                .maxPlayers(6)
+                .isPrivate(false)
+                .status(LobbyStatus.WAITING.name())
                 .createdAtEpochMillis(createdAtEpochMillis)
                 .build();
     }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -359,12 +359,11 @@ class LobbyQueryServiceTest {
         assertThat(result.items())
                 .extracting(
                         LobbyListItemResponse::code,
-                        LobbyListItemResponse::hostId,
                         LobbyListItemResponse::hostNickname
                 )
                 .containsExactly(
-                        tuple("ROOM-1", memberHostId, "정식회원닉"),
-                        tuple("ROOM-2", guestHostId, "게스트닉")
+                        tuple("ROOM-1", "정식회원닉"),
+                        tuple("ROOM-2", "게스트닉")
                 );
 
         // N+1 방지: 페이지 내 방장 닉네임은 단 1회 조회로 처리한다.

--- a/src/test/java/io/github/ascrew/monomatbe/global/constant/RedisKeysTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/constant/RedisKeysTest.java
@@ -1,0 +1,38 @@
+package io.github.ascrew.monomatbe.global.constant;
+
+import io.github.ascrew.monomatbe.global.security.jwt.TokenHashUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RedisKeys 키 생성 정책 검증.
+ *
+ * 특히 userNicknameKey는 세션/게스트 토큰 성격의 식별자 원문을 키에 노출하지 않아야 한다.
+ */
+class RedisKeysTest {
+
+    @Test
+    @DisplayName("userNicknameKey는 식별자 원문 대신 SHA-256 해시를 사용한다")
+    void userNicknameKey_usesSha256Hash() {
+        String userIdentifier = "11111111-2222-3333-4444-555555555555";
+
+        String key = RedisKeys.userNicknameKey(userIdentifier);
+
+        assertThat(key).isEqualTo("user:nickname:" + TokenHashUtils.sha256(userIdentifier));
+    }
+
+    @Test
+    @DisplayName("userNicknameKey는 식별자 원문 fragment를 키에 노출하지 않는다")
+    void userNicknameKey_doesNotExposeRawIdentifier() {
+        String userIdentifier = "guest-token-abcdef123456";
+
+        String key = RedisKeys.userNicknameKey(userIdentifier);
+
+        assertThat(key)
+                .startsWith("user:nickname:")
+                .doesNotContain(userIdentifier)
+                .matches("user:nickname:[0-9a-f]{64}");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #149

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `GET /api/lobbies` 응답 각 로비 item에 방장 닉네임(`hostNickname`)을 추가했습니다.
- Redis Hash 매핑 전용 `LobbyRedisDto`와 API 응답 계약을 분리하기 위해 응답 전용 DTO `LobbyListItemResponse`를 신설했습니다.
- 정식 회원·게스트 방장 모두 닉네임이 내려오도록, 기존 `LobbyPlayerNicknameResolver`(→ `UserNicknameLookupService`)를 재사용했습니다.
- 페이지 내 `hostId`를 모아 닉네임을 **단 1회** batch 조회(게스트/회원 IN 쿼리 각 1회)하여 N+1을 방지했습니다.
- 닉네임 조회 실패(세션 만료 등) 시 로비 상세 조회와 동일하게 `fallbackNickname`(`Unknown-xxxxxx`)을 적용했습니다.
- API 문서(`docs/API.md`)와 `LobbyQueryServiceTest`를 보강했습니다.

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 응답 타입이 `LobbyPageResponse<LobbyRedisDto>` → `LobbyPageResponse<LobbyListItemResponse>`로 변경됩니다. `hostId`를 포함한 기존 필드(`questionCount`, `timeLimitSeconds` 포함)는 모두 유지하여 응답 계약 호환을 보장합니다.
- 닉네임 enrichment는 ZSET 인덱스 경로/메모리 폴백 경로 공통으로 페이지 아이템 확정 후 1곳(`toListItemResponses`)에서만 수행됩니다.
- Redis `hostId`는 userIdentifier(session_id/guest_token)로 저장되어 `resolveNicknameMap` 조회 키와 일치합니다. (`LobbyLuaScriptExecutor`, `LobbyMapUpdateService` 기준 확인)
- FE는 응답 item의 `hostNickname`을 그대로 사용하면 되고, 조회 실패 케이스에서는 `Unknown-xxxxxx` 형태 값이 내려갑니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 기존 닉네임 조회 인프라: `LobbyPlayerNicknameResolver`, `UserNicknameLookupService`
- 동일 패턴 선례: `LobbyQueryService#getLobbyDetail` (참여자/방장 닉네임 조립)
