### PR TITLE
[Feat/#145] 게임 세션 Redis 키 정리 및 비정상 종료 복구 정책 구현

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1104,3 +1104,48 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 - **랭킹 및 가점 연출**: `rankings` 리스트 내부의 각 객체는 `PlayerRankingDto` 타입으로, 플레이어의 현재 총점(`score`), 순위(`rank`), 그리고 해당 라운드에서 획득한 가점(`scoreAdded` - 1등 140점, 그 외 정답자 100점, 오답자 0점)을 가지고 있습니다. FE는 `scoreAdded`를 활용하여 "+140" 등 가점 애니메이션을 UI상에 연출하고 랭킹 리스트를 갱신합니다.
 - **자동 전환**: 라운드가 종료된 후 10초간 결과 화면을 노출한 뒤, 서버에 의해 자동으로 다음 라운드가 준비 상태(`ROUND_READY`)로 넘어가게 되므로 FE는 이에 맞춰 인게임 화면으로 복귀하여 비디오 재생 준비 신호를 다시 송신해야 합니다. 마지막 라운드인 경우에는 로비 및 게임 상태가 `FINISHED`로 변경되며 결과화면으로 자동 전환됩니다.
 
+## 게임 세션 Redis 키 정리 정책
+
+게임 세션 관련 Redis 키는 생성 시 **2시간(7200초) TTL**을 최종 안전망으로 가지며, 종료/폭파/롤백 시점에 명시적으로 정리한다.
+
+### 정리 대상 키 (`game:session:{code}*`)
+
+| 키 | 타입 | 설명 |
+| --- | --- | --- |
+| `game:session:{code}` | Hash | 세션 메타데이터 (current_round_no, total_question_count, status 등) |
+| `game:session:{code}:rounds` | List | 라운드별 MapItem ID |
+| `game:session:{code}:players` | Hash | 플레이어별 점수 |
+| `game:session:{code}:round:{n}:ready` | Set | 라운드 재생 준비 완료 유저 |
+| `game:session:{code}:round:{n}:playback_lock` | String | 재생 시작 중복 방지 락 |
+| `game:session:{code}:round:{n}:data` | Hash | 라운드 문제 데이터 캐시 |
+| `game:session:{code}:round:{n}:correct_players` | Set | 정답자 |
+| `game:session:{code}:round:{n}:correct_times` | Hash | 정답 제출 시각 |
+| `game:session:{code}:round:{n}:ended_lock` | String | 라운드 종료 중복 방지 락 |
+
+### 생명주기와 정리 트리거
+
+| 시점 | 정책 | 구현 |
+| --- | --- | --- |
+| 게임 생성 | 모든 키에 2시간 TTL 부여 | `init_game_session.lua`, `GameSessionCreateService` |
+| **게임 정상 종료** (마지막 라운드) | 모든 키를 **300초 짧은 TTL로 전환** (종료 직후 재조회 grace period) | `GameRoundEndService` afterCommit → `GameSessionCleanupService.expireWithGracePeriod()` |
+| **로비 폭파** (게임 중 전원 퇴장) | 모든 키 **즉시 삭제** | `LobbyLeaveEventHandler`(Destroyed) → `LobbyClosedEvent` → `GameSessionCleanupEventHandler` → `deleteNow()` |
+| **게임 시작 DB 롤백** | 모든 키 **즉시 삭제** (보상) | `GameSessionCreateService` afterCompletion(ROLLED_BACK) → `deleteNow()` |
+
+> 정상 종료 시 짧은 TTL을 쓰는 이유: 최종 점수/랭킹은 DB(`GameSessionPlayer`)에 영구 저장되므로 grace period 후 만료되어도 안전하며, 종료 직후 클라이언트 재조회 여유를 둔다.
+
+### 정리 메커니즘
+
+- `cleanup_game_session.lua` 단일 스크립트가 base 3종 + 라운드별 6종 키를 **원자적**으로 `DELETE` 또는 `EXPIRE`한다.
+- 라운드 수는 `total_question_count` 해시 필드(없으면 `:rounds` LLEN)로 판별하고, 모든 하위 키 이름을 `sessionKey`로부터 **결정적으로 조립**한다. → 운영 비용·블로킹 위험이 있는 `SCAN`/`KEYS` 패턴 매칭을 사용하지 않는다.
+- **전제: 단일(standalone) Redis.** 라운드별 키는 KEYS로 선언하지 않고 직접 접근하므로, Redis Cluster 도입 시 `{code}` hash-tag 적용이 필요하다.
+
+### 정리 실패 대응 (경량 reconciliation)
+
+모든 키가 2시간 TTL 안전망을 가지므로 정리 실패는 치명적이지 않다. `GameSessionCleanupService`는 정리 실패 시 예외를 전파하지 않고 다음만 수행한다.
+
+- `[MONITORING_REQUIRED]` 로그 기록
+- 실패 metric counter 증가 (`metric:game:session:cleanup:failed`)
+- 2시간 TTL 자동 만료에 의존 (별도 재처리 스케줄러를 두지 않음)
+
+성공 시 `metric:game:session:cleanup:success`를 증가시켜 정리 처리량을 관측한다.
+

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/config/GameSessionProperties.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/config/GameSessionProperties.java
@@ -1,0 +1,38 @@
+package io.github.ascrew.monomatbe.domain.game.config;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+/**
+ * 게임 세션 정책 설정.
+ *
+ * 새 게임 시작 시 동일 로비에 미종료(active) 세션이 남아 있으면 기본적으로 차단하되,
+ * 비정상 종료 등으로 정체된 세션은 복구(강제 종료 후 재시작 허용)해야 한다.
+ * 정체 판별 임계 기간을 설정값으로 관리한다.
+ */
+@Validated
+@Component
+@ConfigurationProperties(prefix = "monomat.game.session")
+public class GameSessionProperties {
+
+    /**
+     * active 세션을 stale(정체)로 간주하는 임계 기간.
+     *
+     * {@code started_at}으로부터 이 기간이 지난 미종료 세션은 비정상 종료로 정체된 것으로 보고
+     * 새 게임 시작 시 복구 대상으로 삼는다. 정상 게임 1판 최대 진행 시간보다 충분히 길게 둔다.
+     */
+    @NotNull
+    private Duration staleThreshold = Duration.ofMinutes(30);
+
+    public Duration getStaleThreshold() {
+        return staleThreshold;
+    }
+
+    public void setStaleThreshold(Duration staleThreshold) {
+        this.staleThreshold = staleThreshold;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
@@ -4,6 +4,7 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Getter
@@ -64,5 +65,19 @@ public class GameSession {
 
     public void nextRound() {
         this.currentRoundNo++;
+    }
+
+    /**
+     * 미종료 세션이 임계 시간 이상 정체되어 stale(복구 대상)로 간주되는지 판별한다.
+     *
+     * {@code startedAt + threshold < now}이면 정상 진행 중으로 보기 어려운 정체 세션이다.
+     * 새 게임 시작 시 이 조건을 만족하는 기존 active 세션만 강제 종료·복구하고,
+     * 그렇지 않으면 진행 중 게임 보호를 위해 새 시작을 차단한다.
+     *
+     * @param now       현재 시각 (startedAt과 동일한 기준 zone — UTC)
+     * @param threshold 정체 판별 임계 기간
+     */
+    public boolean isStale(LocalDateTime now, Duration threshold) {
+        return startedAt.plus(threshold).isBefore(now);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/redis/GameRoundRecoveryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/redis/GameRoundRecoveryRepository.java
@@ -1,0 +1,83 @@
+package io.github.ascrew.monomatbe.domain.game.repository.redis;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 다음 라운드 진행 정지 복구 재처리 queue 전용 Repository.
+ *
+ * [사용 목적]
+ * 다음 라운드 시작은 인메모리 TaskScheduler에 의존하므로 인스턴스 재시작/afterCommit 중단 시
+ * 영구 정지될 수 있다. scheduleNextRound 시 durable 복구 요청을 Redis queue에 적재해 두고,
+ * 복구 워커가 실제 라운드 진행 여부를 확인해 미진행분만 재트리거한다.
+ *
+ * [payload 형식]
+ * lobbyCode|expectedRoundNo|attempt|nextRetryAtEpochMillis
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class GameRoundRecoveryRepository {
+
+    private static final String PAYLOAD_DELIMITER = "|";
+    private static final String INITIAL_ATTEMPT = "0";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 다음 라운드 진행 복구 요청을 queue에 적재한다.
+     *
+     * 적재 실패는 복구 누락(라운드 영구 정지 가능)으로 이어질 수 있으므로 로그/실패 metric을 남기되,
+     * 이 메서드 자체는 예외를 전파하지 않는다. (afterCommit 후처리 흐름을 깨지 않기 위함)
+     *
+     * @param lobbyCode              로비 초대 코드
+     * @param expectedRoundNo        진행되어야 하는 다음 라운드 번호
+     * @param nextRetryAtEpochMillis 최초 점검 가능 시각 (예약 지연 + grace 이후)
+     */
+    public void enqueueRoundRecovery(String lobbyCode, int expectedRoundNo, long nextRetryAtEpochMillis) {
+        String payload = String.join(
+                PAYLOAD_DELIMITER,
+                lobbyCode,
+                String.valueOf(expectedRoundNo),
+                INITIAL_ATTEMPT,
+                String.valueOf(nextRetryAtEpochMillis)
+        );
+
+        try {
+            redisTemplate.opsForList().rightPush(RedisKeys.GAME_ROUND_RECOVERY_QUEUE, payload);
+            incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_ENQUEUED);
+        } catch (Exception e) {
+            incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+            log.error("[MONITORING_REQUIRED] 다음 라운드 복구 큐 적재 실패 - code: {}, expectedRoundNo: {}",
+                    lobbyCode, expectedRoundNo, e);
+        }
+    }
+
+    /**
+     * 복구 queue에서 payload를 하나 꺼낸다. queue가 비어 있으면 null을 반환한다.
+     */
+    public String pollRoundRecovery() {
+        return redisTemplate.opsForList().leftPop(RedisKeys.GAME_ROUND_RECOVERY_QUEUE);
+    }
+
+    /**
+     * 아직 처리 시각이 아니거나 재시도가 필요한 payload를 queue 뒤쪽에 다시 적재한다.
+     */
+    public void requeueRoundRecovery(String payload) {
+        redisTemplate.opsForList().rightPush(RedisKeys.GAME_ROUND_RECOVERY_QUEUE, payload);
+    }
+
+    /**
+     * 복구 관련 Redis metric counter를 증가시킨다. metric 증가 실패가 흐름을 막지 않도록 흡수한다.
+     */
+    public void incrementRoundRecoveryMetric(String metricKey) {
+        try {
+            redisTemplate.opsForValue().increment(metricKey);
+        } catch (Exception e) {
+            log.warn("다음 라운드 복구 metric 증가 실패 - metricKey: {}", metricKey, e);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/redis/GameRoundRecoveryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/redis/GameRoundRecoveryRepository.java
@@ -71,6 +71,22 @@ public class GameRoundRecoveryRepository {
     }
 
     /**
+     * 복구 워커의 최상위 보상 경로에서 호출하는 안전 재적재 메서드.
+     *
+     * 복구 워커는 leftPop으로 payload를 큐에서 꺼낸 뒤 처리하므로, 처리 중 예외가 나면 원본 payload가
+     * 유실될 수 있다. 이 메서드는 rightPush 실패까지도 흡수해(보상 경로가 다시 예외로 중단되지 않도록)
+     * 원본 payload를 best-effort로 다시 큐에 넣는다. 재적재마저 실패하면 ALERT 로그와 실패 metric을 남긴다.
+     */
+    public void safeRequeueRoundRecovery(String payload) {
+        try {
+            redisTemplate.opsForList().rightPush(RedisKeys.GAME_ROUND_RECOVERY_QUEUE, payload);
+        } catch (Exception e) {
+            incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+            log.error("[ALERT_REQUIRED] 다음 라운드 복구 payload 안전 재적재 실패 - payload 유실. payload: {}", payload, e);
+        }
+    }
+
+    /**
      * 복구 관련 Redis metric counter를 증가시킨다. metric 증가 실패가 흐름을 막지 않도록 흡수한다.
      */
     public void incrementRoundRecoveryMetric(String metricKey) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -10,9 +10,7 @@ import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
-import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
-import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyPlayerNicknameResolver;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyRealtimeNotifier;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
@@ -41,7 +39,6 @@ public class GameRoundEndService {
     private final StringRedisTemplate redisTemplate;
     private final GameSessionJpaRepository gameSessionJpaRepository;
     private final GameSessionPlayerJpaRepository gameSessionPlayerJpaRepository;
-    private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final MapItemJpaRepository mapItemJpaRepository;
     private final UserSessionRepository userSessionRepository;
     private final GuestSessionRepository guestSessionRepository;
@@ -115,8 +112,8 @@ public class GameRoundEndService {
             scoreAddedMap.put(identifier, scoreAdded);
 
             if (scoreAdded > 0) {
+                // 영속 상태 엔티티의 점수 변경은 Dirty Checking으로 커밋 시 자동 반영된다. (명시적 save 불필요)
                 dbPlayer.addScore(scoreAdded);
-                gameSessionPlayerJpaRepository.save(dbPlayer);
             }
         }
 
@@ -188,15 +185,10 @@ public class GameRoundEndService {
         boolean isLastRound = roundNo >= gameSession.getTotalQuestionCount();
 
         if (isLastRound) {
+            // DB 상태 변경은 Dirty Checking으로 커밋 시 자동 반영된다. (명시적 save 불필요)
             gameSession.finish();
-            gameSessionJpaRepository.save(gameSession);
-
-            GameLobby lobby = gameSession.getLobby();
-            lobby.changeStatus(LobbyStatus.FINISHED);
-            gameLobbyJpaRepository.save(lobby);
-
-            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "FINISHED");
-            redisTemplate.opsForHash().put(RedisKeys.lobbyKey(lobbyCode), "status", "FINISHED");
+            gameSession.getLobby().changeStatus(LobbyStatus.FINISHED);
+            // Redis status=FINISHED 쓰기는 커밋 성공 후(afterCommit)로 미뤄 DB-Redis 불일치를 막는다.
         }
 
         // 8. 트랜잭션 성공 후 STOMP 브로드캐스트 및 스케줄링 등록
@@ -204,32 +196,26 @@ public class GameRoundEndService {
             @Override
             public void afterCommit() {
                 log.info("라운드 종료 트랜잭션 커밋 완료 - Redis 점수 반영 및 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
-                
-                scoreAddedMap.forEach((identifier, scoreAdded) -> {
-                    if (scoreAdded > 0) {
-                        redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
-                    }
-                });
 
-                gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+                /*
+                 * afterCommit의 각 후처리(점수 반영/브로드캐스트/상태전환/다음라운드)는 서로 독립이다.
+                 * 한 단계 실패가 이후 단계를 막지 않도록 단계별로 격리한다.
+                 */
+                syncRedisScoresQuietly(playersKey, scoreAddedMap);
+                notifyRoundEndQuietly(lobbyCode, metadataDto);
 
-                GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
                 if (isLastRound) {
-                    try {
-                        lobbyRealtimeNotifier.notifyLobbyInfoRefresh(lobbyCode, "SYSTEM");
-                    } catch (Exception e) {
-                        log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
-                    }
-
                     /*
-                     * 게임 정상 종료 - 게임 세션 Redis 키를 짧은 TTL(grace period)로 전환한다.
-                     * 점수 반영(HINCRBY) 이후에 호출해야 grace period 동안 최종 점수 조회가 가능하다.
-                     * 최종 점수/랭킹은 DB에 영구 저장되므로 grace period 후 만료되어도 안전하다.
+                     * 게임 정상 종료 - 점수 반영(HINCRBY) 이후 Redis status를 FINISHED로 전환하고
+                     * 짧은 TTL(grace period)로 키를 만료시킨다. 최종 점수/랭킹은 DB에 영구 저장된다.
                      */
+                    finishStatusInRedisQuietly(lobbyCode);
+                    notifyLobbyRefreshQuietly(lobbyCode);
                     gameSessionCleanupService.expireWithGracePeriod(lobbyCode);
-                } else {
-                    progressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                    return;
                 }
+
+                scheduleNextRoundSafely(lobbyCode, roundNo + 1);
             }
 
             @Override
@@ -240,6 +226,57 @@ public class GameRoundEndService {
                 }
             }
         });
+    }
+
+    /** Redis 누적 점수(HINCRBY)를 반영한다. 실패해도 이후 후처리 단계 진행에 영향을 주지 않는다. */
+    private void syncRedisScoresQuietly(String playersKey, Map<String, Integer> scoreAddedMap) {
+        try {
+            scoreAddedMap.forEach((identifier, scoreAdded) -> {
+                if (scoreAdded > 0) {
+                    redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
+                }
+            });
+        } catch (Exception e) {
+            log.error("[MONITORING_REQUIRED] Redis 점수 반영 실패 - playersKey: {}", playersKey, e);
+        }
+    }
+
+    /** 라운드 종료 결과(랭킹/곡 정보)를 브로드캐스트한다. */
+    private void notifyRoundEndQuietly(String lobbyCode, RoundMetadataDto metadataDto) {
+        try {
+            gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+        } catch (Exception e) {
+            log.error("라운드 종료 브로드캐스트 실패 - code: {}", lobbyCode, e);
+        }
+    }
+
+    /** 게임 정상 종료 시 Redis 세션/로비 status를 FINISHED로 전환한다. (커밋 성공 후 수행) */
+    private void finishStatusInRedisQuietly(String lobbyCode) {
+        try {
+            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "FINISHED");
+            redisTemplate.opsForHash().put(RedisKeys.lobbyKey(lobbyCode), "status", "FINISHED");
+        } catch (Exception e) {
+            log.error("[MONITORING_REQUIRED] 게임 종료 Redis status 전환 실패 - code: {}", lobbyCode, e);
+        }
+    }
+
+    /** 게임 종료 후 로비 갱신 알림을 보낸다. */
+    private void notifyLobbyRefreshQuietly(String lobbyCode) {
+        try {
+            lobbyRealtimeNotifier.notifyLobbyInfoRefresh(lobbyCode, "SYSTEM");
+        } catch (Exception e) {
+            log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
+        }
+    }
+
+    /** 다음 라운드 시작을 예약한다. */
+    private void scheduleNextRoundSafely(String lobbyCode, int nextRoundNo) {
+        try {
+            GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
+            progressService.scheduleNextRound(lobbyCode, nextRoundNo);
+        } catch (Exception e) {
+            log.error("[MONITORING_REQUIRED] 다음 라운드 예약 실패 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
+        }
     }
 
     private static class PlayerTemp {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -50,6 +50,7 @@ public class GameRoundEndService {
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
     private final JsonMapper jsonMapper;
     private final ApplicationContext applicationContext;
+    private final GameSessionCleanupService gameSessionCleanupService;
 
     /**
      * 특정 라운드를 종료하고 점수 계산 및 DB/Redis 업데이트를 수행합니다.
@@ -219,6 +220,13 @@ public class GameRoundEndService {
                     } catch (Exception e) {
                         log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
                     }
+
+                    /*
+                     * 게임 정상 종료 - 게임 세션 Redis 키를 짧은 TTL(grace period)로 전환한다.
+                     * 점수 반영(HINCRBY) 이후에 호출해야 grace period 동안 최종 점수 조회가 가능하다.
+                     * 최종 점수/랭킹은 DB에 영구 저장되므로 grace period 후 만료되어도 안전하다.
+                     */
+                    gameSessionCleanupService.expireWithGracePeriod(lobbyCode);
                 } else {
                     progressService.scheduleNextRound(lobbyCode, roundNo + 1);
                 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
@@ -81,13 +81,9 @@ public class GameRoundNextRoundExecutor {
                 return;
             }
 
-            // 4. DB 및 Redis 라운드 갱신
+            // 4. DB 라운드 갱신 (Redis 라운드 상태 갱신은 afterCommit으로 미룬다)
             gameSession.moveToNextRound(nextRoundNo);
             gameSessionJpaRepository.save(gameSession);
-
-            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, String.valueOf(nextRoundNo));
-            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
-            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, "READY");
 
             // 5. 다음 라운드 MapItem 조회
             String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
@@ -120,6 +116,13 @@ public class GameRoundNextRoundExecutor {
                 @Override
                 public void afterCommit() {
                     log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+
+                    // DB 커밋이 확정된 뒤에만 Redis 라운드 상태를 advance한다.
+                    // (커밋 전에 갱신하면 롤백 시 Redis만 다음 라운드로 남아 복구 워커가 ALREADY_PROGRESSED로 오판 → 게임 정지)
+                    redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, String.valueOf(nextRoundNo));
+                    redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
+                    redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, "READY");
+
                     try {
                         gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
                     } catch (Exception e) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
@@ -69,7 +69,7 @@ public class GameRoundNextRoundExecutor {
 
         log.info("다음 라운드 시작 처리 실행 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
 
-        boolean registered = false;
+        boolean lockReleaseHandled = false;
         try {
             // 3. 게임 세션 조회
             GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
@@ -78,6 +78,9 @@ public class GameRoundNextRoundExecutor {
             // DB에서 2차 완료 여부 검증
             if (gameSession.getCurrentRoundNo() >= nextRoundNo) {
                 log.info("다음 라운드가 이미 시작되었습니다. (DB 검증 통과) - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
+                // 동기화 미등록 경로 → afterCompletion이 없으므로 여기서 락 해제
+                redisTemplate.delete(nextRoundLockKey);
+                lockReleaseHandled = true; // finally의 WARN/중복 삭제 건너뜀
                 return;
             }
 
@@ -143,9 +146,9 @@ public class GameRoundNextRoundExecutor {
                     redisTemplate.delete(nextRoundLockKey);
                 }
             });
-            registered = true;
+            lockReleaseHandled = true; // 커밋/롤백 시 afterCompletion이 락을 해제하므로 finally는 건너뜀
         } finally {
-            if (!registered) {
+            if (!lockReleaseHandled) {
                 // 트랜잭션 동기화 등록조차 실패하고 예외 발생 시 예외 안전성 확보를 위한 즉시 해제
                 log.warn("트랜잭션 동기화 등록 실패 - 처리 락 해제. code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
                 redisTemplate.delete(nextRoundLockKey);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
@@ -3,6 +3,7 @@ package io.github.ascrew.monomatbe.domain.game.service;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.repository.redis.GameRoundRecoveryRepository;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
@@ -16,8 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -26,12 +27,22 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 public class GameRoundProgressService {
 
+    /** 라운드 결과 화면 노출 후 다음 라운드 시작까지의 지연(초). */
+    private static final int NEXT_ROUND_DELAY_SECONDS = 10;
+
+    /** 복구 워커가 다음 라운드 진행 여부를 점검하기까지의 추가 여유(초). */
+    private static final int RECOVERY_GRACE_SECONDS = 10;
+
+    /** 다음 라운드 시작 멱등 락 TTL. */
+    private static final Duration NEXT_ROUND_LOCK_TTL = Duration.ofMinutes(5);
+
     private final TaskScheduler taskScheduler;
     private final StringRedisTemplate redisTemplate;
     private final GameSessionJpaRepository gameSessionJpaRepository;
     private final MapItemJpaRepository mapItemJpaRepository;
     private final GameRealtimeNotifier gameRealtimeNotifier;
     private final ApplicationContext applicationContext;
+    private final GameRoundRecoveryRepository gameRoundRecoveryRepository;
 
     /**
      * 라운드 종료 스케줄링을 등록합니다. (재생 시작 시점 기준 1.5초 완충 시간 포함)
@@ -52,10 +63,23 @@ public class GameRoundProgressService {
 
     /**
      * 다음 라운드 시작 스케줄링을 등록합니다. (결과 화면 노출 10초)
+     *
+     * 인메모리 TaskScheduler 예약은 인스턴스 재시작 시 유실되므로, durable 복구 마커와
+     * 복구 큐 적재를 함께 수행해 정지된 라운드를 복구 워커가 재트리거할 수 있게 한다.
      */
     public void scheduleNextRound(String lobbyCode, int nextRoundNo) {
-        log.info("다음 라운드 시작 예약 - code: {}, nextRoundNo: {}, delay: 10s", lobbyCode, nextRoundNo);
-        
+        log.info("다음 라운드 시작 예약 - code: {}, nextRoundNo: {}, delay: {}s", lobbyCode, nextRoundNo, NEXT_ROUND_DELAY_SECONDS);
+
+        long nextRoundStartAt = System.currentTimeMillis() + NEXT_ROUND_DELAY_SECONDS * 1000L;
+
+        // durable 상태 마커: 다음 라운드 시작 예정 시각을 세션 해시에 기록한다. (복구 판별/진단용)
+        markNextRoundStartAtQuietly(lobbyCode, nextRoundStartAt);
+
+        // 인메모리 예약이 유실되어도 진행되도록 durable 복구 요청을 적재한다.
+        // 예약 지연 + grace 이후부터 복구 워커가 점검하도록 nextRetryAt을 설정한다.
+        gameRoundRecoveryRepository.enqueueRoundRecovery(
+                lobbyCode, nextRoundNo, nextRoundStartAt + RECOVERY_GRACE_SECONDS * 1000L);
+
         taskScheduler.schedule(() -> {
             try {
                 GameRoundProgressService self = applicationContext.getBean(GameRoundProgressService.class);
@@ -63,7 +87,19 @@ public class GameRoundProgressService {
             } catch (Exception e) {
                 log.error("다음 라운드 시작 예약 처리 중 예외 발생 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
             }
-        }, Instant.now().plusSeconds(10));
+        }, Instant.now().plusSeconds(NEXT_ROUND_DELAY_SECONDS));
+    }
+
+    /** 다음 라운드 시작 예정 시각 마커를 세션 해시에 best-effort로 기록한다. */
+    private void markNextRoundStartAtQuietly(String lobbyCode, long nextRoundStartAt) {
+        try {
+            redisTemplate.opsForHash().put(
+                    RedisKeys.gameSessionKey(lobbyCode),
+                    RedisKeys.FIELD_NEXT_ROUND_START_AT,
+                    String.valueOf(nextRoundStartAt));
+        } catch (Exception e) {
+            log.warn("다음 라운드 시작 마커 기록 실패 - code: {}", lobbyCode, e);
+        }
     }
 
     /**
@@ -73,16 +109,27 @@ public class GameRoundProgressService {
     public void startNextRound(String lobbyCode, int nextRoundNo) {
         log.info("다음 라운드 시작 처리 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
 
+        /*
+         * 멱등 락: 인메모리 예약과 복구 워커가 동시에 호출해도 한 번만 진행시킨다.
+         * GameSession.nextRound()는 currentRoundNo를 증가시키는 비멱등 연산이므로,
+         * 락 없이 중복 실행되면 라운드를 건너뛰게 된다.
+         */
+        String nextLockKey = RedisKeys.gameSessionRoundNextLockKey(lobbyCode, nextRoundNo);
+        Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(nextLockKey, "1", NEXT_ROUND_LOCK_TTL);
+        if (Boolean.FALSE.equals(lockAcquired)) {
+            log.info("다음 라운드 시작 무시됨 (이미 진행/처리됨) - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+            return;
+        }
+
         // 1. 게임 세션 조회
         GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
                 .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
 
-        // 2. DB 및 Redis 라운드 갱신
+        // 2. DB 및 Redis 라운드 갱신 (DB는 Dirty Checking으로 커밋 시 반영)
         gameSession.nextRound();
-        gameSessionJpaRepository.save(gameSession);
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
-        redisTemplate.opsForHash().put(sessionKey, "current_round_no", String.valueOf(nextRoundNo));
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, String.valueOf(nextRoundNo));
         redisTemplate.opsForHash().put(sessionKey, "status", "READY");
 
         // 3. 다음 라운드 MapItem 조회
@@ -111,7 +158,7 @@ public class GameRoundProgressService {
                 .serverStartedAt(serverStartedAt)
                 .build();
 
-        // 5. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동
+        // 5. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동, 롤백 시 멱등 락 해제
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
@@ -120,6 +167,15 @@ public class GameRoundProgressService {
 
                 GameRoundStartService startService = applicationContext.getBean(GameRoundStartService.class);
                 startService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_ROLLED_BACK) {
+                    // 롤백 시 멱등 락을 해제해야 복구 워커가 다음 라운드를 다시 진행시킬 수 있다.
+                    log.warn("다음 라운드 시작 트랜잭션 롤백 감지 - 멱등 락 해제. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+                    redisTemplate.delete(nextLockKey);
+                }
             }
         });
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
@@ -143,13 +143,21 @@ public class GameRoundProgressService {
             log.warn("다음 라운드 복구 큐 적재 실패 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
         }
 
-        taskScheduler.schedule(() -> {
-            try {
-                gameRoundNextRoundExecutor.startNextRound(lobbyCode, nextRoundNo);
-            } catch (Exception e) {
-                log.error("다음 라운드 시작 예약 처리 중 예외 발생 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
-            }
-        }, Instant.now().plusMillis(delayMillis));
+        // in-memory 예약 등록 실패는 durable 복구 큐 적재 실패와 별도 metric으로 집계한다.
+        // (둘 중 하나라도 살아 있으면 다음 라운드가 진행되도록, 예약 실패가 복구 경로를 막지 않게 한다)
+        try {
+            taskScheduler.schedule(() -> {
+                try {
+                    gameRoundNextRoundExecutor.startNextRound(lobbyCode, nextRoundNo);
+                } catch (Exception e) {
+                    log.error("다음 라운드 시작 예약 처리 중 예외 발생 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
+                }
+            }, Instant.now().plusMillis(delayMillis));
+        } catch (Exception e) {
+            log.error("[MONITORING_REQUIRED] 다음 라운드 in-memory 예약 등록 실패 - durable 복구 큐로 복구 예정. code: {}, nextRoundNo: {}",
+                    lobbyCode, nextRoundNo, e);
+            gameRoundRecoveryRepository.incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_INMEMORY_SCHEDULE_FAILED);
+        }
     }
 
     /** 다음 라운드 시작 예정 시각 마커를 세션 해시에 best-effort로 기록한다. */

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryService.java
@@ -1,0 +1,220 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.repository.redis.GameRoundRecoveryRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * 다음 라운드 진행 정지 복구 서비스.
+ *
+ * [처리 대상]
+ * 다음 라운드 시작은 인메모리 TaskScheduler에 의존하므로, 인스턴스 재시작/afterCommit 중단으로
+ * 예약 태스크가 유실되면 게임이 특정 라운드에서 영구 정지될 수 있다. scheduleNextRound가 적재한
+ * durable 복구 큐를 점검해, 예약 시각이 지났는데도 진행되지 않은 라운드만 재트리거한다.
+ *
+ * [멱등성]
+ * 재트리거는 GameRoundProgressService.startNextRound의 SETNX 멱등 락으로 보호되므로,
+ * 인메모리 예약과 복구가 동시에 동작해도 라운드가 중복 진행/스킵되지 않는다.
+ *
+ * [재시도 정책]
+ * payload에 attempt/nextRetryAtEpochMillis를 포함한다. 아직 점검 시각이 아니면 다시 큐에 넣고,
+ * 실패 시 exponential backoff로 간격을 늘리며 최대 횟수 초과 시 ALERT 로그를 남긴다.
+ *
+ * [payload 형식]
+ * lobbyCode|expectedRoundNo|attempt|nextRetryAtEpochMillis
+ *
+ * LobbyStartReconciliationService와 동일한 큐/backoff/metric 패턴을 따른다.
+ */
+@Slf4j
+@Service
+@Profile("!test")
+@RequiredArgsConstructor
+public class GameRoundRecoveryService {
+
+    private static final String LOG_ALERT_REQUIRED = "[ALERT_REQUIRED]";
+
+    private static final String PAYLOAD_DELIMITER_REGEX = "\\|";
+    private static final String PAYLOAD_DELIMITER = "|";
+    private static final int EXPECTED_PAYLOAD_PARTS = 4;
+
+    private static final long BASE_BACKOFF_MS = 30_000L;
+    private static final long MAX_BACKOFF_MS = 5 * 60_000L;
+    private static final int MAX_RETRY_ATTEMPT = 5;
+
+    private static final String STATUS_FINISHED = "FINISHED";
+
+    private final GameRoundRecoveryRepository gameRoundRecoveryRepository;
+    private final GameRoundProgressService gameRoundProgressService;
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 다음 라운드 진행 정지 복구 큐를 주기적으로 처리한다.
+     */
+    @Scheduled(fixedDelayString = "${monomat.game.round-recovery.fixed-delay-ms:30000}")
+    public void recoverStalledRounds() {
+        String payload = gameRoundRecoveryRepository.pollRoundRecovery();
+
+        if (!StringUtils.hasText(payload)) {
+            return;
+        }
+
+        RecoveryPayload parsed = parsePayload(payload);
+        if (parsed == null) {
+            log.error("{} 다음 라운드 복구 payload 파싱 실패 - payload: {}", LOG_ALERT_REQUIRED, payload);
+            gameRoundRecoveryRepository.incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        if (parsed.nextRetryAtEpochMillis() > now) {
+            // 아직 점검 시각이 아니다(예약 지연 + grace 미경과). 큐 뒤로 보낸다.
+            gameRoundRecoveryRepository.requeueRoundRecovery(payload);
+            return;
+        }
+
+        RoundProgressState state = inspectProgress(parsed.lobbyCode(), parsed.expectedRoundNo());
+
+        if (state != RoundProgressState.STALLED) {
+            // 이미 진행됐거나(세션 정상 진행/종료) 세션이 사라짐 → 복구 불필요. 성공으로 집계하고 드롭한다.
+            gameRoundRecoveryRepository.incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_SUCCESS);
+            log.info("다음 라운드 복구 불필요({}) - code: {}, expectedRoundNo: {}",
+                    state, parsed.lobbyCode(), parsed.expectedRoundNo());
+            return;
+        }
+
+        if (retriggerStartNextRound(parsed.lobbyCode(), parsed.expectedRoundNo())) {
+            gameRoundRecoveryRepository.incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_SUCCESS);
+            log.warn("정지된 다음 라운드 복구 재트리거 완료 - code: {}, expectedRoundNo: {}, attempt: {}",
+                    parsed.lobbyCode(), parsed.expectedRoundNo(), parsed.attempt());
+            return;
+        }
+
+        gameRoundRecoveryRepository.incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+
+        if (parsed.attempt() >= MAX_RETRY_ATTEMPT) {
+            log.error("{} 다음 라운드 복구 최대 횟수 초과 - code: {}, expectedRoundNo: {}, attempt: {}. "
+                            + "수동 확인이 필요합니다.",
+                    LOG_ALERT_REQUIRED, parsed.lobbyCode(), parsed.expectedRoundNo(), parsed.attempt());
+            return;
+        }
+
+        gameRoundRecoveryRepository.requeueRoundRecovery(parsed.nextRetryPayload());
+    }
+
+    /**
+     * 세션 진행 상태를 점검한다.
+     *
+     * <ul>
+     *   <li>세션 해시가 없으면(SESSION_GONE): 정리/만료됨 → 복구 불필요</li>
+     *   <li>status가 FINISHED이거나 current_round_no >= expectedRoundNo(ALREADY_PROGRESSED): 이미 진행됨</li>
+     *   <li>그 외(STALLED): 예약이 유실되어 정지된 상태 → 재트리거 대상</li>
+     * </ul>
+     */
+    private RoundProgressState inspectProgress(String lobbyCode, int expectedRoundNo) {
+        try {
+            String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+            String currentRoundNoStr = (String) redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO);
+
+            if (currentRoundNoStr == null) {
+                return RoundProgressState.SESSION_GONE;
+            }
+
+            String status = (String) redisTemplate.opsForHash().get(sessionKey, "status");
+            if (STATUS_FINISHED.equals(status)) {
+                return RoundProgressState.ALREADY_PROGRESSED;
+            }
+
+            int currentRoundNo = Integer.parseInt(currentRoundNoStr.trim());
+            return currentRoundNo >= expectedRoundNo
+                    ? RoundProgressState.ALREADY_PROGRESSED
+                    : RoundProgressState.STALLED;
+        } catch (Exception e) {
+            // 점검 자체 실패 시 STALLED로 보수적으로 처리해 재시도/백오프 경로를 타게 한다.
+            log.warn("다음 라운드 진행 상태 점검 실패 - code: {}, expectedRoundNo: {}", lobbyCode, expectedRoundNo, e);
+            return RoundProgressState.STALLED;
+        }
+    }
+
+    /**
+     * startNextRound를 재트리거한다. (멱등 락으로 중복 진행 방지)
+     *
+     * @return 예외 없이 처리되면 true, 예외 발생 시 false
+     */
+    private boolean retriggerStartNextRound(String lobbyCode, int expectedRoundNo) {
+        try {
+            gameRoundProgressService.startNextRound(lobbyCode, expectedRoundNo);
+            return true;
+        } catch (Exception e) {
+            log.error("정지된 다음 라운드 복구 재트리거 실패 - code: {}, expectedRoundNo: {}", lobbyCode, expectedRoundNo, e);
+            return false;
+        }
+    }
+
+    private RecoveryPayload parsePayload(String payload) {
+        String[] parts = payload.split(PAYLOAD_DELIMITER_REGEX, EXPECTED_PAYLOAD_PARTS);
+
+        if (parts.length != EXPECTED_PAYLOAD_PARTS
+                || !StringUtils.hasText(parts[0])
+                || !StringUtils.hasText(parts[1])
+                || !StringUtils.hasText(parts[2])
+                || !StringUtils.hasText(parts[3])) {
+            return null;
+        }
+
+        try {
+            return new RecoveryPayload(
+                    parts[0],
+                    Integer.parseInt(parts[1]),
+                    Integer.parseInt(parts[2]),
+                    Long.parseLong(parts[3])
+            );
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private enum RoundProgressState {
+        STALLED,
+        ALREADY_PROGRESSED,
+        SESSION_GONE
+    }
+
+    /**
+     * 다음 라운드 진행 복구 payload.
+     *
+     * @param lobbyCode              로비 초대 코드
+     * @param expectedRoundNo        진행되어야 하는 다음 라운드 번호
+     * @param attempt                현재 재시도 횟수
+     * @param nextRetryAtEpochMillis 다음 점검 가능 시각
+     */
+    private record RecoveryPayload(
+            String lobbyCode,
+            int expectedRoundNo,
+            int attempt,
+            long nextRetryAtEpochMillis
+    ) {
+
+        String nextRetryPayload() {
+            int nextAttempt = attempt + 1;
+            long backoffMs = Math.min(
+                    BASE_BACKOFF_MS * (1L << Math.min(nextAttempt, 4)),
+                    MAX_BACKOFF_MS
+            );
+            long nextRetryAt = System.currentTimeMillis() + backoffMs;
+
+            return String.join(
+                    PAYLOAD_DELIMITER,
+                    lobbyCode,
+                    String.valueOf(expectedRoundNo),
+                    String.valueOf(nextAttempt),
+                    String.valueOf(nextRetryAt)
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryService.java
@@ -69,6 +69,19 @@ public class GameRoundStallRecoveryService {
             return;
         }
 
+        // payload는 이미 leftPop으로 큐에서 제거되었다. 처리 중 어떤 예외가 나도 유실되지 않도록
+        // 최상위에서 보상한다: 실패 metric을 남기고 원본 payload를 안전하게 다시 큐에 넣는다.
+        try {
+            processStalledRound(payload);
+        } catch (Exception e) {
+            log.error("{} 다음 라운드 복구 처리 중 예기치 못한 예외 - 원본 payload 안전 재적재. payload: {}",
+                    LOG_ALERT_REQUIRED, payload, e);
+            gameRoundRecoveryRepository.incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+            gameRoundRecoveryRepository.safeRequeueRoundRecovery(payload);
+        }
+    }
+
+    private void processStalledRound(String payload) {
         RecoveryPayload parsed = parsePayload(payload);
         if (parsed == null) {
             log.error("{} 다음 라운드 복구 payload 파싱 실패 - payload: {}", LOG_ALERT_REQUIRED, payload);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryService.java
@@ -10,6 +10,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
+
 /**
  * 다음 라운드 진행 정지 복구 서비스. (상시 동작 큐 워커)
  *
@@ -122,13 +124,16 @@ public class GameRoundStallRecoveryService {
     private RoundProgressState inspectProgress(String lobbyCode, int expectedRoundNo) {
         try {
             String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
-            String currentRoundNoStr = (String) redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO);
+            // current_round_no와 status를 단일 RTT(HMGET)로 함께 조회한다.
+            List<Object> fields = redisTemplate.opsForHash().multiGet(
+                    sessionKey, List.of(RedisKeys.FIELD_CURRENT_ROUND_NO, RedisKeys.FIELD_STATUS));
+            String currentRoundNoStr = (String) fields.get(0);
 
             if (currentRoundNoStr == null) {
                 return RoundProgressState.SESSION_GONE;
             }
 
-            String status = (String) redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_STATUS);
+            String status = (String) fields.get(1);
             if (STATUS_FINISHED.equals(status)) {
                 return RoundProgressState.ALREADY_PROGRESSED;
             }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupEventHandler.java
@@ -1,0 +1,38 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 로비 폭파 이벤트를 수신하여 게임 세션 Redis 키를 정리하는 핸들러
+ *
+ * [설계 의도]
+ * 로비 폭파는 domain/lobby의 책임이고, 게임 세션 키 정리는 domain/game의 책임이다.
+ * 두 도메인을 직접 결합하지 않기 위해 global의 LobbyClosedEvent로 디커플링한다.
+ * (global/websocket의 PlayerLeaveEvent -> LobbyLeaveEventHandler 패턴과 동일)
+ *
+ * 게임 도중 전원 퇴장으로 로비가 폭파되면 게임 세션 키가 orphan으로 남으므로,
+ * 이 핸들러가 즉시 삭제(deleteNow)한다. 게임 세션이 없으면 안전하게 no-op이다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GameSessionCleanupEventHandler {
+
+    private final GameSessionCleanupService gameSessionCleanupService;
+
+    @EventListener
+    public void handleLobbyClosed(LobbyClosedEvent event) {
+        String lobbyCode = event.lobbyCode();
+        if (!StringUtils.hasText(lobbyCode)) {
+            return;
+        }
+
+        log.info("[handleLobbyClosed] 로비 폭파 감지 - 게임 세션 키 정리 시도. code: {}", lobbyCode);
+        gameSessionCleanupService.deleteNow(lobbyCode);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
@@ -27,6 +27,10 @@ import java.util.List;
  * 모든 게임 세션 키는 생성 시 2시간 TTL을 가지므로 정리 실패는 치명적이지 않다.
  * 정리 실패 시 [MONITORING_REQUIRED] 로그와 실패 metric만 남기고 예외를 전파하지 않으며,
  * 2시간 TTL을 최종 안전망으로 삼는다. (별도 재처리 스케줄러를 두지 않는다)
+ *
+ * [집계 정책]
+ * 스크립트 반환값(처리한 키 수)을 파싱해 성공(>=1) / no-op(0) / 실패(null·파싱불가)를
+ * 구분 집계한다. no-op은 정상 종료(EXPIRE) 경로에서는 이상 신호이므로 별도 metric/로그로 분리한다.
  */
 @Slf4j
 @Service
@@ -81,13 +85,61 @@ public class GameSessionCleanupService {
                     ttlSeconds
             );
 
-            incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS);
-            log.info("게임 세션 Redis 키 정리 완료 - code: {}, mode: {}, processedKeys: {}",
-                    lobbyCode, mode, processed);
+            recordOutcome(lobbyCode, mode, processed);
         } catch (Exception e) {
             incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_FAILED);
             log.error("[MONITORING_REQUIRED] 게임 세션 Redis 키 정리 실패 - 2시간 TTL 자동 만료에 의존. "
                     + "code: {}, mode: {}", lobbyCode, mode, e);
+        }
+    }
+
+    /**
+     * 스크립트 반환값(처리한 키 수)을 파싱해 성공 / no-op / 실패를 구분 집계한다.
+     *
+     * <ul>
+     *   <li>{@code processed >= 1} : 성공 — SUCCESS metric + info 로그</li>
+     *   <li>{@code processed == 0} : 정리 대상 없음(no-op) — NOOP metric.
+     *       EXPIRE(정상 종료)에서는 세션이 이미 사라진 이상 신호이므로 warn, DELETE는 info.</li>
+     *   <li>{@code null}·파싱 불가 : 실패로 간주 — FAILED metric + [MONITORING_REQUIRED] 로그</li>
+     * </ul>
+     */
+    private void recordOutcome(String lobbyCode, String mode, String processed) {
+        Long count = parseProcessed(processed);
+        if (count == null) {
+            incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_FAILED);
+            log.error("[MONITORING_REQUIRED] 게임 세션 Redis 키 정리 반환값 파싱 불가 - 실패로 간주. "
+                    + "code: {}, mode: {}, processed: {}", lobbyCode, mode, processed);
+            return;
+        }
+
+        if (count >= 1) {
+            incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS);
+            log.info("게임 세션 Redis 키 정리 완료 - code: {}, mode: {}, processedKeys: {}",
+                    lobbyCode, mode, count);
+            return;
+        }
+
+        // count == 0 → 정리 대상 키 없음(no-op)
+        incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_NOOP);
+        if (MODE_EXPIRE.equals(mode)) {
+            log.warn("게임 세션 정리 대상 키 없음(no-op) - 정상 종료 경로에서 이상 신호. code: {}", lobbyCode);
+        } else {
+            log.info("게임 세션 정리 대상 키 없음(no-op) - code: {}, mode: {}", lobbyCode, mode);
+        }
+    }
+
+    /**
+     * 스크립트가 반환한 처리 키 수 문자열을 long으로 파싱한다.
+     * null이거나 숫자로 파싱할 수 없으면 null을 반환해 호출부가 실패로 처리하게 한다.
+     */
+    private Long parseProcessed(String processed) {
+        if (processed == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(processed.trim());
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
@@ -87,10 +87,20 @@ public class GameSessionCleanupService {
 
             recordOutcome(lobbyCode, mode, processed);
         } catch (Exception e) {
-            incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_FAILED);
+            incrementMetricQuietly(failedMetricFor(mode));
             log.error("[MONITORING_REQUIRED] 게임 세션 Redis 키 정리 실패 - 2시간 TTL 자동 만료에 의존. "
                     + "code: {}, mode: {}", lobbyCode, mode, e);
         }
+    }
+
+    /**
+     * 정리 모드에 따라 실패 metric 키를 선택한다.
+     * DELETE 실패(orphan 잔존)와 EXPIRE 실패(grace period 누락)는 영향도가 달라 분리 집계한다.
+     */
+    private String failedMetricFor(String mode) {
+        return MODE_DELETE.equals(mode)
+                ? RedisKeys.METRIC_GAME_SESSION_CLEANUP_DELETE_FAILED
+                : RedisKeys.METRIC_GAME_SESSION_CLEANUP_EXPIRE_FAILED;
     }
 
     /**
@@ -106,7 +116,7 @@ public class GameSessionCleanupService {
     private void recordOutcome(String lobbyCode, String mode, String processed) {
         Long count = parseProcessed(processed);
         if (count == null) {
-            incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_FAILED);
+            incrementMetricQuietly(failedMetricFor(mode));
             log.error("[MONITORING_REQUIRED] 게임 세션 Redis 키 정리 반환값 파싱 불가 - 실패로 간주. "
                     + "code: {}, mode: {}, processed: {}", lobbyCode, mode, processed);
             return;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
@@ -1,0 +1,108 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * 게임 세션 Redis 키 정리를 담당하는 서비스
+ *
+ * [책임]
+ * cleanup_game_session.lua를 실행하여 하나의 로비 코드에 속한 모든 게임 세션 키를
+ * 원자적으로 정리한다. (base 3종 + 라운드별 6종)
+ *
+ * [정리 시점]
+ * - 게임 정상 종료      : expireWithGracePeriod() — 300초 짧은 TTL 전환
+ * - 로비 폭파(전원 퇴장) : deleteNow() — 즉시 삭제
+ * - 게임 시작 DB 롤백   : deleteNow() — 즉시 삭제 (보상)
+ *
+ * [실패 정책 — 경량 reconciliation]
+ * 모든 게임 세션 키는 생성 시 2시간 TTL을 가지므로 정리 실패는 치명적이지 않다.
+ * 정리 실패 시 [MONITORING_REQUIRED] 로그와 실패 metric만 남기고 예외를 전파하지 않으며,
+ * 2시간 TTL을 최종 안전망으로 삼는다. (별도 재처리 스케줄러를 두지 않는다)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameSessionCleanupService {
+
+    private static final String MODE_DELETE = "DELETE";
+    private static final String MODE_EXPIRE = "EXPIRE";
+
+    /** 게임 정상 종료 후 클라이언트 재조회를 위한 grace period (초) */
+    private static final int GRACE_PERIOD_SECONDS = 300;
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Qualifier("cleanupGameSessionScript")
+    private final RedisScript<String> cleanupGameSessionScript;
+
+    /**
+     * 게임 정상 종료 시 게임 세션 키를 짧은 TTL(grace period)로 전환한다.
+     *
+     * 최종 점수/랭킹은 DB에 영구 저장되므로, Redis 키는 종료 직후 재조회 여유만 두고 만료된다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     */
+    public void expireWithGracePeriod(String lobbyCode) {
+        cleanup(lobbyCode, MODE_EXPIRE, String.valueOf(GRACE_PERIOD_SECONDS));
+    }
+
+    /**
+     * 게임 세션 키를 즉시 삭제한다. (로비 폭파 / 게임 시작 DB 롤백 보상)
+     *
+     * 게임 세션 키가 없으면 Lua가 안전하게 no-op 처리한다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     */
+    public void deleteNow(String lobbyCode) {
+        cleanup(lobbyCode, MODE_DELETE, "0");
+    }
+
+    private void cleanup(String lobbyCode, String mode, String ttlSeconds) {
+        if (!StringUtils.hasText(lobbyCode)) {
+            return;
+        }
+
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+
+        try {
+            String processed = stringRedisTemplate.execute(
+                    cleanupGameSessionScript,
+                    List.of(sessionKey),
+                    mode,
+                    ttlSeconds
+            );
+
+            incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS);
+            log.info("게임 세션 Redis 키 정리 완료 - code: {}, mode: {}, processedKeys: {}",
+                    lobbyCode, mode, processed);
+        } catch (Exception e) {
+            incrementMetricQuietly(RedisKeys.METRIC_GAME_SESSION_CLEANUP_FAILED);
+            log.error("[MONITORING_REQUIRED] 게임 세션 Redis 키 정리 실패 - 2시간 TTL 자동 만료에 의존. "
+                    + "code: {}, mode: {}", lobbyCode, mode, e);
+        }
+    }
+
+    /**
+     * 메트릭 카운터를 증가시키되, 실패 시에도 예외를 전파하지 않는다.
+     *
+     * 정리 실패의 주요 원인은 Redis 장애인데, 같은 Redis로 메트릭을 증가시키면
+     * 동일한 예외가 다시 발생한다. 이 메서드는 cleanup()의 "예외 미전파" 보장을 지키기 위해
+     * 메트릭 증가 자체의 실패를 흡수한다. (2시간 TTL이 최종 안전망)
+     */
+    private void incrementMetricQuietly(String metricKey) {
+        try {
+            stringRedisTemplate.opsForValue().increment(metricKey);
+        } catch (Exception e) {
+            log.warn("게임 세션 정리 메트릭 증가 실패 - metricKey: {}", metricKey, e);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -50,6 +50,7 @@ public class GameSessionCreateService {
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<String> initGameSessionScript;
     private final JsonMapper jsonMapper;
+    private final GameSessionCleanupService gameSessionCleanupService;
 
     /**
      * 로비 게임 시작 시 호출되어 게임 세션을 초기화한다.
@@ -170,11 +171,11 @@ public class GameSessionCreateService {
             public void afterCompletion(int status) {
                 if (status == STATUS_ROLLED_BACK) {
                     log.warn("DB 트랜잭션 롤백 감지 - Redis 세션 잔여 데이터 정리. code: {}", code);
-                    redisTemplate.delete(List.of(sessionKey, roundsKey, playersKey));
-                    for (int i = 1; i <= lobby.getQuestionCount(); i++) {
-                        redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(code, i));
-                        redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(code, i));
-                    }
+                    /*
+                     * 통합 정리 스크립트로 base 3종 + 라운드별 6종 키를 원자적으로 삭제한다.
+                     * (기존 개별 delete는 ready/playback_lock/correct_times/ended_lock 등을 누락할 수 있었다)
+                     */
+                    gameSessionCleanupService.deleteNow(code);
                 }
             }
         });

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -5,6 +5,7 @@ import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
+import io.github.ascrew.monomatbe.domain.game.config.GameSessionProperties;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
 import io.github.ascrew.monomatbe.domain.game.exception.GameSessionAlreadyExistsException;
@@ -16,6 +17,8 @@ import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
@@ -25,8 +28,12 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 import io.github.ascrew.monomatbe.domain.map.support.AnswerNormalizer;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -51,6 +58,7 @@ public class GameSessionCreateService {
     private final RedisScript<String> initGameSessionScript;
     private final JsonMapper jsonMapper;
     private final GameSessionCleanupService gameSessionCleanupService;
+    private final GameSessionProperties gameSessionProperties;
 
     /**
      * 로비 게임 시작 시 호출되어 게임 세션을 초기화한다.
@@ -71,14 +79,22 @@ public class GameSessionCreateService {
         }
 
         long serverStartedAt = System.currentTimeMillis();
-        java.time.LocalDateTime startedAt = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(serverStartedAt), java.time.ZoneId.systemDefault());
+        // WAS OS 로컬 타임존 의존을 피하기 위해 UTC로 고정한다. (코드베이스 타임스탬프 관례와 일치)
+        LocalDateTime startedAt = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(serverStartedAt), ZoneOffset.UTC);
 
-        // 0. 기존 미종료 활성 세션 정리 (정체 방지)
+        // 0. 기존 미종료 활성 세션 처리: 기본은 차단, 정체(stale)된 세션만 복구한다.
         gameSessionJpaRepository.findActiveSessionByLobbyCode(code)
-                .ifPresent(oldSession -> {
-                    log.warn("미종료된 이전 게임 세션 발견 - 강제 FINISHED 처리. code: {}, oldSessionId: {}", code, oldSession.getId());
-                    oldSession.finish();
-                    gameSessionJpaRepository.save(oldSession);
+                .ifPresent(activeSession -> {
+                    if (activeSession.isStale(startedAt, gameSessionProperties.getStaleThreshold())) {
+                        log.warn("정체(stale) 게임 세션 복구 후 재시작 허용 - code: {}, oldSessionId: {}, startedAt: {}",
+                                code, activeSession.getId(), activeSession.getStartedAt());
+                        activeSession.finish();
+                        // Redis 잔존 세션 키를 즉시 제거해 이후 init Lua의 ERROR_ALREADY_EXISTS를 방지한다.
+                        gameSessionCleanupService.deleteNow(code);
+                    } else {
+                        // 실제 진행 중인 게임을 중복 시작 요청으로부터 보호한다.
+                        throw new GameSessionAlreadyExistsException("이미 진행 중인 게임 세션이 있습니다.");
+                    }
                 });
 
         // 2. DB 세션 생성
@@ -136,14 +152,14 @@ public class GameSessionCreateService {
             throw new IllegalStateException("게임 세션 Redis 초기화 실패: " + result);
         }
 
-        // 4-1. 라운드별 문제 데이터 Redis 캐싱
+        // 4-1. 라운드별 문제 데이터 캐싱 데이터 구성 (JSON 정규화는 파이프라인 밖에서 수행)
+        List<RoundCacheEntry> roundCacheEntries = new ArrayList<>();
         for (int i = 0; i < selectedItems.size(); i++) {
             MapItem item = selectedItems.get(i);
             int roundNo = i + 1;
-            String roundDataKey = RedisKeys.gameSessionRoundDataKey(code, roundNo);
-            java.util.Map<String, String> roundData = new java.util.HashMap<>();
+            Map<String, String> roundData = new java.util.HashMap<>();
             roundData.put("answers", item.getAnswers());
-            
+
             // 정규화된 정답 목록 캐싱 추가
             try {
                 List<String> rawAnswers = jsonMapper.readValue(item.getAnswers(), new TypeReference<List<String>>() {});
@@ -159,9 +175,18 @@ public class GameSessionCreateService {
 
             roundData.put("title", item.getTitle() == null ? "" : item.getTitle());
             roundData.put("artist", item.getArtist() == null ? "" : item.getArtist());
-            redisTemplate.opsForHash().putAll(roundDataKey, roundData);
-            redisTemplate.expire(roundDataKey, java.time.Duration.ofSeconds(7200));
+            roundCacheEntries.add(new RoundCacheEntry(RedisKeys.gameSessionRoundDataKey(code, roundNo), roundData));
         }
+
+        // putAll + expire를 단일 파이프라인으로 일괄 전송해 라운드당 2 RTT 누적(N라운드 = 2N RTT)을 줄인다.
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            StringRedisConnection stringConnection = (StringRedisConnection) connection;
+            for (RoundCacheEntry entry : roundCacheEntries) {
+                stringConnection.hMSet(entry.key(), entry.data());
+                stringConnection.expire(entry.key(), 7200L);
+            }
+            return null;
+        });
 
         log.info("게임 세션 생성 완료 - 로비 코드: {}, 문제 갯수: {}, 참여자 수: {}",
                  code, lobby.getQuestionCount(), participantIdentifiers.size());
@@ -192,5 +217,9 @@ public class GameSessionCreateService {
                 .roundNo(1)
                 .serverStartedAt(serverStartedAt)
                 .build();
+    }
+
+    /** 라운드별 문제 데이터 캐싱을 파이프라인으로 일괄 전송하기 위한 (키, 해시 필드) 묶음. */
+    private record RoundCacheEntry(String key, Map<String, String> data) {
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepository.java
@@ -156,6 +156,13 @@ public interface LobbyRepository {
   void requeueStartReconciliation(String payload);
 
   /**
+   * 워커의 최상위 보상 경로용 안전 재적재. 재적재 실패까지 흡수해 payload 유실만 막는다.
+   *
+   * @param payload 재처리 payload
+   */
+  void safeRequeueStartReconciliation(String payload);
+
+  /**
    * 게임 시작 상태 재처리 metric counter를 증가시킨다.
    *
    * @param metricKey Redis metric key

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyRepositoryImpl.java
@@ -377,6 +377,11 @@ public class LobbyRepositoryImpl implements LobbyRepository {
   }
 
   @Override
+  public void safeRequeueStartReconciliation(String payload) {
+    lobbyStartReconciliationRepository.safeRequeueStartReconciliation(payload);
+  }
+
+  @Override
   public void incrementStartReconciliationMetric(String metricKey) {
     lobbyStartReconciliationRepository.incrementStartReconciliationMetric(metricKey);
   }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyStartReconciliationRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyStartReconciliationRepository.java
@@ -128,6 +128,27 @@ public class LobbyStartReconciliationRepository {
     }
 
     /**
+     * 재처리 워커의 최상위 보상 경로에서 호출하는 안전 재적재 메서드.
+     *
+     * 워커는 leftPop으로 payload를 큐에서 꺼낸 뒤 처리하므로, 처리 중 예외가 나면 원본 payload가
+     * 유실될 수 있다. 이 메서드는 rightPush 실패까지도 흡수해(보상 경로가 다시 예외로 중단되지 않도록)
+     * 원본 payload를 best-effort로 다시 큐에 넣는다. 재적재마저 실패하면 ALERT 로그와 실패 metric을 남긴다.
+     *
+     * @param payload 재처리 payload
+     */
+    public void safeRequeueStartReconciliation(String payload) {
+        try {
+            redisTemplate.opsForList().rightPush(
+                    RedisKeys.LOBBY_START_RECONCILIATION_QUEUE,
+                    payload
+            );
+        } catch (Exception e) {
+            incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED);
+            log.error("[ALERT_REQUIRED] 게임 시작 상태 재처리 payload 안전 재적재 실패 - payload 유실. payload: {}", payload, e);
+        }
+    }
+
+    /**
      * 게임 시작 상태 재처리 관련 Redis metric counter를 증가시킨다.
      *
      * [정책]

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
@@ -60,13 +60,26 @@ public class LobbyLeaveEventHandler {
         switch (result) {
             case LeaveLobbyResult.Destroyed destroyed -> {
                 log.info("[handlePlayerLeave] 로비 폭파 - 로비: {}", destroyed.lobbyCode());
-                lobbyRealtimeNotifier.notifyLobbyListRefresh();
 
                 /*
                  * 게임 도중 전원 퇴장으로 로비가 폭파되면 게임 세션 Redis 키가 orphan으로 남는다.
                  * 도메인 간 직접 결합을 피하기 위해 LobbyClosedEvent로 game 도메인에 정리를 위임한다.
+                 *
+                 * [순서·격리] 내부 정합성(세션 정리) 이벤트를 실시간 STOMP 브로드캐스트보다 먼저 발행하고,
+                 * 브로드캐스트는 try-catch로 격리한다. STOMP 전송 실패가 정리 이벤트 발행을 막아
+                 * Redis에 orphan 세션 키가 영구 잔존하는 것을 방지한다.
                  */
                 eventPublisher.publishEvent(new LobbyClosedEvent(destroyed.lobbyCode()));
+
+                try {
+                    lobbyRealtimeNotifier.notifyLobbyListRefresh();
+                } catch (Exception e) {
+                    log.warn(
+                            "[handlePlayerLeave] 로비 폭파 목록 갱신 알림 실패 - 로비: {}",
+                            destroyed.lobbyCode(),
+                            e
+                    );
+                }
             }
 
             case LeaveLobbyResult.Delegated delegated -> {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
@@ -19,9 +19,11 @@ package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -33,6 +35,7 @@ public class LobbyLeaveEventHandler {
 
     private final LobbyRepository lobbyRepository;
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 플레이어 퇴장 이벤트를 수신하여 퇴장 처리를 수행한다.
@@ -58,6 +61,12 @@ public class LobbyLeaveEventHandler {
             case LeaveLobbyResult.Destroyed destroyed -> {
                 log.info("[handlePlayerLeave] 로비 폭파 - 로비: {}", destroyed.lobbyCode());
                 lobbyRealtimeNotifier.notifyLobbyListRefresh();
+
+                /*
+                 * 게임 도중 전원 퇴장으로 로비가 폭파되면 게임 세션 Redis 키가 orphan으로 남는다.
+                 * 도메인 간 직접 결합을 피하기 위해 LobbyClosedEvent로 game 도메인에 정리를 위임한다.
+                 */
+                eventPublisher.publishEvent(new LobbyClosedEvent(destroyed.lobbyCode()));
             }
 
             case LeaveLobbyResult.Delegated delegated -> {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationService.java
@@ -73,6 +73,25 @@ public class LobbyStartReconciliationService {
             return;
         }
 
+        // payload는 이미 leftPop으로 큐에서 제거되었다. 처리 중 어떤 예외가 나도 유실되지 않도록
+        // 최상위에서 보상한다: 실패 metric을 남기고 원본 payload를 안전하게 다시 큐에 넣는다.
+        try {
+            processReconciliation(payload);
+        } catch (Exception e) {
+            log.error(
+                    "{} 게임 시작 상태 재처리 중 예기치 못한 예외 - 원본 payload 안전 재적재. payload: {}",
+                    LOG_ALERT_REQUIRED,
+                    payload,
+                    e
+            );
+            lobbyRepository.incrementStartReconciliationMetric(
+                    RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED
+            );
+            lobbyRepository.safeRequeueStartReconciliation(payload);
+        }
+    }
+
+    private void processReconciliation(String payload) {
         ReconciliationPayload parsedPayload = parsePayload(payload);
 
         if (parsedPayload == null) {

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -162,4 +162,20 @@ public class RedisScriptConfig {
         redisScript.setResultType(String.class);
         return redisScript;
     }
+
+    /**
+     * 게임 세션 Redis 키 통합 정리 Lua 스크립트
+     *
+     * [처리 내용]
+     * - game:session:{code}* 의 base 3종 + 라운드별 6종 키를 원자적으로 정리
+     * - DELETE 모드: 즉시 삭제 (로비 폭파 / 게임 시작 DB 롤백 보상)
+     * - EXPIRE 모드: 존재하는 키만 짧은 TTL로 전환 (게임 정상 종료 후 grace period)
+     */
+    @Bean
+    public RedisScript<String> cleanupGameSessionScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setLocation(new ClassPathResource("scripts/cleanup_game_session.lua"));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -412,6 +412,14 @@ public final class RedisKeys {
     public static final String METRIC_START_LOBBY_UNKNOWN_RESULT =
             "metric:lobby:start:unknown-result";
 
+    /** 게임 세션 Redis 키 정리 성공 횟수 metric counter */
+    public static final String METRIC_GAME_SESSION_CLEANUP_SUCCESS =
+            "metric:game:session:cleanup:success";
+
+    /** 게임 세션 Redis 키 정리 실패 횟수 metric counter (2시간 TTL이 최종 안전망) */
+    public static final String METRIC_GAME_SESSION_CLEANUP_FAILED =
+            "metric:game:session:cleanup:failed";
+
     /** 게임 시작 전 stale ready 데이터 정리 횟수 */
     public static final String METRIC_LOBBY_READY_STALE_CLEANUP =
             "metric:lobby:ready:stale-cleanup";

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -416,13 +416,49 @@ public final class RedisKeys {
     public static final String METRIC_GAME_SESSION_CLEANUP_SUCCESS =
             "metric:game:session:cleanup:success";
 
-    /** 게임 세션 Redis 키 정리 실패 횟수 metric counter (2시간 TTL이 최종 안전망) */
-    public static final String METRIC_GAME_SESSION_CLEANUP_FAILED =
-            "metric:game:session:cleanup:failed";
+    /**
+     * 게임 세션 Redis 키 즉시 삭제(DELETE) 실패 횟수 metric counter.
+     * DELETE 실패는 orphan 키 잔존(로비 폭파/롤백 보상 누락)을 의미해 EXPIRE 실패와 영향도가 다르다.
+     * (2시간 TTL이 최종 안전망)
+     */
+    public static final String METRIC_GAME_SESSION_CLEANUP_DELETE_FAILED =
+            "metric:game:session:cleanup:delete-failed";
+
+    /**
+     * 게임 세션 Redis 키 TTL 전환(EXPIRE) 실패 횟수 metric counter.
+     * EXPIRE 실패는 정상 종료 후 grace period 전환 누락을 의미한다. (2시간 TTL이 최종 안전망)
+     */
+    public static final String METRIC_GAME_SESSION_CLEANUP_EXPIRE_FAILED =
+            "metric:game:session:cleanup:expire-failed";
 
     /** 게임 세션 Redis 키 정리 no-op(정리 대상 키 없음) 횟수 metric counter */
     public static final String METRIC_GAME_SESSION_CLEANUP_NOOP =
             "metric:game:session:cleanup:noop";
+
+    /**
+     * 다음 라운드 진행 정지 복구 재처리 큐.
+     *
+     * 다음 라운드 시작은 인메모리 TaskScheduler에 의존하므로 인스턴스 재시작/afterCommit 중단 시
+     * 영구 정지될 수 있다. scheduleNextRound 시 durable 복구 요청을 적재해 두고, 복구 워커가
+     * 실제 라운드 진행 여부를 확인해 미진행분만 재트리거한다.
+     *
+     * - Type  : List
+     * - Value : "lobbyCode|expectedRoundNo|attempt|nextRetryAtEpochMillis"
+     */
+    public static final String GAME_ROUND_RECOVERY_QUEUE =
+            "game:round:recovery";
+
+    /** 다음 라운드 진행 복구 큐 적재 횟수 metric counter */
+    public static final String METRIC_GAME_ROUND_RECOVERY_ENQUEUED =
+            "metric:game:round:recovery:enqueued";
+
+    /** 다음 라운드 진행 복구 성공(재트리거 또는 이미 진행 확인) 횟수 metric counter */
+    public static final String METRIC_GAME_ROUND_RECOVERY_SUCCESS =
+            "metric:game:round:recovery:success";
+
+    /** 다음 라운드 진행 복구 실패 횟수 metric counter */
+    public static final String METRIC_GAME_ROUND_RECOVERY_FAILED =
+            "metric:game:round:recovery:failed";
 
     /** 게임 시작 전 stale ready 데이터 정리 횟수 */
     public static final String METRIC_LOBBY_READY_STALE_CLEANUP =

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -460,6 +460,10 @@ public final class RedisKeys {
     public static final String METRIC_GAME_ROUND_RECOVERY_FAILED =
             "metric:game:round:recovery:failed";
 
+    /** 다음 라운드 in-memory TaskScheduler 예약 등록 실패 횟수 metric counter (durable 복구 큐와 분리 집계) */
+    public static final String METRIC_GAME_ROUND_INMEMORY_SCHEDULE_FAILED =
+            "metric:game:round:inmemory-schedule:failed";
+
     /** 게임 시작 전 stale ready 데이터 정리 횟수 */
     public static final String METRIC_LOBBY_READY_STALE_CLEANUP =
             "metric:lobby:ready:stale-cleanup";

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -420,6 +420,10 @@ public final class RedisKeys {
     public static final String METRIC_GAME_SESSION_CLEANUP_FAILED =
             "metric:game:session:cleanup:failed";
 
+    /** 게임 세션 Redis 키 정리 no-op(정리 대상 키 없음) 횟수 metric counter */
+    public static final String METRIC_GAME_SESSION_CLEANUP_NOOP =
+            "metric:game:session:cleanup:noop";
+
     /** 게임 시작 전 stale ready 데이터 정리 횟수 */
     public static final String METRIC_LOBBY_READY_STALE_CLEANUP =
             "metric:lobby:ready:stale-cleanup";

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -724,6 +724,39 @@ public final class RedisKeys {
 
     private static final String GAME_SESSION_PREFIX = "game:session:";
 
+    // --- 게임 세션 진행 상태 마커 (game:session:{code} Hash 내부 필드명) ---
+    // 비정상 종료 복구 진단/판별을 위해 진행 단계를 durable하게 기록한다.
+
+    /** 다음 라운드 시작 예정 시각(epoch millis). 정지 라운드 복구 판별/진단에 사용한다. */
+    public static final String FIELD_NEXT_ROUND_START_AT = "next_round_start_at";
+
+    /** 직전 라운드 종료 브로드캐스트 완료 라운드 번호. */
+    public static final String FIELD_ROUND_END_BROADCASTED = "round_end_broadcasted";
+
+    /** Redis 점수 반영(score sync) 완료 라운드 번호. */
+    public static final String FIELD_SCORE_SYNCED = "score_synced";
+
+    /** 게임 세션 현재 라운드 번호 필드. */
+    public static final String FIELD_CURRENT_ROUND_NO = "current_round_no";
+
+    /**
+     * 게임 세션 키의 base 부분을 반환합니다. ({lobbyCode} hash-tag 적용)
+     *
+     * [Redis Cluster 대비 hash-tag]
+     * cleanup_game_session.lua 등은 하나의 게임 세션에 속한 다수의 키를 단일 Lua로 다룬다.
+     * Redis Cluster는 키 문자열 전체를 해싱하므로 hash-tag가 없으면 같은 게임 세션의 키들이
+     * 서로 다른 슬롯에 분산되어 CROSSSLOT 오류가 발생한다. lobbyCode를 중괄호로 감싸 해시 슬롯
+     * 결정 대상을 lobbyCode로 한정함으로써, game:session 패밀리의 모든 키가 동일 슬롯에 모이게 한다.
+     *
+     * [한계]
+     * ready_to_play.lua는 game:session 키와 lobby:{code}:participants 키를 함께 사용한다.
+     * 완전한 클러스터 안전을 위해선 lobby 패밀리에도 동일한 {code} hash-tag가 필요하며,
+     * 이는 blast radius가 커 별도 후속 작업으로 분리한다. (현 단계는 game:session 패밀리 한정)
+     */
+    private static String gameSessionBase(String lobbyCode) {
+        return GAME_SESSION_PREFIX + "{" + lobbyCode + "}";
+    }
+
     /**
      * 게임 세션 메타데이터 키를 반환합니다.
      *
@@ -731,7 +764,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}"
      */
     public static String gameSessionKey(String lobbyCode) {
-        return GAME_SESSION_PREFIX + lobbyCode;
+        return gameSessionBase(lobbyCode);
     }
 
     /**
@@ -741,7 +774,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:rounds"
      */
     public static String gameSessionRoundsKey(String lobbyCode) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":rounds";
+        return gameSessionBase(lobbyCode) + ":rounds";
     }
 
     /**
@@ -751,7 +784,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:players"
      */
     public static String gameSessionPlayersKey(String lobbyCode) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":players";
+        return gameSessionBase(lobbyCode) + ":players";
     }
 
     /**
@@ -762,7 +795,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:round:{roundNo}:ready"
      */
     public static String gameSessionRoundReadyKey(String lobbyCode, int roundNo) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":ready";
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":ready";
     }
 
     /**
@@ -773,7 +806,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:round:{roundNo}:playback_lock"
      */
     public static String gameSessionPlaybackLockKey(String lobbyCode, int roundNo) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":playback_lock";
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":playback_lock";
     }
 
     /**
@@ -784,7 +817,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:round:{roundNo}:data"
      */
     public static String gameSessionRoundDataKey(String lobbyCode, int roundNo) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":data";
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":data";
     }
 
     /**
@@ -795,7 +828,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:round:{roundNo}:correct_players"
      */
     public static String gameSessionRoundCorrectPlayersKey(String lobbyCode, int roundNo) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":correct_players";
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":correct_players";
     }
 
     /**
@@ -816,7 +849,7 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:round:{roundNo}:correct_times"
      */
     public static String gameSessionRoundCorrectTimesKey(String lobbyCode, int roundNo) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":correct_times";
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":correct_times";
     }
 
     /**
@@ -827,6 +860,20 @@ public final class RedisKeys {
      * @return "game:session:{lobbyCode}:round:{roundNo}:ended_lock"
      */
     public static String gameSessionRoundEndedLockKey(String lobbyCode, int roundNo) {
-        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":ended_lock";
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":ended_lock";
+    }
+
+    /**
+     * 다음 라운드 시작 중복 방지 SETNX 락 키를 반환합니다.
+     *
+     * 인메모리 TaskScheduler 예약과 복구 워커가 동시에 startNextRound를 호출해도
+     * (GameSession.nextRound()가 비멱등이라 라운드를 건너뛰지 않도록) 한 번만 진행시키기 위한 락이다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 시작할 다음 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:next_round_lock"
+     */
+    public static String gameSessionRoundNextLockKey(String lobbyCode, int roundNo) {
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":next_round_lock";
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/event/LobbyClosedEvent.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/event/LobbyClosedEvent.java
@@ -1,0 +1,19 @@
+package io.github.ascrew.monomatbe.global.event;
+
+/**
+ * 로비가 폭파(마지막 유저 퇴장으로 완전 삭제)되었을 때 발행되는 이벤트.
+ *
+ * [위치 선정 이유 — global/event]
+ * 발행자는 domain/lobby(LobbyLeaveEventHandler), 수신자는 domain/game이다.
+ * 이벤트 객체를 어느 한 도메인에 두면 다른 도메인이 그 도메인에 직접 의존하게 되어
+ * 도메인 간 결합이 생긴다. 따라서 global에 위치시켜 domain -> global 단방향 의존을 유지한다.
+ *
+ * [용도]
+ * 게임 도중 전원이 퇴장해 로비가 폭파되면, 게임 세션 Redis 키가 orphan으로 남는다.
+ * domain/game의 핸들러가 이 이벤트를 수신해 해당 로비의 게임 세션 키를 정리한다.
+ *
+ * @param lobbyCode 폭파된 로비의 초대 코드
+ */
+public record LobbyClosedEvent(
+        String lobbyCode
+) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,10 @@ report.policy.auto-private-enabled=${REPORT_POLICY_AUTO_PRIVATE_ENABLED:false}
 # 여러 명은 콤마로 구분한다. 예: 1,2
 monomat.admin.user-ids=${MONOMAT_ADMIN_USER_IDS:}
 
+# 게임 세션 정체(stale) 판별 임계 기간.
+# 새 게임 시작 시 동일 로비의 미종료 active 세션이 이 기간을 넘겼으면 비정상 정체로 보고 복구(강제 종료)한다.
+monomat.game.session.stale-threshold=${GAME_SESSION_STALE_THRESHOLD:30m}
+
 # Flyway: 모든 스키마 변경은 src/main/resources/db/migration 의 Vn__*.sql 로만 관리.
 # baseline-on-migrate=true: 기존 운영/dev DB(이미 ddl-auto/수동 ALTER 로 만들어진 스키마)에 처음 적용될 때
 #   schema_history 테이블만 생성하고 baseline-version까지를 실행 없이 baseline 으로 마킹한다.

--- a/src/main/resources/scripts/cleanup_game_session.lua
+++ b/src/main/resources/scripts/cleanup_game_session.lua
@@ -1,0 +1,72 @@
+-- ============================================================================
+-- 게임 세션 Redis 키 통합 정리 스크립트
+--
+-- [책임]
+-- 하나의 로비 코드에 속한 모든 game:session:{code}* 키를 원자적으로 정리한다.
+--   - base 키 3종      : game:session:{code}, :rounds, :players
+--   - 라운드별 키 6종   : :round:{n}:ready, :playback_lock, :data,
+--                        :correct_players, :correct_times, :ended_lock
+--
+-- [정리 모드]
+--   - DELETE : 모든 키 즉시 삭제 (로비 폭파 / 게임 시작 DB 롤백 보상)
+--   - EXPIRE : 존재하는 키만 짧은 TTL로 전환 (게임 정상 종료 후 grace period)
+--
+-- [라운드 수 판별]
+--   game:session:{code} 해시의 total_question_count 필드를 우선 사용하고,
+--   없으면 :rounds 리스트 길이(LLEN)로 폴백한다. 둘 다 없으면 0(no-op).
+--
+-- [SCAN 미사용]
+--   운영 중 SCAN/KEYS 패턴 매칭은 비용·블로킹 위험이 있어 사용하지 않는다.
+--   대신 sessionKey 문자열로부터 모든 하위 키 이름을 결정적으로 조립한다.
+--
+-- [전제: 단일(standalone) Redis]
+--   라운드별 키는 KEYS로 선언하지 않고 sessionKey에서 조립해 직접 접근한다.
+--   모든 키가 동일 prefix를 공유하지만 hash-tag가 없으므로 Redis Cluster에서는
+--   슬롯이 분산될 수 있다. 본 프로젝트는 단일 Redis를 사용한다는 전제이며,
+--   클러스터 도입 시 {code} hash-tag 적용이 필요하다.
+-- ============================================================================
+
+local sessionKey = KEYS[1]
+
+local mode = ARGV[1]            -- "DELETE" | "EXPIRE"
+local ttlSeconds = tonumber(ARGV[2])
+
+local roundsKey  = sessionKey .. ':rounds'
+local playersKey = sessionKey .. ':players'
+
+-- 라운드 수 판별: total_question_count 우선, 없으면 LLEN(:rounds) 폴백
+local totalRounds = tonumber(redis.call('HGET', sessionKey, 'total_question_count'))
+if totalRounds == nil then
+    totalRounds = redis.call('LLEN', roundsKey)
+end
+if totalRounds == nil then
+    totalRounds = 0
+end
+
+-- 정리 대상 키 수집 (base 3종 + 라운드별 6종)
+local keys = { sessionKey, roundsKey, playersKey }
+local roundSuffixes = { ':ready', ':playback_lock', ':data', ':correct_players', ':correct_times', ':ended_lock' }
+for n = 1, totalRounds do
+    local roundBase = sessionKey .. ':round:' .. n
+    for _, suffix in ipairs(roundSuffixes) do
+        table.insert(keys, roundBase .. suffix)
+    end
+end
+
+local processed = 0
+
+if mode == 'DELETE' then
+    for _, key in ipairs(keys) do
+        processed = processed + redis.call('DEL', key)
+    end
+else
+    -- EXPIRE: 존재하는 키에만 TTL 전환
+    for _, key in ipairs(keys) do
+        if redis.call('EXISTS', key) == 1 then
+            redis.call('EXPIRE', key, ttlSeconds)
+            processed = processed + 1
+        end
+    end
+end
+
+return tostring(processed)

--- a/src/main/resources/scripts/cleanup_game_session.lua
+++ b/src/main/resources/scripts/cleanup_game_session.lua
@@ -21,11 +21,11 @@
 --   운영 중 SCAN/KEYS 패턴 매칭은 비용·블로킹 위험이 있어 사용하지 않는다.
 --   대신 sessionKey 문자열로부터 모든 하위 키 이름을 결정적으로 조립한다.
 --
--- [전제: 단일(standalone) Redis]
---   라운드별 키는 KEYS로 선언하지 않고 sessionKey에서 조립해 직접 접근한다.
---   모든 키가 동일 prefix를 공유하지만 hash-tag가 없으므로 Redis Cluster에서는
---   슬롯이 분산될 수 있다. 본 프로젝트는 단일 Redis를 사용한다는 전제이며,
---   클러스터 도입 시 {code} hash-tag 적용이 필요하다.
+-- [Redis Cluster / hash-tag]
+--   라운드별 키는 KEYS로 선언하지 않고 sessionKey(KEYS[1])에서 조립해 직접 접근한다.
+--   sessionKey는 game:session:{code} 형태로 {code} hash-tag가 적용되어 있어(RedisKeys.gameSessionKey),
+--   여기서 조립되는 모든 하위 키도 동일 hash-tag를 상속한다 → 클러스터에서도 같은 슬롯에 모인다.
+--   (참고: lobby 패밀리 키 hash-tag는 별도 후속 작업이며 ready_to_play.lua의 cross-family 한계는 남아 있다)
 -- ============================================================================
 
 local sessionKey = KEYS[1]

--- a/src/main/resources/scripts/cleanup_game_session.lua
+++ b/src/main/resources/scripts/cleanup_game_session.lua
@@ -10,6 +10,8 @@
 -- [정리 모드]
 --   - DELETE : 모든 키 즉시 삭제 (로비 폭파 / 게임 시작 DB 롤백 보상)
 --   - EXPIRE : 존재하는 키만 짧은 TTL로 전환 (게임 정상 종료 후 grace period)
+--             ttlSeconds >= 1 필수. 위반 시(nil/0/음수) 즉시만료·스크립트 에러를
+--             막기 위해 error_reply로 fail-fast한다.
 --
 -- [라운드 수 판별]
 --   game:session:{code} 해시의 total_question_count 필드를 우선 사용하고,
@@ -30,6 +32,14 @@ local sessionKey = KEYS[1]
 
 local mode = ARGV[1]            -- "DELETE" | "EXPIRE"
 local ttlSeconds = tonumber(ARGV[2])
+
+-- EXPIRE 모드 TTL 방어: 잘못된 TTL로 인한 즉시만료/스크립트 에러를 fail-fast로 차단
+-- (DELETE는 ttlSeconds를 사용하지 않으므로 검증 대상에서 제외)
+if mode == 'EXPIRE' then
+    if ttlSeconds == nil or ttlSeconds < 1 then
+        return redis.error_reply('INVALID_TTL: EXPIRE requires ttlSeconds >= 1')
+    end
+end
 
 local roundsKey  = sessionKey .. ':rounds'
 local playersKey = sessionKey .. ':players'

--- a/src/main/resources/scripts/cleanup_game_session.lua
+++ b/src/main/resources/scripts/cleanup_game_session.lua
@@ -70,12 +70,10 @@ if mode == 'DELETE' then
         processed = processed + redis.call('DEL', key)
     end
 else
-    -- EXPIRE: 존재하는 키에만 TTL 전환
+    -- EXPIRE: 사전 EXISTS 체크 없이 EXPIRE 반환값으로 집계한다.
+    -- (EXPIRE는 키가 없으면 0, TTL을 설정했으면 1을 반환하므로 EXISTS는 불필요한 중복 호출)
     for _, key in ipairs(keys) do
-        if redis.call('EXISTS', key) == 1 then
-            redis.call('EXPIRE', key, ttlSeconds)
-            processed = processed + 1
-        end
+        processed = processed + redis.call('EXPIRE', key, ttlSeconds)
     end
 end
 

--- a/src/main/resources/scripts/cleanup_game_session.lua
+++ b/src/main/resources/scripts/cleanup_game_session.lua
@@ -4,8 +4,8 @@
 -- [책임]
 -- 하나의 로비 코드에 속한 모든 game:session:{code}* 키를 원자적으로 정리한다.
 --   - base 키 3종      : game:session:{code}, :rounds, :players
---   - 라운드별 키 6종   : :round:{n}:ready, :playback_lock, :data,
---                        :correct_players, :correct_times, :ended_lock
+--   - 라운드별 키 7종   : :round:{n}:ready, :playback_lock, :data,
+--                        :correct_players, :correct_times, :ended_lock, :next_lock
 --
 -- [정리 모드]
 --   - DELETE : 모든 키 즉시 삭제 (로비 폭파 / 게임 시작 DB 롤백 보상)
@@ -53,9 +53,9 @@ if totalRounds == nil then
     totalRounds = 0
 end
 
--- 정리 대상 키 수집 (base 3종 + 라운드별 6종)
+-- 정리 대상 키 수집 (base 3종 + 라운드별 7종)
 local keys = { sessionKey, roundsKey, playersKey }
-local roundSuffixes = { ':ready', ':playback_lock', ':data', ':correct_players', ':correct_times', ':ended_lock' }
+local roundSuffixes = { ':ready', ':playback_lock', ':data', ':correct_players', ':correct_times', ':ended_lock', ':next_lock' }
 for n = 1, totalRounds do
     local roundBase = sessionKey .. ':round:' .. n
     for _, suffix in ipairs(roundSuffixes) do

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutorTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutorTest.java
@@ -1,16 +1,21 @@
 package io.github.ascrew.monomatbe.domain.game.service;
 
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
 import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,5 +68,54 @@ class GameRoundNextRoundExecutorTest {
 
         // 락 미획득 → 라운드 진행 로직(세션 조회/갱신)에 진입하지 않는다.
         verify(gameSessionJpaRepository, never()).findActiveSessionByLobbyCode(anyString());
+    }
+
+    @Test
+    @DisplayName("커밋 전 트랜잭션 본문에서 예외가 나면 Redis current_round_no를 advance하지 않는다 (롤백 후 영구 정지 방지)")
+    @SuppressWarnings("unchecked")
+    void startNextRound_doesNotAdvanceRedisBeforeCommit() {
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        HashOperations<String, Object, Object> hashOperations = mock(HashOperations.class);
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        ListOperations<String, String> listOperations = mock(ListOperations.class);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+
+        // 1차 Redis 완료 검증 통과 + 락 획득 성공
+        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn(null);
+        String lockKey = RedisKeys.gameSessionNextRoundLockKey(CODE, NEXT_ROUND);
+        when(valueOperations.setIfAbsent(eq(lockKey), eq("1"), any(Duration.class))).thenReturn(true);
+
+        // DB 세션 조회 통과(현재 라운드 < 다음 라운드)
+        GameSession gameSession = mock(GameSession.class);
+        when(gameSession.getCurrentRoundNo()).thenReturn(NEXT_ROUND - 1);
+        GameSessionJpaRepository gameSessionJpaRepository = mock(GameSessionJpaRepository.class);
+        when(gameSessionJpaRepository.findActiveSessionByLobbyCode(CODE)).thenReturn(Optional.of(gameSession));
+
+        // MapItem 조회 단계에서 라운드 데이터가 없어 트랜잭션 본문이 실패하도록 한다(커밋 전 예외).
+        String roundsKey = RedisKeys.gameSessionRoundsKey(CODE);
+        when(listOperations.index(roundsKey, NEXT_ROUND - 1)).thenReturn(null);
+
+        GameRoundNextRoundExecutor executor = new GameRoundNextRoundExecutor(
+                gameSessionJpaRepository,
+                mock(MapItemJpaRepository.class),
+                mock(GameRealtimeNotifier.class),
+                redisTemplate,
+                mock(GameRoundStartService.class)
+        );
+
+        assertThatThrownBy(() -> executor.startNextRound(CODE, NEXT_ROUND))
+                .isInstanceOf(NoSuchElementException.class);
+
+        // 핵심: current_round_no/status/round_phase는 afterCommit으로 미뤄졌으므로
+        // 커밋 전 실패 시 Redis가 다음 라운드로 advance되면 안 된다. (복구 워커의 ALREADY_PROGRESSED 오판 방지)
+        verify(hashOperations, never()).put(eq(SESSION_KEY), eq(RedisKeys.FIELD_CURRENT_ROUND_NO), anyString());
+        verify(hashOperations, never()).put(eq(SESSION_KEY), eq(RedisKeys.FIELD_STATUS), anyString());
+        verify(hashOperations, never()).put(eq(SESSION_KEY), eq(RedisKeys.FIELD_ROUND_PHASE), anyString());
+        // DB advance는 시도되었지만(트랜잭션이 롤백할 것), Redis는 깨끗해야 한다.
+        verify(gameSession).moveToNextRound(NEXT_ROUND);
+        // 동기화 등록 전 예외이므로 처리 락은 finally에서 즉시 해제된다.
+        verify(redisTemplate).delete(lockKey);
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -228,8 +228,9 @@ class GameRoundProgressIntegrationTest {
 
         // then
         assertThat(gameSession.getStatus()).isEqualTo(GameSessionStatus.FINISHED);
+        // DB 상태 변경은 Dirty Checking으로 커밋 시 반영되므로 명시적 save 호출은 없다.
+        // (상태 전환 자체는 changeStatus 호출로 검증한다)
         verify(lobby).changeStatus(LobbyStatus.FINISHED);
-        verify(gameLobbyJpaRepository).save(lobby);
 
         assertThat(redisTemplate.opsForHash().get(RedisKeys.gameSessionKey(LOBBY_CODE), "status")).isEqualTo("FINISHED");
         assertThat(redisTemplate.opsForHash().get(RedisKeys.lobbyKey(LOBBY_CODE), "status")).isEqualTo("FINISHED");

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressServiceTest.java
@@ -1,0 +1,63 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.game.repository.redis.GameRoundRecoveryRepository;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.scheduling.TaskScheduler;
+
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * GameRoundProgressService 멱등 락 동작 검증.
+ *
+ * 인메모리 예약과 복구 워커가 동시에 startNextRound를 호출해도, next_round_lock SETNX 락을
+ * 획득하지 못한 호출은 라운드를 진행시키지 않고 즉시 종료해야 한다. (라운드 스킵 방지)
+ */
+class GameRoundProgressServiceTest {
+
+    private static final String CODE = "ABC123";
+    private static final int NEXT_ROUND = 2;
+
+    @Test
+    @DisplayName("next_round 멱등 락 획득에 실패하면 DB 조회 없이 즉시 종료한다")
+    @SuppressWarnings("unchecked")
+    void startNextRound_skipsWhenLockNotAcquired() {
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        String lockKey = RedisKeys.gameSessionRoundNextLockKey(CODE, NEXT_ROUND);
+        when(valueOperations.setIfAbsent(eq(lockKey), eq("1"), any(Duration.class))).thenReturn(false);
+
+        GameSessionJpaRepository gameSessionJpaRepository = mock(GameSessionJpaRepository.class);
+
+        GameRoundProgressService service = new GameRoundProgressService(
+                mock(TaskScheduler.class),
+                redisTemplate,
+                gameSessionJpaRepository,
+                mock(MapItemJpaRepository.class),
+                mock(GameRealtimeNotifier.class),
+                mock(ApplicationContext.class),
+                mock(GameRoundRecoveryRepository.class)
+        );
+
+        service.startNextRound(CODE, NEXT_ROUND);
+
+        // 락 미획득 → 라운드 진행 로직(세션 조회/갱신)에 진입하지 않는다.
+        verify(gameSessionJpaRepository, never()).findActiveSessionByLobbyCode(anyString());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryServiceTest.java
@@ -1,0 +1,158 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.repository.redis.GameRoundRecoveryRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * GameRoundRecoveryService 복구 워커 로직 검증.
+ *
+ * 실제 Redis/스케줄러 없이 큐 payload 분기(미도래/이미 진행/세션 소멸/정지 재트리거/실패 백오프)를 단위 검증한다.
+ */
+class GameRoundRecoveryServiceTest {
+
+    private static final String CODE = "ABC123";
+    private static final String SESSION_KEY = RedisKeys.gameSessionKey(CODE);
+
+    private final GameRoundRecoveryRepository repository = mock(GameRoundRecoveryRepository.class);
+    private final GameRoundProgressService progressService = mock(GameRoundProgressService.class);
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+
+    @SuppressWarnings("unchecked")
+    private final HashOperations<String, Object, Object> hashOperations = mock(HashOperations.class);
+
+    private final GameRoundRecoveryService service = new GameRoundRecoveryService(
+            repository, progressService, redisTemplate);
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+    }
+
+    private String payload(int expectedRoundNo, int attempt, long nextRetryAt) {
+        return String.join("|", CODE, String.valueOf(expectedRoundNo), String.valueOf(attempt), String.valueOf(nextRetryAt));
+    }
+
+    @Test
+    @DisplayName("아직 점검 시각 전이면 상태 점검 없이 큐 뒤로 재적재한다")
+    void notDueYet_requeuesWithoutInspecting() {
+        String notDue = payload(3, 0, System.currentTimeMillis() + 60_000L);
+        when(repository.pollRoundRecovery()).thenReturn(notDue);
+
+        service.recoverStalledRounds();
+
+        verify(repository).requeueRoundRecovery(notDue);
+        verify(progressService, never()).startNextRound(anyString(), anyInt());
+        verify(hashOperations, never()).get(any(), any());
+    }
+
+    @Test
+    @DisplayName("current_round_no가 기대치 이상이면 이미 진행됨으로 보고 성공 집계 후 드롭한다")
+    void alreadyProgressed_marksSuccessAndDrops() {
+        when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
+        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("3");
+        when(hashOperations.get(SESSION_KEY, "status")).thenReturn("READY");
+
+        service.recoverStalledRounds();
+
+        verify(repository).incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_SUCCESS);
+        verify(progressService, never()).startNextRound(anyString(), anyInt());
+        verify(repository, never()).requeueRoundRecovery(anyString());
+    }
+
+    @Test
+    @DisplayName("세션 해시가 없으면(정리/만료) 복구 불필요로 보고 성공 집계 후 드롭한다")
+    void sessionGone_marksSuccessAndDrops() {
+        when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
+        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn(null);
+
+        service.recoverStalledRounds();
+
+        verify(repository).incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_SUCCESS);
+        verify(progressService, never()).startNextRound(anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("정지된 라운드(current_round_no < 기대치)는 startNextRound를 재트리거하고 성공 집계한다")
+    void stalled_retriggersStartNextRound() {
+        when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
+        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("2");
+        when(hashOperations.get(SESSION_KEY, "status")).thenReturn("PLAYING");
+
+        service.recoverStalledRounds();
+
+        verify(progressService).startNextRound(CODE, 3);
+        verify(repository).incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_SUCCESS);
+        verify(repository, never()).requeueRoundRecovery(anyString());
+    }
+
+    @Test
+    @DisplayName("재트리거가 실패하면 실패 집계 후 backoff payload로 재적재한다")
+    void retriggerFailure_marksFailedAndRequeues() {
+        when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
+        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("2");
+        when(hashOperations.get(SESSION_KEY, "status")).thenReturn("PLAYING");
+        doThrow(new RuntimeException("db down")).when(progressService).startNextRound(CODE, 3);
+
+        service.recoverStalledRounds();
+
+        verify(repository).incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+        verify(repository).requeueRoundRecovery(anyString());
+    }
+
+    @Test
+    @DisplayName("최대 재시도 횟수를 초과하면 재적재하지 않는다")
+    void exceedsMaxRetry_doesNotRequeue() {
+        when(repository.pollRoundRecovery()).thenReturn(payload(3, 5, pastTime()));
+        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("2");
+        when(hashOperations.get(SESSION_KEY, "status")).thenReturn("PLAYING");
+        doThrow(new RuntimeException("db down")).when(progressService).startNextRound(CODE, 3);
+
+        service.recoverStalledRounds();
+
+        verify(repository).incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+        verify(repository, never()).requeueRoundRecovery(anyString());
+    }
+
+    @Test
+    @DisplayName("큐가 비어 있으면 아무 작업도 하지 않는다")
+    void emptyQueue_isNoOp() {
+        when(repository.pollRoundRecovery()).thenReturn(null);
+
+        service.recoverStalledRounds();
+
+        verify(progressService, never()).startNextRound(anyString(), anyInt());
+        verify(repository, never()).incrementRoundRecoveryMetric(anyString());
+        verify(repository, never()).requeueRoundRecovery(anyString());
+    }
+
+    @Test
+    @DisplayName("payload 형식이 잘못되면 실패 집계만 하고 재적재하지 않는다")
+    void malformedPayload_marksFailedOnly() {
+        when(repository.pollRoundRecovery()).thenReturn("broken-payload");
+
+        service.recoverStalledRounds();
+
+        verify(repository).incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+        verify(repository, never()).requeueRoundRecovery(anyString());
+        verify(progressService, never()).startNextRound(anyString(), anyInt());
+    }
+
+    private long pastTime() {
+        return System.currentTimeMillis() - 1_000L;
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryServiceTest.java
@@ -133,6 +133,21 @@ class GameRoundStallRecoveryServiceTest {
     }
 
     @Test
+    @DisplayName("처리 중 예외가 발생하면 실패 집계 후 원본 payload를 안전 재적재한다 (payload 유실 방지)")
+    void processingThrows_safeRequeuesOriginalPayload() {
+        // not-due 경로의 requeue가 Redis 장애로 실패하는 상황을 모사한다.
+        String notDue = payload(3, 0, System.currentTimeMillis() + 60_000L);
+        when(repository.pollRoundRecovery()).thenReturn(notDue);
+        doThrow(new RuntimeException("redis down")).when(repository).requeueRoundRecovery(notDue);
+
+        service.recoverStalledRounds();
+
+        // 최상위 보상: 실패 집계 + 원본 payload 안전 재적재
+        verify(repository).incrementRoundRecoveryMetric(RedisKeys.METRIC_GAME_ROUND_RECOVERY_FAILED);
+        verify(repository).safeRequeueRoundRecovery(notDue);
+    }
+
+    @Test
     @DisplayName("큐가 비어 있으면 아무 작업도 하지 않는다")
     void emptyQueue_isNoOp() {
         when(repository.pollRoundRecovery()).thenReturn(null);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStallRecoveryServiceTest.java
@@ -8,9 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
+import java.util.Arrays;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -46,6 +49,12 @@ class GameRoundStallRecoveryServiceTest {
         return String.join("|", CODE, String.valueOf(expectedRoundNo), String.valueOf(attempt), String.valueOf(nextRetryAt));
     }
 
+    /** inspectProgress가 single-RTT multiGet([current_round_no, status])으로 조회하는 값을 스텁한다. */
+    private void stubSessionFields(String currentRoundNo, String status) {
+        when(hashOperations.multiGet(eq(SESSION_KEY), any()))
+                .thenReturn(Arrays.asList(currentRoundNo, status));
+    }
+
     @Test
     @DisplayName("아직 점검 시각 전이면 상태 점검 없이 큐 뒤로 재적재한다")
     void notDueYet_requeuesWithoutInspecting() {
@@ -56,15 +65,14 @@ class GameRoundStallRecoveryServiceTest {
 
         verify(repository).requeueRoundRecovery(notDue);
         verify(nextRoundExecutor, never()).startNextRound(anyString(), anyInt());
-        verify(hashOperations, never()).get(any(), any());
+        verify(hashOperations, never()).multiGet(any(), any());
     }
 
     @Test
     @DisplayName("current_round_no가 기대치 이상이면 이미 진행됨으로 보고 성공 집계 후 드롭한다")
     void alreadyProgressed_marksSuccessAndDrops() {
         when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("3");
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_STATUS)).thenReturn("READY");
+        stubSessionFields("3", "READY");
 
         service.recoverStalledRounds();
 
@@ -77,7 +85,7 @@ class GameRoundStallRecoveryServiceTest {
     @DisplayName("세션 해시가 없으면(정리/만료) 복구 불필요로 보고 성공 집계 후 드롭한다")
     void sessionGone_marksSuccessAndDrops() {
         when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn(null);
+        stubSessionFields(null, null);
 
         service.recoverStalledRounds();
 
@@ -89,8 +97,7 @@ class GameRoundStallRecoveryServiceTest {
     @DisplayName("정지된 라운드(current_round_no < 기대치)는 startNextRound를 재트리거하고 성공 집계한다")
     void stalled_retriggersStartNextRound() {
         when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("2");
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_STATUS)).thenReturn("PLAYING");
+        stubSessionFields("2", "PLAYING");
 
         service.recoverStalledRounds();
 
@@ -103,8 +110,7 @@ class GameRoundStallRecoveryServiceTest {
     @DisplayName("재트리거가 실패하면 실패 집계 후 backoff payload로 재적재한다")
     void retriggerFailure_marksFailedAndRequeues() {
         when(repository.pollRoundRecovery()).thenReturn(payload(3, 0, pastTime()));
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("2");
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_STATUS)).thenReturn("PLAYING");
+        stubSessionFields("2", "PLAYING");
         doThrow(new RuntimeException("db down")).when(nextRoundExecutor).startNextRound(CODE, 3);
 
         service.recoverStalledRounds();
@@ -117,8 +123,7 @@ class GameRoundStallRecoveryServiceTest {
     @DisplayName("최대 재시도 횟수를 초과하면 재적재하지 않는다")
     void exceedsMaxRetry_doesNotRequeue() {
         when(repository.pollRoundRecovery()).thenReturn(payload(3, 5, pastTime()));
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_CURRENT_ROUND_NO)).thenReturn("2");
-        when(hashOperations.get(SESSION_KEY, RedisKeys.FIELD_STATUS)).thenReturn("PLAYING");
+        stubSessionFields("2", "PLAYING");
         doThrow(new RuntimeException("db down")).when(nextRoundExecutor).startNextRound(CODE, 3);
 
         service.recoverStalledRounds();

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -18,6 +20,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * 게임 세션 Redis 키 정리(cleanup) 통합 테스트
@@ -46,12 +49,26 @@ class GameSessionCleanupIntegrationTest {
     @Autowired
     private StringRedisTemplate redisTemplate;
 
+    @Autowired
+    @Qualifier("cleanupGameSessionScript")
+    private RedisScript<String> cleanupGameSessionScript;
+
     @MockitoBean
     private SimpMessagingTemplate messagingTemplate;
 
     @AfterEach
     void tearDown() {
         redisTemplate.delete(allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS));
+        redisTemplate.delete(List.of(
+                RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS,
+                RedisKeys.METRIC_GAME_SESSION_CLEANUP_FAILED,
+                RedisKeys.METRIC_GAME_SESSION_CLEANUP_NOOP));
+    }
+
+    /** metric 카운터 현재값을 읽는다. (미설정 시 0) */
+    private long metricCount(String metricKey) {
+        String value = redisTemplate.opsForValue().get(metricKey);
+        return value == null ? 0L : Long.parseLong(value);
     }
 
     @Test
@@ -62,11 +79,15 @@ class GameSessionCleanupIntegrationTest {
         List<String> keys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
         assertThat(keys).allMatch(redisTemplate::hasKey);
 
+        long successBefore = metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS);
+
         // when
         gameSessionCleanupService.deleteNow(LOBBY_CODE);
 
         // then
         assertThat(keys).noneMatch(redisTemplate::hasKey);
+        assertThat(metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS))
+                .isEqualTo(successBefore + 1);
     }
 
     @Test
@@ -76,6 +97,7 @@ class GameSessionCleanupIntegrationTest {
         givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
         List<String> keys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
         keys.forEach(key -> redisTemplate.expire(key, Duration.ofSeconds(7200)));
+        long successBefore = metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS);
 
         // when
         gameSessionCleanupService.expireWithGracePeriod(LOBBY_CODE);
@@ -89,17 +111,54 @@ class GameSessionCleanupIntegrationTest {
                     .isGreaterThan(0L)
                     .isLessThanOrEqualTo(300L);
         }
+        assertThat(metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS))
+                .isEqualTo(successBefore + 1);
     }
 
     @Test
-    @DisplayName("게임 세션이 없으면 정리는 예외 없이 안전하게 no-op이다")
+    @DisplayName("EXPIRE 모드에서 ttlSeconds < 1이면 즉시만료 없이 스크립트가 fail-fast한다")
+    void expireScript_failsFastOnInvalidTtl() {
+        // given - 생성 시점처럼 2시간 TTL을 부여해 둔다
+        givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
+        List<String> keys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
+        keys.forEach(key -> redisTemplate.expire(key, Duration.ofSeconds(7200)));
+        String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
+
+        // when & then - ttl="0"(즉시만료 위험)/""(nil)은 스크립트가 실패해야 한다
+        assertThatThrownBy(() -> redisTemplate.execute(
+                cleanupGameSessionScript, List.of(sessionKey), "EXPIRE", "0"))
+                .isInstanceOf(Exception.class);
+        assertThatThrownBy(() -> redisTemplate.execute(
+                cleanupGameSessionScript, List.of(sessionKey), "EXPIRE", ""))
+                .isInstanceOf(Exception.class);
+
+        // 키가 즉시 만료되지 않고 원래 TTL(2시간)을 유지한다
+        for (String key : keys) {
+            Long ttl = redisTemplate.getExpire(key);
+            assertThat(ttl)
+                    .as("key=%s TTL", key)
+                    .isNotNull()
+                    .isGreaterThan(300L);
+        }
+    }
+
+    @Test
+    @DisplayName("게임 세션이 없으면 정리는 예외 없이 no-op metric으로 집계되고 success는 오르지 않는다")
     void cleanup_isSafeNoOpWhenSessionMissing() {
         // given - 키를 전혀 만들지 않음
+        long noopBefore = metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_NOOP);
+        long successBefore = metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS);
 
         // when & then
         assertThatCode(() -> gameSessionCleanupService.deleteNow(LOBBY_CODE)).doesNotThrowAnyException();
         assertThatCode(() -> gameSessionCleanupService.expireWithGracePeriod(LOBBY_CODE)).doesNotThrowAnyException();
         assertThat(allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS)).noneMatch(redisTemplate::hasKey);
+
+        // deleteNow + expireWithGracePeriod 두 번 모두 정리 대상이 없어 NOOP만 2회 증가한다
+        assertThat(metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_NOOP))
+                .isEqualTo(noopBefore + 2);
+        assertThat(metricCount(RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS))
+                .isEqualTo(successBefore);
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * 게임 세션 Redis 키 정리(cleanup) 통합 테스트
  *
  * [검증 정책]
- * - deleteNow: base 3종 + 라운드별 6종 키를 모두 삭제한다. (로비 폭파 / 시작 롤백)
+ * - deleteNow: base 3종 + 라운드별 7종 키를 모두 삭제한다. (로비 폭파 / 시작 롤백)
  * - expireWithGracePeriod: 존재하는 모든 키를 0<ttl<=300 으로 전환한다. (정상 종료)
  * - 게임 세션이 없을 때 정리는 예외 없이 안전 no-op이다.
  * - 로비 폭파 이벤트(LobbyClosedEvent) 수신 시 게임 세션 키가 정리된다. (stale game session 방지)
@@ -73,7 +73,7 @@ class GameSessionCleanupIntegrationTest {
     }
 
     @Test
-    @DisplayName("deleteNow는 base 3종 + 라운드별 6종 게임 세션 키를 모두 삭제한다")
+    @DisplayName("deleteNow는 base 3종 + 라운드별 7종 게임 세션 키를 모두 삭제한다")
     void deleteNow_removesAllGameSessionKeys() {
         // given
         givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
@@ -94,7 +94,7 @@ class GameSessionCleanupIntegrationTest {
     @Test
     @DisplayName("cleanup Lua는 RedisKeys가 생성하는 모든 게임 세션 키를 빠짐없이 정리한다 (키 계약 고정)")
     void cleanupScript_deletesExactlyAllRedisKeysGameSessionKeys() {
-        // given - RedisKeys 팩토리로 만드는 base 3종 + 라운드별 6종을 모두 생성
+        // given - RedisKeys 팩토리로 만드는 base 3종 + 라운드별 7종을 모두 생성
         givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
         List<String> expectedKeys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
         String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
@@ -198,7 +198,7 @@ class GameSessionCleanupIntegrationTest {
 
     /**
      * 실제 게임 진행 중 생성되는 모든 게임 세션 키를 채운다.
-     * base 3종(session/rounds/players) + 라운드별 6종을 모두 만든다.
+     * base 3종(session/rounds/players) + 라운드별 7종을 모두 만든다.
      */
     private void givenFullGameSession(String code, int totalRounds) {
         String sessionKey = RedisKeys.gameSessionKey(code);
@@ -220,6 +220,7 @@ class GameSessionCleanupIntegrationTest {
             redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundCorrectPlayersKey(code, n), "player-1");
             redisTemplate.opsForHash().put(RedisKeys.gameSessionRoundCorrectTimesKey(code, n), "player-1", "1000");
             redisTemplate.opsForValue().set(RedisKeys.gameSessionRoundEndedLockKey(code, n), "1");
+            redisTemplate.opsForValue().set(RedisKeys.gameSessionNextRoundLockKey(code, n), "1");
         }
     }
 
@@ -235,6 +236,7 @@ class GameSessionCleanupIntegrationTest {
             keys.add(RedisKeys.gameSessionRoundCorrectPlayersKey(code, n));
             keys.add(RedisKeys.gameSessionRoundCorrectTimesKey(code, n));
             keys.add(RedisKeys.gameSessionRoundEndedLockKey(code, n));
+            keys.add(RedisKeys.gameSessionNextRoundLockKey(code, n));
         }
         return keys;
     }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
@@ -61,7 +61,8 @@ class GameSessionCleanupIntegrationTest {
         redisTemplate.delete(allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS));
         redisTemplate.delete(List.of(
                 RedisKeys.METRIC_GAME_SESSION_CLEANUP_SUCCESS,
-                RedisKeys.METRIC_GAME_SESSION_CLEANUP_FAILED,
+                RedisKeys.METRIC_GAME_SESSION_CLEANUP_DELETE_FAILED,
+                RedisKeys.METRIC_GAME_SESSION_CLEANUP_EXPIRE_FAILED,
                 RedisKeys.METRIC_GAME_SESSION_CLEANUP_NOOP));
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
@@ -91,6 +91,25 @@ class GameSessionCleanupIntegrationTest {
     }
 
     @Test
+    @DisplayName("cleanup Lua는 RedisKeys가 생성하는 모든 게임 세션 키를 빠짐없이 정리한다 (키 계약 고정)")
+    void cleanupScript_deletesExactlyAllRedisKeysGameSessionKeys() {
+        // given - RedisKeys 팩토리로 만드는 base 3종 + 라운드별 6종을 모두 생성
+        givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
+        List<String> expectedKeys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
+        String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
+
+        // when - 스크립트를 직접 실행해 처리 키 수(processed) 반환값을 확인한다
+        String processed = redisTemplate.execute(
+                cleanupGameSessionScript, List.of(sessionKey), "DELETE", "0");
+
+        // then - RedisKeys가 만든 모든 키가 삭제되고, Lua가 정리한 키 수가 정확히 일치한다.
+        // (RedisKeys suffix 변경/신규 라운드 키 추가 시 allGameSessionKeys와 Lua roundSuffixes 불일치를 잡는다.
+        //  새 라운드 키 메서드를 RedisKeys에 추가하면 allGameSessionKeys에도 반드시 추가해야 한다.)
+        assertThat(expectedKeys).noneMatch(redisTemplate::hasKey);
+        assertThat(processed).isEqualTo(String.valueOf(expectedKeys.size()));
+    }
+
+    @Test
     @DisplayName("expireWithGracePeriod는 존재하는 모든 키를 0<ttl<=300으로 전환한다")
     void expireWithGracePeriod_setsShortTtlOnAllKeys() {
         // given - 생성 시점처럼 2시간 TTL을 부여해 둔다

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
@@ -1,0 +1,162 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 게임 세션 Redis 키 정리(cleanup) 통합 테스트
+ *
+ * [검증 정책]
+ * - deleteNow: base 3종 + 라운드별 6종 키를 모두 삭제한다. (로비 폭파 / 시작 롤백)
+ * - expireWithGracePeriod: 존재하는 모든 키를 0<ttl<=300 으로 전환한다. (정상 종료)
+ * - 게임 세션이 없을 때 정리는 예외 없이 안전 no-op이다.
+ * - 로비 폭파 이벤트(LobbyClosedEvent) 수신 시 게임 세션 키가 정리된다. (stale game session 방지)
+ */
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=none"
+})
+class GameSessionCleanupIntegrationTest {
+
+    private static final String LOBBY_CODE = "CLEAN1";
+    private static final int TOTAL_ROUNDS = 3;
+
+    @Autowired
+    private GameSessionCleanupService gameSessionCleanupService;
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private SimpMessagingTemplate messagingTemplate;
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS));
+    }
+
+    @Test
+    @DisplayName("deleteNow는 base 3종 + 라운드별 6종 게임 세션 키를 모두 삭제한다")
+    void deleteNow_removesAllGameSessionKeys() {
+        // given
+        givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
+        List<String> keys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
+        assertThat(keys).allMatch(redisTemplate::hasKey);
+
+        // when
+        gameSessionCleanupService.deleteNow(LOBBY_CODE);
+
+        // then
+        assertThat(keys).noneMatch(redisTemplate::hasKey);
+    }
+
+    @Test
+    @DisplayName("expireWithGracePeriod는 존재하는 모든 키를 0<ttl<=300으로 전환한다")
+    void expireWithGracePeriod_setsShortTtlOnAllKeys() {
+        // given - 생성 시점처럼 2시간 TTL을 부여해 둔다
+        givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
+        List<String> keys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
+        keys.forEach(key -> redisTemplate.expire(key, Duration.ofSeconds(7200)));
+
+        // when
+        gameSessionCleanupService.expireWithGracePeriod(LOBBY_CODE);
+
+        // then
+        for (String key : keys) {
+            Long ttl = redisTemplate.getExpire(key);
+            assertThat(ttl)
+                    .as("key=%s TTL", key)
+                    .isNotNull()
+                    .isGreaterThan(0L)
+                    .isLessThanOrEqualTo(300L);
+        }
+    }
+
+    @Test
+    @DisplayName("게임 세션이 없으면 정리는 예외 없이 안전하게 no-op이다")
+    void cleanup_isSafeNoOpWhenSessionMissing() {
+        // given - 키를 전혀 만들지 않음
+
+        // when & then
+        assertThatCode(() -> gameSessionCleanupService.deleteNow(LOBBY_CODE)).doesNotThrowAnyException();
+        assertThatCode(() -> gameSessionCleanupService.expireWithGracePeriod(LOBBY_CODE)).doesNotThrowAnyException();
+        assertThat(allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS)).noneMatch(redisTemplate::hasKey);
+    }
+
+    @Test
+    @DisplayName("로비 폭파 이벤트(LobbyClosedEvent) 수신 시 게임 세션 키가 정리된다")
+    void lobbyClosedEvent_cleansUpStaleGameSession() {
+        // given - 게임 도중 전원 퇴장으로 로비가 폭파된 상황
+        givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
+        List<String> keys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
+        assertThat(keys).anyMatch(redisTemplate::hasKey);
+
+        // when - @EventListener는 동기 실행되므로 발행 직후 정리가 완료된다
+        eventPublisher.publishEvent(new LobbyClosedEvent(LOBBY_CODE));
+
+        // then
+        assertThat(keys).noneMatch(redisTemplate::hasKey);
+    }
+
+    /**
+     * 실제 게임 진행 중 생성되는 모든 게임 세션 키를 채운다.
+     * base 3종(session/rounds/players) + 라운드별 6종을 모두 만든다.
+     */
+    private void givenFullGameSession(String code, int totalRounds) {
+        String sessionKey = RedisKeys.gameSessionKey(code);
+        redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, "current_round_no", String.valueOf(totalRounds));
+        redisTemplate.opsForHash().put(sessionKey, "total_question_count", String.valueOf(totalRounds));
+
+        String roundsKey = RedisKeys.gameSessionRoundsKey(code);
+        for (int n = 1; n <= totalRounds; n++) {
+            redisTemplate.opsForList().rightPush(roundsKey, String.valueOf(n));
+        }
+
+        redisTemplate.opsForHash().put(RedisKeys.gameSessionPlayersKey(code), "player-1", "0");
+
+        for (int n = 1; n <= totalRounds; n++) {
+            redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundReadyKey(code, n), "player-1");
+            redisTemplate.opsForValue().set(RedisKeys.gameSessionPlaybackLockKey(code, n), "1");
+            redisTemplate.opsForHash().put(RedisKeys.gameSessionRoundDataKey(code, n), "title", "song-" + n);
+            redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundCorrectPlayersKey(code, n), "player-1");
+            redisTemplate.opsForHash().put(RedisKeys.gameSessionRoundCorrectTimesKey(code, n), "player-1", "1000");
+            redisTemplate.opsForValue().set(RedisKeys.gameSessionRoundEndedLockKey(code, n), "1");
+        }
+    }
+
+    private List<String> allGameSessionKeys(String code, int totalRounds) {
+        List<String> keys = new ArrayList<>();
+        keys.add(RedisKeys.gameSessionKey(code));
+        keys.add(RedisKeys.gameSessionRoundsKey(code));
+        keys.add(RedisKeys.gameSessionPlayersKey(code));
+        for (int n = 1; n <= totalRounds; n++) {
+            keys.add(RedisKeys.gameSessionRoundReadyKey(code, n));
+            keys.add(RedisKeys.gameSessionPlaybackLockKey(code, n));
+            keys.add(RedisKeys.gameSessionRoundDataKey(code, n));
+            keys.add(RedisKeys.gameSessionRoundCorrectPlayersKey(code, n));
+            keys.add(RedisKeys.gameSessionRoundCorrectTimesKey(code, n));
+            keys.add(RedisKeys.gameSessionRoundEndedLockKey(code, n));
+        }
+        return keys;
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateServiceTest.java
@@ -22,7 +22,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -57,9 +56,11 @@ class GameSessionCreateServiceTest {
     @Mock
     private RedisScript<String> initGameSessionScript;
     @Mock
-    private HashOperations<String, Object, Object> hashOperations;
-    @Mock
     private JsonMapper jsonMapper;
+    @Mock
+    private GameSessionCleanupService gameSessionCleanupService;
+    @Mock
+    private io.github.ascrew.monomatbe.domain.game.config.GameSessionProperties gameSessionProperties;
 
     @InjectMocks
     private GameSessionCreateService gameSessionCreateService;
@@ -129,7 +130,6 @@ class GameSessionCreateServiceTest {
                 anyString(),
                 anyString()
         )).thenReturn("OK");
-        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
 
         // when
         RoundStartDto result = gameSessionCreateService.createGameSession(lobby, quizMap);
@@ -195,5 +195,77 @@ class GameSessionCreateServiceTest {
         org.assertj.core.api.Assertions.assertThatThrownBy(() -> gameSessionCreateService.createGameSession(lobby, quizMap))
                 .isInstanceOf(GameSessionAlreadyExistsException.class)
                 .hasMessage("게임 세션이 이미 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("정체되지 않은 active 세션이 있으면 GameSessionAlreadyExistsException으로 차단한다")
+    void createGameSession_blocksWhenActiveSessionNotStale() {
+        // given
+        GameLobby lobby = GameLobby.builder()
+                .inviteCode("ABC1234").mapId(1L).questionCount(1).timeLimitSeconds(30)
+                .status(LobbyStatus.PLAYING).build();
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(1).build();
+        MapItem mapItem = MapItem.builder().map(quizMap).orderNum(1).videoId("vId").build();
+
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L)).thenReturn(List.of(mapItem));
+
+        // 1분 전에 시작된 세션 + 임계값 30분 → 정체 아님 → 차단
+        GameSession active = GameSession.builder()
+                .startedAt(java.time.LocalDateTime.now(java.time.ZoneOffset.UTC).minusMinutes(1)).build();
+        when(gameSessionProperties.getStaleThreshold()).thenReturn(java.time.Duration.ofMinutes(30));
+        when(gameSessionJpaRepository.findActiveSessionByLobbyCode("ABC1234"))
+                .thenReturn(java.util.Optional.of(active));
+
+        // when & then
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> gameSessionCreateService.createGameSession(lobby, quizMap))
+                .isInstanceOf(GameSessionAlreadyExistsException.class)
+                .hasMessage("이미 진행 중인 게임 세션이 있습니다.");
+
+        assertThat(active.getStatus()).isNotEqualTo(GameSessionStatus.FINISHED);
+    }
+
+    @Test
+    @DisplayName("정체(stale)된 active 세션은 강제 종료·정리 후 새 게임 생성을 진행한다")
+    void createGameSession_recoversStaleActiveSession() {
+        // given
+        GameLobby lobby = GameLobby.builder()
+                .inviteCode("ABC1234").mapId(1L).questionCount(1).timeLimitSeconds(30)
+                .status(LobbyStatus.PLAYING).build();
+        QuizMap quizMap = QuizMap.builder().id(1L).numOfSong(1).build();
+        MapItem mapItem = MapItem.builder()
+                .map(quizMap).orderNum(1).videoId("vId").youtubeUrl("https://youtube.com/vId")
+                .startTime(10).endTime(20).title("t").artist("a").answers("[\"정답\"]").build();
+        User user = User.builder().id(1L).username("uId").userType(UserType.REGISTERED).build();
+
+        when(mapItemJpaRepository.findAllByMapIdAndIsDeletedFalseOrderByOrderNumAsc(1L)).thenReturn(List.of(mapItem));
+
+        // 2시간 전에 시작된 세션 + 임계값 30분 → 정체 → 복구
+        GameSession stale = GameSession.builder()
+                .startedAt(java.time.LocalDateTime.now(java.time.ZoneOffset.UTC).minusHours(2)).build();
+        when(gameSessionProperties.getStaleThreshold()).thenReturn(java.time.Duration.ofMinutes(30));
+        when(gameSessionJpaRepository.findActiveSessionByLobbyCode("ABC1234"))
+                .thenReturn(java.util.Optional.of(stale));
+
+        when(lobbyRepository.getParticipantIdentifiers("ABC1234")).thenReturn(List.of("uId"));
+        when(gameParticipantResolver.resolveUsers(List.of("uId"))).thenReturn(List.of(user));
+        try {
+            when(jsonMapper.readValue(eq("[\"정답\"]"), any(tools.jackson.core.type.TypeReference.class)))
+                    .thenReturn(List.of("정답"));
+            when(jsonMapper.writeValueAsString(any())).thenReturn("[\"정답\"]");
+        } catch (Exception e) {
+            // ignore for mock
+        }
+        when(redisTemplate.execute(eq(initGameSessionScript), any(List.class),
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("OK");
+
+        // when
+        RoundStartDto result = gameSessionCreateService.createGameSession(lobby, quizMap);
+
+        // then - 정체 세션은 FINISHED 처리되고 Redis 잔존 키 정리(deleteNow)가 호출되며, 새 게임 생성이 진행된다.
+        assertThat(stale.getStatus()).isEqualTo(GameSessionStatus.FINISHED);
+        verify(gameSessionCleanupService).deleteNow("ABC1234");
+        verify(gameSessionJpaRepository).save(any(GameSession.class));
+        assertThat(result.roundNo()).isEqualTo(1);
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandlerTest.java
@@ -2,9 +2,11 @@ package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,10 +21,12 @@ class LobbyLeaveEventHandlerTest {
 
     private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier = mock(LobbyRealtimeNotifier.class);
+    private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
 
     private final LobbyLeaveEventHandler handler = new LobbyLeaveEventHandler(
             lobbyRepository,
-            lobbyRealtimeNotifier
+            lobbyRealtimeNotifier,
+            eventPublisher
     );
 
     @Test
@@ -90,6 +94,38 @@ class LobbyLeaveEventHandlerTest {
         // then
         verify(lobbyRealtimeNotifier).notifyLobbyListRefresh();
         verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
+    }
+
+    @Test
+    @DisplayName("로비가 폭파되면 게임 세션 정리를 위한 LobbyClosedEvent를 발행한다")
+    void publishLobbyClosedEventWhenLobbyDestroyed() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Destroyed(LOBBY_CODE));
+
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(eventPublisher).publishEvent(new LobbyClosedEvent(LOBBY_CODE));
+    }
+
+    @Test
+    @DisplayName("로비가 폭파되지 않은 일반 퇴장에서는 LobbyClosedEvent를 발행하지 않는다")
+    void doesNotPublishLobbyClosedEventWhenNotDestroyed() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
+
+        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
+
+        // when
+        handler.handlePlayerLeave(event);
+
+        // then
+        verify(eventPublisher, never()).publishEvent(new LobbyClosedEvent(LOBBY_CODE));
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyStartReconciliationServiceTest.java
@@ -1,0 +1,70 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * LobbyStartReconciliationService 재처리 워커 로직 검증.
+ *
+ * 큐에서 leftPop으로 꺼낸 payload는 처리 중 예외가 나면 유실될 수 있으므로,
+ * 최상위 보상 가드가 원본 payload를 안전하게 재적재하는지 단위 검증한다.
+ */
+class LobbyStartReconciliationServiceTest {
+
+    private static final String CODE = "ABC123";
+    private static final String REASON = "START_DB_SYNC_FAILED";
+
+    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
+
+    private final LobbyStartReconciliationService service =
+            new LobbyStartReconciliationService(lobbyRepository);
+
+    private String payload(int attempt, long nextRetryAt) {
+        return String.join("|", CODE, REASON, String.valueOf(attempt), String.valueOf(nextRetryAt));
+    }
+
+    @Test
+    @DisplayName("처리 중 예외가 발생하면 실패 집계 후 원본 payload를 안전 재적재한다 (payload 유실 방지)")
+    void processingThrows_safeRequeuesOriginalPayload() {
+        // not-due 경로의 requeue가 Redis 장애로 실패하는 상황을 모사한다.
+        String notDue = payload(0, System.currentTimeMillis() + 60_000L);
+        when(lobbyRepository.pollStartReconciliation()).thenReturn(notDue);
+        doThrow(new RuntimeException("redis down")).when(lobbyRepository).requeueStartReconciliation(notDue);
+
+        service.reconcileStartState();
+
+        verify(lobbyRepository).incrementStartReconciliationMetric(RedisKeys.METRIC_LOBBY_START_RECONCILIATION_FAILED);
+        verify(lobbyRepository).safeRequeueStartReconciliation(notDue);
+    }
+
+    @Test
+    @DisplayName("아직 점검 시각 전이면 정상적으로 큐 뒤로 재적재하며 보상 경로를 타지 않는다")
+    void notDueYet_requeuesWithoutCompensation() {
+        String notDue = payload(0, System.currentTimeMillis() + 60_000L);
+        when(lobbyRepository.pollStartReconciliation()).thenReturn(notDue);
+
+        service.reconcileStartState();
+
+        verify(lobbyRepository).requeueStartReconciliation(notDue);
+        verify(lobbyRepository, never()).safeRequeueStartReconciliation(notDue);
+    }
+
+    @Test
+    @DisplayName("큐가 비어 있으면 아무 작업도 하지 않는다")
+    void emptyQueue_isNoOp() {
+        when(lobbyRepository.pollStartReconciliation()).thenReturn(null);
+
+        service.reconcileStartState();
+
+        verify(lobbyRepository, never()).requeueStartReconciliation(org.mockito.ArgumentMatchers.anyString());
+        verify(lobbyRepository, never()).safeRequeueStartReconciliation(org.mockito.ArgumentMatchers.anyString());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/constant/RedisKeysTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/constant/RedisKeysTest.java
@@ -1,0 +1,49 @@
+package io.github.ascrew.monomatbe.global.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RedisKeys 게임 세션 키 생성 정책 검증.
+ *
+ * Redis Cluster 대비 hash-tag({lobbyCode})가 game:session 패밀리 전 키에 일관되게 적용되어
+ * 동일 게임 세션 키들이 같은 슬롯에 모이는지(= 같은 hash-tag를 공유하는지) 고정한다.
+ */
+class RedisKeysTest {
+
+    private static final String CODE = "ABC123";
+
+    @Test
+    @DisplayName("게임 세션 base 키는 {lobbyCode} hash-tag를 포함한다")
+    void gameSessionKey_containsHashTag() {
+        assertThat(RedisKeys.gameSessionKey(CODE)).isEqualTo("game:session:{ABC123}");
+    }
+
+    @Test
+    @DisplayName("game:session 패밀리의 모든 키가 동일한 {lobbyCode} hash-tag를 공유한다")
+    void allGameSessionKeys_shareSameHashTag() {
+        String tag = "{" + CODE + "}";
+
+        assertThat(RedisKeys.gameSessionKey(CODE)).contains(tag);
+        assertThat(RedisKeys.gameSessionRoundsKey(CODE)).contains(tag).endsWith(":rounds");
+        assertThat(RedisKeys.gameSessionPlayersKey(CODE)).contains(tag).endsWith(":players");
+        assertThat(RedisKeys.gameSessionRoundReadyKey(CODE, 2)).contains(tag).endsWith(":round:2:ready");
+        assertThat(RedisKeys.gameSessionPlaybackLockKey(CODE, 2)).contains(tag).endsWith(":round:2:playback_lock");
+        assertThat(RedisKeys.gameSessionRoundDataKey(CODE, 2)).contains(tag).endsWith(":round:2:data");
+        assertThat(RedisKeys.gameSessionRoundCorrectPlayersKey(CODE, 2)).contains(tag).endsWith(":round:2:correct_players");
+        assertThat(RedisKeys.gameSessionRoundCorrectTimesKey(CODE, 2)).contains(tag).endsWith(":round:2:correct_times");
+        assertThat(RedisKeys.gameSessionRoundEndedLockKey(CODE, 2)).contains(tag).endsWith(":round:2:ended_lock");
+        assertThat(RedisKeys.gameSessionRoundNextLockKey(CODE, 2)).contains(tag).endsWith(":round:2:next_round_lock");
+    }
+
+    @Test
+    @DisplayName("하위 키는 base 키를 접두로 하여 hash-tag를 상속한다 (Lua concat 조립 호환)")
+    void derivedKeys_arePrefixedByBaseKey() {
+        String base = RedisKeys.gameSessionKey(CODE);
+
+        assertThat(RedisKeys.gameSessionRoundsKey(CODE)).startsWith(base + ":");
+        assertThat(RedisKeys.gameSessionRoundReadyKey(CODE, 1)).startsWith(base + ":round:1:");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #145

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 게임 세션 Redis 키(`game:session:{code}*`)를 **정상 종료 / 로비 폭파 / 게임 시작 DB 롤백** 시점에 안전하게 정리하는 정책을 구현했습니다.
- 통합 정리 Lua 스크립트 `cleanup_game_session.lua` 신설: base 3종 + 라운드별 6종 키를 원자적으로 `DELETE`/`EXPIRE`. `sessionKey`로부터 모든 하위 키를 결정적으로 조립해 `SCAN` 없이 처리합니다.
- `GameSessionCleanupService`: 정상 종료 시 **300초 짧은 TTL 전환**(`expireWithGracePeriod`), 폭파·롤백 시 **즉시 삭제**(`deleteNow`).
- 트리거 연결: `GameRoundEndService`(마지막 라운드 afterCommit), `LobbyLeaveEventHandler`(폭파 → `LobbyClosedEvent` → `GameSessionCleanupEventHandler`), `GameSessionCreateService`(시작 롤백 보상 통합).
- 정리 실패 시 경량 처리: `[MONITORING_REQUIRED]` 로그 + 메트릭만 남기고 예외를 전파하지 않으며, 생성 시 부여된 **2시간 TTL을 최종 안전망**으로 둡니다.
- `docs/ARCHITECTURE.md`에 정리 정책 섹션, stale 방지 통합 테스트 추가.

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- **정상 종료에 즉시 삭제 대신 300초 TTL 전환**을 택한 이유: 최종 점수/랭킹은 DB(`GameSessionPlayer`)에 영구 저장되므로, 종료 직후 클라이언트 재조회 여유만 두고 만료시켜도 안전합니다.
- **로비↔게임 도메인 결합 회피**: 로비 폭파 정리는 `global/event/LobbyClosedEvent`로 디커플링했습니다(기존 `PlayerLeaveEvent` 패턴 동일).
- **단일(standalone) Redis 전제**: 라운드별 키를 KEYS 미선언 상태로 `sessionKey`에서 조립해 접근합니다. 클러스터 도입 시 `{code}` hash-tag 적용이 필요하며 스크립트 주석에 명시했습니다.
- 정리 실패 경로의 메트릭 증가가 Redis 장애 시 재차 예외를 던지지 않도록 `incrementMetricQuietly`로 흡수해 "예외 미전파" 보장을 유지합니다.
- reconciliation 큐/스케줄러는 신설하지 않았습니다(2시간 TTL 백스톱 + 메트릭/로그로 충분하다고 판단). 추후 필요 시 `lobby:start:reconciliation` 패턴으로 확장 가능합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- Lua 빈 등록 패턴: `RedisScriptConfig`
- 메트릭/로그 정책: `LobbyStartReconciliationService`, `RedisKeys.METRIC_LOBBY_START_RECONCILIATION_*`
- 이벤트 디커플링: `PlayerLeaveEvent` + `LobbyLeaveEventHandler`
- 테스트 셋업: `GameChatAnswerIntegrationTest`
