### PR TITLE
[Feat/#173] 내 맵 목록 검색·필터·정렬 지원

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -301,40 +301,67 @@ HTTP/1.1 200 OK
 ### 내 맵 목록 조회
 
 ```http
-GET /api/maps/me?page=0&size=20
+GET /api/maps/me?page=0&size=20&keyword=ost&category=OST&sort=NEWEST
 Authorization: Bearer {accessToken}
 ```
 
-로그인한 사용자가 생성한 맵 목록을 조회합니다. 공개/비공개 맵을 모두 포함하되, 삭제된 맵은 제외합니다.
-
 #### Query Parameters
 
-| 필드     | 타입     | 필수 | 기본값 | 설명             |
-| ------ | ------ | -: | --: | -------------- |
-| `page` | number |  X |   0 | 0-based 페이지 번호 |
-| `size` | number |  X |  20 | 페이지 크기. 최대 100 |
+| 이름 | 타입 | 필수 | 기본값 | 설명 |
+| --- | --- | --- | --- | --- |
+| page | number | N | 0 | 페이지 번호 |
+| size | number | N | 20 | 페이지 크기 |
+| keyword | string | N | - | 내 맵 제목 검색어. 카테고리 값으로 해석 가능한 경우 카테고리도 검색 대상에 포함 |
+| category | string | N | - | 명시적 카테고리 필터 |
+| sort | string | N | NEWEST | 정렬 기준 |
 
-#### Success Response
+#### category 지원 값
 
-```http
-HTTP/1.1 200 OK
+| 입력 예시 | 처리 결과 |
+| --- | --- |
+| K-POP, KPOP, kpop | K-POP |
+| J-POP, JPOP, jpop | J-POP |
+| POP, pop | POP |
+| OST, ost | OST |
+| 애니, ANIME, anime | 애니 |
+
+#### sort 지원 값
+
+| 값 | 설명 |
+| --- | --- |
+| NEWEST | 최신순 |
+| OLDEST | 오래된순 |
+| MOST_SONGS | 곡 수 많은 순 |
+| TITLE_ASC | 제목 오름차순 |
+
+#### 검색 조건
+
+```txt
+ownerId = 로그인 사용자 ID
+AND isDeleted = false
+AND keyword 조건
+AND category 조건
 ```
+
+`keyword`와 `category`가 함께 들어오면 AND 조건으로 동작합니다.
+
+#### Response
 
 ```json
 {
   "content": [
     {
       "mapId": 1,
-      "title": "내 K-POP 퀴즈",
-      "description": "직접 만든 문제 모음",
-      "category": "KPOP",
+      "title": "OST 모음",
+      "description": "내가 만든 OST 퀴즈",
+      "category": "OST",
       "numOfSong": 10,
       "totalPlayTime": 300,
       "isPublic": false,
-      "pendingPublic": false,
+      "pendingPublic": true,
       "ownerId": 10,
-      "ownerNickname": "owner",
-      "playCount": 7
+      "ownerNickname": "hyeon",
+      "playCount": 12
     }
   ],
   "page": 0,
@@ -344,16 +371,6 @@ HTTP/1.1 200 OK
   "hasNext": false
 }
 ```
-
-#### Response Fields
-
-공개 맵 목록 조회의 `Map Summary` 응답 필드와 동일합니다.
-
-#### Error Response
-
-| HTTP Status | 상황                               |
-| ----------: | -------------------------------- |
-|         401 | 인증 정보 없음 또는 유효하지 않은 Access Token |
 
 ---
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
@@ -46,15 +46,18 @@ public class MapController {
         return ResponseEntity.ok(mapService.getPublicMaps(page, size, keyword, category, sort));
     }
 
-    @Operation(summary = "내 맵 목록 조회", description = "로그인한 사용자의 공개/비공개 맵을 모두 조회합니다.")
+    @Operation(summary = "내 맵 목록 조회", description = "로그인한 사용자의 공개/비공개/공개 대기 맵을 검색/필터/정렬하여 조회합니다.")
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<MapPageResponse> getMyMaps(
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "20") Integer size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) MapSortType sort,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        return ResponseEntity.ok(mapService.getMyMaps(page, size, principal));
+        return ResponseEntity.ok(mapService.getMyMaps(page, size, keyword, category, sort, principal));
     }
 
     @Operation(summary = "공개 맵 단건 조회")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
@@ -29,9 +29,43 @@ public class QuizMapSpecification {
         if (keyword == null || keyword.isBlank()) {
             return (root, query, cb) -> null;
         }
+
         String pattern = "%" + keyword.toLowerCase() + "%";
         return (root, query, cb) ->
                 cb.like(cb.lower(root.get("title")), pattern);
+    }
+
+    /**
+     * title LIKE %keyword% OR category = parsedKeywordCategory
+     *
+     * <p>내 맵 목록 검색에서 사용한다.
+     * keyword가 "J-POP", "jpop", "애니", "ANIME" 등 카테고리로 해석 가능하면
+     * 제목 검색과 카테고리 검색을 함께 수행한다.
+     *
+     * <p>공개 맵 목록의 기존 검색 결과 변경을 피하기 위해 기존 withKeyword()는 유지한다.
+     */
+    public static Specification<QuizMap> withKeywordIncludingCategory(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return (root, query, cb) -> null;
+        }
+
+        String normalizedKeyword = keyword.trim().toLowerCase();
+        String pattern = "%" + normalizedKeyword + "%";
+
+        MapCategory keywordCategory = tryParseCategory(keyword);
+
+        return (root, query, cb) -> {
+            var titlePredicate = cb.like(cb.lower(root.get("title")), pattern);
+
+            if (keywordCategory == null) {
+                return titlePredicate;
+            }
+
+            return cb.or(
+                    titlePredicate,
+                    cb.equal(root.get("category"), keywordCategory)
+            );
+        };
     }
 
     /** category = ? (null → no-op) */
@@ -39,6 +73,15 @@ public class QuizMapSpecification {
         if (category == null) {
             return (root, query, cb) -> null;
         }
+
         return (root, query, cb) -> cb.equal(root.get("category"), category);
+    }
+
+    private static MapCategory tryParseCategory(String rawCategory) {
+        try {
+            return MapCategory.from(rawCategory);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecification.java
@@ -4,7 +4,11 @@ import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.Locale;
+
 public class QuizMapSpecification {
+
+    private static final char LIKE_ESCAPE = '\\';
 
     private QuizMapSpecification() {}
 
@@ -30,9 +34,9 @@ public class QuizMapSpecification {
             return (root, query, cb) -> null;
         }
 
-        String pattern = "%" + keyword.toLowerCase() + "%";
+        String pattern = toContainsLikePattern(keyword);
         return (root, query, cb) ->
-                cb.like(cb.lower(root.get("title")), pattern);
+                cb.like(cb.lower(root.get("title")), pattern, LIKE_ESCAPE);
     }
 
     /**
@@ -49,13 +53,11 @@ public class QuizMapSpecification {
             return (root, query, cb) -> null;
         }
 
-        String normalizedKeyword = keyword.trim().toLowerCase();
-        String pattern = "%" + normalizedKeyword + "%";
-
+        String pattern = toContainsLikePattern(keyword);
         MapCategory keywordCategory = tryParseCategory(keyword);
 
         return (root, query, cb) -> {
-            var titlePredicate = cb.like(cb.lower(root.get("title")), pattern);
+            var titlePredicate = cb.like(cb.lower(root.get("title")), pattern, LIKE_ESCAPE);
 
             if (keywordCategory == null) {
                 return titlePredicate;
@@ -75,6 +77,17 @@ public class QuizMapSpecification {
         }
 
         return (root, query, cb) -> cb.equal(root.get("category"), category);
+    }
+
+    private static String toContainsLikePattern(String keyword) {
+        return "%" + escapeLike(keyword.trim().toLowerCase(Locale.ROOT)) + "%";
+    }
+
+    private static String escapeLike(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
     }
 
     private static MapCategory tryParseCategory(String rawCategory) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -32,6 +32,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @Service
@@ -152,7 +153,7 @@ public class MapService {
     }
 
     // 로그인한 사용자의 맵 목록(공개/비공개/공개 대기 모두, 삭제 제외)을 페이징하여 조회합니다.
-// 개인 데이터이므로 Redis 캐시를 적용하지 않습니다.
+    // 개인 데이터이므로 Redis 캐시를 적용하지 않습니다.
     @Transactional(readOnly = true)
     public MapPageResponse getMyMaps(Integer page, Integer size, CustomPrincipal principal) {
         return getMyMaps(page, size, null, null, null, principal);
@@ -348,7 +349,7 @@ public class MapService {
             return null;
         }
 
-        return keyword.trim().toLowerCase();
+        return keyword.trim().toLowerCase(Locale.ROOT);
     }
 
     private MapCategory parseCategory(String rawCategory) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -151,22 +151,39 @@ public class MapService {
                 .build();
     }
 
-    // 로그인한 사용자의 맵 목록(공개/비공개 모두, 삭제 제외)을 페이징하여 조회합니다.
-    // 개인 데이터이므로 Redis 캐시를 적용하지 않습니다.
+    // 로그인한 사용자의 맵 목록(공개/비공개/공개 대기 모두, 삭제 제외)을 페이징하여 조회합니다.
+// 개인 데이터이므로 Redis 캐시를 적용하지 않습니다.
     @Transactional(readOnly = true)
     public MapPageResponse getMyMaps(Integer page, Integer size, CustomPrincipal principal) {
+        return getMyMaps(page, size, null, null, null, principal);
+    }
+
+    @Transactional(readOnly = true)
+    public MapPageResponse getMyMaps(
+            Integer page,
+            Integer size,
+            String keyword,
+            String rawCategory,
+            MapSortType sort,
+            CustomPrincipal principal
+    ) {
         validatePrincipal(principal);
 
         int normalizedPage = page == null || page < 0 ? DEFAULT_PAGE : page;
         int normalizedSize = size == null || size <= 0 ? DEFAULT_SIZE : Math.min(size, MAX_SIZE);
+        MapSortType normalizedSort = sort == null ? MapSortType.NEWEST : sort;
+        String normalizedKeyword = normalizeKeyword(keyword);
+        MapCategory category = parseCategory(rawCategory);
 
-        Specification<QuizMap> spec =
-                QuizMapSpecification.ownedByAndNotDeleted(principal.userId());
+        Specification<QuizMap> spec = Specification
+                .where(QuizMapSpecification.ownedByAndNotDeleted(principal.userId()))
+                .and(QuizMapSpecification.withKeywordIncludingCategory(normalizedKeyword))
+                .and(QuizMapSpecification.withCategory(category));
 
         Pageable pageable = PageRequest.of(
                 normalizedPage,
                 normalizedSize,
-                Sort.by(Sort.Direction.DESC, "updatedAt")
+                toSort(normalizedSort)
         );
 
         Page<QuizMap> pageResult = quizMapJpaRepository.findAll(spec, pageable);
@@ -322,6 +339,29 @@ public class MapService {
             throw new ResponseStatusException(
                     HttpStatus.FORBIDDEN,
                     ERROR_REGISTERED_ONLY
+            );
+        }
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+
+        return keyword.trim().toLowerCase();
+    }
+
+    private MapCategory parseCategory(String rawCategory) {
+        if (rawCategory == null || rawCategory.isBlank()) {
+            return null;
+        }
+
+        try {
+            return MapCategory.from(rawCategory);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "지원하지 않는 category입니다: " + rawCategory
             );
         }
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -5,15 +5,14 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
-import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapPageResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.MapSummaryResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.MapSortType;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapSpecification;
-import org.springframework.data.jpa.domain.Specification;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -81,10 +81,7 @@ public class MapService {
         int normalizedPage = page == null || page < 0 ? DEFAULT_PAGE : page;
         int normalizedSize = size == null || size <= 0 ? DEFAULT_SIZE : Math.min(size, MAX_SIZE);
         MapSortType normalizedSort = sort == null ? MapSortType.NEWEST : sort;
-
-        String normalizedKeyword = (keyword == null || keyword.isBlank())
-                ? null
-                : keyword.trim().toLowerCase();
+        String normalizedKeyword = normalizeKeyword(keyword);
 
         if (normalizedKeyword != null) {
             return queryPublicMaps(normalizedKeyword, category, normalizedPage, normalizedSize, normalizedSort);
@@ -411,16 +408,16 @@ public class MapService {
         try {
             redisTemplate.delete(key);
         } catch (Exception e) {
-            log.warn("손상 캐시 삭제 실패 - key: {}", key, e);
+            log.warn("손상 캐시 삭제 실패 - key: {}", key);
         }
     }
 
     private Sort toSort(MapSortType sort) {
         return switch (sort) {
-            case NEWEST     -> Sort.by(Sort.Direction.DESC, "updatedAt");
-            case OLDEST     -> Sort.by(Sort.Direction.ASC,  "updatedAt");
+            case NEWEST -> Sort.by(Sort.Direction.DESC, "updatedAt");
+            case OLDEST -> Sort.by(Sort.Direction.ASC, "updatedAt");
             case MOST_SONGS -> Sort.by(Sort.Direction.DESC, "numOfSong");
-            case TITLE_ASC  -> Sort.by(Sort.Direction.ASC,  "title");
+            case TITLE_ASC -> Sort.by(Sort.Direction.ASC, "title");
         };
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecificationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecificationTest.java
@@ -1,0 +1,179 @@
+package io.github.ascrew.monomatbe.domain.map.repository;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@DataJpaTest(properties = {
+        "spring.test.database.replace=none",
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class QuizMapSpecificationTest {
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("monomat_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private QuizMapJpaRepository quizMapJpaRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void myMapSearch_appliesOwnerDeletedKeywordAndCategoryWithAndCondition() {
+        User owner = userRepository.save(User.builder()
+                .username("spec-owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        User anotherOwner = userRepository.save(User.builder()
+                .username("spec-another-owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        QuizMap matched = quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("OST 모음")
+                .description("matched")
+                .category(MapCategory.OST)
+                .isPublic(false)
+                .pendingPublic(true)
+                .build());
+
+        quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("JPOP 모음")
+                .description("category mismatch")
+                .category(MapCategory.JPOP)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+
+        quizMapJpaRepository.save(QuizMap.builder()
+                .owner(anotherOwner)
+                .title("OST 모음")
+                .description("another owner")
+                .category(MapCategory.OST)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+
+        QuizMap deleted = quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("OST 삭제 맵")
+                .description("deleted")
+                .category(MapCategory.OST)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+        deleted.softDelete();
+        quizMapJpaRepository.flush();
+
+        Specification<QuizMap> spec = Specification
+                .where(QuizMapSpecification.ownedByAndNotDeleted(owner.getId()))
+                .and(QuizMapSpecification.withKeywordIncludingCategory("ost"))
+                .and(QuizMapSpecification.withCategory(MapCategory.OST));
+
+        List<QuizMap> result = quizMapJpaRepository.findAll(spec);
+
+        assertThat(result)
+                .extracting(QuizMap::getId)
+                .containsExactly(matched.getId());
+    }
+
+    @Test
+    void myMapSearch_keywordCanMatchCategoryDisplayValue() {
+        User owner = userRepository.save(User.builder()
+                .username("spec-owner-anime")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        QuizMap animeMap = quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("노래 모음")
+                .description("keyword category match")
+                .category(MapCategory.ANIME)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+
+        Specification<QuizMap> spec = Specification
+                .where(QuizMapSpecification.ownedByAndNotDeleted(owner.getId()))
+                .and(QuizMapSpecification.withKeywordIncludingCategory("애니"));
+
+        List<QuizMap> result = quizMapJpaRepository.findAll(spec);
+
+        assertThat(result)
+                .extracting(QuizMap::getId)
+                .containsExactly(animeMap.getId());
+    }
+
+    @Test
+    void keywordSearch_treatsLikeWildcardCharactersAsPlainText() {
+        User owner = userRepository.save(User.builder()
+                .username("spec-owner-wildcard")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        QuizMap literalPercentMap = quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("100% OST")
+                .description("literal percent")
+                .category(MapCategory.OST)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+
+        quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("100점 OST")
+                .description("should not match percent wildcard")
+                .category(MapCategory.OST)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+
+        Specification<QuizMap> spec = Specification
+                .where(QuizMapSpecification.ownedByAndNotDeleted(owner.getId()))
+                .and(QuizMapSpecification.withKeywordIncludingCategory("100%"));
+
+        List<QuizMap> result = quizMapJpaRepository.findAll(spec);
+
+        assertThat(result)
+                .extracting(QuizMap::getId)
+                .containsExactly(literalPercentMap.getId());
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecificationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/repository/QuizMapSpecificationTest.java
@@ -6,41 +6,22 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.support.RepositoryTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers
 @DataJpaTest(properties = {
         "spring.test.database.replace=none",
         "spring.flyway.enabled=false",
         "spring.jpa.hibernate.ddl-auto=create-drop"
 })
-class QuizMapSpecificationTest {
-
-    @Container
-    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
-            .withDatabaseName("monomat_test")
-            .withUsername("test")
-            .withPassword("test");
-
-    @DynamicPropertySource
-    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
-        registry.add("spring.datasource.username", MYSQL::getUsername);
-        registry.add("spring.datasource.password", MYSQL::getPassword);
-        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
-    }
+class QuizMapSpecificationTest extends RepositoryTestSupport {
 
     @Autowired
     private QuizMapJpaRepository quizMapJpaRepository;
@@ -141,9 +122,9 @@ class QuizMapSpecificationTest {
     }
 
     @Test
-    void keywordSearch_treatsLikeWildcardCharactersAsPlainText() {
+    void keywordSearch_treatsPercentWildcardCharacterAsPlainText() {
         User owner = userRepository.save(User.builder()
-                .username("spec-owner-wildcard")
+                .username("spec-owner-percent")
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.ACTIVE)
                 .build());
@@ -175,5 +156,42 @@ class QuizMapSpecificationTest {
         assertThat(result)
                 .extracting(QuizMap::getId)
                 .containsExactly(literalPercentMap.getId());
+    }
+
+    @Test
+    void keywordSearch_treatsUnderscoreWildcardCharacterAsPlainText() {
+        User owner = userRepository.save(User.builder()
+                .username("spec-owner-underscore")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        QuizMap literalUnderscoreMap = quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("A_B OST")
+                .description("literal underscore")
+                .category(MapCategory.OST)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+
+        quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title("ACB OST")
+                .description("should not match underscore wildcard")
+                .category(MapCategory.OST)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build());
+
+        Specification<QuizMap> spec = Specification
+                .where(QuizMapSpecification.ownedByAndNotDeleted(owner.getId()))
+                .and(QuizMapSpecification.withKeywordIncludingCategory("A_B"));
+
+        List<QuizMap> result = quizMapJpaRepository.findAll(spec);
+
+        assertThat(result)
+                .extracting(QuizMap::getId)
+                .containsExactly(literalUnderscoreMap.getId());
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
@@ -8,6 +8,7 @@ import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.MapSortType;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -408,6 +410,118 @@ class MapServiceTest {
         assertThat(response.content().get(0).ownerId()).isEqualTo(10L);
         assertThat(response.content().get(0).ownerNickname()).isEqualTo("owner");
         assertThat(response.content().get(0).playCount()).isEqualTo(12L);
+    }
+
+    @Test
+    void getMyMaps_withKeywordCategoryAndSort_queriesRepositoryWithConditions() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(100L)
+                .owner(owner)
+                .title("OST 모음")
+                .description("내 맵 설명")
+                .category(MapCategory.OST)
+                .numOfSong(3)
+                .totalPlayTime(600)
+                .playCount(12L)
+                .isPublic(false)
+                .pendingPublic(true)
+                .build();
+
+        when(quizMapJpaRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(quizMap)));
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        var response = mapService.getMyMaps(
+                0,
+                20,
+                "ost",
+                "OST",
+                MapSortType.TITLE_ASC,
+                principal
+        );
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).mapId()).isEqualTo(100L);
+        assertThat(response.content().get(0).category()).isEqualTo(MapCategory.OST);
+        assertThat(response.content().get(0).pendingPublic()).isTrue();
+        assertThat(response.content().get(0).playCount()).isEqualTo(12L);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(quizMapJpaRepository).findAll(any(Specification.class), pageableCaptor.capture());
+
+        Pageable pageable = pageableCaptor.getValue();
+        assertThat(pageable.getPageNumber()).isZero();
+        assertThat(pageable.getPageSize()).isEqualTo(20);
+        assertThat(pageable.getSort().getOrderFor("title")).isNotNull();
+        assertThat(pageable.getSort().getOrderFor("title").isAscending()).isTrue();
+    }
+
+    @Test
+    void getMyMaps_acceptsFlexibleCategoryValue() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(101L)
+                .owner(owner)
+                .title("애니 노래")
+                .description("애니 맵")
+                .category(MapCategory.ANIME)
+                .numOfSong(5)
+                .totalPlayTime(800)
+                .playCount(3L)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build();
+
+        when(quizMapJpaRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(quizMap)));
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        var response = mapService.getMyMaps(
+                0,
+                20,
+                "애니",
+                "anime",
+                MapSortType.NEWEST,
+                principal
+        );
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).category()).isEqualTo(MapCategory.ANIME);
+        assertThat(response.content().get(0).title()).isEqualTo("애니 노래");
+    }
+
+    @Test
+    void getMyMaps_invalidCategory_throws400AndDoesNotQueryRepository() {
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        assertThatThrownBy(() -> mapService.getMyMaps(
+                0,
+                20,
+                null,
+                "INVALID_CATEGORY",
+                MapSortType.NEWEST,
+                principal
+        ))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST))
+                .hasMessageContaining("지원하지 않는 category입니다");
+
+        verify(quizMapJpaRepository, never()).findAll(any(Specification.class), any(Pageable.class));
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/support/RepositoryTestSupport.java
+++ b/src/test/java/io/github/ascrew/monomatbe/support/RepositoryTestSupport.java
@@ -1,0 +1,30 @@
+package io.github.ascrew.monomatbe.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class RepositoryTestSupport {
+
+    private static final String MYSQL_IMAGE = "mysql:8.0";
+    private static final String DATABASE_NAME = "monomat_test";
+    private static final String DATABASE_USERNAME = "test";
+    private static final String DATABASE_PASSWORD = "test";
+
+    @Container
+    protected static final MySQLContainer<?> MYSQL = new MySQLContainer<>(MYSQL_IMAGE)
+            .withDatabaseName(DATABASE_NAME)
+            .withUsername(DATABASE_USERNAME)
+            .withPassword(DATABASE_PASSWORD);
+
+    @DynamicPropertySource
+    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #173

## 📝 Summary

- `GET /api/maps/me`에 `keyword`, `category`, `sort` query parameter를 추가했습니다.
- 내 맵 목록 조회 시 기존 `page`, `size` 동작을 유지하면서 검색/필터/정렬을 지원하도록 확장했습니다.
- 조회 조건은 기존과 동일하게 로그인 사용자 소유 맵만 대상으로 하며, 삭제된 맵은 제외합니다.
- 내 맵 목록에는 공개/비공개/공개 대기 맵이 모두 포함됩니다.
- `category`는 `MapCategory.from(rawCategory)` 정책을 사용해 `K-POP`, `KPOP`, `kpop`, `애니`, `anime` 등 유연한 입력을 지원합니다.
- `sort`는 기존 `MapSortType`의 `NEWEST`, `OLDEST`, `MOST_SONGS`, `TITLE_ASC`를 사용합니다.
- 내 맵 목록은 사용자별 데이터이므로 Redis 캐시는 적용하지 않았습니다.
- 관련 테스트와 API 문서를 갱신했습니다.

## 🙏PR point

- `keyword`와 `category`가 함께 전달되면 AND 조건으로 동작합니다.
- `keyword`는 제목 검색을 기본으로 하며, 카테고리 값으로 해석 가능한 경우 카테고리도 검색 대상에 포함합니다.
- 공개 맵 목록 API의 기존 검색 결과 변경을 피하기 위해 내 맵 목록 검색 로직에만 카테고리 keyword 매칭을 적용했습니다.
- DB 컬럼 추가, Redis 캐시 구조 변경, 공개 맵 목록 API 변경은 포함하지 않았습니다.

## 📬 Reference

- 기존 공개 맵 목록 조회 API의 `keyword`, `category`, `sort` 처리 정책
- `MapCategory.from(rawCategory)`
- `MapSortType`
- `QuizMapSpecification`