### PR TITLE
[Fix/#159] 사용자 API AuthException 표준 응답 처리 추가

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/user/exception/UserAuthExceptionHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/user/exception/UserAuthExceptionHandler.java
@@ -1,0 +1,34 @@
+package io.github.ascrew.monomatbe.domain.user.exception;
+
+import io.github.ascrew.monomatbe.domain.auth.dto.AuthErrorResponse;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthErrorCode;
+import io.github.ascrew.monomatbe.domain.auth.exception.AuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 사용자 API에서 발생하는 인증 도메인 예외를 표준 에러 응답으로 변환한다.
+ *
+ * [설계 의도]
+ * - UserController는 정식 회원 닉네임/비밀번호 변경 과정에서 AuthException 계열 예외를 사용할 수 있다.
+ * - 기존 AuthExceptionHandler는 domain.auth 컨트롤러에만 적용되므로 domain.user 컨트롤러의 AuthException은 처리하지 못한다.
+ * - user 도메인 DTO의 @Valid 메시지 정책은 기존 AuthExceptionHandler와 다르므로,
+ *   이 핸들러에서는 AuthException 계열만 처리하여 검증 예외 처리 부작용을 피한다.
+ */
+@Slf4j
+@RestControllerAdvice(basePackages = UserAuthExceptionHandler.USER_BASE_PACKAGE)
+public class UserAuthExceptionHandler {
+
+    static final String USER_BASE_PACKAGE = "io.github.ascrew.monomatbe.domain.user";
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<AuthErrorResponse> handleAuthException(AuthException exception) {
+        AuthErrorCode errorCode = exception.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(AuthErrorResponse.from(errorCode));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #159 

## 📝 Summary

- `domain.user` 하위 컨트롤러에서 발생하는 `AuthException` 계열 예외를 `AuthErrorResponse`로 변환하는 `UserAuthExceptionHandler`를 추가했습니다.
- `PATCH /api/users/me/password`에서 현재 비밀번호 불일치 시 `500 Internal Server Error`가 아니라 `401 AUTH_CURRENT_PASSWORD_MISMATCH` 응답이 내려가도록 수정했습니다.
- 기존 `AuthExceptionHandler`의 적용 범위를 직접 확장하지 않고, user 도메인 전용 핸들러를 추가해 `@Valid` 검증 예외 처리 범위가 의도치 않게 변경되지 않도록 했습니다.

## 🙏PR point

- 이번 PR은 `AuthException` 계열 예외만 처리하는 최소 수정입니다.
- `MethodArgumentNotValidException` 등 DTO 검증 실패 응답 포맷은 이번 PR에서 변경하지 않았습니다.
- user 도메인 DTO의 `@Valid` 메시지는 기존 auth validation handler의 `AuthErrorCode` 기반 정책과 다르기 때문에, 기존 `AuthExceptionHandler`에 `domain.user`를 단순 추가하지 않고 별도 핸들러를 추가했습니다.
- FE #68 정식 회원 프로필 모달에서 비밀번호 변경 API를 연동할 때, 현재 비밀번호 불일치/새 비밀번호 동일 등 BE 에러 메시지를 정상적으로 표시하기 위한 선행 수정입니다.

## 📬 Reference

- `AuthExceptionHandler`
- `UserController`
- `UserCommandService.changeMyPassword()`
- `AuthPasswordChangeFailureException`
- `AuthErrorCode.AUTH_CURRENT_PASSWORD_MISMATCH`