### PR TITLE
[Feat/#106] 라운드 종료 및 다음 라운드 진행 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1627,10 +1627,10 @@ SEND /app/lobby/{code}/kick
 - **응답 (Response)**:
   ```json
   {
-    "status": "PLAYING", // READY, PLAYING, FINISHED
-    "currentRoundNo": 1,
+    "status": "PLAYING", // WAITING, PLAYING, FINISHED
+    "roundNo": 1,
     "timeLimitSeconds": 30,
-    "playbackStartedAt": 1716500000000 // 아직 재생 전인 경우 null
+    "serverStartedAt": 1716500000000 // 아직 재생 전인 경우 null
   }
   ```
 
@@ -1699,7 +1699,9 @@ SEND /app/lobby/{code}/kick
           "rank": 2,
           "scoreAdded": 100
         }
-      ]
+      ],
+      "waitTimeSeconds": 10,
+      "isLastRound": false
     }
     ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -876,6 +876,7 @@ GameRealtimeNotifier / LobbyRealtimeNotifier
 | `current_round_no` | 현재 진행 중인 라운드 번호 (1-based) |
 | `time_limit_seconds` | 라운드별 재생 시간 제한 |
 | `playback_started_at` | 현재 라운드의 비디오 재생 개시 시각 (Clock sync용, 아직 재생 전이면 null) |
+| `round_ended_at:{roundNo}` | 특정 라운드가 종료된 시각 (Epoch milliseconds, 결과 화면 대기 10초 및 중복 정답 차단 검사에 사용) |
 
 ### `game:session:{lobbyCode}:round:{roundNo}:data` Hash 구조
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
@@ -13,7 +13,9 @@ public record RoundMetadataDto(
         String artist,
         String answer,
         String thumbnailUrl,
-        List<PlayerRankingDto> rankings
+        List<PlayerRankingDto> rankings,
+        int waitTimeSeconds,
+        boolean isLastRound
 ) {
 }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
@@ -63,7 +63,10 @@ public class GameSession {
         this.endedAt = java.time.LocalDateTime.now();
     }
 
-    public void nextRound() {
-        this.currentRoundNo++;
+    public void moveToRound(int targetRoundNo) {
+        if (targetRoundNo <= this.currentRoundNo) {
+            throw new IllegalStateException("이미 진행된 라운드입니다. current: " + this.currentRoundNo + ", target: " + targetRoundNo);
+        }
+        this.currentRoundNo = targetRoundNo;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
@@ -63,9 +63,12 @@ public class GameSession {
         this.endedAt = java.time.LocalDateTime.now();
     }
 
-    public void moveToRound(int targetRoundNo) {
-        if (targetRoundNo <= this.currentRoundNo) {
-            throw new IllegalStateException("이미 진행된 라운드입니다. current: " + this.currentRoundNo + ", target: " + targetRoundNo);
+    public void moveToNextRound(int targetRoundNo) {
+        if (targetRoundNo != this.currentRoundNo + 1) {
+            throw new IllegalStateException("다음 라운드로만 이동할 수 있습니다. current: " + this.currentRoundNo + ", target: " + targetRoundNo);
+        }
+        if (targetRoundNo > this.totalQuestionCount) {
+            throw new IllegalStateException("최대 라운드 수를 초과할 수 없습니다. total: " + this.totalQuestionCount + ", target: " + targetRoundNo);
         }
         this.currentRoundNo = targetRoundNo;
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/entity/GameSession.java
@@ -60,6 +60,7 @@ public class GameSession {
 
     public void finish() {
         this.status = GameSessionStatus.FINISHED;
+        this.endedAt = java.time.LocalDateTime.now();
     }
 
     public void nextRound() {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/GameSessionJpaRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/repository/GameSessionJpaRepository.java
@@ -10,4 +10,9 @@ public interface GameSessionJpaRepository extends JpaRepository<GameSession, Lon
 
     @org.springframework.data.jpa.repository.Query("select s from GameSession s where s.lobby.inviteCode = :inviteCode and s.status != io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus.FINISHED")
     Optional<GameSession> findActiveSessionByLobbyCode(@org.springframework.data.repository.query.Param("inviteCode") String inviteCode);
+
+    java.util.List<GameSession> findAllByStatusNot(io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus status);
+
+    @org.springframework.data.jpa.repository.Query("select s from GameSession s join fetch s.lobby where s.status != io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus.FINISHED")
+    java.util.List<GameSession> findAllActiveSessionsWithLobby();
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -66,10 +66,11 @@ public class GameAnswerService {
 
         String sessionKey = RedisKeys.gameSessionKey(code);
         List<Object> fields = List.of(
-                "status",
-                "current_round_no",
-                "time_limit_seconds",
-                RedisKeys.gameSessionRoundPlaybackStartedAtField(messageDto.roundNo())
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.gameSessionRoundPlaybackStartedAtField(messageDto.roundNo()),
+                RedisKeys.FIELD_ROUND_PHASE
         );
         List<Object> values = redisTemplate.opsForHash().multiGet(sessionKey, fields);
         if (values == null || values.get(0) == null) {
@@ -78,8 +79,9 @@ public class GameAnswerService {
         }
 
         String status = (String) values.get(0);
-        if (!"PLAYING".equals(status)) {
-            log.warn("processGameChat: 게임 진행 중이 아님 (status: {}) - code: {}", status, code);
+        String roundPhase = (String) values.get(4);
+        if (!"PLAYING".equals(status) || !"PLAYING".equals(roundPhase)) {
+            log.warn("processGameChat: 게임 진행 중이 아님 (status: {}, phase: {}) - code: {}", status, roundPhase, code);
             return;
         }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -199,8 +199,8 @@ public class GameAnswerService {
                 checkAndTriggerEarlyRoundEnd(code, currentRoundNo, correctPlayersKey);
             } else if ("ALREADY_CORRECT".equals(result)) {
                 broadcastChatMessage(code, userIdentifier, messageDto.content());
-            } else if ("TIMEOUT".equals(result) || "ROUND_NOT_STARTED".equals(result)) {
-                log.info("processGameChat: Lua 검증 기준 제출 시간 초과 또는 미시작 (result: {}) - code: {}, user: {}", result, code, userIdentifier);
+            } else if ("TIMEOUT".equals(result) || "ROUND_NOT_STARTED".equals(result) || "ROUND_ALREADY_ENDED".equals(result)) {
+                log.info("processGameChat: Lua 검증 기준 제출 시간 초과, 미시작 또는 이미 종료됨 (result: {}) - code: {}, user: {}", result, code, userIdentifier);
                 String content = messageDto.content();
                 for (String normalizedTarget : normalizedAnswers) {
                     if (normalizedUserAnswer.contains(normalizedTarget) || FuzzyMatcher.isMatch(normalizedUserAnswer, normalizedTarget)) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
@@ -1,0 +1,75 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GameLeaveEventHandler {
+
+    private final StringRedisTemplate redisTemplate;
+    private final GameRoundEndService gameRoundEndService;
+
+    @EventListener
+    public void handlePlayerLeave(PlayerLeaveEvent event) {
+        String code = event.lobbyCode();
+        String userIdentifier = event.userIdentifier();
+
+        if (!StringUtils.hasText(code) || !StringUtils.hasText(userIdentifier)) {
+            return;
+        }
+
+        // 1. 게임 세션 존재 여부 및 status 검증
+        String sessionKey = RedisKeys.gameSessionKey(code);
+        String status = (String) redisTemplate.opsForHash().get(sessionKey, "status");
+        if (status == null || !"PLAYING".equals(status)) {
+            return;
+        }
+
+        String currentRoundNoStr = (String) redisTemplate.opsForHash().get(sessionKey, "current_round_no");
+        if (currentRoundNoStr == null) {
+            return;
+        }
+        int currentRoundNo = Integer.parseInt(currentRoundNoStr);
+
+        // 2. 남은 참가자가 모두 정답을 맞췄는지 확인
+        String participantsKey = RedisKeys.lobbyParticipantsKey(code);
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(code, currentRoundNo);
+
+        Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
+        if (participants == null || participants.isEmpty()) {
+            return;
+        }
+
+        // 이미 나간 유저는 제외하고 체크해야 하므로, participants에서 현재 나간 userIdentifier는 제외
+        participants.remove(userIdentifier);
+
+        if (participants.isEmpty()) {
+            return;
+        }
+
+        Set<String> correctPlayers = redisTemplate.opsForSet().members(correctPlayersKey);
+        if (correctPlayers == null) {
+            correctPlayers = Collections.emptySet();
+        }
+
+        if (correctPlayers.containsAll(participants)) {
+            log.info("GameLeaveEventHandler: 이탈 발생 후 남은 모든 참가자가 정답을 맞췄습니다. 라운드를 즉시 조기 종료합니다. - code: {}, roundNo: {}", code, currentRoundNo);
+            try {
+                gameRoundEndService.endRound(code, currentRoundNo);
+            } catch (Exception e) {
+                log.error("GameLeaveEventHandler: 이탈 처리 중 라운드 조기 종료 실패 - code: {}, roundNo: {}", code, currentRoundNo, e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 @Slf4j
@@ -29,14 +30,16 @@ public class GameLeaveEventHandler {
             return;
         }
 
-        // 1. 게임 세션 존재 여부 및 status 검증
+        // 1. 게임 세션 존재 여부 및 status/round_phase 검증
         String sessionKey = RedisKeys.gameSessionKey(code);
-        String status = (String) redisTemplate.opsForHash().get(sessionKey, "status");
-        if (status == null || !"PLAYING".equals(status)) {
+        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of(RedisKeys.FIELD_STATUS, RedisKeys.FIELD_ROUND_PHASE, RedisKeys.FIELD_CURRENT_ROUND_NO));
+        String status = (String) hashValues.get(0);
+        String roundPhase = (String) hashValues.get(1);
+        if (status == null || !"PLAYING".equals(status) || !"PLAYING".equals(roundPhase)) {
             return;
         }
 
-        String currentRoundNoStr = (String) redisTemplate.opsForHash().get(sessionKey, "current_round_no");
+        String currentRoundNoStr = (String) hashValues.get(2);
         if (currentRoundNoStr == null) {
             return;
         }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -174,15 +174,6 @@ public class GameRoundEndService {
             }
         }
 
-        RoundMetadataDto metadataDto = RoundMetadataDto.builder()
-                .type("ROUND_END")
-                .title(title)
-                .artist(artist)
-                .answer(representativeAnswer)
-                .thumbnailUrl(thumbnailUrl)
-                .rankings(rankings)
-                .build();
-
         // 7. 다음 라운드 또는 게임 종료 전환
         boolean isLastRound = roundNo >= gameSession.getTotalQuestionCount();
 
@@ -196,7 +187,24 @@ public class GameRoundEndService {
 
             redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "FINISHED");
             redisTemplate.opsForHash().put(RedisKeys.lobbyKey(lobbyCode), "status", "FINISHED");
+        } else {
+            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "ENDED");
         }
+
+        // 7.5. Redis에 라운드 종료 시각 기록
+        String endedAtField = RedisKeys.gameSessionRoundEndedAtField(roundNo);
+        redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), endedAtField, String.valueOf(System.currentTimeMillis()));
+
+        RoundMetadataDto metadataDto = RoundMetadataDto.builder()
+                .type("ROUND_END")
+                .title(title)
+                .artist(artist)
+                .answer(representativeAnswer)
+                .thumbnailUrl(thumbnailUrl)
+                .rankings(rankings)
+                .waitTimeSeconds(10)
+                .isLastRound(isLastRound)
+                .build();
 
         // 8. 트랜잭션 성공 후 STOMP 브로드캐스트 및 스케줄링 등록
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -1,13 +1,11 @@
 package io.github.ascrew.monomatbe.domain.game.service;
 
-import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.domain.game.dto.PlayerRankingDto;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
-import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionPlayerJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
@@ -35,7 +33,6 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class GameRoundEndService {
 
     private final StringRedisTemplate redisTemplate;
@@ -49,7 +46,35 @@ public class GameRoundEndService {
     private final GameRealtimeNotifier gameRealtimeNotifier;
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
     private final JsonMapper jsonMapper;
-    private final ApplicationContext applicationContext;
+    private final GameRoundProgressService gameRoundProgressService;
+
+    @org.springframework.context.annotation.Lazy
+    public GameRoundEndService(
+            StringRedisTemplate redisTemplate,
+            GameSessionJpaRepository gameSessionJpaRepository,
+            GameSessionPlayerJpaRepository gameSessionPlayerJpaRepository,
+            GameLobbyJpaRepository gameLobbyJpaRepository,
+            MapItemJpaRepository mapItemJpaRepository,
+            UserSessionRepository userSessionRepository,
+            GuestSessionRepository guestSessionRepository,
+            LobbyPlayerNicknameResolver nicknameResolver,
+            GameRealtimeNotifier gameRealtimeNotifier,
+            LobbyRealtimeNotifier lobbyRealtimeNotifier,
+            JsonMapper jsonMapper,
+            @org.springframework.context.annotation.Lazy GameRoundProgressService gameRoundProgressService) {
+        this.redisTemplate = redisTemplate;
+        this.gameSessionJpaRepository = gameSessionJpaRepository;
+        this.gameSessionPlayerJpaRepository = gameSessionPlayerJpaRepository;
+        this.gameLobbyJpaRepository = gameLobbyJpaRepository;
+        this.mapItemJpaRepository = mapItemJpaRepository;
+        this.userSessionRepository = userSessionRepository;
+        this.guestSessionRepository = guestSessionRepository;
+        this.nicknameResolver = nicknameResolver;
+        this.gameRealtimeNotifier = gameRealtimeNotifier;
+        this.lobbyRealtimeNotifier = lobbyRealtimeNotifier;
+        this.jsonMapper = jsonMapper;
+        this.gameRoundProgressService = gameRoundProgressService;
+    }
 
     /**
      * 특정 라운드를 종료하고 점수 계산 및 DB/Redis 업데이트를 수행합니다.
@@ -66,180 +91,190 @@ public class GameRoundEndService {
 
         log.info("라운드 종료 처리 시작 - code: {}, roundNo: {}", lobbyCode, roundNo);
 
-        // 1. 게임 세션 및 플레이어 조회
-        GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
-                .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
+        boolean registered = false;
+        try {
+            // 1. 게임 세션 및 플레이어 조회
+            GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
+                    .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
 
-        List<GameSessionPlayer> dbPlayers = gameSessionPlayerJpaRepository.findAllByGameSessionId(gameSession.getId());
+            List<GameSessionPlayer> dbPlayers = gameSessionPlayerJpaRepository.findAllByGameSessionId(gameSession.getId());
 
-        // 2. Redis에서 정답자 및 1등 정보 조회
-        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(lobbyCode, roundNo);
-        Set<String> correctPlayerIdentifiers = redisTemplate.opsForSet().members(correctPlayersKey);
-        if (correctPlayerIdentifiers == null) {
-            correctPlayerIdentifiers = Collections.emptySet();
-        }
-
-        String roundDataKey = RedisKeys.gameSessionRoundDataKey(lobbyCode, roundNo);
-        String firstCorrectIdentifier = (String) redisTemplate.opsForHash().get(roundDataKey, "first_correct_user_id");
-
-        // 3. userIdentifier -> User 매핑 정보 빌드
-        String playersKey = RedisKeys.gameSessionPlayersKey(lobbyCode);
-        Map<Object, Object> playersMap = redisTemplate.opsForHash().entries(playersKey);
-        Set<String> participantIdentifiers = playersMap.keySet().stream()
-                .map(Object::toString)
-                .collect(Collectors.toSet());
-
-        Map<Long, String> userIdToIdentifier = new HashMap<>();
-        userSessionRepository.findBySessionIdIn(participantIdentifiers)
-                .forEach(s -> userIdToIdentifier.put(s.getUser().getId(), s.getSessionId()));
-        guestSessionRepository.findByGuestTokenIn(participantIdentifiers)
-                .forEach(g -> userIdToIdentifier.put(g.getUser().getId(), g.getGuestToken()));
-
-        // 4. 각 플레이어별 득점 계산 및 반영
-        Map<String, Integer> scoreAddedMap = new HashMap<>();
-        for (GameSessionPlayer dbPlayer : dbPlayers) {
-            String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
-            if (identifier == null) {
-                continue;
+            // 2. Redis에서 정답자 및 1등 정보 조회
+            String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(lobbyCode, roundNo);
+            Set<String> correctPlayerIdentifiers = redisTemplate.opsForSet().members(correctPlayersKey);
+            if (correctPlayerIdentifiers == null) {
+                correctPlayerIdentifiers = Collections.emptySet();
             }
 
-            int scoreAdded = 0;
-            if (correctPlayerIdentifiers.contains(identifier)) {
-                scoreAdded += 100; // 기본 점수
-                if (identifier.equals(firstCorrectIdentifier)) {
-                    scoreAdded += 40; // 1등 보너스
+            String roundDataKey = RedisKeys.gameSessionRoundDataKey(lobbyCode, roundNo);
+            String firstCorrectIdentifier = (String) redisTemplate.opsForHash().get(roundDataKey, "first_correct_user_id");
+
+            // 3. userIdentifier -> User 매핑 정보 빌드
+            String playersKey = RedisKeys.gameSessionPlayersKey(lobbyCode);
+            Map<Object, Object> playersMap = redisTemplate.opsForHash().entries(playersKey);
+            Set<String> participantIdentifiers = playersMap.keySet().stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toSet());
+
+            Map<Long, String> userIdToIdentifier = new HashMap<>();
+            userSessionRepository.findBySessionIdIn(participantIdentifiers)
+                    .forEach(s -> userIdToIdentifier.put(s.getUser().getId(), s.getSessionId()));
+            guestSessionRepository.findByGuestTokenIn(participantIdentifiers)
+                    .forEach(g -> userIdToIdentifier.put(g.getUser().getId(), g.getGuestToken()));
+
+            // 4. 각 플레이어별 득점 계산 및 반영
+            Map<String, Integer> scoreAddedMap = new HashMap<>();
+            for (GameSessionPlayer dbPlayer : dbPlayers) {
+                String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
+                if (identifier == null) {
+                    continue;
                 }
-            }
 
-            scoreAddedMap.put(identifier, scoreAdded);
-
-            if (scoreAdded > 0) {
-                dbPlayer.addScore(scoreAdded);
-                gameSessionPlayerJpaRepository.save(dbPlayer);
-            }
-        }
-
-        // 5. 실시간 랭킹 산정
-        Map<String, String> nicknameMap = nicknameResolver.resolveNicknameMap(participantIdentifiers);
-        List<PlayerTemp> tempPlayers = new ArrayList<>();
-        for (GameSessionPlayer dbPlayer : dbPlayers) {
-            String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
-            if (identifier == null) {
-                continue;
-            }
-            String nickname = nicknameMap.getOrDefault(identifier, nicknameResolver.fallbackNickname(identifier));
-            tempPlayers.add(new PlayerTemp(identifier, nickname, dbPlayer.getScore(), scoreAddedMap.getOrDefault(identifier, 0)));
-        }
-
-        // 점수 기준 내림차순 정렬
-        tempPlayers.sort((p1, p2) -> Integer.compare(p2.totalScore, p1.totalScore));
-
-        List<PlayerRankingDto> rankings = new ArrayList<>();
-        int currentRank = 1;
-        for (int i = 0; i < tempPlayers.size(); i++) {
-            PlayerTemp p = tempPlayers.get(i);
-            if (i > 0 && p.totalScore < tempPlayers.get(i - 1).totalScore) {
-                currentRank = i + 1;
-            }
-            rankings.add(PlayerRankingDto.builder()
-                    .userIdentifier(p.userIdentifier)
-                    .nickname(p.nickname)
-                    .score(p.totalScore)
-                    .rank(currentRank)
-                    .scoreAdded(p.scoreAdded)
-                    .build());
-        }
-
-        // 6. 라운드 종료 메타데이터 구성 (곡 정보)
-        String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
-        String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, roundNo - 1);
-        String title = "";
-        String artist = "";
-        String representativeAnswer = "";
-        String thumbnailUrl = "";
-
-        if (mapItemIdStr != null) {
-            try {
-                Long mapItemId = Long.parseLong(mapItemIdStr);
-                MapItem mapItem = mapItemJpaRepository.findById(mapItemId).orElse(null);
-                if (mapItem != null) {
-                    title = mapItem.getTitle();
-                    artist = mapItem.getArtist();
-                    thumbnailUrl = mapItem.getThumbnailUrl();
-                    List<String> rawAnswers = jsonMapper.readValue(mapItem.getAnswers(), new TypeReference<List<String>>() {});
-                    representativeAnswer = rawAnswers.isEmpty() ? title : rawAnswers.get(0);
-                }
-            } catch (Exception e) {
-                log.error("라운드 종료 메타데이터 파싱 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
-            }
-        }
-
-        // 7. 다음 라운드 또는 게임 종료 전환
-        boolean isLastRound = roundNo >= gameSession.getTotalQuestionCount();
-
-        if (isLastRound) {
-            gameSession.finish();
-            gameSessionJpaRepository.save(gameSession);
-
-            GameLobby lobby = gameSession.getLobby();
-            lobby.changeStatus(LobbyStatus.FINISHED);
-            gameLobbyJpaRepository.save(lobby);
-
-            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "FINISHED");
-            redisTemplate.opsForHash().put(RedisKeys.lobbyKey(lobbyCode), "status", "FINISHED");
-        } else {
-            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), "status", "ENDED");
-        }
-
-        // 7.5. Redis에 라운드 종료 시각 기록
-        String endedAtField = RedisKeys.gameSessionRoundEndedAtField(roundNo);
-        redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), endedAtField, String.valueOf(System.currentTimeMillis()));
-
-        RoundMetadataDto metadataDto = RoundMetadataDto.builder()
-                .type("ROUND_END")
-                .title(title)
-                .artist(artist)
-                .answer(representativeAnswer)
-                .thumbnailUrl(thumbnailUrl)
-                .rankings(rankings)
-                .waitTimeSeconds(10)
-                .isLastRound(isLastRound)
-                .build();
-
-        // 8. 트랜잭션 성공 후 STOMP 브로드캐스트 및 스케줄링 등록
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                log.info("라운드 종료 트랜잭션 커밋 완료 - Redis 점수 반영 및 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
-                
-                scoreAddedMap.forEach((identifier, scoreAdded) -> {
-                    if (scoreAdded > 0) {
-                        redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
+                int scoreAdded = 0;
+                if (correctPlayerIdentifiers.contains(identifier)) {
+                    scoreAdded += 100; // 기본 점수
+                    if (identifier.equals(firstCorrectIdentifier)) {
+                        scoreAdded += 40; // 1등 보너스
                     }
-                });
+                }
 
-                gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+                scoreAddedMap.put(identifier, scoreAdded);
 
-                GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
-                if (isLastRound) {
-                    try {
-                        lobbyRealtimeNotifier.notifyLobbyInfoRefresh(lobbyCode, "SYSTEM");
-                    } catch (Exception e) {
-                        log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
+                if (scoreAdded > 0) {
+                    dbPlayer.addScore(scoreAdded);
+                    gameSessionPlayerJpaRepository.save(dbPlayer);
+                }
+            }
+
+            // 5. 실시간 랭킹 산정
+            Map<String, String> nicknameMap = nicknameResolver.resolveNicknameMap(participantIdentifiers);
+            List<PlayerTemp> tempPlayers = new ArrayList<>();
+            for (GameSessionPlayer dbPlayer : dbPlayers) {
+                String identifier = userIdToIdentifier.get(dbPlayer.getUser().getId());
+                if (identifier == null) {
+                    continue;
+                }
+                String nickname = nicknameMap.getOrDefault(identifier, nicknameResolver.fallbackNickname(identifier));
+                tempPlayers.add(new PlayerTemp(identifier, nickname, dbPlayer.getScore(), scoreAddedMap.getOrDefault(identifier, 0)));
+            }
+
+            // 점수 기준 내림차순 정렬
+            tempPlayers.sort((p1, p2) -> Integer.compare(p2.totalScore, p1.totalScore));
+
+            List<PlayerRankingDto> rankings = new ArrayList<>();
+            int currentRank = 1;
+            for (int i = 0; i < tempPlayers.size(); i++) {
+                PlayerTemp p = tempPlayers.get(i);
+                if (i > 0 && p.totalScore < tempPlayers.get(i - 1).totalScore) {
+                    currentRank = i + 1;
+                }
+                rankings.add(PlayerRankingDto.builder()
+                        .userIdentifier(p.userIdentifier)
+                        .nickname(p.nickname)
+                        .score(p.totalScore)
+                        .rank(currentRank)
+                        .scoreAdded(p.scoreAdded)
+                        .build());
+            }
+
+            // 6. 라운드 종료 메타데이터 구성 (곡 정보)
+            String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+            String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, roundNo - 1);
+            String title = "";
+            String artist = "";
+            String representativeAnswer = "";
+            String thumbnailUrl = "";
+
+            if (mapItemIdStr != null) {
+                try {
+                    Long mapItemId = Long.parseLong(mapItemIdStr);
+                    MapItem mapItem = mapItemJpaRepository.findById(mapItemId).orElse(null);
+                    if (mapItem != null) {
+                        title = mapItem.getTitle();
+                        artist = mapItem.getArtist();
+                        thumbnailUrl = mapItem.getThumbnailUrl();
+                        List<String> rawAnswers = jsonMapper.readValue(mapItem.getAnswers(), new TypeReference<List<String>>() {});
+                        representativeAnswer = rawAnswers.isEmpty() ? title : rawAnswers.get(0);
                     }
-                } else {
-                    progressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                } catch (Exception e) {
+                    log.error("라운드 종료 메타데이터 파싱 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
                 }
             }
 
-            @Override
-            public void afterCompletion(int status) {
-                if (status == STATUS_ROLLED_BACK) {
-                    log.warn("라운드 종료 트랜잭션 롤백 감지 - 멱등 락 해제. code: {}, roundNo: {}", lobbyCode, roundNo);
-                    redisTemplate.delete(endedLockKey);
-                }
+            // 7. 다음 라운드 또는 게임 종료 전환
+            boolean isLastRound = roundNo >= gameSession.getTotalQuestionCount();
+
+            if (isLastRound) {
+                gameSession.finish();
+                gameSessionJpaRepository.save(gameSession);
+
+                GameLobby lobby = gameSession.getLobby();
+                lobby.changeStatus(LobbyStatus.FINISHED);
+                gameLobbyJpaRepository.save(lobby);
+
+                redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), RedisKeys.FIELD_STATUS, "FINISHED");
+                redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), RedisKeys.FIELD_ROUND_PHASE, "FINISHED");
+                redisTemplate.opsForHash().put(RedisKeys.lobbyKey(lobbyCode), RedisKeys.FIELD_STATUS, "FINISHED");
+            } else {
+                redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), RedisKeys.FIELD_ROUND_PHASE, "ENDED");
             }
-        });
+
+            // 7.5. Redis에 라운드 종료 시각 기록
+            String endedAtField = RedisKeys.gameSessionRoundEndedAtField(roundNo);
+            redisTemplate.opsForHash().put(RedisKeys.gameSessionKey(lobbyCode), endedAtField, String.valueOf(System.currentTimeMillis()));
+
+            RoundMetadataDto metadataDto = RoundMetadataDto.builder()
+                    .type("ROUND_END")
+                    .title(title)
+                    .artist(artist)
+                    .answer(representativeAnswer)
+                    .thumbnailUrl(thumbnailUrl)
+                    .rankings(rankings)
+                    .waitTimeSeconds(10)
+                    .isLastRound(isLastRound)
+                    .build();
+
+            // 8. 트랜잭션 성공 후 STOMP 브로드캐스트 및 스케줄링 등록
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    log.info("라운드 종료 트랜잭션 커밋 완료 - Redis 점수 반영 및 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
+                    
+                    scoreAddedMap.forEach((identifier, scoreAdded) -> {
+                        if (scoreAdded > 0) {
+                            redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
+                        }
+                    });
+
+                    gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+
+                    if (isLastRound) {
+                        try {
+                            lobbyRealtimeNotifier.notifyLobbyInfoRefresh(lobbyCode, "SYSTEM");
+                        } catch (Exception e) {
+                            log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
+                        }
+                    } else {
+                        gameRoundProgressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                    }
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    if (status == STATUS_ROLLED_BACK) {
+                        log.warn("라운드 종료 트랜잭션 롤백 감지 - 멱등 락 해제. code: {}, roundNo: {}", lobbyCode, roundNo);
+                        redisTemplate.delete(endedLockKey);
+                    }
+                }
+            });
+            registered = true;
+        } catch (Throwable t) {
+            if (!registered) {
+                log.warn("라운드 종료 처리 중 예외 발생 - 멱등 락 해제. code: {}, roundNo: {}", lobbyCode, roundNo, t);
+                redisTemplate.delete(endedLockKey);
+            }
+            throw t;
+        }
     }
 
     private static class PlayerTemp {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -240,13 +240,21 @@ public class GameRoundEndService {
                 public void afterCommit() {
                     log.info("라운드 종료 트랜잭션 커밋 완료 - Redis 점수 반영 및 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
                     
-                    scoreAddedMap.forEach((identifier, scoreAdded) -> {
-                        if (scoreAdded > 0) {
-                            redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
-                        }
-                    });
+                    try {
+                        scoreAddedMap.forEach((identifier, scoreAdded) -> {
+                            if (scoreAdded > 0) {
+                                redisTemplate.opsForHash().increment(playersKey, identifier, scoreAdded);
+                            }
+                        });
+                    } catch (Exception e) {
+                        log.error("Redis 점수 증액 반영 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+                    }
 
-                    gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+                    try {
+                        gameRealtimeNotifier.notifyRoundEnd(lobbyCode, metadataDto);
+                    } catch (Exception e) {
+                        log.error("ROUND_END 브로드캐스트 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+                    }
 
                     if (isLastRound) {
                         try {
@@ -255,7 +263,11 @@ public class GameRoundEndService {
                             log.error("게임 종료 후 로비 갱신 알림 실패 - code: {}", lobbyCode, e);
                         }
                     } else {
-                        gameRoundProgressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                        try {
+                            gameRoundProgressService.scheduleNextRound(lobbyCode, roundNo + 1);
+                        } catch (Exception e) {
+                            log.error("다음 라운드 시작 스케줄 등록 실패 - code: {}, nextRoundNo: {}", lobbyCode, roundNo + 1, e);
+                        }
                     }
                 }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
@@ -1,0 +1,144 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@Component
+public class GameRoundNextRoundExecutor {
+
+    private final GameSessionJpaRepository gameSessionJpaRepository;
+    private final MapItemJpaRepository mapItemJpaRepository;
+    private final GameRealtimeNotifier gameRealtimeNotifier;
+    private final StringRedisTemplate redisTemplate;
+    private final GameRoundStartService gameRoundStartService;
+
+    @Lazy
+    public GameRoundNextRoundExecutor(
+            GameSessionJpaRepository gameSessionJpaRepository,
+            MapItemJpaRepository mapItemJpaRepository,
+            GameRealtimeNotifier gameRealtimeNotifier,
+            StringRedisTemplate redisTemplate,
+            @Lazy GameRoundStartService gameRoundStartService) {
+        this.gameSessionJpaRepository = gameSessionJpaRepository;
+        this.mapItemJpaRepository = mapItemJpaRepository;
+        this.gameRealtimeNotifier = gameRealtimeNotifier;
+        this.redisTemplate = redisTemplate;
+        this.gameRoundStartService = gameRoundStartService;
+    }
+
+    /**
+     * 다음 라운드 데이터를 로드하고 준비 신호(ROUND_READY)를 브로드캐스트합니다.
+     */
+    @Transactional
+    public void startNextRound(String lobbyCode, int nextRoundNo) {
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+
+        // [중요: 락과 완료 상태 분리]
+        // 1. 이미 완료되었는지 Redis 필드로 1차 검증
+        String currentRoundStr = (String) redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO);
+        if (currentRoundStr != null && Integer.parseInt(currentRoundStr) >= nextRoundNo) {
+            log.info("다음 라운드가 이미 시작되었습니다. (Redis 검증 통과) - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
+            return;
+        }
+
+        // 2. 동시성 제어를 위한 처리 중 락 획득 (짧은 TTL 10초)
+        String nextRoundLockKey = RedisKeys.gameSessionNextRoundLockKey(lobbyCode, nextRoundNo);
+        Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(nextRoundLockKey, "1", Duration.ofSeconds(10));
+
+        if (Boolean.FALSE.equals(lockAcquired)) {
+            log.info("다음 라운드 시작 처리 중이므로 무시됨 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
+            return;
+        }
+
+        log.info("다음 라운드 시작 처리 실행 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+
+        boolean registered = false;
+        try {
+            // 3. 게임 세션 조회
+            GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
+                    .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
+
+            // DB에서 2차 완료 여부 검증
+            if (gameSession.getCurrentRoundNo() >= nextRoundNo) {
+                log.info("다음 라운드가 이미 시작되었습니다. (DB 검증 통과) - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
+                return;
+            }
+
+            // 4. DB 및 Redis 라운드 갱신
+            gameSession.moveToNextRound(nextRoundNo);
+            gameSessionJpaRepository.save(gameSession);
+
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, String.valueOf(nextRoundNo));
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, "READY");
+
+            // 5. 다음 라운드 MapItem 조회
+            String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+            String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, nextRoundNo - 1);
+            if (mapItemIdStr == null) {
+                throw new NoSuchElementException("다음 라운드의 문제 ID를 Redis에서 찾을 수 없습니다. roundNo: " + nextRoundNo);
+            }
+
+            Long mapItemId = Long.parseLong(mapItemIdStr);
+            MapItem mapItem = mapItemJpaRepository.findById(mapItemId)
+                    .orElseThrow(() -> new NoSuchElementException("MapItem을 찾을 수 없습니다. id: " + mapItemId));
+
+            // 6. 다음 라운드 DTO 구성
+            long serverStartedAt = System.currentTimeMillis();
+            int effectiveEndTime = mapItem.getStartTime() + gameSession.getLobby().getTimeLimitSeconds();
+
+            RoundStartDto nextRoundDto = RoundStartDto.builder()
+                      .type("ROUND_READY")
+                      .videoId(mapItem.getVideoId())
+                      .youtubeUrl(mapItem.getYoutubeUrl())
+                      .startTime(mapItem.getStartTime())
+                      .endTime(effectiveEndTime)
+                      .timeLimitSeconds(gameSession.getLobby().getTimeLimitSeconds())
+                      .roundNo(nextRoundNo)
+                      .serverStartedAt(serverStartedAt)
+                      .build();
+
+            // 7. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+                    gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
+
+                    gameRoundStartService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    // 완료 또는 실패에 관계없이 처리 중 락을 즉시 해제하여 락 방치를 차단한다.
+                    log.info("다음 라운드 시작 트랜잭션 완료(status={}) - 처리 락 해제. code: {}, nextRoundNo: {}", status, lobbyCode, nextRoundNo);
+                    redisTemplate.delete(nextRoundLockKey);
+                }
+            });
+            registered = true;
+        } finally {
+            if (!registered) {
+                // 트랜잭션 동기화 등록조차 실패하고 예외 발생 시 예외 안전성 확보를 위한 즉시 해제
+                log.warn("트랜잭션 동기화 등록 실패 - 처리 락 해제. code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
+                redisTemplate.delete(nextRoundLockKey);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundNextRoundExecutor.java
@@ -120,9 +120,17 @@ public class GameRoundNextRoundExecutor {
                 @Override
                 public void afterCommit() {
                     log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
-                    gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
+                    try {
+                        gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
+                    } catch (Exception e) {
+                        log.error("ROUND_READY 브로드캐스트 실패 - code: {}, roundNo: {}", lobbyCode, nextRoundNo, e);
+                    }
 
-                    gameRoundStartService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+                    try {
+                        gameRoundStartService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+                    } catch (Exception e) {
+                        log.error("강제 재생 시작 스케줄 등록 실패 - code: {}, roundNo: {}", lobbyCode, nextRoundNo, e);
+                    }
                 }
 
                 @Override

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
@@ -6,9 +6,8 @@ import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepositor
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
@@ -16,8 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,7 +24,6 @@ import java.util.concurrent.ScheduledFuture;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class GameRoundProgressService {
 
     private final TaskScheduler taskScheduler;
@@ -33,9 +31,31 @@ public class GameRoundProgressService {
     private final GameSessionJpaRepository gameSessionJpaRepository;
     private final MapItemJpaRepository mapItemJpaRepository;
     private final GameRealtimeNotifier gameRealtimeNotifier;
-    private final ApplicationContext applicationContext;
+    private final GameRoundEndService gameRoundEndService;
+    private final GameRoundStartService gameRoundStartService;
+    private final GameRoundProgressService self;
 
     private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+    @Lazy
+    public GameRoundProgressService(
+            TaskScheduler taskScheduler,
+            StringRedisTemplate redisTemplate,
+            GameSessionJpaRepository gameSessionJpaRepository,
+            MapItemJpaRepository mapItemJpaRepository,
+            GameRealtimeNotifier gameRealtimeNotifier,
+            GameRoundEndService gameRoundEndService,
+            GameRoundStartService gameRoundStartService,
+            @Lazy GameRoundProgressService self) {
+        this.taskScheduler = taskScheduler;
+        this.redisTemplate = redisTemplate;
+        this.gameSessionJpaRepository = gameSessionJpaRepository;
+        this.mapItemJpaRepository = mapItemJpaRepository;
+        this.gameRealtimeNotifier = gameRealtimeNotifier;
+        this.gameRoundEndService = gameRoundEndService;
+        this.gameRoundStartService = gameRoundStartService;
+        this.self = self;
+    }
 
     /**
      * 라운드 종료 스케줄링을 등록합니다. (재생 시작 시점 기준 1.5초 완충 시간 포함)
@@ -48,8 +68,7 @@ public class GameRoundProgressService {
         ScheduledFuture<?> future = taskScheduler.schedule(() -> {
             try {
                 scheduledTasks.remove(key);
-                GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
-                endService.endRound(lobbyCode, roundNo);
+                gameRoundEndService.endRound(lobbyCode, roundNo);
             } catch (Exception e) {
                 log.error("자동 라운드 종료 처리 중 예외 발생 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
             }
@@ -76,8 +95,7 @@ public class GameRoundProgressService {
         ScheduledFuture<?> future = taskScheduler.schedule(() -> {
             try {
                 scheduledTasks.remove(key);
-                GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
-                endService.endRound(lobbyCode, roundNo);
+                gameRoundEndService.endRound(lobbyCode, roundNo);
             } catch (Exception e) {
                 log.error("자동 라운드 종료 처리 중 예외 발생 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
             }
@@ -90,16 +108,22 @@ public class GameRoundProgressService {
      * 다음 라운드 시작 스케줄링을 등록합니다. (결과 화면 노출 10초)
      */
     public void scheduleNextRound(String lobbyCode, int nextRoundNo) {
-        log.info("다음 라운드 시작 예약 - code: {}, nextRoundNo: {}, delay: 10s", lobbyCode, nextRoundNo);
+        scheduleNextRoundWithDelay(lobbyCode, nextRoundNo, 10000L);
+    }
+
+    /**
+     * 특정 지연 시간(ms) 후 다음 라운드 시작 스케줄링을 등록합니다.
+     */
+    public void scheduleNextRoundWithDelay(String lobbyCode, int nextRoundNo, long delayMillis) {
+        log.info("다음 라운드 시작 예약 - code: {}, nextRoundNo: {}, delay: {}ms", lobbyCode, nextRoundNo, delayMillis);
         
         taskScheduler.schedule(() -> {
             try {
-                GameRoundProgressService self = applicationContext.getBean(GameRoundProgressService.class);
                 self.startNextRound(lobbyCode, nextRoundNo);
             } catch (Exception e) {
                 log.error("다음 라운드 시작 예약 처리 중 예외 발생 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
             }
-        }, Instant.now().plusSeconds(10));
+        }, Instant.now().plusMillis(delayMillis));
     }
 
     /**
@@ -107,56 +131,82 @@ public class GameRoundProgressService {
      */
     @Transactional
     public void startNextRound(String lobbyCode, int nextRoundNo) {
-        log.info("다음 라운드 시작 처리 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+        String nextRoundLockKey = RedisKeys.gameSessionNextRoundLockKey(lobbyCode, nextRoundNo);
+        Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(nextRoundLockKey, "1", Duration.ofMinutes(5));
 
-        // 1. 게임 세션 조회
-        GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
-                .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
-
-        // 2. DB 및 Redis 라운드 갱신
-        gameSession.nextRound();
-        gameSessionJpaRepository.save(gameSession);
-
-        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
-        redisTemplate.opsForHash().put(sessionKey, "current_round_no", String.valueOf(nextRoundNo));
-        redisTemplate.opsForHash().put(sessionKey, "status", "READY");
-
-        // 3. 다음 라운드 MapItem 조회
-        String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
-        String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, nextRoundNo - 1);
-        if (mapItemIdStr == null) {
-            throw new NoSuchElementException("다음 라운드의 문제 ID를 Redis에서 찾을 수 없습니다. roundNo: " + nextRoundNo);
+        if (Boolean.FALSE.equals(lockAcquired)) {
+            log.info("다음 라운드 시작 무시됨 (이미 시작 처리됨) - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
+            return;
         }
 
-        Long mapItemId = Long.parseLong(mapItemIdStr);
-        MapItem mapItem = mapItemJpaRepository.findById(mapItemId)
-                .orElseThrow(() -> new NoSuchElementException("MapItem을 찾을 수 없습니다. id: " + mapItemId));
+        log.info("다음 라운드 시작 처리 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
 
-        // 4. 다음 라운드 DTO 구성
-        long serverStartedAt = System.currentTimeMillis();
-        int effectiveEndTime = mapItem.getStartTime() + gameSession.getLobby().getTimeLimitSeconds();
+        boolean registered = false;
+        try {
+            // 1. 게임 세션 조회
+            GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
+                    .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
 
-        RoundStartDto nextRoundDto = RoundStartDto.builder()
-                .type("ROUND_READY")
-                .videoId(mapItem.getVideoId())
-                .youtubeUrl(mapItem.getYoutubeUrl())
-                .startTime(mapItem.getStartTime())
-                .endTime(effectiveEndTime)
-                .timeLimitSeconds(gameSession.getLobby().getTimeLimitSeconds())
-                .roundNo(nextRoundNo)
-                .serverStartedAt(serverStartedAt)
-                .build();
+            // 2. DB 및 Redis 라운드 갱신
+            gameSession.moveToRound(nextRoundNo);
+            gameSessionJpaRepository.save(gameSession);
 
-        // 5. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
-                gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
+            String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, String.valueOf(nextRoundNo));
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, "READY");
 
-                GameRoundStartService startService = applicationContext.getBean(GameRoundStartService.class);
-                startService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+            // 3. 다음 라운드 MapItem 조회
+            String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+            String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, nextRoundNo - 1);
+            if (mapItemIdStr == null) {
+                throw new NoSuchElementException("다음 라운드의 문제 ID를 Redis에서 찾을 수 없습니다. roundNo: " + nextRoundNo);
             }
-        });
+
+            Long mapItemId = Long.parseLong(mapItemIdStr);
+            MapItem mapItem = mapItemJpaRepository.findById(mapItemId)
+                    .orElseThrow(() -> new NoSuchElementException("MapItem을 찾을 수 없습니다. id: " + mapItemId));
+
+            // 4. 다음 라운드 DTO 구성
+            long serverStartedAt = System.currentTimeMillis();
+            int effectiveEndTime = mapItem.getStartTime() + gameSession.getLobby().getTimeLimitSeconds();
+
+            RoundStartDto nextRoundDto = RoundStartDto.builder()
+                    .type("ROUND_READY")
+                    .videoId(mapItem.getVideoId())
+                    .youtubeUrl(mapItem.getYoutubeUrl())
+                    .startTime(mapItem.getStartTime())
+                    .endTime(effectiveEndTime)
+                    .timeLimitSeconds(gameSession.getLobby().getTimeLimitSeconds())
+                    .roundNo(nextRoundNo)
+                    .serverStartedAt(serverStartedAt)
+                    .build();
+
+            // 5. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
+                    gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
+
+                    gameRoundStartService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    if (status == STATUS_ROLLED_BACK) {
+                        log.warn("다음 라운드 시작 트랜잭션 롤백 감지 - 락 해제. code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
+                        redisTemplate.delete(nextRoundLockKey);
+                    }
+                }
+            });
+            registered = true;
+        } catch (Throwable t) {
+            if (!registered) {
+                log.warn("다음 라운드 시작 처리 중 예외 발생 - 락 해제. code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, t);
+                redisTemplate.delete(nextRoundLockKey);
+            }
+            throw t;
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
@@ -20,6 +20,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 @Slf4j
 @Service
@@ -33,6 +35,8 @@ public class GameRoundProgressService {
     private final GameRealtimeNotifier gameRealtimeNotifier;
     private final ApplicationContext applicationContext;
 
+    private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
     /**
      * 라운드 종료 스케줄링을 등록합니다. (재생 시작 시점 기준 1.5초 완충 시간 포함)
      */
@@ -40,14 +44,46 @@ public class GameRoundProgressService {
         long delayMillis = (timeLimitSeconds * 1000L) + 1500L;
         log.info("라운드 종료 자동 태스크 예약 - code: {}, roundNo: {}, delay: {}ms", lobbyCode, roundNo, delayMillis);
         
-        taskScheduler.schedule(() -> {
+        String key = lobbyCode + ":" + roundNo;
+        ScheduledFuture<?> future = taskScheduler.schedule(() -> {
             try {
+                scheduledTasks.remove(key);
                 GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
                 endService.endRound(lobbyCode, roundNo);
             } catch (Exception e) {
                 log.error("자동 라운드 종료 처리 중 예외 발생 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
             }
         }, Instant.now().plusMillis(delayMillis));
+
+        scheduledTasks.put(key, future);
+    }
+
+    /**
+     * 특정 라운드의 종료 타이머가 예약되어 있는지 확인합니다.
+     */
+    public boolean isRoundEndScheduled(String lobbyCode, int roundNo) {
+        String key = lobbyCode + ":" + roundNo;
+        ScheduledFuture<?> future = scheduledTasks.get(key);
+        return future != null && !future.isDone() && !future.isCancelled();
+    }
+
+    /**
+     * 유실된 라운드 종료 타이머를 특정 지연 시간으로 다시 등록합니다.
+     */
+    public void rescheduleRoundEnd(String lobbyCode, int roundNo, long remainingDelayMillis) {
+        log.info("유실된 라운드 종료 자동 태스크 복구 및 재등록 - code: {}, roundNo: {}, delay: {}ms", lobbyCode, roundNo, remainingDelayMillis);
+        String key = lobbyCode + ":" + roundNo;
+        ScheduledFuture<?> future = taskScheduler.schedule(() -> {
+            try {
+                scheduledTasks.remove(key);
+                GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
+                endService.endRound(lobbyCode, roundNo);
+            } catch (Exception e) {
+                log.error("자동 라운드 종료 처리 중 예외 발생 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
+            }
+        }, Instant.now().plusMillis(remainingDelayMillis));
+
+        scheduledTasks.put(key, future);
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressService.java
@@ -33,7 +33,7 @@ public class GameRoundProgressService {
     private final GameRealtimeNotifier gameRealtimeNotifier;
     private final GameRoundEndService gameRoundEndService;
     private final GameRoundStartService gameRoundStartService;
-    private final GameRoundProgressService self;
+    private final GameRoundNextRoundExecutor gameRoundNextRoundExecutor;
 
     private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
 
@@ -46,7 +46,7 @@ public class GameRoundProgressService {
             GameRealtimeNotifier gameRealtimeNotifier,
             GameRoundEndService gameRoundEndService,
             GameRoundStartService gameRoundStartService,
-            @Lazy GameRoundProgressService self) {
+            @Lazy GameRoundNextRoundExecutor gameRoundNextRoundExecutor) {
         this.taskScheduler = taskScheduler;
         this.redisTemplate = redisTemplate;
         this.gameSessionJpaRepository = gameSessionJpaRepository;
@@ -54,7 +54,7 @@ public class GameRoundProgressService {
         this.gameRealtimeNotifier = gameRealtimeNotifier;
         this.gameRoundEndService = gameRoundEndService;
         this.gameRoundStartService = gameRoundStartService;
-        this.self = self;
+        this.gameRoundNextRoundExecutor = gameRoundNextRoundExecutor;
     }
 
     /**
@@ -74,7 +74,10 @@ public class GameRoundProgressService {
             }
         }, Instant.now().plusMillis(delayMillis));
 
-        scheduledTasks.put(key, future);
+        ScheduledFuture<?> oldFuture = scheduledTasks.put(key, future);
+        if (oldFuture != null) {
+            oldFuture.cancel(false);
+        }
     }
 
     /**
@@ -101,7 +104,10 @@ public class GameRoundProgressService {
             }
         }, Instant.now().plusMillis(remainingDelayMillis));
 
-        scheduledTasks.put(key, future);
+        ScheduledFuture<?> oldFuture = scheduledTasks.put(key, future);
+        if (oldFuture != null) {
+            oldFuture.cancel(false);
+        }
     }
 
     /**
@@ -119,94 +125,10 @@ public class GameRoundProgressService {
         
         taskScheduler.schedule(() -> {
             try {
-                self.startNextRound(lobbyCode, nextRoundNo);
+                gameRoundNextRoundExecutor.startNextRound(lobbyCode, nextRoundNo);
             } catch (Exception e) {
                 log.error("다음 라운드 시작 예약 처리 중 예외 발생 - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, e);
             }
         }, Instant.now().plusMillis(delayMillis));
-    }
-
-    /**
-     * 다음 라운드 데이터를 로드하고 준비 신호(ROUND_READY)를 브로드캐스트합니다.
-     */
-    @Transactional
-    public void startNextRound(String lobbyCode, int nextRoundNo) {
-        String nextRoundLockKey = RedisKeys.gameSessionNextRoundLockKey(lobbyCode, nextRoundNo);
-        Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(nextRoundLockKey, "1", Duration.ofMinutes(5));
-
-        if (Boolean.FALSE.equals(lockAcquired)) {
-            log.info("다음 라운드 시작 무시됨 (이미 시작 처리됨) - code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
-            return;
-        }
-
-        log.info("다음 라운드 시작 처리 - code: {}, roundNo: {}", lobbyCode, nextRoundNo);
-
-        boolean registered = false;
-        try {
-            // 1. 게임 세션 조회
-            GameSession gameSession = gameSessionJpaRepository.findActiveSessionByLobbyCode(lobbyCode)
-                    .orElseThrow(() -> new NoSuchElementException("게임 세션을 찾을 수 없습니다. code: " + lobbyCode));
-
-            // 2. DB 및 Redis 라운드 갱신
-            gameSession.moveToRound(nextRoundNo);
-            gameSessionJpaRepository.save(gameSession);
-
-            String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
-            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, String.valueOf(nextRoundNo));
-            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
-            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, "READY");
-
-            // 3. 다음 라운드 MapItem 조회
-            String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
-            String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, nextRoundNo - 1);
-            if (mapItemIdStr == null) {
-                throw new NoSuchElementException("다음 라운드의 문제 ID를 Redis에서 찾을 수 없습니다. roundNo: " + nextRoundNo);
-            }
-
-            Long mapItemId = Long.parseLong(mapItemIdStr);
-            MapItem mapItem = mapItemJpaRepository.findById(mapItemId)
-                    .orElseThrow(() -> new NoSuchElementException("MapItem을 찾을 수 없습니다. id: " + mapItemId));
-
-            // 4. 다음 라운드 DTO 구성
-            long serverStartedAt = System.currentTimeMillis();
-            int effectiveEndTime = mapItem.getStartTime() + gameSession.getLobby().getTimeLimitSeconds();
-
-            RoundStartDto nextRoundDto = RoundStartDto.builder()
-                    .type("ROUND_READY")
-                    .videoId(mapItem.getVideoId())
-                    .youtubeUrl(mapItem.getYoutubeUrl())
-                    .startTime(mapItem.getStartTime())
-                    .endTime(effectiveEndTime)
-                    .timeLimitSeconds(gameSession.getLobby().getTimeLimitSeconds())
-                    .roundNo(nextRoundNo)
-                    .serverStartedAt(serverStartedAt)
-                    .build();
-
-            // 5. 트랜잭션 성공 후 이벤트 발행 및 재생 타이머 시동
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    log.info("다음 라운드 시작 트랜잭션 커밋 완료 - ROUND_READY 브로드캐스트. code: {}, roundNo: {}", lobbyCode, nextRoundNo);
-                    gameRealtimeNotifier.notifyRoundStart(lobbyCode, nextRoundDto);
-
-                    gameRoundStartService.scheduleForcePlaybackStart(lobbyCode, nextRoundNo, gameSession.getLobby().getTimeLimitSeconds());
-                }
-
-                @Override
-                public void afterCompletion(int status) {
-                    if (status == STATUS_ROLLED_BACK) {
-                        log.warn("다음 라운드 시작 트랜잭션 롤백 감지 - 락 해제. code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo);
-                        redisTemplate.delete(nextRoundLockKey);
-                    }
-                }
-            });
-            registered = true;
-        } catch (Throwable t) {
-            if (!registered) {
-                log.warn("다음 라운드 시작 처리 중 예외 발생 - 락 해제. code: {}, nextRoundNo: {}", lobbyCode, nextRoundNo, t);
-                redisTemplate.delete(nextRoundLockKey);
-            }
-            throw t;
-        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryService.java
@@ -1,0 +1,132 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
+import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
+import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class GameRoundRecoveryService {
+
+    private final GameSessionJpaRepository gameSessionJpaRepository;
+    private final StringRedisTemplate redisTemplate;
+    private final GameRoundEndService gameRoundEndService;
+    private final GameRoundProgressService gameRoundProgressService;
+    private final GameRoundStartService gameRoundStartService;
+
+    @Lazy
+    public GameRoundRecoveryService(
+            GameSessionJpaRepository gameSessionJpaRepository,
+            StringRedisTemplate redisTemplate,
+            @Lazy GameRoundEndService gameRoundEndService,
+            @Lazy GameRoundProgressService gameRoundProgressService,
+            @Lazy GameRoundStartService gameRoundStartService) {
+        this.gameSessionJpaRepository = gameSessionJpaRepository;
+        this.redisTemplate = redisTemplate;
+        this.gameRoundEndService = gameRoundEndService;
+        this.gameRoundProgressService = gameRoundProgressService;
+        this.gameRoundStartService = gameRoundStartService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void recoverActiveSessions() {
+        log.info("GameRoundRecoveryService: 서버 시작에 따른 활성 게임 세션 복구 프로세스 시작");
+        
+        List<GameSession> activeSessions = gameSessionJpaRepository.findAllActiveSessionsWithLobby();
+        log.info("복구 대상 active DB 세션 개수: {}", activeSessions.size());
+
+        for (GameSession session : activeSessions) {
+            String lobbyCode = session.getLobby().getInviteCode();
+            try {
+                recoverSession(lobbyCode, session);
+            } catch (Exception e) {
+                log.error("게임 세션 복구 실패 - code: {}", lobbyCode, e);
+            }
+        }
+    }
+
+    private void recoverSession(String lobbyCode, GameSession session) {
+        String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
+        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ));
+
+        if (hashValues.get(0) == null) {
+            log.info("Redis에 세션 정보 없음, 복구 건너뜀 (이미 만료됨) - code: {}", lobbyCode);
+            return;
+        }
+
+        int roundNo = Integer.parseInt((String) hashValues.get(0));
+        int timeLimitSeconds = hashValues.get(1) != null ? Integer.parseInt((String) hashValues.get(1)) : 30;
+        String status = (String) hashValues.get(2);
+        String roundPhase = hashValues.get(3) != null ? (String) hashValues.get(3) : "READY";
+
+        log.info("게임 세션 복구 중 - code: {}, roundNo: {}, status: {}, phase: {}", lobbyCode, roundNo, status, roundPhase);
+
+        if ("FINISHED".equals(status) || "FINISHED".equals(roundPhase)) {
+            log.info("이미 종료된 세션 - code: {}", lobbyCode);
+            return;
+        }
+
+        if ("PLAYING".equals(roundPhase)) {
+            // PLAYING 단계 복구
+            String playbackStartedKey = RedisKeys.gameSessionRoundPlaybackStartedAtField(roundNo);
+            String playbackStartedAtStr = (String) redisTemplate.opsForHash().get(sessionKey, playbackStartedKey);
+            if (playbackStartedAtStr != null) {
+                long serverStartedAt = Long.parseLong(playbackStartedAtStr);
+                long elapsed = System.currentTimeMillis() - serverStartedAt;
+                long limitTimeMillis = timeLimitSeconds * 1000L + 1500L;
+
+                if (elapsed >= limitTimeMillis) {
+                    log.warn("시간 초과가 이미 발생함 -> 즉시 종료 처리. code: {}, roundNo: {}", lobbyCode, roundNo);
+                    gameRoundEndService.endRound(lobbyCode, roundNo);
+                } else {
+                    long remainingDelay = limitTimeMillis - elapsed;
+                    log.info("남은 시간으로 라운드 종료 타이머 복구 등록 - code: {}, roundNo: {}, remaining: {}ms", lobbyCode, roundNo, remainingDelay);
+                    gameRoundProgressService.rescheduleRoundEnd(lobbyCode, roundNo, remainingDelay);
+                }
+            } else {
+                log.warn("PLAYING 단계이나 재생 시작 시각이 없음 -> 강제 재생 시작 처리. code: {}, roundNo: {}", lobbyCode, roundNo);
+                gameRoundStartService.scheduleForcePlaybackStart(lobbyCode, roundNo, timeLimitSeconds);
+            }
+        } else if ("READY".equals(roundPhase)) {
+            // READY 단계 복구: 재생 강제 시작 타이머 재등록 (10초 대기 시간 중 일부가 흘렀겠지만, 안전하게 새로 10초 대기)
+            log.info("READY 단계 복구 -> 강제 재생 시작 타이머 복구 등록 - code: {}, roundNo: {}", lobbyCode, roundNo);
+            gameRoundStartService.scheduleForcePlaybackStart(lobbyCode, roundNo, timeLimitSeconds);
+        } else if ("ENDED".equals(roundPhase)) {
+            // ENDED 단계 복구: 다음 라운드 시작 타이머 복구
+            String endedAtField = RedisKeys.gameSessionRoundEndedAtField(roundNo);
+            String endedAtStr = (String) redisTemplate.opsForHash().get(sessionKey, endedAtField);
+            if (endedAtStr != null) {
+                long endedAt = Long.parseLong(endedAtStr);
+                long elapsed = System.currentTimeMillis() - endedAt;
+                long limitTimeMillis = 10000L; // 10초 결과 화면 노출
+
+                if (elapsed >= limitTimeMillis) {
+                    log.info("결과화면 대기 시간 초과 -> 즉시 다음 라운드 시작. code: {}, nextRound: {}", lobbyCode, roundNo + 1);
+                    gameRoundProgressService.startNextRound(lobbyCode, roundNo + 1);
+                } else {
+                    long remainingDelay = limitTimeMillis - elapsed;
+                    log.info("남은 시간으로 다음 라운드 시작 타이머 복구 등록 - code: {}, nextRound: {}, remaining: {}ms", lobbyCode, roundNo + 1, remainingDelay);
+                    gameRoundProgressService.scheduleNextRoundWithDelay(lobbyCode, roundNo + 1, remainingDelay);
+                }
+            } else {
+                log.warn("ENDED 단계이나 라운드 종료 시각이 없음 -> 즉시 다음 라운드 시작. code: {}, nextRound: {}", lobbyCode, roundNo + 1);
+                gameRoundProgressService.startNextRound(lobbyCode, roundNo + 1);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundRecoveryService.java
@@ -23,6 +23,7 @@ public class GameRoundRecoveryService {
     private final GameRoundEndService gameRoundEndService;
     private final GameRoundProgressService gameRoundProgressService;
     private final GameRoundStartService gameRoundStartService;
+    private final GameRoundNextRoundExecutor gameRoundNextRoundExecutor;
 
     @Lazy
     public GameRoundRecoveryService(
@@ -30,12 +31,14 @@ public class GameRoundRecoveryService {
             StringRedisTemplate redisTemplate,
             @Lazy GameRoundEndService gameRoundEndService,
             @Lazy GameRoundProgressService gameRoundProgressService,
-            @Lazy GameRoundStartService gameRoundStartService) {
+            @Lazy GameRoundStartService gameRoundStartService,
+            @Lazy GameRoundNextRoundExecutor gameRoundNextRoundExecutor) {
         this.gameSessionJpaRepository = gameSessionJpaRepository;
         this.redisTemplate = redisTemplate;
         this.gameRoundEndService = gameRoundEndService;
         this.gameRoundProgressService = gameRoundProgressService;
         this.gameRoundStartService = gameRoundStartService;
+        this.gameRoundNextRoundExecutor = gameRoundNextRoundExecutor;
     }
 
     @EventListener(ApplicationReadyEvent.class)
@@ -117,7 +120,7 @@ public class GameRoundRecoveryService {
 
                 if (elapsed >= limitTimeMillis) {
                     log.info("결과화면 대기 시간 초과 -> 즉시 다음 라운드 시작. code: {}, nextRound: {}", lobbyCode, roundNo + 1);
-                    gameRoundProgressService.startNextRound(lobbyCode, roundNo + 1);
+                    gameRoundNextRoundExecutor.startNextRound(lobbyCode, roundNo + 1);
                 } else {
                     long remainingDelay = limitTimeMillis - elapsed;
                     log.info("남은 시간으로 다음 라운드 시작 타이머 복구 등록 - code: {}, nextRound: {}, remaining: {}ms", lobbyCode, roundNo + 1, remainingDelay);
@@ -125,7 +128,7 @@ public class GameRoundRecoveryService {
                 }
             } else {
                 log.warn("ENDED 단계이나 라운드 종료 시각이 없음 -> 즉시 다음 라운드 시작. code: {}, nextRound: {}", lobbyCode, roundNo + 1);
-                gameRoundProgressService.startNextRound(lobbyCode, roundNo + 1);
+                gameRoundNextRoundExecutor.startNextRound(lobbyCode, roundNo + 1);
             }
         }
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartService.java
@@ -25,19 +25,19 @@ public class GameRoundStartService {
     private final SimpMessagingTemplate messagingTemplate;
     private final RedisScript<String> readyToPlayScript;
     private final TaskScheduler taskScheduler;
-    private final ApplicationContext applicationContext;
+    private final GameRoundProgressService gameRoundProgressService;
 
     public GameRoundStartService(
             StringRedisTemplate redisTemplate,
             SimpMessagingTemplate messagingTemplate,
             @Qualifier("readyToPlayScript") RedisScript<String> readyToPlayScript,
             TaskScheduler taskScheduler,
-            ApplicationContext applicationContext) {
+            @org.springframework.context.annotation.Lazy GameRoundProgressService gameRoundProgressService) {
         this.redisTemplate = redisTemplate;
         this.messagingTemplate = messagingTemplate;
         this.readyToPlayScript = readyToPlayScript;
         this.taskScheduler = taskScheduler;
-        this.applicationContext = applicationContext;
+        this.gameRoundProgressService = gameRoundProgressService;
     }
 
     public void scheduleForcePlaybackStart(String lobbyCode, int roundNo, int timeLimitSeconds) {
@@ -62,7 +62,7 @@ public class GameRoundStartService {
         log.info("라운드 재생 준비 처리 - code: {}, user: {}, roundNo: {}, result: {}", lobbyCode, userIdentifier, roundNo, result);
 
         if ("ALL_READY".equals(result)) {
-            String timeLimitStr = (String) redisTemplate.opsForHash().get(sessionKey, "time_limit_seconds");
+            String timeLimitStr = (String) redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_TIME_LIMIT_SECONDS);
             int timeLimitSeconds = timeLimitStr != null ? Integer.parseInt(timeLimitStr) : 30;
             broadcastPlaybackStarted(lobbyCode, roundNo, timeLimitSeconds);
         }
@@ -95,7 +95,8 @@ public class GameRoundStartService {
         Boolean isSaved = redisTemplate.opsForHash().putIfAbsent(sessionKey, playbackStartedKey, String.valueOf(serverStartedAt));
 
         if (Boolean.TRUE.equals(isSaved)) {
-            redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
+            redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, "PLAYING");
 
             RoundPlaybackStartedDto dto = RoundPlaybackStartedDto.builder()
                     .type(GameEventTypes.ROUND_PLAYBACK_STARTED)
@@ -108,8 +109,7 @@ public class GameRoundStartService {
 
             // 라운드 종료 스케줄링 호출
             try {
-                GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
-                progressService.scheduleRoundEnd(lobbyCode, roundNo, durationSeconds);
+                gameRoundProgressService.scheduleRoundEnd(lobbyCode, roundNo, durationSeconds);
             } catch (Exception e) {
                 log.error("라운드 종료 자동 스케줄링 예약 실패 - code: {}, roundNo: {}", lobbyCode, roundNo, e);
             }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -87,6 +87,7 @@ public class GameSessionCreateService {
                 .currentRoundNo(1)
                 .totalQuestionCount(lobby.getQuestionCount())
                 .startedAt(startedAt)
+                .status(io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus.PLAYING)
                 .build();
         gameSessionJpaRepository.save(gameSession);
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
@@ -5,7 +5,7 @@ import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -15,12 +15,24 @@ import java.util.List;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class GameSessionQueryService {
 
     private final StringRedisTemplate redisTemplate;
     private final LobbyRepository lobbyRepository;
-    private final ApplicationContext applicationContext;
+    private final GameRoundEndService gameRoundEndService;
+    private final GameRoundProgressService gameRoundProgressService;
+
+    @Lazy
+    public GameSessionQueryService(
+            StringRedisTemplate redisTemplate,
+            LobbyRepository lobbyRepository,
+            @Lazy GameRoundEndService gameRoundEndService,
+            @Lazy GameRoundProgressService gameRoundProgressService) {
+        this.redisTemplate = redisTemplate;
+        this.lobbyRepository = lobbyRepository;
+        this.gameRoundEndService = gameRoundEndService;
+        this.gameRoundProgressService = gameRoundProgressService;
+    }
 
     public CurrentRoundStatusResponse getCurrentRoundStatus(String lobbyCode, String userIdentifier) {
         if (!lobbyRepository.isParticipant(lobbyCode, userIdentifier)) {
@@ -29,7 +41,12 @@ public class GameSessionQueryService {
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
         
-        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of("current_round_no", "time_limit_seconds", "status"));
+        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ));
         
         if (hashValues.get(0) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "진행 중인 게임 세션이 없습니다.");
@@ -37,7 +54,8 @@ public class GameSessionQueryService {
 
         int roundNo = Integer.parseInt((String) hashValues.get(0));
         int timeLimitSeconds = hashValues.get(1) != null ? Integer.parseInt((String) hashValues.get(1)) : 30;
-        String redisStatus = hashValues.get(2) != null ? (String) hashValues.get(2) : "READY";
+        String redisStatus = hashValues.get(2) != null ? (String) hashValues.get(2) : "PLAYING";
+        String roundPhase = hashValues.get(3) != null ? (String) hashValues.get(3) : "READY";
         
         String playbackStartedKey = RedisKeys.gameSessionRoundPlaybackStartedAtField(roundNo);
         String playbackStartedAtStr = (String) redisTemplate.opsForHash().get(sessionKey, playbackStartedKey);
@@ -47,7 +65,7 @@ public class GameSessionQueryService {
         boolean isPlaying = Boolean.TRUE.equals(redisTemplate.hasKey(playbackLockKey));
 
         // 타이머 유실 대응 복구 메커니즘 (Self-Healing)
-        if ("PLAYING".equals(redisStatus) && serverStartedAt != null) {
+        if ("PLAYING".equals(redisStatus) && "PLAYING".equals(roundPhase) && serverStartedAt != null) {
             long elapsed = System.currentTimeMillis() - serverStartedAt;
             long limitTimeMillis = timeLimitSeconds * 1000L + 1500L;
             
@@ -55,20 +73,18 @@ public class GameSessionQueryService {
                 // 시간 초과가 이미 발생했으나 라운드가 미종료 상태인 경우 -> 즉시 조기 종료 처리
                 log.warn("getCurrentRoundStatus: 타이머 유실 감지 - 시간 초과로 라운드를 즉시 종료합니다. code: {}, roundNo: {}", lobbyCode, roundNo);
                 try {
-                    GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
-                    endService.endRound(lobbyCode, roundNo);
+                    gameRoundEndService.endRound(lobbyCode, roundNo);
                 } catch (Exception e) {
                     log.error("getCurrentRoundStatus: 타이머 유실 복구 중 라운드 종료 실패", e);
                 }
                 isPlaying = false;
-                redisStatus = "ENDED";
+                roundPhase = "ENDED";
             } else {
                 // 아직 제한 시간 이전이나 스케줄러에 등록되어 있지 않은 경우 -> 타이머 재등록
                 try {
-                    GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
-                    if (!progressService.isRoundEndScheduled(lobbyCode, roundNo)) {
+                    if (!gameRoundProgressService.isRoundEndScheduled(lobbyCode, roundNo)) {
                         long remainingDelay = limitTimeMillis - elapsed;
-                        progressService.rescheduleRoundEnd(lobbyCode, roundNo, remainingDelay);
+                        gameRoundProgressService.rescheduleRoundEnd(lobbyCode, roundNo, remainingDelay);
                     }
                 } catch (Exception e) {
                     log.error("getCurrentRoundStatus: 타이머 유실 복구 중 스케줄링 실패", e);
@@ -77,12 +93,14 @@ public class GameSessionQueryService {
         }
 
         // status는 코드와 이전 이슈 기준을 맞추기 위해 isPlaying 상태에 따라 PLAYING/WAITING으로 매핑하여 반환하되,
-        // FINISHED이거나 ENDED인 경우를 구분합니다.
+        // FINISHED이거나 ENDED/READY 인 경우를 구분합니다.
         String responseStatus;
-        if ("FINISHED".equals(redisStatus)) {
+        if ("FINISHED".equals(redisStatus) || "FINISHED".equals(roundPhase)) {
             responseStatus = "FINISHED";
-        } else if ("ENDED".equals(redisStatus)) {
+        } else if ("ENDED".equals(roundPhase) || "ENDED".equals(redisStatus)) {
             responseStatus = "WAITING"; // 라운드 종료 상태(결과화면 대기)
+        } else if ("READY".equals(roundPhase) || "READY".equals(redisStatus)) {
+            responseStatus = "WAITING"; // 라운드 대기 상태
         } else {
             responseStatus = isPlaying ? "PLAYING" : "WAITING";
         }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
@@ -4,6 +4,8 @@ import io.github.ascrew.monomatbe.domain.game.dto.CurrentRoundStatusResponse;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -11,12 +13,14 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameSessionQueryService {
 
     private final StringRedisTemplate redisTemplate;
     private final LobbyRepository lobbyRepository;
+    private final ApplicationContext applicationContext;
 
     public CurrentRoundStatusResponse getCurrentRoundStatus(String lobbyCode, String userIdentifier) {
         if (!lobbyRepository.isParticipant(lobbyCode, userIdentifier)) {
@@ -25,7 +29,7 @@ public class GameSessionQueryService {
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
         
-        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of("current_round_no", "time_limit_seconds"));
+        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of("current_round_no", "time_limit_seconds", "status"));
         
         if (hashValues.get(0) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "진행 중인 게임 세션이 없습니다.");
@@ -33,6 +37,7 @@ public class GameSessionQueryService {
 
         int roundNo = Integer.parseInt((String) hashValues.get(0));
         int timeLimitSeconds = hashValues.get(1) != null ? Integer.parseInt((String) hashValues.get(1)) : 30;
+        String redisStatus = hashValues.get(2) != null ? (String) hashValues.get(2) : "READY";
         
         String playbackStartedKey = RedisKeys.gameSessionRoundPlaybackStartedAtField(roundNo);
         String playbackStartedAtStr = (String) redisTemplate.opsForHash().get(sessionKey, playbackStartedKey);
@@ -41,9 +46,50 @@ public class GameSessionQueryService {
         String playbackLockKey = RedisKeys.gameSessionPlaybackLockKey(lobbyCode, roundNo);
         boolean isPlaying = Boolean.TRUE.equals(redisTemplate.hasKey(playbackLockKey));
 
+        // 타이머 유실 대응 복구 메커니즘 (Self-Healing)
+        if ("PLAYING".equals(redisStatus) && serverStartedAt != null) {
+            long elapsed = System.currentTimeMillis() - serverStartedAt;
+            long limitTimeMillis = timeLimitSeconds * 1000L + 1500L;
+            
+            if (elapsed >= limitTimeMillis) {
+                // 시간 초과가 이미 발생했으나 라운드가 미종료 상태인 경우 -> 즉시 조기 종료 처리
+                log.warn("getCurrentRoundStatus: 타이머 유실 감지 - 시간 초과로 라운드를 즉시 종료합니다. code: {}, roundNo: {}", lobbyCode, roundNo);
+                try {
+                    GameRoundEndService endService = applicationContext.getBean(GameRoundEndService.class);
+                    endService.endRound(lobbyCode, roundNo);
+                } catch (Exception e) {
+                    log.error("getCurrentRoundStatus: 타이머 유실 복구 중 라운드 종료 실패", e);
+                }
+                isPlaying = false;
+                redisStatus = "ENDED";
+            } else {
+                // 아직 제한 시간 이전이나 스케줄러에 등록되어 있지 않은 경우 -> 타이머 재등록
+                try {
+                    GameRoundProgressService progressService = applicationContext.getBean(GameRoundProgressService.class);
+                    if (!progressService.isRoundEndScheduled(lobbyCode, roundNo)) {
+                        long remainingDelay = limitTimeMillis - elapsed;
+                        progressService.rescheduleRoundEnd(lobbyCode, roundNo, remainingDelay);
+                    }
+                } catch (Exception e) {
+                    log.error("getCurrentRoundStatus: 타이머 유실 복구 중 스케줄링 실패", e);
+                }
+            }
+        }
+
+        // status는 코드와 이전 이슈 기준을 맞추기 위해 isPlaying 상태에 따라 PLAYING/WAITING으로 매핑하여 반환하되,
+        // FINISHED이거나 ENDED인 경우를 구분합니다.
+        String responseStatus;
+        if ("FINISHED".equals(redisStatus)) {
+            responseStatus = "FINISHED";
+        } else if ("ENDED".equals(redisStatus)) {
+            responseStatus = "WAITING"; // 라운드 종료 상태(결과화면 대기)
+        } else {
+            responseStatus = isPlaying ? "PLAYING" : "WAITING";
+        }
+
         return CurrentRoundStatusResponse.builder()
                 .roundNo(roundNo)
-                .status(isPlaying ? "PLAYING" : "WAITING")
+                .status(responseStatus)
                 .timeLimitSeconds(timeLimitSeconds)
                 .serverStartedAt(serverStartedAt)
                 .build();

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -761,6 +761,16 @@ public final class RedisKeys {
     }
 
     /**
+     * 특정 라운드의 종료 시각 필드명을 반환합니다.
+     *
+     * @param roundNo 라운드 번호
+     * @return "round_ended_at:{roundNo}"
+     */
+    public static String gameSessionRoundEndedAtField(int roundNo) {
+        return "round_ended_at:" + roundNo;
+    }
+
+    /**
      * 특정 라운드에서 정답을 맞춘 유저들의 제출 시각을 저장하는 Hash 키를 반환합니다.
      *
      * @param lobbyCode 로비 초대 코드

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -676,6 +676,12 @@ public final class RedisKeys {
 
     private static final String GAME_SESSION_PREFIX = "game:session:";
 
+    /** 게임 세션 Hash의 현재 라운드 번호 필드 */
+    public static final String FIELD_CURRENT_ROUND_NO = "current_round_no";
+
+    /** 게임 세션 Hash의 라운드 진행 단계 필드 (READY, PLAYING, ENDED, FINISHED) */
+    public static final String FIELD_ROUND_PHASE = "round_phase";
+
     /**
      * 게임 세션 메타데이터 키를 반환합니다.
      *
@@ -790,5 +796,16 @@ public final class RedisKeys {
      */
     public static String gameSessionRoundEndedLockKey(String lobbyCode, int roundNo) {
         return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":ended_lock";
+    }
+
+    /**
+     * 특정 라운드 시작 중복 방지 락 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:next_lock"
+     */
+    public static String gameSessionNextRoundLockKey(String lobbyCode, int roundNo) {
+        return GAME_SESSION_PREFIX + lobbyCode + ":round:" + roundNo + ":next_lock";
     }
 }

--- a/src/main/resources/scripts/init_game_session.lua
+++ b/src/main/resources/scripts/init_game_session.lua
@@ -30,7 +30,8 @@ redis.call('DEL', sessionKey, roundsKey, playersKey)
 redis.call('HSET', sessionKey,
     'current_round_no', '1',
     'total_question_count', totalRounds,
-    'status', 'READY',
+    'status', 'PLAYING',
+    'round_phase', 'READY',
     'time_limit_seconds', timeLimitSeconds,
     'round_started_at', roundStartedAt
 )

--- a/src/main/resources/scripts/submit_game_answer.lua
+++ b/src/main/resources/scripts/submit_game_answer.lua
@@ -22,6 +22,12 @@ if currentRoundNo ~= requestRoundNo then
     return 'WRONG_ROUND'
 end
 
+-- 2.5 이미 종료된 라운드인지 검증 (round_ended_at 존재 여부 확인)
+local endedField = 'round_ended_at:' .. requestRoundNo
+if redis.call('HEXISTS', sessionKey, endedField) == 1 then
+    return 'ROUND_ALREADY_ENDED'
+end
+
 -- 3. 시간 초과 검증 (지연 완충 시간 1.5초 고려)
 -- Java RedisKeys.gameSessionRoundPlaybackStartedAtField() 계약과 일치하는 필드명 사용
 local playbackStartedKey = 'playback_started_at:' .. requestRoundNo

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -87,9 +87,10 @@ class GameChatAnswerIntegrationTest {
 
     private void givenGameSession(String status, int currentRoundNo, int timeLimit, Long playbackStartedAt) {
         String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
-        redisTemplate.opsForHash().put(sessionKey, "status", status);
-        redisTemplate.opsForHash().put(sessionKey, "current_round_no", String.valueOf(currentRoundNo));
-        redisTemplate.opsForHash().put(sessionKey, "time_limit_seconds", String.valueOf(timeLimit));
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, status);
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, String.valueOf(currentRoundNo));
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_TIME_LIMIT_SECONDS, String.valueOf(timeLimit));
         if (playbackStartedAt != null) {
             redisTemplate.opsForHash().put(sessionKey, RedisKeys.gameSessionRoundPlaybackStartedAtField(currentRoundNo), String.valueOf(playbackStartedAt));
         }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -6,6 +6,8 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
 import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
+import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionStatus;
@@ -20,6 +22,8 @@ import io.github.ascrew.monomatbe.domain.lobby.service.LobbyRealtimeNotifier;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.websocket.dto.ChatMessageDto;
+import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +32,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
@@ -51,6 +56,15 @@ class GameRoundProgressIntegrationTest {
 
     @Autowired
     private GameRoundEndService gameRoundEndService;
+
+    @Autowired
+    private GameRoundProgressService gameRoundProgressService;
+
+    @Autowired
+    private GameAnswerService gameAnswerService;
+
+    @Autowired
+    private GameLeaveEventHandler gameLeaveEventHandler;
 
     @Autowired
     private StringRedisTemplate redisTemplate;
@@ -81,6 +95,15 @@ class GameRoundProgressIntegrationTest {
 
     @MockitoBean
     private LobbyRealtimeNotifier lobbyRealtimeNotifier;
+
+    @MockitoBean
+    private SimpMessagingTemplate messagingTemplate;
+
+    @MockitoBean
+    private LobbyRepository lobbyRepository;
+
+    @MockitoBean
+    private GameRoundStartService gameRoundStartService;
 
     private GameLobby lobby;
     private GameSession gameSession;
@@ -145,6 +168,9 @@ class GameRoundProgressIntegrationTest {
         nicknames.put(USER_ID_2, "유저2");
         nicknames.put(USER_ID_3, "유저3");
         when(nicknameResolver.resolveNicknameMap(any())).thenReturn(nicknames);
+        when(nicknameResolver.fallbackNickname(USER_ID_1)).thenReturn("유저1");
+        when(nicknameResolver.fallbackNickname(USER_ID_2)).thenReturn("유저2");
+        when(nicknameResolver.fallbackNickname(USER_ID_3)).thenReturn("유저3");
 
         // MapItem mock
         MapItem mapItem = mock(MapItem.class);
@@ -156,6 +182,9 @@ class GameRoundProgressIntegrationTest {
 
         String roundsKey = RedisKeys.gameSessionRoundsKey(LOBBY_CODE);
         redisTemplate.opsForList().rightPushAll(roundsKey, "1001", "1002", "1003");
+
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        when(lobbyRepository.isParticipant(eq(LOBBY_CODE), anyString())).thenReturn(true);
     }
 
     @AfterEach
@@ -235,5 +264,91 @@ class GameRoundProgressIntegrationTest {
         assertThat(redisTemplate.opsForHash().get(RedisKeys.lobbyKey(LOBBY_CODE), "status")).isEqualTo("FINISHED");
 
         verify(lobbyRealtimeNotifier, times(1)).notifyLobbyInfoRefresh(eq(LOBBY_CODE), eq("SYSTEM"));
+    }
+
+    @Test
+    @DisplayName("다음 라운드 시작(startNextRound) 시 세션 상태가 READY가 되고 ROUND_READY 이벤트가 브로드캐스트된다")
+    void startNextRoundTransitionsToReadyAndBroadcasts() {
+        // given
+        // 2라운드 시작 시도
+        
+        // when
+        gameRoundProgressService.startNextRound(LOBBY_CODE, 2);
+
+        // then
+        assertThat(gameSession.getCurrentRoundNo()).isEqualTo(2);
+
+        String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
+        assertThat(redisTemplate.opsForHash().get(sessionKey, "current_round_no")).isEqualTo("2");
+        assertThat(redisTemplate.opsForHash().get(sessionKey, "status")).isEqualTo("READY");
+
+        ArgumentCaptor<RoundStartDto> captor = ArgumentCaptor.forClass(RoundStartDto.class);
+        verify(gameRealtimeNotifier, times(1)).notifyRoundStart(eq(LOBBY_CODE), captor.capture());
+        
+        RoundStartDto captured = captor.getValue();
+        assertThat(captured.type()).isEqualTo("ROUND_READY");
+        assertThat(captured.roundNo()).isEqualTo(2);
+        assertThat(captured.timeLimitSeconds()).isEqualTo(30);
+
+        verify(gameRoundStartService, times(1)).scheduleForcePlaybackStart(eq(LOBBY_CODE), eq(2), eq(30));
+    }
+
+    @Test
+    @DisplayName("플레이어 이탈 시 남은 플레이어들이 모두 정답 상태이면 라운드가 조기 종료된다")
+    void playerLeaveTriggersEarlyRoundEndIfAllRemainingCorrect() {
+        // given
+        String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
+        redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, "current_round_no", "1");
+
+        String participantsKey = RedisKeys.lobbyParticipantsKey(LOBBY_CODE);
+        redisTemplate.opsForSet().add(participantsKey, USER_ID_1, USER_ID_2, USER_ID_3);
+
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1);
+        redisTemplate.opsForSet().add(correctPlayersKey, USER_ID_1, USER_ID_2);
+
+        PlayerLeaveEvent leaveEvent = new PlayerLeaveEvent(LOBBY_CODE, USER_ID_3);
+
+        // when
+        gameLeaveEventHandler.handlePlayerLeave(leaveEvent);
+
+        // then
+        String endedLockKey = RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 1);
+        assertThat(redisTemplate.hasKey(endedLockKey)).isTrue();
+        
+        verify(gameRealtimeNotifier, times(1)).notifyRoundEnd(eq(LOBBY_CODE), any(RoundMetadataDto.class));
+    }
+
+    @Test
+    @DisplayName("라운드가 이미 종료되어 round_ended_at 필드가 존재하면 정답을 제출해도 ROUND_ALREADY_ENDED 처리되어 정답자로 등록되지 않고 마스킹 채팅으로 전파된다")
+    void answerSubmissionBlockedIfRoundAlreadyEnded() {
+        // given
+        String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
+        redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, "current_round_no", "1");
+        redisTemplate.opsForHash().put(sessionKey, "time_limit_seconds", "30");
+        
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.gameSessionRoundPlaybackStartedAtField(1), String.valueOf(System.currentTimeMillis() - 5000));
+
+        String roundDataKey = RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1);
+        redisTemplate.opsForHash().put(roundDataKey, "normalized_answers", "[\"testanswer\"]");
+
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.gameSessionRoundEndedAtField(1), String.valueOf(System.currentTimeMillis() - 1000));
+
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "test answer");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID_1, messageDto);
+
+        // then
+        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1);
+        assertThat(redisTemplate.opsForSet().isMember(correctPlayersKey, USER_ID_1)).isFalse();
+
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/game/" + LOBBY_CODE + "/chat"), chatCaptor.capture());
+        
+        ChatMessageDto capturedChat = chatCaptor.getValue();
+        assertThat(capturedChat.getContent()).isEqualTo("***");
+        assertThat(capturedChat.getSender()).isEqualTo("유저1");
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -195,6 +195,7 @@ class GameRoundProgressIntegrationTest {
         redisTemplate.delete(RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 3));
+        redisTemplate.delete(RedisKeys.gameSessionNextRoundLockKey(LOBBY_CODE, 2));
         redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 3));
         redisTemplate.delete(RedisKeys.gameSessionKey(LOBBY_CODE));
@@ -267,7 +268,7 @@ class GameRoundProgressIntegrationTest {
     }
 
     @Test
-    @DisplayName("다음 라운드 시작(startNextRound) 시 세션 상태가 READY가 되고 ROUND_READY 이벤트가 브로드캐스트된다")
+    @DisplayName("다음 라운드 시작(startNextRound) 시 세션 상태가 PLAYING이 되고 라운드 페이즈가 READY가 되며 ROUND_READY 이벤트가 브로드캐스트된다")
     void startNextRoundTransitionsToReadyAndBroadcasts() {
         // given
         // 2라운드 시작 시도
@@ -279,8 +280,9 @@ class GameRoundProgressIntegrationTest {
         assertThat(gameSession.getCurrentRoundNo()).isEqualTo(2);
 
         String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
-        assertThat(redisTemplate.opsForHash().get(sessionKey, "current_round_no")).isEqualTo("2");
-        assertThat(redisTemplate.opsForHash().get(sessionKey, "status")).isEqualTo("READY");
+        assertThat(redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO)).isEqualTo("2");
+        assertThat(redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_STATUS)).isEqualTo("PLAYING");
+        assertThat(redisTemplate.opsForHash().get(sessionKey, RedisKeys.FIELD_ROUND_PHASE)).isEqualTo("READY");
 
         ArgumentCaptor<RoundStartDto> captor = ArgumentCaptor.forClass(RoundStartDto.class);
         verify(gameRealtimeNotifier, times(1)).notifyRoundStart(eq(LOBBY_CODE), captor.capture());
@@ -299,6 +301,7 @@ class GameRoundProgressIntegrationTest {
         // given
         String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
         redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, "round_phase", "PLAYING");
         redisTemplate.opsForHash().put(sessionKey, "current_round_no", "1");
 
         String participantsKey = RedisKeys.lobbyParticipantsKey(LOBBY_CODE);
@@ -324,9 +327,10 @@ class GameRoundProgressIntegrationTest {
     void answerSubmissionBlockedIfRoundAlreadyEnded() {
         // given
         String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
-        redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
-        redisTemplate.opsForHash().put(sessionKey, "current_round_no", "1");
-        redisTemplate.opsForHash().put(sessionKey, "time_limit_seconds", "30");
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_STATUS, "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_ROUND_PHASE, "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_CURRENT_ROUND_NO, "1");
+        redisTemplate.opsForHash().put(sessionKey, RedisKeys.FIELD_TIME_LIMIT_SECONDS, "30");
         
         redisTemplate.opsForHash().put(sessionKey, RedisKeys.gameSessionRoundPlaybackStartedAtField(1), String.valueOf(System.currentTimeMillis() - 5000));
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -61,6 +61,9 @@ class GameRoundProgressIntegrationTest {
     private GameRoundProgressService gameRoundProgressService;
 
     @Autowired
+    private GameRoundNextRoundExecutor gameRoundNextRoundExecutor;
+
+    @Autowired
     private GameAnswerService gameAnswerService;
 
     @Autowired
@@ -274,7 +277,7 @@ class GameRoundProgressIntegrationTest {
         // 2라운드 시작 시도
         
         // when
-        gameRoundProgressService.startNextRound(LOBBY_CODE, 2);
+        gameRoundNextRoundExecutor.startNextRound(LOBBY_CODE, 2);
 
         // then
         assertThat(gameSession.getCurrentRoundNo()).isEqualTo(2);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundStartServiceTest.java
@@ -15,8 +15,6 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
-import org.springframework.context.ApplicationContext;
-
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +39,7 @@ class GameRoundStartServiceTest {
     @Mock
     private org.springframework.scheduling.TaskScheduler taskScheduler;
     @Mock
-    private ApplicationContext applicationContext;
+    private GameRoundProgressService gameRoundProgressService;
 
     private GameRoundStartService gameRoundStartService;
 
@@ -51,7 +49,7 @@ class GameRoundStartServiceTest {
 
     @BeforeEach
     void setUp() {
-        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript, taskScheduler, applicationContext);
+        gameRoundStartService = new GameRoundStartService(redisTemplate, messagingTemplate, readyToPlayScript, taskScheduler, gameRoundProgressService);
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

- #101 
- #106

## 📝 Summary

- **라운드 종료 및 다음 라운드 자동 진행 스케줄러 구현**
  - `GameRoundProgressService`에 TaskScheduler를 이용한 자동 라운드 종료(`scheduleRoundEnd`) 및 다음 라운드 시작(`scheduleNextRound`) 태스크를 관리하는 스케줄링 로직을 추가했습니다.
- **조기 종료 조건 다각화 및 동적 재계산**
  - 제한 시간 만료 외에도 모든 참여자가 정답을 맞췄을 때(`checkAndTriggerEarlyRoundEnd`)와 플레이어가 이탈했을 때(`PlayerLeaveEvent` 수신 시 `GameLeaveEventHandler`가 동작) 남은 유저들이 모두 맞춘 상태이면 즉시 조기 종료되도록 개선했습니다.
- **정밀한 상태 관리 및 중복 종료 방지**
  - 라운드 종료 시 Redis 세션 상태를 `PLAYING`에서 `ENDED`로 변경하고, 중복 종료 호출을 방지하기 위해 멱등 락(`ended_lock`)을 적용했습니다.
  - Redis 해시에 해당 라운드가 종료된 시각인 `round_ended_at:{roundNo}`를 기록하여, 이미 종료된 라운드의 정답 제출 시도를 Lua 스크립트(`submit_game_answer.lua`) 단에서 차단(`ROUND_ALREADY_ENDED` 리턴)하고 마스킹(`***`) 처리 후 일반 채팅으로 브로드캐스트 전송되도록 보강했습니다.
  - DB `GAME_SESSION` 테이블의 `ended_at` 컬럼에 최종 종료 시각이 정상 저장되도록 `finish()` 엔티티 로직을 보완했습니다.
- **자가 치유 (Self-Healing) 타이머 복구 메커니즘 구축**
  - 서버 재시작 등으로 인해 인메모리 스케줄러가 유실된 상황에서 현재 라운드 정보 조회(`getCurrentRoundStatus`) 인입 시, 잔여 시간을 동적으로 계산하여 타이머를 자동 복구 등록(또는 시간 초과 시 즉시 종료)하도록 자가 치유 로직을 구현했습니다.
- **문서 동기화 및 테스트 코드 보강 검증**
  - `docs/API.md`와 `docs/ARCHITECTURE.md`에 API 스키마 변경 사항(roundNo, serverStartedAt, waitTimeSeconds, isLastRound 필드 등) 및 Redis 키 패턴을 최신화했습니다.
  - `GameRoundProgressIntegrationTest`에 다음 라운드 전환, 이탈 시 조기 종료 조건 재계산, 종료 라운드 정답 제출 차단 검증 등의 통합 테스트 3종을 보강하여 성공 통과시켰습니다.

## 🙏PR point

- **도메인 결합도 최소화**: 
  - `game` 도메인 내의 `GameLeaveEventHandler`가 `PlayerLeaveEvent`를 수신하여 로비 이탈 상태를 조회한 뒤 `GameRoundEndService`를 직접 호출하므로, 다른 도메인(로비, 채팅)과의 순환 의존 없이 깔끔하게 이탈 처리가 수행됩니다.
- **네트워크 I/O 격리 및 원자성**: 
  - Lua 스크립트(`submit_game_answer.lua`) 내부에서 `HEXISTS`를 통해 `round_ended_at` 존재 여부를 1차 검증하고, 시간 초과 및 중복 정답 여부를 원자적으로 검사하여 데이터 정합성을 보장합니다.
- **Self-Healing 조건**: 
  - `getCurrentRoundStatus` 호출 시점에 `status == PLAYING` 이고 `serverStartedAt`이 null이 아니며 인메모리에 타이머 예약이 유실된 경우에만 지연 시간을 계산하여 복구를 수행합니다. (이미 초과한 경우는 즉시 종료 처리)
- **FE와의 핵심 계약 사항**: 
  - `CurrentRoundStatusResponse` DTO의 포맷 변경: `currentRoundNo` -> `roundNo`, `playbackStartedAt` -> `serverStartedAt` (코드 기준 명세서 업데이트 적용).
  - `RoundMetadataDto` DTO의 waitTimeSeconds(10초) 및 isLastRound 필드를 활용하여 FE에서 라운드 종료 랭킹 연출 및 마지막 라운드일 때 `FINISHED` 대기실/결과 화면 자동 전환을 처리해야 합니다.

## 📬 Reference
