### PR TITLE
[Feat/#157] 정식 회원 비밀번호 변경 API 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -171,6 +171,205 @@ JWT Access Token이 필요합니다.
 
 ---
 
+## 7단계: API 문서화
+
+이번 단계에서는 `docs/API.md`에 FE가 사용할 비밀번호 변경 API 계약을 추가합니다.
+
+추가할 내용은 다음입니다.
+
+```text
+PATCH /api/users/me/password
+```
+
+성공 시 `204 No Content`이고, 비밀번호 변경 성공 후 기존 세션이 모두 만료되므로 FE는 로그인 화면으로 이동해야 합니다.
+
+---
+
+# 7-1. `docs/API.md`에 추가할 내용
+
+`docs/API.md`에서 `User` 또는 `내 사용자 정보 조회`, `닉네임 변경` API가 있는 위치를 찾으세요.
+
+```bash
+grep -n "닉네임\|users/me\|User" docs/API.md
+```
+
+그 근처에 아래 내용을 추가하면 됩니다.
+
+````markdown
+### 내 비밀번호 변경
+
+```http
+PATCH /api/users/me/password
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+````
+
+로그인한 정식 회원의 비밀번호를 변경합니다.
+
+비밀번호 변경 성공 후 서버는 해당 사용자의 모든 활성 세션을 만료합니다.
+따라서 클라이언트는 성공 응답을 받으면 저장 중인 accessToken, refreshToken, 사용자 정보를 제거하고 로그인 화면으로 이동해야 합니다.
+
+#### Request Body
+
+```json
+{
+  "currentPassword": "oldPassword123",
+  "newPassword": "newPassword123",
+  "newPasswordConfirm": "newPassword123"
+}
+```
+
+| 필드                   | 타입     | 필수 | 설명        |
+| -------------------- | ------ | -: | --------- |
+| `currentPassword`    | string |  O | 현재 비밀번호   |
+| `newPassword`        | string |  O | 새 비밀번호    |
+| `newPasswordConfirm` | string |  O | 새 비밀번호 확인 |
+
+#### 비밀번호 정책
+
+회원가입과 동일한 비밀번호 정책을 적용합니다.
+
+| 정책    | 내용      |
+| ----- | ------- |
+| 최소 길이 | 8자      |
+| 최대 길이 | 100자    |
+| 공백    | 허용하지 않음 |
+
+#### Success Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+응답 본문은 없습니다.
+
+#### Error Response
+
+공통 에러 응답 형식은 기존 인증 API와 동일합니다.
+
+```json
+{
+  "code": "AUTH_CURRENT_PASSWORD_MISMATCH",
+  "message": "현재 비밀번호가 올바르지 않습니다.",
+  "field": "currentPassword"
+}
+```
+
+| HTTP Status | code                                 | field                | 상황                         |
+| ----------: | ------------------------------------ | -------------------- | -------------------------- |
+|         400 | `AUTH_INVALID_REQUEST_BODY`          | `null`               | 요청 본문 형식이 올바르지 않음          |
+|         400 | `AUTH_PASSWORD_REQUIRED`             | `password`           | 새 비밀번호가 비어 있음              |
+|         400 | `AUTH_PASSWORD_INVALID_LENGTH`       | `password`           | 새 비밀번호가 8자 미만 또는 100자 초과   |
+|         400 | `AUTH_PASSWORD_CONTAINS_WHITESPACE`  | `password`           | 새 비밀번호에 공백 포함              |
+|         400 | `AUTH_NEW_PASSWORD_CONFIRM_MISMATCH` | `newPasswordConfirm` | 새 비밀번호와 새 비밀번호 확인이 일치하지 않음 |
+|         401 | `AUTH_UNAUTHENTICATED`               | `null`               | 인증 정보가 없거나 유효하지 않음         |
+|         401 | `AUTH_CURRENT_PASSWORD_MISMATCH`     | `currentPassword`    | 현재 비밀번호가 일치하지 않음           |
+|         403 | `AUTH_REGISTERED_USER_ONLY`          | `null`               | 게스트 사용자가 요청함               |
+
+#### FE 처리 정책
+
+비밀번호 변경 성공 시 기존 세션은 모두 만료됩니다.
+
+FE는 `204 No Content` 수신 후 다음 처리를 수행해야 합니다.
+
+1. 저장된 `accessToken` 제거
+2. 저장된 `refreshToken` 제거
+3. 사용자 상태 초기화
+4. 로그인 화면으로 이동
+5. “비밀번호가 변경되었습니다. 다시 로그인해주세요.” 메시지 표시
+
+주의할 점은 성공 직후 기존 accessToken으로 `/api/users/me`를 재요청하지 않는 것입니다.
+서버에서 활성 세션 키를 제거하기 때문에 이후 인증 요청은 실패할 수 있습니다.
+
+---
+
+### 내 비밀번호 변경
+
+```http
+PATCH /api/users/me/password
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+`````
+
+로그인한 정식 회원의 비밀번호를 변경합니다.
+
+비밀번호 변경 성공 후 서버는 해당 사용자의 모든 활성 세션을 만료합니다.
+따라서 클라이언트는 성공 응답을 받으면 저장 중인 accessToken, refreshToken, 사용자 정보를 제거하고 로그인 화면으로 이동해야 합니다.
+
+#### Request Body
+
+```json
+{
+  "currentPassword": "oldPassword123",
+  "newPassword": "newPassword123",
+  "newPasswordConfirm": "newPassword123"
+}
+```
+
+| 필드                   | 타입     | 필수 | 설명        |
+| -------------------- | ------ | -: | --------- |
+| `currentPassword`    | string |  O | 현재 비밀번호   |
+| `newPassword`        | string |  O | 새 비밀번호    |
+| `newPasswordConfirm` | string |  O | 새 비밀번호 확인 |
+
+#### 비밀번호 정책
+
+회원가입과 동일한 비밀번호 정책을 적용합니다.
+
+| 정책    | 내용      |
+| ----- | ------- |
+| 최소 길이 | 8자      |
+| 최대 길이 | 100자    |
+| 공백    | 허용하지 않음 |
+
+#### Success Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+응답 본문은 없습니다.
+
+#### Error Response
+
+공통 에러 응답 형식은 기존 인증 API와 동일합니다.
+
+```json
+{
+  "code": "AUTH_CURRENT_PASSWORD_MISMATCH",
+  "message": "현재 비밀번호가 올바르지 않습니다.",
+  "field": "currentPassword"
+}
+```
+
+| HTTP Status | code                                 | field                | 상황                         |
+| ----------: | ------------------------------------ | -------------------- | -------------------------- |
+|         400 | `AUTH_INVALID_REQUEST_BODY`          | `null`               | 요청 본문 형식이 올바르지 않음          |
+|         400 | `AUTH_PASSWORD_REQUIRED`             | `password`           | 새 비밀번호가 비어 있음              |
+|         400 | `AUTH_PASSWORD_INVALID_LENGTH`       | `password`           | 새 비밀번호가 8자 미만 또는 100자 초과   |
+|         400 | `AUTH_PASSWORD_CONTAINS_WHITESPACE`  | `password`           | 새 비밀번호에 공백 포함              |
+|         400 | `AUTH_NEW_PASSWORD_CONFIRM_MISMATCH` | `newPasswordConfirm` | 새 비밀번호와 새 비밀번호 확인이 일치하지 않음 |
+|         401 | `AUTH_UNAUTHENTICATED`               | `null`               | 인증 정보가 없거나 유효하지 않음         |
+|         401 | `AUTH_CURRENT_PASSWORD_MISMATCH`     | `currentPassword`    | 현재 비밀번호가 일치하지 않음           |
+|         403 | `AUTH_REGISTERED_USER_ONLY`          | `null`               | 게스트 사용자가 요청함               |
+
+#### FE 처리 정책
+
+비밀번호 변경 성공 시 기존 세션은 모두 만료됩니다.
+
+FE는 `204 No Content` 수신 후 다음 처리를 수행해야 합니다.
+
+1. 저장된 `accessToken` 제거
+2. 저장된 `refreshToken` 제거
+3. 사용자 상태 초기화
+4. 로그인 화면으로 이동
+5. “비밀번호가 변경되었습니다. 다시 로그인해주세요.” 메시지 표시
+
+주의할 점은 성공 직후 기존 accessToken으로 `/api/users/me`를 재요청하지 않는 것입니다.
+서버에서 활성 세션 키를 제거하기 때문에 이후 인증 요청은 실패할 수 있습니다.
+
+---
+
 ### 관리자 - 닉네임 금칙어 관리
 
 닉네임 금칙어 목록을 관리자 API로 조회, 추가, 삭제합니다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 /**
- * 회원 인증정보 엔티티.
+ * 회원 인증정보 엔티티
  *
  * users와 분리하여 관리하는 이유:
  * - 비밀번호 해시/로그인 실패 카운트/잠금 시각은 보안 민감 데이터
@@ -106,8 +106,8 @@ public class UserCredential {
      * [정책]
      * - raw password는 엔티티로 전달하지 않는다.
      * - 해시는 서비스 계층에서 PasswordEncoder로 생성한 뒤 전달한다.
-     * - 현재 비밀번호 검증을 통과한 사용자는 계정 소유자임이 확인된 상태이므로
-     *   기존 로그인 실패 횟수와 잠금 상태를 초기화한다.
+     * - 현재 비밀번호 검증을 통과한 경우에만 호출된다.
+     * - 재인증에 성공한 사용자의 비밀번호 변경이므로 기존 로그인 실패 횟수와 잠금 상태를 초기화한다.
      *
      * @param passwordHash 새 비밀번호 해시
      * @param changedAt 비밀번호 변경 시각

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/entity/UserCredential.java
@@ -68,7 +68,7 @@ public class UserCredential {
         LocalDateTime now = LocalDateTime.now();
         this.createdAt = now;
         this.updatedAt = now;
-        // 로그인 실패 카운트 초기값 보정
+
         if (this.failedLoginCount == null) {
             this.failedLoginCount = 0;
         }
@@ -76,7 +76,6 @@ public class UserCredential {
 
     @PreUpdate
     public void preUpdate() {
-        // 인증정보 변경 시각 자동 갱신
         this.updatedAt = LocalDateTime.now();
     }
 
@@ -88,6 +87,7 @@ public class UserCredential {
         if (this.failedLoginCount == null) {
             this.failedLoginCount = 0;
         }
+
         this.failedLoginCount += 1;
     }
 
@@ -98,5 +98,24 @@ public class UserCredential {
 
     public void lockUntil(LocalDateTime lockedUntil) {
         this.lockedUntil = lockedUntil;
+    }
+
+    /**
+     * 비밀번호를 새 해시로 변경하고 변경 시각을 갱신한다.
+     *
+     * [정책]
+     * - raw password는 엔티티로 전달하지 않는다.
+     * - 해시는 서비스 계층에서 PasswordEncoder로 생성한 뒤 전달한다.
+     * - 현재 비밀번호 검증을 통과한 사용자는 계정 소유자임이 확인된 상태이므로
+     *   기존 로그인 실패 횟수와 잠금 상태를 초기화한다.
+     *
+     * @param passwordHash 새 비밀번호 해시
+     * @param changedAt 비밀번호 변경 시각
+     */
+    public void changePassword(String passwordHash, LocalDateTime changedAt) {
+        this.passwordHash = passwordHash;
+        this.passwordChangedAt = changedAt;
+        this.updatedAt = changedAt;
+        resetFailedLoginState();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -80,6 +80,18 @@ public enum AuthErrorCode {
             AuthErrorFields.PASSWORD
     ),
 
+    AUTH_CURRENT_PASSWORD_MISMATCH(
+            HttpStatus.UNAUTHORIZED,
+            "현재 비밀번호가 올바르지 않습니다.",
+            AuthErrorFields.CURRENT_PASSWORD
+    ),
+
+    AUTH_NEW_PASSWORD_CONFIRM_MISMATCH(
+            HttpStatus.BAD_REQUEST,
+            "새 비밀번호가 일치하지 않습니다.",
+            AuthErrorFields.NEW_PASSWORD_CONFIRM
+    ),
+
     // =========================================================
     // Nickname
     // =========================================================
@@ -182,6 +194,12 @@ public enum AuthErrorCode {
             null
     ),
 
+    AUTH_REGISTERED_USER_ONLY(
+            HttpStatus.FORBIDDEN,
+            "정식 회원만 사용할 수 있는 기능입니다.",
+            null
+    ),
+
     AUTH_TEMPORARY_UNAVAILABLE(
             HttpStatus.SERVICE_UNAVAILABLE,
             "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
@@ -230,6 +248,8 @@ public enum AuthErrorCode {
 
         private static final String LOGIN_ID = "loginId";
         private static final String PASSWORD = "password";
+        private static final String CURRENT_PASSWORD = "currentPassword";
+        private static final String NEW_PASSWORD_CONFIRM = "newPasswordConfirm";
         private static final String NICKNAME = "nickname";
         private static final String REFRESH_TOKEN = "refreshToken";
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthErrorCode.java
@@ -92,6 +92,12 @@ public enum AuthErrorCode {
             AuthErrorFields.NEW_PASSWORD_CONFIRM
     ),
 
+    AUTH_NEW_PASSWORD_SAME_AS_CURRENT(
+            HttpStatus.BAD_REQUEST,
+            "새 비밀번호는 현재 비밀번호와 달라야 합니다.",
+            AuthErrorFields.NEW_PASSWORD
+    ),
+
     // =========================================================
     // Nickname
     // =========================================================
@@ -249,6 +255,7 @@ public enum AuthErrorCode {
         private static final String LOGIN_ID = "loginId";
         private static final String PASSWORD = "password";
         private static final String CURRENT_PASSWORD = "currentPassword";
+        private static final String NEW_PASSWORD = "newPassword";
         private static final String NEW_PASSWORD_CONFIRM = "newPasswordConfirm";
         private static final String NICKNAME = "nickname";
         private static final String REFRESH_TOKEN = "refreshToken";

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthPasswordChangeFailureException.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/exception/AuthPasswordChangeFailureException.java
@@ -1,0 +1,17 @@
+package io.github.ascrew.monomatbe.domain.auth.exception;
+
+/**
+ * 비밀번호 변경 과정에서 현재 비밀번호 검증 실패를 나타내는 예외
+ *
+ * [설계 의도]
+ * - 현재 비밀번호 불일치 시 failedLoginCount / lockedUntil 변경은 커밋되어야 한다.
+ * - 일반 AuthException은 트랜잭션 롤백 대상이지만,
+ *   이 예외는 UserCommandService.changeMyPassword(...)의 noRollbackFor 대상이다.
+ * - 로그인 실패(AuthLoginFailureException)와 동일한 보안 정책을 비밀번호 변경 흐름에도 적용한다.
+ */
+public class AuthPasswordChangeFailureException extends AuthException {
+
+    public AuthPasswordChangeFailureException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserCredentialRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/repository/UserCredentialRepository.java
@@ -6,15 +6,26 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 /**
- * user_credentials 접근 리포지토리.
+ * user_credentials 접근 리포지토리
  */
 public interface UserCredentialRepository extends JpaRepository<UserCredential, Long> {
 
     boolean existsByLoginId(String loginId);
 
     /**
-     * 로그인 ID로 인증정보 조회.
-     * 회원 로그인 시 패스워드 검증 진입점이 됩니다.
+     * 로그인 ID로 인증정보 조회
+     * 회원 로그인 시 패스워드 검증 진입점이 된다.
      */
     Optional<UserCredential> findByLoginId(String loginId);
+
+    /**
+     * 사용자 ID로 인증정보를 조회한다.
+     *
+     * [사용처]
+     * - 현재 로그인한 정식 회원의 비밀번호 변경
+     *
+     * [주의]
+     * 게스트 사용자는 user_credentials row가 없으므로 Optional.empty()가 정상 케이스다.
+     */
+    Optional<UserCredential> findByUser_Id(Long userId);
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/PasswordPolicyValidator.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/PasswordPolicyValidator.java
@@ -1,0 +1,54 @@
+package io.github.ascrew.monomatbe.domain.auth.service;
+
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import org.springframework.stereotype.Component;
+
+/**
+ * 비밀번호 정책 검증기
+ *
+ * [책임]
+ * - 회원가입, 비밀번호 변경 등 비밀번호를 새로 설정하는 유스케이스의 공통 정책을 검증한다.
+ *
+ * [정책]
+ * - null / blank 불가
+ * - 공백 문자 포함 불가
+ * - 8자 이상 100자 이하
+ *
+ * [주의]
+ * 로그인 시점의 비밀번호 검증에는 사용하지 않는다.
+ * 로그인은 기존 계정 호환성을 위해 null / blank만 차단하고,
+ * 실제 인증 실패는 PasswordEncoder.matches() 결과로 판단한다.
+ */
+@Component
+public class PasswordPolicyValidator {
+
+    private static final int MIN_PASSWORD_LENGTH = 8;
+    private static final int MAX_PASSWORD_LENGTH = 100;
+
+    public String validateNewPassword(String rawPassword) {
+        String password = normalizeRequired(rawPassword);
+
+        if (containsWhitespace(password)) {
+            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE);
+        }
+
+        if (password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
+            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_INVALID_LENGTH);
+        }
+
+        return password;
+    }
+
+    private String normalizeRequired(String value) {
+        if (value == null || value.isBlank()) {
+            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_REQUIRED);
+        }
+
+        return value;
+    }
+
+    private boolean containsWhitespace(String value) {
+        return value.chars().anyMatch(Character::isWhitespace);
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthService.java
@@ -28,8 +28,6 @@ public class RegisterAuthService {
 
     private static final int MIN_LOGIN_ID_LENGTH = 4;
     private static final int MAX_LOGIN_ID_LENGTH = 50;
-    private static final int MIN_PASSWORD_LENGTH = 8;
-    private static final int MAX_PASSWORD_LENGTH = 100;
     private static final int MIN_NICKNAME_LENGTH = 2;
     private static final int MAX_NICKNAME_LENGTH = 12;
 
@@ -39,11 +37,12 @@ public class RegisterAuthService {
     private final UserCredentialRepository userCredentialRepository;
     private final PasswordEncoder passwordEncoder;
     private final NicknamePolicyValidator nicknamePolicyValidator;
+    private final PasswordPolicyValidator passwordPolicyValidator;
 
     @Transactional
     public RegisterResponse register(String rawLoginId, String rawPassword, String rawNickname) {
         String loginId = normalizeLoginId(rawLoginId);
-        String password = normalizePassword(rawPassword);
+        String password = passwordPolicyValidator.validateNewPassword(rawPassword);
         String nickname = normalizeNickname(rawNickname);
 
         nicknamePolicyValidator.validate(nickname);
@@ -110,20 +109,6 @@ public class RegisterAuthService {
         }
 
         return loginId;
-    }
-
-    private String normalizePassword(String value) {
-        String password = normalizeRequired(value, AuthErrorCode.AUTH_PASSWORD_REQUIRED);
-
-        if (containsWhitespace(password)) {
-            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE);
-        }
-
-        if (password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
-            throw new AuthException(AuthErrorCode.AUTH_PASSWORD_INVALID_LENGTH);
-        }
-
-        return password;
     }
 
     private String normalizeNickname(String value) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/controller/UserController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.domain.user.controller;
 
+import io.github.ascrew.monomatbe.domain.user.dto.ChangePasswordRequest;
 import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
 import io.github.ascrew.monomatbe.domain.user.dto.UpdateNicknameRequest;
 import io.github.ascrew.monomatbe.domain.user.service.UserCommandService;
@@ -40,12 +41,16 @@ public class UserController {
             "요청 수신: 내 닉네임 변경 [PATCH /api/users/me/nickname] - userId: {}, userIdentifier: {}";
     private static final String LOG_UPDATE_MY_NICKNAME_RESPONSE =
             "변경 완료: 내 닉네임 변경 - userId: {}, username: {}";
+    private static final String LOG_CHANGE_MY_PASSWORD_REQUEST =
+            "요청 수신: 내 비밀번호 변경 [PATCH /api/users/me/password] - userId: {}, userIdentifier: {}";
+    private static final String LOG_CHANGE_MY_PASSWORD_RESPONSE =
+            "변경 완료: 내 비밀번호 변경 및 활성 세션 만료 - userId: {}";
 
     private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
 
     /**
-     * 로그인한 사용자의 기본 정보를 조회
+     * 로그인한 사용자의 기본 정보를 조회한다.
      *
      * @param principal JWT 인증 후 SecurityContext에 저장된 사용자 주체
      * @return 내 사용자 기본 정보
@@ -113,5 +118,45 @@ public class UserController {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 로그인한 정식 회원의 비밀번호를 변경한다.
+     *
+     * @param principal JWT 인증 후 SecurityContext에 저장된 사용자 주체
+     * @param request 비밀번호 변경 요청
+     * @return 204 No Content
+     */
+    @Operation(
+            summary = "내 비밀번호 변경",
+            description = """
+                    로그인한 정식 회원의 비밀번호를 변경합니다.
+                    게스트 사용자는 비밀번호를 변경할 수 없습니다.
+                    현재 비밀번호가 일치해야 새 비밀번호로 변경할 수 있습니다.
+                    새 비밀번호는 회원가입과 동일한 비밀번호 정책을 따릅니다.
+                    비밀번호 변경 성공 후 모든 활성 세션을 만료합니다.
+                    따라서 클라이언트는 성공 응답 수신 후 로그인 화면으로 이동해야 합니다.
+                    """
+    )
+    @PatchMapping("/me/password")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> changeMyPassword(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody ChangePasswordRequest request
+    ) {
+        log.info(
+                LOG_CHANGE_MY_PASSWORD_REQUEST,
+                principal != null ? principal.userId() : null,
+                principal != null ? principal.userIdentifier() : null
+        );
+
+        userCommandService.changeMyPassword(principal, request);
+
+        log.info(
+                LOG_CHANGE_MY_PASSWORD_RESPONSE,
+                principal != null ? principal.userId() : null
+        );
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,24 @@
+package io.github.ascrew.monomatbe.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 정식 회원 비밀번호 변경 요청 DTO
+ *
+ * [검증 책임 분리]
+ * - DTO는 필드 존재 여부만 1차 검증한다.
+ * - 비밀번호 길이, 공백 포함 여부 등 실제 정책 검증은 PasswordPolicyValidator에서 수행한다.
+ * - 새 비밀번호 확인 일치 여부는 UserCommandService에서 명시적으로 검증한다.
+ */
+public record ChangePasswordRequest(
+
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        String newPassword,
+
+        @NotBlank(message = "새 비밀번호 확인을 입력해주세요.")
+        String newPasswordConfirm
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandService.java
@@ -1,29 +1,41 @@
 package io.github.ascrew.monomatbe.domain.user.service;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.auth.service.PasswordPolicyValidator;
+import io.github.ascrew.monomatbe.domain.auth.service.UserSessionLifecycleService;
 import io.github.ascrew.monomatbe.domain.chat.service.ChatSenderProfileCacheEvictor;
+import io.github.ascrew.monomatbe.domain.user.dto.ChangePasswordRequest;
 import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
 import io.github.ascrew.monomatbe.domain.user.dto.UpdateNicknameRequest;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
+
 /**
  * 사용자 쓰기 유스케이스를 담당하는 서비스
  *
  * [책임]
  * - 정식 회원 닉네임 변경
+ * - 정식 회원 비밀번호 변경
  * - 사용자 상태 검증
  * - 닉네임 중복 검증
  * - 닉네임 변경 후 채팅 발신자 프로필 캐시 무효화 예약
+ * - 비밀번호 변경 후 전체 활성 세션 만료
  */
 @Service
 @RequiredArgsConstructor
@@ -47,10 +59,16 @@ public class UserCommandService {
             "닉네임은 50자 이하로 입력해주세요.";
     private static final String ERROR_NICKNAME_DUPLICATED =
             "이미 사용 중인 닉네임입니다.";
+    private static final String ERROR_USER_CREDENTIAL_NOT_FOUND =
+            "사용자 인증 정보를 찾을 수 없습니다. 다시 로그인해주세요.";
 
     private static final int NICKNAME_MAX_LENGTH = 50;
 
     private final UserRepository userRepository;
+    private final UserCredentialRepository userCredentialRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final PasswordPolicyValidator passwordPolicyValidator;
+    private final UserSessionLifecycleService userSessionLifecycleService;
     private final ChatSenderProfileCacheEvictor chatSenderProfileCacheEvictor;
 
     /**
@@ -90,6 +108,50 @@ public class UserCommandService {
         return toResponse(user);
     }
 
+    /**
+     * 정식 회원 비밀번호를 변경한다.
+     *
+     * [보안 정책]
+     * - 현재 Access Token의 userId를 기준으로 사용자와 인증정보를 조회한다.
+     * - 게스트 사용자는 비밀번호를 변경할 수 없다.
+     * - 현재 비밀번호가 일치해야만 새 비밀번호로 변경할 수 있다.
+     * - 새 비밀번호는 회원가입과 동일한 PasswordPolicyValidator 정책을 통과해야 한다.
+     * - 비밀번호 변경 성공 후 모든 활성 세션을 만료한다.
+     *
+     * @param principal 인증 주체
+     * @param request 비밀번호 변경 요청
+     */
+    @Transactional
+    public void changeMyPassword(
+            CustomPrincipal principal,
+            ChangePasswordRequest request
+    ) {
+        validatePasswordChangePrincipal(principal);
+        validateChangePasswordRequest(request);
+
+        User user = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.AUTH_UNAUTHENTICATED));
+
+        validateRegisteredUserForPasswordChange(user);
+        validateUsableUser(user.getStatus());
+
+        UserCredential credential = userCredentialRepository.findByUser_Id(user.getId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED,
+                        ERROR_USER_CREDENTIAL_NOT_FOUND
+                ));
+
+        validateCurrentPassword(request.currentPassword(), credential);
+        validateNewPasswordConfirm(request.newPassword(), request.newPasswordConfirm());
+
+        String newPassword = passwordPolicyValidator.validateNewPassword(request.newPassword());
+        String newPasswordHash = passwordEncoder.encode(newPassword);
+        LocalDateTime changedAt = LocalDateTime.now();
+
+        credential.changePassword(newPasswordHash, changedAt);
+        userSessionLifecycleService.revokeAllActiveSessions(user.getId(), changedAt);
+    }
+
     private void validatePrincipal(CustomPrincipal principal) {
         if (principal == null || principal.userId() == null) {
             throw new ResponseStatusException(
@@ -99,12 +161,28 @@ public class UserCommandService {
         }
     }
 
+    private void validatePasswordChangePrincipal(CustomPrincipal principal) {
+        if (principal == null || principal.userId() == null) {
+            throw new AuthException(AuthErrorCode.AUTH_UNAUTHENTICATED);
+        }
+
+        if (principal.userType() != UserType.REGISTERED) {
+            throw new AuthException(AuthErrorCode.AUTH_REGISTERED_USER_ONLY);
+        }
+    }
+
     private void validateRegisteredUser(User user) {
         if (user.getUserType() != UserType.REGISTERED) {
             throw new ResponseStatusException(
                     HttpStatus.FORBIDDEN,
                     ERROR_REGISTERED_USER_ONLY
             );
+        }
+    }
+
+    private void validateRegisteredUserForPasswordChange(User user) {
+        if (user.getUserType() != UserType.REGISTERED) {
+            throw new AuthException(AuthErrorCode.AUTH_REGISTERED_USER_ONLY);
         }
     }
 
@@ -132,6 +210,32 @@ public class UserCommandService {
                     HttpStatus.CONFLICT,
                     ERROR_UNSUPPORTED_USER_STATUS
             );
+        }
+    }
+
+    private void validateChangePasswordRequest(ChangePasswordRequest request) {
+        if (request == null) {
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_REQUEST_BODY);
+        }
+    }
+
+    private void validateCurrentPassword(String currentPassword, UserCredential credential) {
+        if (currentPassword == null || currentPassword.isBlank()) {
+            throw new AuthException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
+        }
+
+        if (!passwordEncoder.matches(currentPassword, credential.getPasswordHash())) {
+            throw new AuthException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
+        }
+    }
+
+    private void validateNewPasswordConfirm(String newPassword, String newPasswordConfirm) {
+        if (newPassword == null || newPasswordConfirm == null) {
+            throw new AuthException(AuthErrorCode.AUTH_NEW_PASSWORD_CONFIRM_MISMATCH);
+        }
+
+        if (!newPassword.equals(newPasswordConfirm)) {
+            throw new AuthException(AuthErrorCode.AUTH_NEW_PASSWORD_CONFIRM_MISMATCH);
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandService.java
@@ -63,6 +63,8 @@ public class UserCommandService {
             "사용자 인증 정보를 찾을 수 없습니다. 다시 로그인해주세요.";
 
     private static final int NICKNAME_MAX_LENGTH = 50;
+    private static final int MAX_PASSWORD_CHANGE_FAILURE_COUNT = 5;
+    private static final int PASSWORD_CHANGE_LOCK_MINUTES = 15;
 
     private final UserRepository userRepository;
     private final UserCredentialRepository userCredentialRepository;
@@ -114,8 +116,11 @@ public class UserCommandService {
      * [보안 정책]
      * - 현재 Access Token의 userId를 기준으로 사용자와 인증정보를 조회한다.
      * - 게스트 사용자는 비밀번호를 변경할 수 없다.
+     * - 잠긴 계정은 비밀번호를 변경할 수 없다.
      * - 현재 비밀번호가 일치해야만 새 비밀번호로 변경할 수 있다.
+     * - 현재 비밀번호 불일치 시 로그인 실패 정책과 동일하게 실패 횟수와 잠금을 적용한다.
      * - 새 비밀번호는 회원가입과 동일한 PasswordPolicyValidator 정책을 통과해야 한다.
+     * - 새 비밀번호는 현재 비밀번호와 동일할 수 없다.
      * - 비밀번호 변경 성공 후 모든 활성 세션을 만료한다.
      *
      * @param principal 인증 주체
@@ -141,12 +146,16 @@ public class UserCommandService {
                         ERROR_USER_CREDENTIAL_NOT_FOUND
                 ));
 
-        validateCurrentPassword(request.currentPassword(), credential);
+        LocalDateTime changedAt = LocalDateTime.now();
+
+        validateCredentialNotLocked(credential, changedAt);
+        validateCurrentPassword(request.currentPassword(), credential, changedAt);
         validateNewPasswordConfirm(request.newPassword(), request.newPasswordConfirm());
 
         String newPassword = passwordPolicyValidator.validateNewPassword(request.newPassword());
+        validateNewPasswordDifferentFromCurrent(newPassword, credential);
+
         String newPasswordHash = passwordEncoder.encode(newPassword);
-        LocalDateTime changedAt = LocalDateTime.now();
 
         credential.changePassword(newPasswordHash, changedAt);
         userSessionLifecycleService.revokeAllActiveSessions(user.getId(), changedAt);
@@ -219,13 +228,33 @@ public class UserCommandService {
         }
     }
 
-    private void validateCurrentPassword(String currentPassword, UserCredential credential) {
+    private void validateCredentialNotLocked(UserCredential credential, LocalDateTime now) {
+        if (credential.isLockedAt(now)) {
+            throw new AuthException(AuthErrorCode.AUTH_ACCOUNT_LOCKED);
+        }
+    }
+
+    private void validateCurrentPassword(
+            String currentPassword,
+            UserCredential credential,
+            LocalDateTime now
+    ) {
         if (currentPassword == null || currentPassword.isBlank()) {
+            recordPasswordChangeFailure(credential, now);
             throw new AuthException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
         }
 
         if (!passwordEncoder.matches(currentPassword, credential.getPasswordHash())) {
+            recordPasswordChangeFailure(credential, now);
             throw new AuthException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
+        }
+    }
+
+    private void recordPasswordChangeFailure(UserCredential credential, LocalDateTime now) {
+        credential.increaseFailedLoginCount();
+
+        if (credential.getFailedLoginCount() >= MAX_PASSWORD_CHANGE_FAILURE_COUNT) {
+            credential.lockUntil(now.plusMinutes(PASSWORD_CHANGE_LOCK_MINUTES));
         }
     }
 
@@ -236,6 +265,15 @@ public class UserCommandService {
 
         if (!newPassword.equals(newPasswordConfirm)) {
             throw new AuthException(AuthErrorCode.AUTH_NEW_PASSWORD_CONFIRM_MISMATCH);
+        }
+    }
+
+    private void validateNewPasswordDifferentFromCurrent(
+            String newPassword,
+            UserCredential credential
+    ) {
+        if (passwordEncoder.matches(newPassword, credential.getPasswordHash())) {
+            throw new AuthException(AuthErrorCode.AUTH_NEW_PASSWORD_SAME_AS_CURRENT);
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandService.java
@@ -6,6 +6,7 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
 import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthPasswordChangeFailureException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.auth.service.PasswordPolicyValidator;
@@ -119,6 +120,7 @@ public class UserCommandService {
      * - 잠긴 계정은 비밀번호를 변경할 수 없다.
      * - 현재 비밀번호가 일치해야만 새 비밀번호로 변경할 수 있다.
      * - 현재 비밀번호 불일치 시 로그인 실패 정책과 동일하게 실패 횟수와 잠금을 적용한다.
+     * - 현재 비밀번호 불일치 예외는 noRollbackFor로 지정하여 실패 횟수/잠금 변경이 커밋되도록 보장한다.
      * - 새 비밀번호는 회원가입과 동일한 PasswordPolicyValidator 정책을 통과해야 한다.
      * - 새 비밀번호는 현재 비밀번호와 동일할 수 없다.
      * - 비밀번호 변경 성공 후 모든 활성 세션을 만료한다.
@@ -126,7 +128,7 @@ public class UserCommandService {
      * @param principal 인증 주체
      * @param request 비밀번호 변경 요청
      */
-    @Transactional
+    @Transactional(noRollbackFor = AuthPasswordChangeFailureException.class)
     public void changeMyPassword(
             CustomPrincipal principal,
             ChangePasswordRequest request
@@ -241,12 +243,12 @@ public class UserCommandService {
     ) {
         if (currentPassword == null || currentPassword.isBlank()) {
             recordPasswordChangeFailure(credential, now);
-            throw new AuthException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
+            throw new AuthPasswordChangeFailureException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
         }
 
         if (!passwordEncoder.matches(currentPassword, credential.getPasswordHash())) {
             recordPasswordChangeFailure(credential, now);
-            throw new AuthException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
+            throw new AuthPasswordChangeFailureException(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH);
         }
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/auth/service/RegisterAuthServiceTest.java
@@ -35,7 +35,8 @@ class RegisterAuthServiceTest {
                 userRepository,
                 userCredentialRepository,
                 passwordEncoder,
-                nicknamePolicyValidator
+                nicknamePolicyValidator,
+                new PasswordPolicyValidator()
         );
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandServiceTest.java
@@ -3,19 +3,24 @@ package io.github.ascrew.monomatbe.domain.user.service;
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.auth.service.PasswordPolicyValidator;
+import io.github.ascrew.monomatbe.domain.auth.service.UserSessionLifecycleService;
 import io.github.ascrew.monomatbe.domain.chat.service.ChatSenderProfileCacheEvictor;
 import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
 import io.github.ascrew.monomatbe.domain.user.dto.UpdateNicknameRequest;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,154 +28,271 @@ import static org.mockito.Mockito.when;
 
 class UserCommandServiceTest {
 
-    private static final Long USER_ID = 1L;
-    private static final String USER_IDENTIFIER = "session-id";
-    private static final String CURRENT_NICKNAME = "기존닉네임";
-    private static final String NEW_NICKNAME = "변경닉네임";
-
     private final UserRepository userRepository = mock(UserRepository.class);
-    private final ChatSenderProfileCacheEvictor chatSenderProfileCacheEvictor =
-            mock(ChatSenderProfileCacheEvictor.class);
+    private final UserCredentialRepository userCredentialRepository = mock(UserCredentialRepository.class);
+    private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+    private final PasswordPolicyValidator passwordPolicyValidator = new PasswordPolicyValidator();
+    private final UserSessionLifecycleService userSessionLifecycleService = mock(UserSessionLifecycleService.class);
+    private final ChatSenderProfileCacheEvictor chatSenderProfileCacheEvictor = mock(ChatSenderProfileCacheEvictor.class);
 
     private final UserCommandService userCommandService = new UserCommandService(
             userRepository,
+            userCredentialRepository,
+            passwordEncoder,
+            passwordPolicyValidator,
+            userSessionLifecycleService,
             chatSenderProfileCacheEvictor
     );
 
     @Test
     @DisplayName("정식 회원은 닉네임을 변경할 수 있다")
-    void updateMyNickname_updatesRegisteredUserNickname() {
-        // given
-        User user = registeredUser(CURRENT_NICKNAME);
-
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(userRepository.existsByUsername(NEW_NICKNAME)).thenReturn(false);
-
-        CustomPrincipal principal = principal();
-        UpdateNicknameRequest request = new UpdateNicknameRequest(NEW_NICKNAME);
-
-        // when
-        MyUserInfoResponse response = userCommandService.updateMyNickname(principal, request);
-
-        // then
-        assertThat(user.getUsername()).isEqualTo(NEW_NICKNAME);
-        assertThat(response.userId()).isEqualTo(USER_ID);
-        assertThat(response.username()).isEqualTo(NEW_NICKNAME);
-    }
-
-    @Test
-    @DisplayName("동일한 닉네임으로 변경 요청하면 중복 검사 없이 현재 정보를 반환한다")
-    void updateMyNickname_returnsCurrentInfoWhenNicknameIsSame() {
-        // given
-        User user = registeredUser(CURRENT_NICKNAME);
-
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-
-        CustomPrincipal principal = principal();
-        UpdateNicknameRequest request = new UpdateNicknameRequest(CURRENT_NICKNAME);
-
-        // when
-        MyUserInfoResponse response = userCommandService.updateMyNickname(principal, request);
-
-        // then
-        assertThat(user.getUsername()).isEqualTo(CURRENT_NICKNAME);
-        assertThat(response.username()).isEqualTo(CURRENT_NICKNAME);
-
-        verify(userRepository, never()).existsByUsername(CURRENT_NICKNAME);
-    }
-
-    @Test
-    @DisplayName("게스트는 닉네임을 변경할 수 없다")
-    void updateMyNickname_rejectsGuestUser() {
-        // given
-        User user = guestUser(CURRENT_NICKNAME);
-
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-
-        CustomPrincipal principal = principal();
-        UpdateNicknameRequest request = new UpdateNicknameRequest(NEW_NICKNAME);
-
-        // when & then
-        assertThatThrownBy(() -> userCommandService.updateMyNickname(principal, request))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("403 FORBIDDEN");
-    }
-
-    @Test
-    @DisplayName("이미 사용 중인 닉네임이면 변경할 수 없다")
-    void updateMyNickname_rejectsDuplicatedNickname() {
-        // given
-        User user = registeredUser(CURRENT_NICKNAME);
-
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(userRepository.existsByUsername(NEW_NICKNAME)).thenReturn(true);
-
-        CustomPrincipal principal = principal();
-        UpdateNicknameRequest request = new UpdateNicknameRequest(NEW_NICKNAME);
-
-        // when & then
-        assertThatThrownBy(() -> userCommandService.updateMyNickname(principal, request))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("409 CONFLICT");
-    }
-
-    @Test
-    @DisplayName("정지된 회원은 닉네임을 변경할 수 없다")
-    void updateMyNickname_rejectsBannedUser() {
-        // given
+    void updateMyNickname_registeredUser_success() {
         User user = User.builder()
-                .id(USER_ID)
-                .username(CURRENT_NICKNAME)
+                .id(1L)
+                .username("oldNickname")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.REGISTERED,
+                user.getRole()
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByUsername("newNickname")).thenReturn(false);
+
+        MyUserInfoResponse response = userCommandService.updateMyNickname(
+                principal,
+                new UpdateNicknameRequest("newNickname")
+        );
+
+        assertEquals(1L, response.userId());
+        assertEquals("newNickname", response.username());
+        assertEquals(UserType.REGISTERED, response.userType());
+        assertEquals(UserStatus.ACTIVE, response.status());
+        assertEquals("newNickname", user.getUsername());
+    }
+
+    @Test
+    @DisplayName("기존 닉네임과 동일하면 중복 검증과 캐시 무효화를 수행하지 않는다")
+    void updateMyNickname_sameNickname_returnsCurrentInfo() {
+        User user = User.builder()
+                .id(1L)
+                .username("sameNickname")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.REGISTERED,
+                user.getRole()
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        MyUserInfoResponse response = userCommandService.updateMyNickname(
+                principal,
+                new UpdateNicknameRequest("sameNickname")
+        );
+
+        assertEquals("sameNickname", response.username());
+        verify(userRepository, never()).existsByUsername("sameNickname");
+        verify(chatSenderProfileCacheEvictor, never()).evictByUserId(1L);
+    }
+
+    @Test
+    @DisplayName("게스트 사용자는 닉네임을 변경할 수 없다")
+    void updateMyNickname_guestUser_forbidden() {
+        User user = User.builder()
+                .id(1L)
+                .username("guest")
+                .userType(UserType.GUEST)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.GUEST,
+                user.getRole()
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.updateMyNickname(
+                        principal,
+                        new UpdateNicknameRequest("newNickname")
+                )
+        );
+
+        assertSame(org.springframework.http.HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("정지된 사용자는 닉네임을 변경할 수 없다")
+    void updateMyNickname_bannedUser_forbidden() {
+        User user = User.builder()
+                .id(1L)
+                .username("banned")
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.BANNED)
                 .build();
 
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.REGISTERED,
+                user.getRole()
+        );
 
-        CustomPrincipal principal = principal();
-        UpdateNicknameRequest request = new UpdateNicknameRequest(NEW_NICKNAME);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-        // when & then
-        assertThatThrownBy(() -> userCommandService.updateMyNickname(principal, request))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("403 FORBIDDEN");
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.updateMyNickname(
+                        principal,
+                        new UpdateNicknameRequest("newNickname")
+                )
+        );
+
+        assertSame(org.springframework.http.HttpStatus.FORBIDDEN, exception.getStatusCode());
     }
 
     @Test
-    @DisplayName("인증 주체가 없으면 닉네임을 변경할 수 없다")
-    void updateMyNickname_rejectsInvalidPrincipal() {
-        // given
-        UpdateNicknameRequest request = new UpdateNicknameRequest(NEW_NICKNAME);
+    @DisplayName("삭제된 사용자는 닉네임을 변경할 수 없다")
+    void updateMyNickname_deletedUser_unauthorized() {
+        User user = User.builder()
+                .id(1L)
+                .username("deleted")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.DELETED)
+                .build();
 
-        // when & then
-        assertThatThrownBy(() -> userCommandService.updateMyNickname(null, request))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("401 UNAUTHORIZED");
-    }
-
-    private CustomPrincipal principal() {
-        return new CustomPrincipal(
-                USER_ID,
-                USER_IDENTIFIER,
-                UserType.REGISTERED
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.REGISTERED,
+                user.getRole()
         );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.updateMyNickname(
+                        principal,
+                        new UpdateNicknameRequest("newNickname")
+                )
+        );
+
+        assertSame(org.springframework.http.HttpStatus.UNAUTHORIZED, exception.getStatusCode());
     }
 
-    private User registeredUser(String username) {
-        return User.builder()
-                .id(USER_ID)
-                .username(username)
+    @Test
+    @DisplayName("중복 닉네임이면 409 Conflict가 발생한다")
+    void updateMyNickname_duplicatedNickname_conflict() {
+        User user = User.builder()
+                .id(1L)
+                .username("oldNickname")
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.ACTIVE)
                 .build();
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.REGISTERED,
+                user.getRole()
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByUsername("duplicated")).thenReturn(true);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.updateMyNickname(
+                        principal,
+                        new UpdateNicknameRequest("duplicated")
+                )
+        );
+
+        assertSame(org.springframework.http.HttpStatus.CONFLICT, exception.getStatusCode());
     }
 
-    private User guestUser(String username) {
-        return User.builder()
-                .id(USER_ID)
-                .username(username)
-                .userType(UserType.GUEST)
+    @Test
+    @DisplayName("닉네임이 blank이면 400 Bad Request가 발생한다")
+    void updateMyNickname_blankNickname_badRequest() {
+        User user = User.builder()
+                .id(1L)
+                .username("oldNickname")
+                .userType(UserType.REGISTERED)
                 .status(UserStatus.ACTIVE)
                 .build();
+
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.REGISTERED,
+                user.getRole()
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.updateMyNickname(
+                        principal,
+                        new UpdateNicknameRequest("   ")
+                )
+        );
+
+        assertSame(org.springframework.http.HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("인증 주체가 없으면 401 Unauthorized가 발생한다")
+    void updateMyNickname_nullPrincipal_unauthorized() {
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.updateMyNickname(
+                        null,
+                        new UpdateNicknameRequest("newNickname")
+                )
+        );
+
+        assertSame(org.springframework.http.HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없으면 401 Unauthorized가 발생한다")
+    void updateMyNickname_userNotFound_unauthorized() {
+        CustomPrincipal principal = new CustomPrincipal(
+                1L,
+                "session-id",
+                UserType.REGISTERED,
+                User.builder()
+                        .userType(UserType.REGISTERED)
+                        .build()
+                        .getRole()
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.updateMyNickname(
+                        principal,
+                        new UpdateNicknameRequest("newNickname")
+                )
+        );
+
+        assertSame(org.springframework.http.HttpStatus.UNAUTHORIZED, exception.getStatusCode());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandServiceTest.java
@@ -119,6 +119,7 @@ class UserCommandServiceTest {
                 .username("banned")
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.BANNED)
+                .role(UserRole.USER)
                 .build();
 
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -142,6 +143,7 @@ class UserCommandServiceTest {
                 .username("deleted")
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.DELETED)
+                .role(UserRole.USER)
                 .build();
 
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -233,6 +235,7 @@ class UserCommandServiceTest {
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
         when(passwordEncoder.matches("oldPassword123", "encoded-old-password")).thenReturn(true);
+        when(passwordEncoder.matches("newPassword123", "encoded-old-password")).thenReturn(false);
         when(passwordEncoder.encode("newPassword123")).thenReturn("encoded-new-password");
 
         userCommandService.changeMyPassword(
@@ -274,7 +277,7 @@ class UserCommandServiceTest {
     }
 
     @Test
-    @DisplayName("현재 비밀번호가 일치하지 않으면 비밀번호를 변경할 수 없다")
+    @DisplayName("현재 비밀번호가 일치하지 않으면 실패 횟수를 증가시키고 비밀번호를 변경할 수 없다")
     void changeMyPassword_currentPasswordMismatch_unauthorized() {
         User user = registeredUser("member");
         UserCredential credential = userCredential(user, "encoded-old-password");
@@ -296,7 +299,66 @@ class UserCommandServiceTest {
         );
 
         assertEquals(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH, exception.getErrorCode());
+        assertEquals(4, credential.getFailedLoginCount());
         assertEquals("encoded-old-password", credential.getPasswordHash());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호 불일치가 누적 5회가 되면 계정을 잠근다")
+    void changeMyPassword_currentPasswordMismatchFiveTimes_locksAccount() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-old-password");
+        credential.increaseFailedLoginCount();
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("wrongPassword123", "encoded-old-password")).thenReturn(false);
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "wrongPassword123",
+                                "newPassword123",
+                                "newPassword123"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH, exception.getErrorCode());
+        assertEquals(5, credential.getFailedLoginCount());
+        assertNotNull(credential.getLockedUntil());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("잠긴 계정은 비밀번호를 변경할 수 없다")
+    void changeMyPassword_lockedAccount_locked() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-old-password");
+        credential.lockUntil(LocalDateTime.now().plusMinutes(15));
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "oldPassword123",
+                                "newPassword123",
+                                "newPassword123"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_ACCOUNT_LOCKED, exception.getErrorCode());
+        verify(passwordEncoder, never()).matches(any(), any());
         verify(passwordEncoder, never()).encode(any());
         verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
     }
@@ -325,6 +387,34 @@ class UserCommandServiceTest {
 
         assertEquals(AuthErrorCode.AUTH_NEW_PASSWORD_CONFIRM_MISMATCH, exception.getErrorCode());
         assertEquals("encoded-old-password", credential.getPasswordHash());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("새 비밀번호가 현재 비밀번호와 같으면 비밀번호를 변경할 수 없다")
+    void changeMyPassword_newPasswordSameAsCurrent_badRequest() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-current-password");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("samePassword123", "encoded-current-password")).thenReturn(true);
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "samePassword123",
+                                "samePassword123",
+                                "samePassword123"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NEW_PASSWORD_SAME_AS_CURRENT, exception.getErrorCode());
+        assertEquals("encoded-current-password", credential.getPasswordHash());
         verify(passwordEncoder, never()).encode(any());
         verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
     }
@@ -470,7 +560,7 @@ class UserCommandServiceTest {
                 .loginId("loginId1")
                 .passwordHash(passwordHash)
                 .failedLoginCount(3)
-                .lockedUntil(LocalDateTime.now().plusMinutes(10))
+                .lockedUntil(null)
                 .build();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/user/service/UserCommandServiceTest.java
@@ -1,32 +1,44 @@
 package io.github.ascrew.monomatbe.domain.user.service;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserCredential;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserRole;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserCredentialRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.auth.service.PasswordPolicyValidator;
 import io.github.ascrew.monomatbe.domain.auth.service.UserSessionLifecycleService;
 import io.github.ascrew.monomatbe.domain.chat.service.ChatSenderProfileCacheEvictor;
+import io.github.ascrew.monomatbe.domain.user.dto.ChangePasswordRequest;
 import io.github.ascrew.monomatbe.domain.user.dto.MyUserInfoResponse;
 import io.github.ascrew.monomatbe.domain.user.dto.UpdateNicknameRequest;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class UserCommandServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String SESSION_ID = "session-id";
 
     private final UserRepository userRepository = mock(UserRepository.class);
     private final UserCredentialRepository userCredentialRepository = mock(UserCredentialRepository.class);
@@ -47,29 +59,17 @@ class UserCommandServiceTest {
     @Test
     @DisplayName("정식 회원은 닉네임을 변경할 수 있다")
     void updateMyNickname_registeredUser_success() {
-        User user = User.builder()
-                .id(1L)
-                .username("oldNickname")
-                .userType(UserType.REGISTERED)
-                .status(UserStatus.ACTIVE)
-                .build();
+        User user = registeredUser("oldNickname");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.REGISTERED,
-                user.getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(userRepository.existsByUsername("newNickname")).thenReturn(false);
 
         MyUserInfoResponse response = userCommandService.updateMyNickname(
-                principal,
+                registeredPrincipal(),
                 new UpdateNicknameRequest("newNickname")
         );
 
-        assertEquals(1L, response.userId());
+        assertEquals(USER_ID, response.userId());
         assertEquals("newNickname", response.username());
         assertEquals(UserType.REGISTERED, response.userType());
         assertEquals(UserStatus.ACTIVE, response.status());
@@ -79,185 +79,123 @@ class UserCommandServiceTest {
     @Test
     @DisplayName("기존 닉네임과 동일하면 중복 검증과 캐시 무효화를 수행하지 않는다")
     void updateMyNickname_sameNickname_returnsCurrentInfo() {
-        User user = User.builder()
-                .id(1L)
-                .username("sameNickname")
-                .userType(UserType.REGISTERED)
-                .status(UserStatus.ACTIVE)
-                .build();
+        User user = registeredUser("sameNickname");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.REGISTERED,
-                user.getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
         MyUserInfoResponse response = userCommandService.updateMyNickname(
-                principal,
+                registeredPrincipal(),
                 new UpdateNicknameRequest("sameNickname")
         );
 
         assertEquals("sameNickname", response.username());
         verify(userRepository, never()).existsByUsername("sameNickname");
-        verify(chatSenderProfileCacheEvictor, never()).evictByUserId(1L);
+        verify(chatSenderProfileCacheEvictor, never()).evictByUserId(USER_ID);
     }
 
     @Test
     @DisplayName("게스트 사용자는 닉네임을 변경할 수 없다")
     void updateMyNickname_guestUser_forbidden() {
-        User user = User.builder()
-                .id(1L)
-                .username("guest")
-                .userType(UserType.GUEST)
-                .status(UserStatus.ACTIVE)
-                .build();
+        User user = guestUser();
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.GUEST,
-                user.getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
                 () -> userCommandService.updateMyNickname(
-                        principal,
+                        guestPrincipal(),
                         new UpdateNicknameRequest("newNickname")
                 )
         );
 
-        assertSame(org.springframework.http.HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertSame(HttpStatus.FORBIDDEN, exception.getStatusCode());
     }
 
     @Test
     @DisplayName("정지된 사용자는 닉네임을 변경할 수 없다")
     void updateMyNickname_bannedUser_forbidden() {
         User user = User.builder()
-                .id(1L)
+                .id(USER_ID)
                 .username("banned")
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.BANNED)
                 .build();
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.REGISTERED,
-                user.getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
                 () -> userCommandService.updateMyNickname(
-                        principal,
+                        registeredPrincipal(),
                         new UpdateNicknameRequest("newNickname")
                 )
         );
 
-        assertSame(org.springframework.http.HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertSame(HttpStatus.FORBIDDEN, exception.getStatusCode());
     }
 
     @Test
     @DisplayName("삭제된 사용자는 닉네임을 변경할 수 없다")
     void updateMyNickname_deletedUser_unauthorized() {
         User user = User.builder()
-                .id(1L)
+                .id(USER_ID)
                 .username("deleted")
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.DELETED)
                 .build();
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.REGISTERED,
-                user.getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
                 () -> userCommandService.updateMyNickname(
-                        principal,
+                        registeredPrincipal(),
                         new UpdateNicknameRequest("newNickname")
                 )
         );
 
-        assertSame(org.springframework.http.HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertSame(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
     }
 
     @Test
     @DisplayName("중복 닉네임이면 409 Conflict가 발생한다")
     void updateMyNickname_duplicatedNickname_conflict() {
-        User user = User.builder()
-                .id(1L)
-                .username("oldNickname")
-                .userType(UserType.REGISTERED)
-                .status(UserStatus.ACTIVE)
-                .build();
+        User user = registeredUser("oldNickname");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.REGISTERED,
-                user.getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(userRepository.existsByUsername("duplicated")).thenReturn(true);
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
                 () -> userCommandService.updateMyNickname(
-                        principal,
+                        registeredPrincipal(),
                         new UpdateNicknameRequest("duplicated")
                 )
         );
 
-        assertSame(org.springframework.http.HttpStatus.CONFLICT, exception.getStatusCode());
+        assertSame(HttpStatus.CONFLICT, exception.getStatusCode());
     }
 
     @Test
     @DisplayName("닉네임이 blank이면 400 Bad Request가 발생한다")
     void updateMyNickname_blankNickname_badRequest() {
-        User user = User.builder()
-                .id(1L)
-                .username("oldNickname")
-                .userType(UserType.REGISTERED)
-                .status(UserStatus.ACTIVE)
-                .build();
+        User user = registeredUser("oldNickname");
 
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.REGISTERED,
-                user.getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
                 () -> userCommandService.updateMyNickname(
-                        principal,
+                        registeredPrincipal(),
                         new UpdateNicknameRequest("   ")
                 )
         );
 
-        assertSame(org.springframework.http.HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertSame(HttpStatus.BAD_REQUEST, exception.getStatusCode());
     }
 
     @Test
-    @DisplayName("인증 주체가 없으면 401 Unauthorized가 발생한다")
+    @DisplayName("인증 주체가 없으면 닉네임 변경 시 401 Unauthorized가 발생한다")
     void updateMyNickname_nullPrincipal_unauthorized() {
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
@@ -267,32 +205,272 @@ class UserCommandServiceTest {
                 )
         );
 
-        assertSame(org.springframework.http.HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertSame(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
     }
 
     @Test
-    @DisplayName("사용자를 찾을 수 없으면 401 Unauthorized가 발생한다")
+    @DisplayName("사용자를 찾을 수 없으면 닉네임 변경 시 401 Unauthorized가 발생한다")
     void updateMyNickname_userNotFound_unauthorized() {
-        CustomPrincipal principal = new CustomPrincipal(
-                1L,
-                "session-id",
-                UserType.REGISTERED,
-                User.builder()
-                        .userType(UserType.REGISTERED)
-                        .build()
-                        .getRole()
-        );
-
-        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
                 () -> userCommandService.updateMyNickname(
-                        principal,
+                        registeredPrincipal(),
                         new UpdateNicknameRequest("newNickname")
                 )
         );
 
-        assertSame(org.springframework.http.HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertSame(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("정식 회원은 현재 비밀번호 확인 후 새 비밀번호로 변경할 수 있다")
+    void changeMyPassword_registeredUser_success() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-old-password");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("oldPassword123", "encoded-old-password")).thenReturn(true);
+        when(passwordEncoder.encode("newPassword123")).thenReturn("encoded-new-password");
+
+        userCommandService.changeMyPassword(
+                registeredPrincipal(),
+                new ChangePasswordRequest(
+                        "oldPassword123",
+                        "newPassword123",
+                        "newPassword123"
+                )
+        );
+
+        assertEquals("encoded-new-password", credential.getPasswordHash());
+        assertNotNull(credential.getPasswordChangedAt());
+        assertEquals(0, credential.getFailedLoginCount());
+        verify(userSessionLifecycleService).revokeAllActiveSessions(
+                USER_ID,
+                credential.getPasswordChangedAt()
+        );
+    }
+
+    @Test
+    @DisplayName("게스트 사용자는 비밀번호를 변경할 수 없다")
+    void changeMyPassword_guestUser_forbidden() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        guestPrincipal(),
+                        new ChangePasswordRequest(
+                                "oldPassword123",
+                                "newPassword123",
+                                "newPassword123"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_REGISTERED_USER_ONLY, exception.getErrorCode());
+        verify(userRepository, never()).findById(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 일치하지 않으면 비밀번호를 변경할 수 없다")
+    void changeMyPassword_currentPasswordMismatch_unauthorized() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-old-password");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("wrongPassword123", "encoded-old-password")).thenReturn(false);
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "wrongPassword123",
+                                "newPassword123",
+                                "newPassword123"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH, exception.getErrorCode());
+        assertEquals("encoded-old-password", credential.getPasswordHash());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("새 비밀번호와 새 비밀번호 확인이 일치하지 않으면 비밀번호를 변경할 수 없다")
+    void changeMyPassword_newPasswordConfirmMismatch_badRequest() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-old-password");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("oldPassword123", "encoded-old-password")).thenReturn(true);
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "oldPassword123",
+                                "newPassword123",
+                                "differentPassword123"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_NEW_PASSWORD_CONFIRM_MISMATCH, exception.getErrorCode());
+        assertEquals("encoded-old-password", credential.getPasswordHash());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("새 비밀번호가 정책 길이보다 짧으면 비밀번호를 변경할 수 없다")
+    void changeMyPassword_newPasswordTooShort_badRequest() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-old-password");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("oldPassword123", "encoded-old-password")).thenReturn(true);
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "oldPassword123",
+                                "short",
+                                "short"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_INVALID_LENGTH, exception.getErrorCode());
+        assertEquals("encoded-old-password", credential.getPasswordHash());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("새 비밀번호에 공백이 포함되면 비밀번호를 변경할 수 없다")
+    void changeMyPassword_newPasswordContainsWhitespace_badRequest() {
+        User user = registeredUser("member");
+        UserCredential credential = userCredential(user, "encoded-old-password");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("oldPassword123", "encoded-old-password")).thenReturn(true);
+
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "oldPassword123",
+                                "new password123",
+                                "new password123"
+                        )
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_CONTAINS_WHITESPACE, exception.getErrorCode());
+        assertEquals("encoded-old-password", credential.getPasswordHash());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 요청 본문이 null이면 실패한다")
+    void changeMyPassword_nullRequest_badRequest() {
+        AuthException exception = assertThrows(
+                AuthException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        null
+                )
+        );
+
+        assertEquals(AuthErrorCode.AUTH_INVALID_REQUEST_BODY, exception.getErrorCode());
+        verify(userRepository, never()).findById(any());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    @Test
+    @DisplayName("인증정보가 없으면 비밀번호를 변경할 수 없다")
+    void changeMyPassword_credentialNotFound_unauthorized() {
+        User user = registeredUser("member");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userCredentialRepository.findByUser_Id(USER_ID)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userCommandService.changeMyPassword(
+                        registeredPrincipal(),
+                        new ChangePasswordRequest(
+                                "oldPassword123",
+                                "newPassword123",
+                                "newPassword123"
+                        )
+                )
+        );
+
+        assertSame(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verify(userSessionLifecycleService, never()).revokeAllActiveSessions(any(), any());
+    }
+
+    private CustomPrincipal registeredPrincipal() {
+        return new CustomPrincipal(
+                USER_ID,
+                SESSION_ID,
+                UserType.REGISTERED,
+                UserRole.USER
+        );
+    }
+
+    private CustomPrincipal guestPrincipal() {
+        return new CustomPrincipal(
+                USER_ID,
+                SESSION_ID,
+                UserType.GUEST,
+                UserRole.USER
+        );
+    }
+
+    private User registeredUser(String username) {
+        return User.builder()
+                .id(USER_ID)
+                .username(username)
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+    }
+
+    private User guestUser() {
+        return User.builder()
+                .id(USER_ID)
+                .username("guest")
+                .userType(UserType.GUEST)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+    }
+
+    private UserCredential userCredential(User user, String passwordHash) {
+        return UserCredential.builder()
+                .id(1L)
+                .user(user)
+                .loginId("loginId1")
+                .passwordHash(passwordHash)
+                .failedLoginCount(3)
+                .lockedUntil(LocalDateTime.now().plusMinutes(10))
+                .build();
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

* #157

## 📝 Summary

* 정식 회원 비밀번호 변경 API를 추가했습니다.

  * `PATCH /api/users/me/password`
  * 성공 시 `204 No Content` 반환
* 비밀번호 변경 요청 DTO를 추가했습니다.

  * `currentPassword`
  * `newPassword`
  * `newPasswordConfirm`
* 회원가입과 비밀번호 변경에서 동일한 정책을 재사용할 수 있도록 `PasswordPolicyValidator`를 분리했습니다.

  * 8자 이상 100자 이하
  * 공백 포함 불가
  * null/blank 불가
* 현재 로그인한 정식 회원만 비밀번호를 변경할 수 있도록 인증 주체와 DB 사용자 상태를 함께 검증했습니다.
* 게스트 사용자의 비밀번호 변경 요청을 차단했습니다.
* 비밀번호 변경 전용 에러 코드를 추가했습니다.

  * `AUTH_CURRENT_PASSWORD_MISMATCH`
  * `AUTH_NEW_PASSWORD_CONFIRM_MISMATCH`
  * `AUTH_REGISTERED_USER_ONLY`
* 새 비밀번호를 기존 회원가입/로그인과 동일하게 `PasswordEncoder`로 해시하여 저장하도록 구현했습니다.
* 비밀번호 변경 시 `UserCredential.passwordChangedAt`을 갱신하도록 구현했습니다.
* 비밀번호 변경 성공 후 모든 활성 세션을 만료하도록 구현했습니다.
* 비밀번호 변경 성공/실패 케이스에 대한 서비스 테스트를 추가했습니다.
* FE 연동을 위한 API 계약을 `docs/API.md`에 문서화했습니다.

## 🙏PR point

* 비밀번호 변경 성공 후 기존 `accessToken`, `refreshToken` 기반 세션은 모두 만료됩니다.
* FE는 `204 No Content` 응답을 받으면 저장된 인증 정보를 제거하고 로그인 화면으로 이동해야 합니다.
* 성공 직후 기존 access token으로 `/api/users/me`를 재요청하지 않도록 `docs/API.md`에 명시했습니다.
* 새 비밀번호 정책은 회원가입과 동일하게 `PasswordPolicyValidator`를 통해 검증합니다.
* 비밀번호 변경 실패 시에는 비밀번호 해시 변경과 세션 만료가 발생하지 않도록 테스트로 검증했습니다.

## 📬 Reference

* 기존 회원가입 비밀번호 해시 처리 로직
* 기존 로그인 비밀번호 검증 로직
* 기존 `UserSessionLifecycleService.revokeAllActiveSessions(...)` 세션 만료 로직
* `docs/API.md` 사용자 API 문서