### PR TITLE
[Feat/#154]: 맵 카테고리에 OST·애니 추가

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -293,6 +293,20 @@ HTTP/1.1 201 Created
 }
 ```
 
+#### 맵 카테고리(`mapCategory`) 값
+
+맵 생성/수정 요청 및 로비 목록 `mapCategory` 필터에서 사용하는 카테고리 값은 아래 5종이다.
+
+| 응답/표시 값 | 허용 입력 값(대소문자·하이픈·언더스코어·공백 무시) |
+| --- | --- |
+| `K-POP` | `K-POP`, `KPOP`, `kpop` |
+| `J-POP` | `J-POP`, `JPOP`, `jpop` |
+| `POP` | `POP`, `pop` |
+| `OST` | `OST`, `ost` |
+| `애니` | `애니`, `ANIME`, `anime` |
+
+목록에 없는 값을 요청하면 400 Bad Request로 응답한다.
+
 #### Error Response
 
 | HTTP Status | 상황 |

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategory.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategory.java
@@ -9,18 +9,21 @@ import java.util.Locale;
  * 퀴즈 맵 카테고리.
  *
  * [역할]
- * - DB에는 EnumType.STRING 정책에 따라 KPOP, JPOP, POP 형태로 저장된다.
- * - HTTP JSON 응답에는 FE 필터 값과 맞춘 표시 값(K-POP, J-POP, POP)을 내려준다.
+ * - DB에는 EnumType.STRING 정책에 따라 KPOP, JPOP, POP, OST, ANIME 형태로 저장된다.
+ * - HTTP JSON 응답에는 FE 필터 값과 맞춘 표시 값(K-POP, J-POP, POP, OST, 애니)을 내려준다.
  *
  * [입력 정책]
  * 요청 값은 하이픈, 언더스코어, 공백, 대소문자 차이를 허용한다.
  * 예: "jpop", "JPOP", "J-POP", "J_POP", "J POP" 모두 JPOP으로 정규화한다.
+ * 애니 카테고리는 FE 표시 값("애니")과 영문 값("anime", "ANIME")을 모두 허용한다.
  */
 public enum MapCategory {
 
     KPOP("K-POP"),
     JPOP("J-POP"),
-    POP("POP");
+    POP("POP"),
+    OST("OST"),
+    ANIME("애니");
 
     private final String displayValue;
 
@@ -56,6 +59,8 @@ public enum MapCategory {
             case "kpop" -> KPOP;
             case "jpop" -> JPOP;
             case "pop" -> POP;
+            case "ost" -> OST;
+            case "anime", "애니" -> ANIME;
             default -> throw new IllegalArgumentException("지원하지 않는 category입니다: " + rawValue);
         };
     }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/entity/MapCategoryTest.java
@@ -16,6 +16,21 @@ class MapCategoryTest {
     }
 
     @Test
+    void from_acceptsOstAndAnimeVariants() {
+        assertThat(MapCategory.from("ost")).isEqualTo(MapCategory.OST);
+        assertThat(MapCategory.from("OST")).isEqualTo(MapCategory.OST);
+        assertThat(MapCategory.from("anime")).isEqualTo(MapCategory.ANIME);
+        assertThat(MapCategory.from("ANIME")).isEqualTo(MapCategory.ANIME);
+        assertThat(MapCategory.from("애니")).isEqualTo(MapCategory.ANIME);
+    }
+
+    @Test
+    void value_returnsDisplayValue() {
+        assertThat(MapCategory.OST.value()).isEqualTo("OST");
+        assertThat(MapCategory.ANIME.value()).isEqualTo("애니");
+    }
+
+    @Test
     void from_rejectsUnsupportedCategory() {
         assertThatThrownBy(() -> MapCategory.from("rock"))
                 .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
## 📣 Related Issue
- #154 

## 📝 Summary
- 맵 카테고리를 기존 K-POP, J-POP, POP 3종에서 OST, 애니를 추가해 5종으로 확장
- MapCategory enum에 OST("OST"), ANIME("애니") 상수 추가 및 from() 변환 케이스(ost, anime, 애니) 추가
- 맵 생성/수정·상세/목록 응답, 로비 목록 mapCategory 필터는 모두 enum을 경유하므로 별도 수정 없이 신규 카테고리 자동 지원
- 잘못된 카테고리 값은 기존과 동일하게 400 Bad Request로 응답
- MapCategoryTest에 신규 카테고리 변환 및 표시값(OST, 애니) 검증 테스트 추가
- docs/API.md에 카테고리 허용값 표 추가, running/Monomat_ERD.sql 컬럼 코멘트 보강

## 🙏PR point
- 저장값/표시값 분리: DB에는 KPOP, JPOP, POP, OST, ANIME(EnumType.STRING)로 저장하고, API 응답·FE 필터에는 표시값 K-POP, J-POP, POP, OST, 애니로 내려갑니다.
- 애니 카테고리 입력 허용 범위: normalize()가 한글은 변형하지 않으므로, FE 표시값 "애니"와 영문 값 "anime"/"ANIME"을 모두 수용하도록 두 케이스를 모두 추가했습니다.
- DB 스키마 변경 없음: category 컬럼이 VARCHAR(100)으로 충분해 Flyway 마이그레이션은 추가하지 않았습니다.
- 테스트 실행 참고: 로컬에서 ./gradlew test --tests "*MapCategoryTest"로 검증 부탁드립니다. (제 환경에서는 테스트 JVM 포크 제약으로 실행하지 못했고 컴파일까지만 확인했습니다.)

## 📬 Reference
- 기존 MapCategory enum의 @JsonValue/@JsonCreator 패턴 그대로 확장