### PR TITLE
[Feat/#163] 맵 목록 응답에 description 필드 추가

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapSummaryResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/MapSummaryResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 public record MapSummaryResponse(
         Long mapId,
         String title,
+        String description,
         MapCategory category,
         int numOfSong,
         int totalPlayTime,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -387,6 +387,7 @@ public class MapService {
         return MapSummaryResponse.builder()
                 .mapId(quizMap.getId())
                 .title(quizMap.getTitle())
+                .description(quizMap.getDescription())
                 .category(quizMap.getCategory())
                 .numOfSong(quizMap.getNumOfSong())
                 .totalPlayTime(quizMap.getTotalPlayTime())

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
@@ -15,12 +15,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -354,5 +358,102 @@ class MapServiceTest {
         verify(publicationValidator, never()).requirePublishable(any());
         assertThat(response.title()).isEqualTo("fixed title");
         assertThat(response.isPublic()).isTrue();
+    }
+
+    @Test
+    void getMyMaps_includesDescriptionInSummary() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(100L)
+                .owner(owner)
+                .title("내 맵")
+                .description("내 맵 설명")
+                .category(MapCategory.KPOP)
+                .numOfSong(3)
+                .totalPlayTime(600)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build();
+
+        when(quizMapJpaRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(quizMap)));
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        var response = mapService.getMyMaps(0, 20, principal);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).mapId()).isEqualTo(100L);
+        assertThat(response.content().get(0).description()).isEqualTo("내 맵 설명");
+    }
+
+    @Test
+    void getMyMaps_nullDescription_returnedAsNull() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(101L)
+                .owner(owner)
+                .title("설명 없는 맵")
+                .description(null)
+                .category(MapCategory.KPOP)
+                .numOfSong(0)
+                .totalPlayTime(0)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build();
+
+        when(quizMapJpaRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(quizMap)));
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        var response = mapService.getMyMaps(0, 20, principal);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).description()).isNull();
+    }
+
+    @Test
+    void getPublicMaps_includesDescriptionInSummary() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(200L)
+                .owner(owner)
+                .title("공개 맵")
+                .description("공개 맵 설명")
+                .category(MapCategory.KPOP)
+                .numOfSong(5)
+                .totalPlayTime(900)
+                .isPublic(true)
+                .pendingPublic(false)
+                .build();
+
+        when(quizMapJpaRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(quizMap)));
+
+        // keyword 를 넘기면 캐시를 우회하고 DB 조회 경로를 그대로 검증할 수 있다.
+        var response = mapService.getPublicMaps(0, 20, "공개", null, null);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).mapId()).isEqualTo(200L);
+        assertThat(response.content().get(0).description()).isEqualTo("공개 맵 설명");
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
- #163 

## 📝 Summary
- 로비 생성 맵 선택 모달에서 카드를 펼쳤을 때 설명을 표시할 수 있도록, 맵 목록 응답 item에 `description` 필드를 추가했습니다.
- 기존에는 `MapDetailResponse`에만 `description`이 있어, 목록 화면에서 카드마다 상세 API를 추가 호출해야 했습니다. 목록 응답에 함께 내려 FE가 효율적으로 구현할 수 있도록 했습니다.
- `MapSummaryResponse`에 `description` 필드 추가
- `MapService.toSummaryResponse`에서 `description` 매핑 → `GET /api/maps`, `GET /api/maps/me` 두 엔드포인트에 동시 반영
- 목록 `description` 포함 / null 정책 검증 테스트 3건 추가

## 🙏PR point
- `description` 값은 상세 응답(`MapDetailResponse`)과 동일하게 **원본 그대로** 반환합니다(null은 null, 빈 문자열은 빈 문자열). 별도 정규화는 하지 않았습니다.
- 공개 맵 목록은 Redis 5분 TTL 캐싱(`MAP_CACHE_TTL`)을 사용합니다. 배포 직후 구 캐시는 역직렬화 시 `description=null`로 무해하게 처리되고 5분 내 자연 만료되므로, 캐시 버전 강제 증가 로직은 추가하지 않았습니다.
- 맵 API는 Swagger `@Operation` + record 기반 자동 문서화에 의존하므로, record 필드 추가만으로 OpenAPI 스키마에 자동 반영됩니다(별도 문서 갱신 불필요).

## 📬 Reference

