### PR TITLE
[Feat/Fix/#143] 인게임 재접속 및 현재 라운드 상태 복구 API 구현과 인증 및 Redis 캐스팅 오류 해결

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -347,3 +347,122 @@ Content-Type: application/json
 - JWT Access Token이 유효해야 합니다.
 - JWT에서 추출한 `userId`가 `admin_users.user_id`에 등록되어 있어야 합니다.
 - 해당 사용자의 `user_type`이 `REGISTERED`여야 합니다.
+
+---
+
+## 게임 및 인게임 (Game & In-Game)
+
+### 현재 게임 및 라운드 상태 복구 조회
+
+```http
+GET /api/game/{code}/round/current
+Authorization: Bearer {accessToken}
+```
+
+게임 도중 접속이 일시 중단(새로고침, 모바일 환경 백그라운드 전환 등)된 사용자가 현재 진행 중인 게임 세션 및 라운드 상태를 복구할 수 있도록 동영상 메타데이터 및 상태를 조회합니다.
+
+#### Success Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+##### 1. `READY` 단계 (ROUND_READY: 비디오 로딩 대기 상태)
+
+```json
+{
+  "roundNo": 1,
+  "status": "WAITING",
+  "roundPhase": "READY",
+  "timeLimitSeconds": 30,
+  "serverStartedAt": null,
+  "videoId": "vid_123",
+  "youtubeUrl": "https://youtube.com/watch?v=vid_123",
+  "startTime": 15,
+  "endTime": 45,
+  "remainingSeconds": null,
+  "isCorrect": false
+}
+```
+
+##### 2. `PLAYING` 단계 (ROUND_PLAYBACK_STARTED: 재생 진행 중 상태)
+
+```json
+{
+  "roundNo": 1,
+  "status": "PLAYING",
+  "roundPhase": "PLAYING",
+  "timeLimitSeconds": 30,
+  "serverStartedAt": 1717148068000,
+  "videoId": "vid_123",
+  "youtubeUrl": "https://youtube.com/watch?v=vid_123",
+  "startTime": 15,
+  "endTime": 45,
+  "remainingSeconds": 20,
+  "isCorrect": true
+}
+```
+
+##### 3. `ENDED` 단계 (ROUND_END: 결과화면 노출 중 상태)
+
+```json
+{
+  "roundNo": 1,
+  "status": "WAITING",
+  "roundPhase": "ENDED",
+  "timeLimitSeconds": 30,
+  "serverStartedAt": null,
+  "videoId": null,
+  "youtubeUrl": null,
+  "startTime": null,
+  "endTime": null,
+  "remainingSeconds": null,
+  "isCorrect": false
+}
+```
+
+##### 4. `FINISHED` 단계 (게임 세션 종료 상태)
+
+```json
+{
+  "roundNo": 5,
+  "status": "FINISHED",
+  "roundPhase": "FINISHED",
+  "timeLimitSeconds": 30,
+  "serverStartedAt": null,
+  "videoId": null,
+  "youtubeUrl": null,
+  "startTime": null,
+  "endTime": null,
+  "remainingSeconds": null,
+  "isCorrect": false
+}
+```
+
+#### Response Fields
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `roundNo` | number | 현재 진행 중인 라운드 번호 (1-based) |
+| `status` | string | 전체 게임 세션 상태 (`WAITING` \| `PLAYING` \| `FINISHED`) |
+| `roundPhase` | string | 현재 라운드 진행 단계 (`READY` \| `PLAYING` \| `ENDED` \| `FINISHED`) |
+| `timeLimitSeconds` | number | 라운드별 제한 시간(초) |
+| `serverStartedAt` | number \| null | YouTube 영상 실제 재생 시작 시점의 서버 epoch milliseconds. 아직 재생을 시작하지 않았거나 종료된 경우 `null` |
+| `videoId` | string \| null | YouTube 비디오 고유 ID. `READY`/`PLAYING` 단계가 아니면 `null` |
+| `youtubeUrl` | string \| null | YouTube 비디오 전체 URL. `READY`/`PLAYING` 단계가 아니면 `null` |
+| `startTime` | number \| null | 비디오 내 재생 시작 지점(초). `READY`/`PLAYING` 단계가 아니면 `null` |
+| `endTime` | number \| null | 비디오 내 재생 종료 지점(초) (`startTime + timeLimitSeconds`). `READY`/`PLAYING` 단계가 아니면 `null` |
+| `remainingSeconds` | number \| null | 영상 종료 시점까지 남은 제한 시간(초). `PLAYING` 단계가 아니면 `null` |
+| `isCorrect` | boolean | 현재 사용자가 해당 라운드에서 정답을 맞췄는지 여부 |
+
+#### Error Response
+
+| HTTP Status | Message | 상황 |
+| ---: | --- | --- |
+| 401 | `유효하지 않은 인증 정보입니다.` | 인증 정보(Access Token)가 누락되거나 잘못됨 |
+| 403 | `로비 참여자만 게임 상태를 조회할 수 있습니다.` | 세션이 활성화된 로비의 정상 참여자가 아님 |
+| 403 | `강퇴된 로비의 게임 상태는 조회할 수 없습니다.` | 해당 로비에서 강퇴된 사용자가 조회를 시도함 |
+| 404 | `존재하지 않는 로비입니다.` | 존재하지 않는 로비 초대 코드 입력 |
+| 404 | `진행 중인 게임 세션이 없습니다.` | 해당 로비에 매핑된 활성화 상태의 게임 세션이 없음 |
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1117,6 +1117,25 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
   - 게임의 최종 종료는 별도 `GAME_FINISHED` 이벤트를 발행하지 않고, 라운드 종료 결과 알림(`ROUND_END`) 내 `isLastRound=true`인 것을 기준으로 처리합니다. 
   - FE는 `isLastRound=true` 조건이 들어오면 다음 라운드 준비를 하지 않고 최종 스코어보드 및 결과 연출 화면으로 전환합니다.
 
+#### 5) 인게임 재접속 및 현재 라운드 상태 복구 (핵심 계약)
+- **상태 조회 API**: 사용자가 일시적으로 네트워크 단절을 겪거나 브라우저를 새로고침(재접속)하여 게임 화면에 다시 접근하면, FE는 가장 먼저 `GET /api/game/{code}/round/current` API를 호출하여 현재 세션과 라운드의 정적/동적 상태 데이터를 획득해야 합니다.
+- **READY 단계 복구**:
+  - `status`가 `"WAITING"`이고 `roundPhase`가 `"READY"`인 경우, 동영상 재생 전 대기 상태입니다.
+  - FE는 `videoId`, `youtubeUrl`, `startTime`, `endTime`을 사용하여 유튜브 IFrame 플레이어에 비디오를 로드(`cueVideoById` 등)하지만, 재생은 시작하지 않고 일시정지/정지 상태로 둡니다.
+  - 비디오 로드가 완료되면 즉시 `SEND /app/game/{code}/ready-to-play`를 전송하여 대기 상태에 참가해야 합니다.
+- **PLAYING 단계 복구**:
+  - `status`가 `"PLAYING"`이고 `roundPhase`가 `"PLAYING"`인 경우, 이미 라운드 재생이 진행 중인 상태입니다.
+  - FE는 비디오 메타데이터를 로드한 뒤, 서버 실제 재생 시작 시각인 `serverStartedAt`과 클라이언트의 현재 시간을 비교(Clock Skew 보정 필수)하여 흘러간 재생 시간(`elapsedSeconds`)을 계산합니다.
+  - `targetSeekPosition = startTime + elapsedSeconds` 지점으로 비디오를 이동(`seekTo`)하고 재생(`playVideo`)하여 싱크를 복구합니다.
+  - `isCorrect` 필드가 `true`인 경우, 해당 유저가 이미 정답을 맞춘 상태이므로 입력 창을 비활성화하고 blind chat/blind 연출을 표시합니다.
+  - 남은 제한 시간(`remainingSeconds`) 필드를 활용해 UI 카운트다운을 복원합니다.
+- **ENDED 단계 복구**:
+  - `status`가 `"WAITING"`이고 `roundPhase`가 `"ENDED"`인 경우, 라운드 종료 후 결과화면 노출 중인 상태입니다.
+  - 비디오 관련 필드는 `null`이며, FE는 인게임 재생을 멈추고 랭킹 및 결과 화면 UI를 유지합니다. (이후 서버에서 자동으로 다음 라운드 시작 `ROUND_READY` 이벤트를 WebSocket으로 브로드캐스트하므로, 이에 따라 READY 단계로 이행해야 합니다.)
+- **FINISHED 단계 복구**:
+  - `status`가 `"FINISHED"`이고 `roundPhase`가 `"FINISHED"`인 경우, 전체 게임이 종료된 상태입니다.
+  - FE는 비디오를 멈추고 최종 결과 및 스코어보드 화면으로 전환합니다.
+
 ## 게임 세션 Redis 키 정리 정책
 
 게임 세션 관련 Redis 키는 생성 시 **2시간(7200초) TTL**을 최종 안전망으로 가지며, 종료/폭파/롤백 시점에 명시적으로 정리한다.

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionController.java
@@ -5,6 +5,7 @@ import io.github.ascrew.monomatbe.domain.game.service.GameSessionQueryService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +21,7 @@ public class GameSessionController {
     @GetMapping("/{code}/round/current")
     public ResponseEntity<CurrentRoundStatusResponse> getCurrentRoundStatus(
             @PathVariable("code") String code,
-            CustomPrincipal principal) {
+            @AuthenticationPrincipal CustomPrincipal principal) {
         if (principal == null || principal.userIdentifier() == null) {
             throw new org.springframework.web.server.ResponseStatusException(
                     org.springframework.http.HttpStatus.UNAUTHORIZED,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/CurrentRoundStatusResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/CurrentRoundStatusResponse.java
@@ -6,7 +6,15 @@ import lombok.Builder;
 public record CurrentRoundStatusResponse(
         int roundNo,
         String status,
+        String roundPhase,
         int timeLimitSeconds,
-        Long serverStartedAt
+        Long serverStartedAt,
+        String videoId,
+        String youtubeUrl,
+        Integer startTime,
+        Integer endTime,
+        Integer remainingSeconds,
+        boolean isCorrect
 ) {
 }
+

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -182,10 +182,14 @@ public class GameSessionCreateService {
 
         // putAll + expire를 단일 파이프라인으로 일괄 전송해 라운드당 2 RTT 누적(N라운드 = 2N RTT)을 줄인다.
         redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            StringRedisConnection stringConnection = (StringRedisConnection) connection;
             for (RoundCacheEntry entry : roundCacheEntries) {
-                stringConnection.hMSet(entry.key(), entry.data());
-                stringConnection.expire(entry.key(), 7200L);
+                byte[] key = entry.key().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                Map<byte[], byte[]> dataMap = new java.util.HashMap<>();
+                entry.data().forEach((k, v) -> {
+                    dataMap.put(k.getBytes(java.nio.charset.StandardCharsets.UTF_8), v.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                });
+                connection.hashCommands().hMSet(key, dataMap);
+                connection.keyCommands().expire(key, 7200L);
             }
             return null;
         });

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryService.java
@@ -1,9 +1,11 @@
 package io.github.ascrew.monomatbe.domain.game.service;
 
 import io.github.ascrew.monomatbe.domain.game.dto.CurrentRoundStatusResponse;
+import io.github.ascrew.monomatbe.domain.lobby.LobbyUserAccessStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -21,22 +24,29 @@ public class GameSessionQueryService {
     private final LobbyRepository lobbyRepository;
     private final GameRoundEndService gameRoundEndService;
     private final GameRoundProgressService gameRoundProgressService;
+    private final MapItemJpaRepository mapItemJpaRepository;
 
     @Lazy
     public GameSessionQueryService(
             StringRedisTemplate redisTemplate,
             LobbyRepository lobbyRepository,
             @Lazy GameRoundEndService gameRoundEndService,
-            @Lazy GameRoundProgressService gameRoundProgressService) {
+            @Lazy GameRoundProgressService gameRoundProgressService,
+            @Lazy MapItemJpaRepository mapItemJpaRepository) {
         this.redisTemplate = redisTemplate;
         this.lobbyRepository = lobbyRepository;
         this.gameRoundEndService = gameRoundEndService;
         this.gameRoundProgressService = gameRoundProgressService;
+        this.mapItemJpaRepository = mapItemJpaRepository;
     }
 
     public CurrentRoundStatusResponse getCurrentRoundStatus(String lobbyCode, String userIdentifier) {
-        if (!lobbyRepository.isParticipant(lobbyCode, userIdentifier)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "로비 참가자만 조회할 수 있습니다.");
+        LobbyUserAccessStatus accessStatus = lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier);
+        switch (accessStatus) {
+            case LOBBY_NOT_FOUND -> throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 로비입니다.");
+            case KICKED -> throw new ResponseStatusException(HttpStatus.FORBIDDEN, "강퇴된 로비의 게임 상태는 조회할 수 없습니다.");
+            case NOT_PARTICIPANT -> throw new ResponseStatusException(HttpStatus.FORBIDDEN, "로비 참여자만 게임 상태를 조회할 수 있습니다.");
+            case PARTICIPANT -> {} // 통과
         }
 
         String sessionKey = RedisKeys.gameSessionKey(lobbyCode);
@@ -105,11 +115,59 @@ public class GameSessionQueryService {
             responseStatus = isPlaying ? "PLAYING" : "WAITING";
         }
 
+        // --- 재접속 복구용 추가 데이터 바인딩 ---
+        String videoId = null;
+        String youtubeUrl = null;
+        Integer startTime = null;
+        Integer endTime = null;
+        Integer remainingSeconds = null;
+        boolean isCorrect = false;
+
+        if ("READY".equals(roundPhase) || "PLAYING".equals(roundPhase)) {
+            // 1. 현재 라운드 비디오 정보 복구
+            String roundsKey = RedisKeys.gameSessionRoundsKey(lobbyCode);
+            String mapItemIdStr = redisTemplate.opsForList().index(roundsKey, roundNo - 1);
+            if (mapItemIdStr != null) {
+                try {
+                    Long mapItemId = Long.parseLong(mapItemIdStr);
+                    Optional<MapItem> mapItemOpt = mapItemJpaRepository.findById(mapItemId);
+                    if (mapItemOpt.isPresent()) {
+                        MapItem mapItem = mapItemOpt.get();
+                        videoId = mapItem.getVideoId();
+                        youtubeUrl = mapItem.getYoutubeUrl();
+                        startTime = mapItem.getStartTime();
+                        endTime = mapItem.getStartTime() + timeLimitSeconds;
+                    }
+                } catch (Exception e) {
+                    log.error("getCurrentRoundStatus: MapItem 조회 중 예외 발생 - code: {}, roundNo: {}, mapItemIdStr: {}",
+                            lobbyCode, roundNo, mapItemIdStr, e);
+                }
+            }
+
+            // 2. 이미 정답을 제출하여 맞췄는지 여부 판별
+            String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(lobbyCode, roundNo);
+            isCorrect = Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(correctPlayersKey, userIdentifier));
+
+            // 3. 실제 재생 시작 시각 기준 남은 시간 계산
+            if ("PLAYING".equals(roundPhase) && serverStartedAt != null) {
+                long elapsed = System.currentTimeMillis() - serverStartedAt;
+                long remainingMillis = (timeLimitSeconds * 1000L) - elapsed;
+                remainingSeconds = (int) Math.max(0, (remainingMillis + 999) / 1000);
+            }
+        }
+
         return CurrentRoundStatusResponse.builder()
                 .roundNo(roundNo)
                 .status(responseStatus)
+                .roundPhase(roundPhase)
                 .timeLimitSeconds(timeLimitSeconds)
                 .serverStartedAt(serverStartedAt)
+                .videoId(videoId)
+                .youtubeUrl(youtubeUrl)
+                .startTime(startTime)
+                .endTime(endTime)
+                .remainingSeconds(remainingSeconds)
+                .isCorrect(isCorrect)
                 .build();
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyPlayerNicknameResolver.java
@@ -165,7 +165,10 @@ public class LobbyPlayerNicknameResolver {
 
         try {
             redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-                StringRedisConnection stringConnection = (StringRedisConnection) connection;
+                org.springframework.data.redis.connection.StringRedisConnection stringConnection =
+                        connection instanceof org.springframework.data.redis.connection.StringRedisConnection ?
+                                (org.springframework.data.redis.connection.StringRedisConnection) connection :
+                                new org.springframework.data.redis.connection.DefaultStringRedisConnection(connection);
                 loadedNicknames.forEach((userIdentifier, nickname) -> {
                     if (nickname == null || nickname.isBlank()) {
                         return;
@@ -174,7 +177,7 @@ public class LobbyPlayerNicknameResolver {
                             RedisKeys.userNicknameKey(userIdentifier),
                             nickname,
                             Expiration.from(ttl),
-                            RedisStringCommands.SetOption.upsert()
+                            org.springframework.data.redis.connection.RedisStringCommands.SetOption.upsert()
                     );
                 });
                 return null;

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionControllerMockMvcTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/controller/GameSessionControllerMockMvcTest.java
@@ -1,0 +1,109 @@
+package io.github.ascrew.monomatbe.domain.game.controller;
+
+import io.github.ascrew.monomatbe.domain.game.dto.CurrentRoundStatusResponse;
+import io.github.ascrew.monomatbe.domain.game.service.GameSessionQueryService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.github.ascrew.monomatbe.global.security.jwt.JwtAuthenticationFilter;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GameSessionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GameSessionControllerMockMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GameSessionQueryService gameSessionQueryService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @TestConfiguration
+    static class Config implements WebMvcConfigurer {
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(new AuthenticationPrincipalArgumentResolver());
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("GET /api/game/{code}/round/current - 인증 정보가 없을 경우 401 Unauthorized를 반환한다")
+    void getCurrentRoundStatus_unauthorized() throws Exception {
+        SecurityContextHolder.clearContext();
+        mockMvc.perform(get("/api/game/ABC123/round/current"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /api/game/{code}/round/current - 인증 정보가 유효할 경우 200 OK와 라운드 상태 정보를 반환한다")
+    void getCurrentRoundStatus_success() throws Exception {
+        // given
+        String code = "ABC123";
+        String userIdentifier = "test-user-identifier";
+        CustomPrincipal principal = new CustomPrincipal(1L, userIdentifier, UserType.REGISTERED);
+
+        CurrentRoundStatusResponse response = new CurrentRoundStatusResponse(
+                1,
+                "PLAYING",
+                "PLAYBACK",
+                30,
+                System.currentTimeMillis(),
+                "vid123",
+                "https://youtube.com/watch?v=vid123",
+                0,
+                30,
+                15,
+                false
+        );
+
+        when(gameSessionQueryService.getCurrentRoundStatus(eq(code), eq(userIdentifier)))
+                .thenReturn(response);
+
+        java.util.List<org.springframework.security.core.GrantedAuthority> authorities =
+                java.util.List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_USER"));
+        org.springframework.security.authentication.UsernamePasswordAuthenticationToken authentication =
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+        // SecurityContextHolder에 직접 인증 객체 설정 (addFilters = false 대응)
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when & then
+        mockMvc.perform(get("/api/game/" + code + "/round/current"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roundNo").value(1))
+                .andExpect(jsonPath("$.status").value("PLAYING"))
+                .andExpect(jsonPath("$.roundPhase").value("PLAYBACK"))
+                .andExpect(jsonPath("$.videoId").value("vid123"))
+                .andExpect(jsonPath("$.youtubeUrl").value("https://youtube.com/watch?v=vid123"))
+                .andExpect(jsonPath("$.remainingSeconds").value(15))
+                .andExpect(jsonPath("$.isCorrect").value(false));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionQueryServiceTest.java
@@ -1,0 +1,323 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.CurrentRoundStatusResponse;
+import io.github.ascrew.monomatbe.domain.lobby.LobbyUserAccessStatus;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GameSessionQueryServiceTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private LobbyRepository lobbyRepository;
+    @Mock
+    private GameRoundEndService gameRoundEndService;
+    @Mock
+    private GameRoundProgressService gameRoundProgressService;
+    @Mock
+    private MapItemJpaRepository mapItemJpaRepository;
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+    @Mock
+    private ListOperations<String, String> listOperations;
+    @Mock
+    private SetOperations<String, String> setOperations;
+
+    private GameSessionQueryService gameSessionQueryService;
+
+    private final String lobbyCode = "ABC123";
+    private final String userIdentifier = "user-uuid";
+
+    @BeforeEach
+    void setUp() {
+        gameSessionQueryService = new GameSessionQueryService(
+                redisTemplate,
+                lobbyRepository,
+                gameRoundEndService,
+                gameRoundProgressService,
+                mapItemJpaRepository
+        );
+    }
+
+    @Test
+    @DisplayName("로비를 찾을 수 없는 경우 404 예외가 발생한다")
+    void getStatus_lobbyNotFound() {
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.LOBBY_NOT_FOUND);
+
+        assertThatThrownBy(() -> gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND)
+                .hasMessageContaining("존재하지 않는 로비입니다.");
+    }
+
+    @Test
+    @DisplayName("강퇴당한 유저인 경우 403 예외가 발생한다")
+    void getStatus_kickedUser() {
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.KICKED);
+
+        assertThatThrownBy(() -> gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.FORBIDDEN)
+                .hasMessageContaining("강퇴된 로비의 게임 상태는 조회할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("로비 참여자가 아닌 경우 403 예외가 발생한다")
+    void getStatus_notParticipant() {
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.NOT_PARTICIPANT);
+
+        assertThatThrownBy(() -> gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.FORBIDDEN)
+                .hasMessageContaining("로비 참여자만 게임 상태를 조회할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("진행 중인 게임 세션이 Redis에 없는 경우 404 예외가 발생한다")
+    void getStatus_noGameSessionInRedis() {
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.PARTICIPANT);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.multiGet(anyString(), anyList())).thenReturn(java.util.Arrays.asList(null, null, null, null));
+
+        assertThatThrownBy(() -> gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND)
+                .hasMessageContaining("진행 중인 게임 세션이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("READY 페이즈일 때 비디오 정보를 포함하고 WAITING 상태를 반환한다")
+    void getStatus_readyPhase() {
+        // given
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.PARTICIPANT);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.multiGet(RedisKeys.gameSessionKey(lobbyCode), List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ))).thenReturn(List.of("1", "30", "PLAYING", "READY"));
+
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+        when(listOperations.index(RedisKeys.gameSessionRoundsKey(lobbyCode), 0)).thenReturn("10");
+
+        MapItem mapItem = MapItem.builder()
+                .videoId("vid_123")
+                .youtubeUrl("https://youtube.com/watch?v=vid_123")
+                .startTime(15)
+                .build();
+        when(mapItemJpaRepository.findById(10L)).thenReturn(Optional.of(mapItem));
+
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        when(setOperations.isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(lobbyCode, 1), userIdentifier))
+                .thenReturn(false);
+
+        // when
+        CurrentRoundStatusResponse response = gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier);
+
+        // then
+        assertThat(response.roundNo()).isEqualTo(1);
+        assertThat(response.status()).isEqualTo("WAITING");
+        assertThat(response.roundPhase()).isEqualTo("READY");
+        assertThat(response.videoId()).isEqualTo("vid_123");
+        assertThat(response.youtubeUrl()).isEqualTo("https://youtube.com/watch?v=vid_123");
+        assertThat(response.startTime()).isEqualTo(15);
+        assertThat(response.endTime()).isEqualTo(45);
+        assertThat(response.remainingSeconds()).isNull();
+        assertThat(response.isCorrect()).isFalse();
+    }
+
+    @Test
+    @DisplayName("PLAYING 페이즈일 때 비디오 정보, 남은 시간, 정답 여부를 포함하여 반환한다")
+    void getStatus_playingPhase() {
+        // given
+        long startTimeMillis = System.currentTimeMillis() - 10000; // 10초 경과
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.PARTICIPANT);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.multiGet(RedisKeys.gameSessionKey(lobbyCode), List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ))).thenReturn(List.of("1", "30", "PLAYING", "PLAYING"));
+
+        when(hashOperations.get(RedisKeys.gameSessionKey(lobbyCode), RedisKeys.gameSessionRoundPlaybackStartedAtField(1)))
+                .thenReturn(String.valueOf(startTimeMillis));
+
+        when(redisTemplate.hasKey(RedisKeys.gameSessionPlaybackLockKey(lobbyCode, 1))).thenReturn(true);
+
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+        when(listOperations.index(RedisKeys.gameSessionRoundsKey(lobbyCode), 0)).thenReturn("10");
+
+        MapItem mapItem = MapItem.builder()
+                .videoId("vid_123")
+                .youtubeUrl("https://youtube.com/watch?v=vid_123")
+                .startTime(15)
+                .build();
+        when(mapItemJpaRepository.findById(10L)).thenReturn(Optional.of(mapItem));
+
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        when(setOperations.isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(lobbyCode, 1), userIdentifier))
+                .thenReturn(true);
+
+        // when
+        CurrentRoundStatusResponse response = gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier);
+
+        // then
+        assertThat(response.roundNo()).isEqualTo(1);
+        assertThat(response.status()).isEqualTo("PLAYING");
+        assertThat(response.roundPhase()).isEqualTo("PLAYING");
+        assertThat(response.videoId()).isEqualTo("vid_123");
+        assertThat(response.startTime()).isEqualTo(15);
+        assertThat(response.endTime()).isEqualTo(45);
+        assertThat(response.serverStartedAt()).isEqualTo(startTimeMillis);
+        assertThat(response.remainingSeconds()).isLessThanOrEqualTo(20);
+        assertThat(response.isCorrect()).isTrue();
+    }
+
+    @Test
+    @DisplayName("ENDED 페이즈일 때 비디오 정보는 null이고 WAITING 상태를 반환한다")
+    void getStatus_endedPhase() {
+        // given
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.PARTICIPANT);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.multiGet(RedisKeys.gameSessionKey(lobbyCode), List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ))).thenReturn(List.of("1", "30", "PLAYING", "ENDED"));
+
+        // when
+        CurrentRoundStatusResponse response = gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier);
+
+        // then
+        assertThat(response.roundNo()).isEqualTo(1);
+        assertThat(response.status()).isEqualTo("WAITING");
+        assertThat(response.roundPhase()).isEqualTo("ENDED");
+        assertThat(response.videoId()).isNull();
+        assertThat(response.isCorrect()).isFalse();
+    }
+
+    @Test
+    @DisplayName("FINISHED 상태일 때 FINISHED 상태를 반환하고 비디오 정보는 null이다")
+    void getStatus_finishedState() {
+        // given
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.PARTICIPANT);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.multiGet(RedisKeys.gameSessionKey(lobbyCode), List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ))).thenReturn(List.of("5", "30", "FINISHED", "FINISHED"));
+
+        // when
+        CurrentRoundStatusResponse response = gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier);
+
+        // then
+        assertThat(response.roundNo()).isEqualTo(5);
+        assertThat(response.status()).isEqualTo("FINISHED");
+        assertThat(response.roundPhase()).isEqualTo("FINISHED");
+        assertThat(response.videoId()).isNull();
+    }
+
+    @Test
+    @DisplayName("타이머 유실 복구: 시간 초과가 발생한 경우 즉시 조기 종료 처리한다")
+    void getStatus_timerHealing_timeout() {
+        // given
+        long startTimeMillis = System.currentTimeMillis() - 35000; // 35초 경과 (제한시간 30초 초과)
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.PARTICIPANT);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.multiGet(RedisKeys.gameSessionKey(lobbyCode), List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ))).thenReturn(List.of("1", "30", "PLAYING", "PLAYING"));
+
+        when(hashOperations.get(RedisKeys.gameSessionKey(lobbyCode), RedisKeys.gameSessionRoundPlaybackStartedAtField(1)))
+                .thenReturn(String.valueOf(startTimeMillis));
+
+        // when
+        CurrentRoundStatusResponse response = gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier);
+
+        // then
+        verify(gameRoundEndService).endRound(lobbyCode, 1);
+        assertThat(response.status()).isEqualTo("WAITING");
+        assertThat(response.roundPhase()).isEqualTo("ENDED");
+    }
+
+    @Test
+    @DisplayName("타이머 유실 복구: 타이머 미등록인 경우 타이머를 재등록한다")
+    void getStatus_timerHealing_reschedule() {
+        // given
+        long startTimeMillis = System.currentTimeMillis() - 10000; // 10초 경과 (제한시간 30초)
+        when(lobbyRepository.getUserAccessStatus(lobbyCode, userIdentifier))
+                .thenReturn(LobbyUserAccessStatus.PARTICIPANT);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.multiGet(RedisKeys.gameSessionKey(lobbyCode), List.of(
+                RedisKeys.FIELD_CURRENT_ROUND_NO,
+                RedisKeys.FIELD_TIME_LIMIT_SECONDS,
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE
+        ))).thenReturn(List.of("1", "30", "PLAYING", "PLAYING"));
+
+        when(hashOperations.get(RedisKeys.gameSessionKey(lobbyCode), RedisKeys.gameSessionRoundPlaybackStartedAtField(1)))
+                .thenReturn(String.valueOf(startTimeMillis));
+
+        when(gameRoundProgressService.isRoundEndScheduled(lobbyCode, 1)).thenReturn(false);
+
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+        when(listOperations.index(RedisKeys.gameSessionRoundsKey(lobbyCode), 0)).thenReturn("10");
+
+        MapItem mapItem = MapItem.builder()
+                .videoId("vid_123")
+                .build();
+        when(mapItemJpaRepository.findById(10L)).thenReturn(Optional.of(mapItem));
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+
+        // when
+        gameSessionQueryService.getCurrentRoundStatus(lobbyCode, userIdentifier);
+
+        // then
+        verify(gameRoundProgressService).rescheduleRoundEnd(eq(lobbyCode), eq(1), anyLong());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #143

## 📝 Summary

### 🚀 Feature
- **인게임 재접속 및 현재 라운드 상태 복구 조회 API 구현**:
  - `GET /api/game/{code}/round/current` 엔드포인트를 구현하여 새로고침/재접속 시 클라이언트가 진행 중이던 라운드 번호, 세션 상태, 라운드 페이즈, 비디오 정보, 남은 시간, 정답 여부를 복구할 수 있도록 응답을 구성했습니다.
- **상세 데이터 및 seekTo 기준값 반환**:
  - `CurrentRoundStatusResponse`에 `videoId`, `youtubeUrl`, `startTime`, `endTime`, `remainingSeconds`, `isCorrect` 필드를 추가했습니다.
  - 서버 시작 시각 `serverStartedAt`과 재생 시작 지점 `startTime`을 반환하여, 클라이언트가 시간 오차를 보정해 `IFrame.seekTo()`로 동기화할 수 있도록 지원합니다.
- **단계(Phase)별 응답 정책**:
  - `READY`(재생 대기), `PLAYING`(재생 중), `ENDED`(결과 화면 대기), `FINISHED`(게임 종료)의 페이즈를 구분하여 페이즈별로 비디오 메타데이터 및 타이머 값을 알맞게 마스킹 처리했습니다.
- **접근 권한 검증 및 보안 강화**:
  - `LobbyRepository.getUserAccessStatus`를 적용하여, 로비의 정상 참여자만 상태를 조회할 수 있게 하고, 강퇴자(`KICKED`)나 비참여자는 `403 Forbidden` 처리되도록 권한 제어를 적용했습니다.
- **회귀 방지를 위한 단위 및 슬라이스 테스트 추가**:
  - `GameSessionControllerMockMvcTest.java`를 추가해 인증 상태에 따른 API 접근 제어와 직렬화 동작을 철저하게 검증했습니다.

### 🛠️ Fix
- **인증 필터 바인딩 오류 수정**:
  - `GameSessionController`의 인자값에 `@AuthenticationPrincipal`을 추가하여, Spring Security 컨텍스트에서 유효한 로그인 토큰의 `CustomPrincipal`이 올바르게 바인딩되도록 조치했습니다.
- **Redis Pipelined ClassCastException 오류 해결**:
  - `GameSessionCreateService`와 `LobbyPlayerNicknameResolver`에서 Redis 파이프라인(`executePipelined`) 호출 시 `StringRedisConnection`으로 직접 캐스팅하여 발생하던 `ClassCastException` 문제를 해결하기 위해, 원시 바이트 단위 `RedisConnection` 명령을 활용하거나 `DefaultStringRedisConnection`으로 조건부 래핑 처리했습니다.

## 🙏PR point

### 🚀 Feature
- **엄격한 참여 권한 확인**:
  - `GET /api/game/{code}/round/current` API는 단순 인증 정보 존재 유무 뿐만 아니라, `LobbyRepository.getUserAccessStatus`를 거쳐 강퇴자(`KICKED`)와 비참여자(`NOT_PARTICIPANT`)를 구분해 403 에러로 철저히 차단합니다.
- **재접속 재생 동기화 공식**:
  - 클라이언트는 API로 받은 `serverStartedAt`과 로컬의 `System.currentTimeMillis()` 차이를 통해 경과 시간(elapsed)을 구한 뒤, 이를 `startTime`에 더해 `IFrame.seekTo()`를 수행함으로써 오차 없는 라운드 동기화가 가능합니다.

### 🛠️ Fix
- **Redis Connection 캐스팅 안정화**:
  - Lettuce 라이브러리가 런타임에 제공하는 실재 커넥션 객체와 테스트 목(Mock) 객체의 구현체 차이로 발생하던 `ClassCastException` 및 `NullPointerException` 문제를 커넥션 타입 동적 분기(DefaultStringRedisConnection 래핑) 방식으로 해결하여 로컬 빌드와 실서버 배포 환경에서의 호환성을 모두 확보했습니다.

## 📬 Reference
