### PR TITLE
[Feat/#176] 맵 문제 재생 구간 duration 검증 구조 추가

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
@@ -29,6 +29,9 @@ public class MapItemService {
     private static final String ERROR_INVALID_PRINCIPAL = "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
     private static final String ERROR_REGISTERED_ONLY = "정식 회원만 맵 문제를 관리할 수 있습니다.";
     private static final String ERROR_INVALID_TIME_RANGE = "재생 구간은 시작 시간보다 종료 시간이 커야 합니다.";
+    private static final String ERROR_INVALID_VIDEO_DURATION = "YouTube 영상 길이 정보가 올바르지 않습니다.";
+    private static final String ERROR_START_TIME_EXCEEDS_DURATION = "재생 시작 시간은 YouTube 영상 길이보다 작아야 합니다.";
+    private static final String ERROR_END_TIME_EXCEEDS_DURATION = "재생 종료 시간은 YouTube 영상 길이를 초과할 수 없습니다.";
     private static final String ERROR_DUPLICATE_ORDER = "이미 사용 중인 문제 순서입니다.";
     private static final String ERROR_NO_VALID_ANSWER = "정답은 최소 1개 이상이어야 합니다.";
 
@@ -60,10 +63,12 @@ public class MapItemService {
 
     public MapItemResponse createMapItem(Long mapId, CreateMapItemRequest request, CustomPrincipal principal) {
         validateRegisteredPrincipal(principal);
-        validateTimeRange(request.startTime(), request.endTime());
+        validateBasicTimeRange(request.startTime(), request.endTime());
 
         // 외부 oEmbed 호출은 트랜잭션/DB 커넥션 점유 밖에서 수행한다.
         YoutubeMetadata metadata = youtubeValidationService.validateYoutubeUrl(request.youtubeUrl());
+        validateTimeRangeWithinDuration(request.startTime(), request.endTime(), metadata.durationSeconds());
+
         String answersJson = serializeAnswers(request.answers());
         int hintTime = request.hintTime() == null ? DEFAULT_HINT_TIME : request.hintTime();
         String hint = request.hint().trim();
@@ -92,10 +97,12 @@ public class MapItemService {
 
     public MapItemResponse updateMapItem(Long mapId, Long itemId, UpdateMapItemRequest request, CustomPrincipal principal) {
         validateRegisteredPrincipal(principal);
-        validateTimeRange(request.startTime(), request.endTime());
+        validateBasicTimeRange(request.startTime(), request.endTime());
 
         // 외부 oEmbed 호출은 트랜잭션/DB 커넥션 점유 밖에서 수행한다.
         YoutubeMetadata metadata = youtubeValidationService.validateYoutubeUrl(request.youtubeUrl());
+        validateTimeRangeWithinDuration(request.startTime(), request.endTime(), metadata.durationSeconds());
+
         String answersJson = serializeAnswers(request.answers());
         int hintTime = request.hintTime() == null ? DEFAULT_HINT_TIME : request.hintTime();
         String hint = request.hint().trim();
@@ -149,9 +156,27 @@ public class MapItemService {
         }
     }
 
-    private void validateTimeRange(Integer startTime, Integer endTime) {
+    private void validateBasicTimeRange(Integer startTime, Integer endTime) {
         if (startTime == null || endTime == null || endTime <= startTime) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_TIME_RANGE);
+        }
+    }
+
+    private void validateTimeRangeWithinDuration(Integer startTime, Integer endTime, Integer durationSeconds) {
+        if (durationSeconds == null) {
+            return;
+        }
+
+        if (durationSeconds <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_VIDEO_DURATION);
+        }
+
+        if (startTime >= durationSeconds) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_START_TIME_EXCEEDS_DURATION);
+        }
+
+        if (endTime > durationSeconds) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_END_TIME_EXCEEDS_DURATION);
         }
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemService.java
@@ -29,6 +29,7 @@ public class MapItemService {
     private static final String ERROR_INVALID_PRINCIPAL = "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
     private static final String ERROR_REGISTERED_ONLY = "정식 회원만 맵 문제를 관리할 수 있습니다.";
     private static final String ERROR_INVALID_TIME_RANGE = "재생 구간은 시작 시간보다 종료 시간이 커야 합니다.";
+    private static final String ERROR_NEGATIVE_START_TIME = "재생 시작 시간은 0초 이상이어야 합니다.";
     private static final String ERROR_INVALID_VIDEO_DURATION = "YouTube 영상 길이 정보가 올바르지 않습니다.";
     private static final String ERROR_START_TIME_EXCEEDS_DURATION = "재생 시작 시간은 YouTube 영상 길이보다 작아야 합니다.";
     private static final String ERROR_END_TIME_EXCEEDS_DURATION = "재생 종료 시간은 YouTube 영상 길이를 초과할 수 없습니다.";
@@ -157,7 +158,15 @@ public class MapItemService {
     }
 
     private void validateBasicTimeRange(Integer startTime, Integer endTime) {
-        if (startTime == null || endTime == null || endTime <= startTime) {
+        if (startTime == null || endTime == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_TIME_RANGE);
+        }
+
+        if (startTime < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_NEGATIVE_START_TIME);
+        }
+
+        if (endTime <= startTime) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_TIME_RANGE);
         }
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/youtube/model/YoutubeMetadata.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/youtube/model/YoutubeMetadata.java
@@ -4,6 +4,16 @@ public record YoutubeMetadata(
         String videoId,
         String title,
         String artist,
-        String thumbnailUrl
+        String thumbnailUrl,
+        Integer durationSeconds
 ) {
+
+    public YoutubeMetadata(
+            String videoId,
+            String title,
+            String artist,
+            String thumbnailUrl
+    ) {
+        this(videoId, title, artist, thumbnailUrl, null);
+    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/youtube/model/YoutubeMetadata.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/youtube/model/YoutubeMetadata.java
@@ -1,5 +1,10 @@
 package io.github.ascrew.monomatbe.domain.youtube.model;
 
+/**
+ * YouTube 영상 검증 후 확보한 메타데이터
+ *
+ * @param durationSeconds 영상 길이(초). YouTube oEmbed는 duration을 제공하지 않으므로 null일 수 있습니다.
+ */
 public record YoutubeMetadata(
         String videoId,
         String title,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationService.java
@@ -101,7 +101,10 @@ public class YoutubeValidationService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_YOUTUBE_VIDEO);
         }
 
-        return new YoutubeMetadata(videoId, title, artist, thumbnailUrl);
+        // YouTube oEmbed는 영상 길이를 제공하지 않는다.
+        // durationSeconds는 향후 Data API, 별도 metadata resolver, IFrame 기반 사전 수집 등으로
+        // 확보할 수 있을 때 채워 넣기 위해 nullable 필드로 유지한다.
+        return new YoutubeMetadata(videoId, title, artist, thumbnailUrl, null);
     }
 
     private boolean isBlank(String value) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
@@ -5,8 +5,8 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ReorderMapItemsRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.UpdateMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
-import org.springframework.dao.DataIntegrityViolationException;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.youtube.model.YoutubeMetadata;
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -79,6 +80,203 @@ class MapItemServiceTest {
     }
 
     @Test
+    void createMapItem_durationUnknown_skipsDurationValidation() throws Exception {
+        CreateMapItemRequest request = new CreateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                10_000,
+                10_030,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb", null);
+        when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
+        when(jsonMapper.writeValueAsString(List.of("정답"))).thenReturn("[\"정답\"]");
+
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        MapItem persisted = mapItem(
+                100L,
+                quizMap,
+                request.orderNum(),
+                request.youtubeUrl(),
+                metadata,
+                request.startTime(),
+                request.endTime(),
+                "[\"정답\"]",
+                request.hint(),
+                request.hintTime()
+        );
+
+        when(persistenceService.create(
+                eq(1L),
+                eq(10L),
+                eq(request),
+                eq(metadata),
+                eq("[\"정답\"]"),
+                eq("힌트"),
+                eq(15)
+        )).thenReturn(persisted);
+
+        var response = mapItemService.createMapItem(1L, request, principal(10L));
+
+        assertThat(response.id()).isEqualTo(100L);
+        assertThat(response.startTime()).isEqualTo(10_000);
+        assertThat(response.endTime()).isEqualTo(10_030);
+
+        verify(persistenceService).create(
+                eq(1L),
+                eq(10L),
+                eq(request),
+                eq(metadata),
+                eq("[\"정답\"]"),
+                eq("힌트"),
+                eq(15)
+        );
+        verify(mapCacheEvictor).evictPublicMapCaches(1L);
+    }
+
+    @Test
+    void createMapItem_startTimeGreaterThanOrEqualDuration_throwsBadRequest() {
+        CreateMapItemRequest request = new CreateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                180,
+                181,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb", 180);
+        when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
+
+        assertThatThrownBy(() -> mapItemService.createMapItem(1L, request, principal(10L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("재생 시작 시간은 YouTube 영상 길이보다 작아야 합니다.");
+
+        verify(persistenceService, never()).create(any(), any(), any(), any(), any(), any(), anyInt());
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
+    }
+
+    @Test
+    void createMapItem_endTimeGreaterThanDuration_throwsBadRequest() {
+        CreateMapItemRequest request = new CreateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                170,
+                181,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb", 180);
+        when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
+
+        assertThatThrownBy(() -> mapItemService.createMapItem(1L, request, principal(10L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("재생 종료 시간은 YouTube 영상 길이를 초과할 수 없습니다.");
+
+        verify(persistenceService, never()).create(any(), any(), any(), any(), any(), any(), anyInt());
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
+    }
+
+    @Test
+    void createMapItem_endTimeEqualsDuration_success() throws Exception {
+        CreateMapItemRequest request = new CreateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                170,
+                180,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb", 180);
+        when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
+        when(jsonMapper.writeValueAsString(List.of("정답"))).thenReturn("[\"정답\"]");
+
+        QuizMap quizMap = quizMap(1L, owner(10L));
+        MapItem persisted = mapItem(
+                100L,
+                quizMap,
+                request.orderNum(),
+                request.youtubeUrl(),
+                metadata,
+                request.startTime(),
+                request.endTime(),
+                "[\"정답\"]",
+                request.hint(),
+                request.hintTime()
+        );
+
+        when(persistenceService.create(
+                eq(1L),
+                eq(10L),
+                eq(request),
+                eq(metadata),
+                eq("[\"정답\"]"),
+                eq("힌트"),
+                eq(15)
+        )).thenReturn(persisted);
+
+        var response = mapItemService.createMapItem(1L, request, principal(10L));
+
+        assertThat(response.startTime()).isEqualTo(170);
+        assertThat(response.endTime()).isEqualTo(180);
+        verify(mapCacheEvictor).evictPublicMapCaches(1L);
+    }
+
+    @Test
+    void updateMapItem_startTimeGreaterThanOrEqualDuration_throwsBadRequest() {
+        UpdateMapItemRequest request = new UpdateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                180,
+                181,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb", 180);
+        when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
+
+        assertThatThrownBy(() -> mapItemService.updateMapItem(1L, 100L, request, principal(10L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("재생 시작 시간은 YouTube 영상 길이보다 작아야 합니다.");
+
+        verify(persistenceService, never()).update(any(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
+    }
+
+    @Test
+    void updateMapItem_endTimeGreaterThanDuration_throwsBadRequest() {
+        UpdateMapItemRequest request = new UpdateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                170,
+                181,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb", 180);
+        when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
+
+        assertThatThrownBy(() -> mapItemService.updateMapItem(1L, 100L, request, principal(10L)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("재생 종료 시간은 YouTube 영상 길이를 초과할 수 없습니다.");
+
+        verify(persistenceService, never()).update(any(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
+    }
+
+    @Test
     void createMapItem_success_callsYoutubeBeforePersistenceAndEvictsCacheAfter() throws Exception {
         // "좋은날"과 "좋은 날"은 정규화 후 동일 → dedup되어 단일 정답으로 저장된다.
         CreateMapItemRequest request = new CreateMapItemRequest(
@@ -91,7 +289,7 @@ class MapItemServiceTest {
                 null
         );
 
-        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb");
+        YoutubeMetadata metadata = new YoutubeMetadata("abcde123456", "title", "artist", "thumb", null);
         when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
         when(jsonMapper.writeValueAsString(List.of("좋은날"))).thenReturn("[\"좋은날\"]");
 
@@ -220,6 +418,35 @@ class MapItemServiceTest {
                 .totalPlayTime(0)
                 .isPublic(false)
                 .isDeleted(false)
+                .build();
+    }
+
+    private MapItem mapItem(
+            Long id,
+            QuizMap quizMap,
+            Integer orderNum,
+            String youtubeUrl,
+            YoutubeMetadata metadata,
+            Integer startTime,
+            Integer endTime,
+            String answers,
+            String hint,
+            Integer hintTime
+    ) {
+        return MapItem.builder()
+                .id(id)
+                .map(quizMap)
+                .orderNum(orderNum)
+                .youtubeUrl(youtubeUrl)
+                .videoId(metadata.videoId())
+                .startTime(startTime)
+                .endTime(endTime)
+                .title(metadata.title())
+                .artist(metadata.artist())
+                .thumbnailUrl(metadata.thumbnailUrl())
+                .answers(answers)
+                .hint(hint)
+                .hintTime(hintTime)
                 .build();
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
@@ -266,6 +266,29 @@ class MapItemServiceTest {
     }
 
     @Test
+    void updateMapItem_negativeStartTime_skipsExternalCallsAndPersistence() {
+        UpdateMapItemRequest request = new UpdateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                -1,
+                30,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        assertThatThrownBy(() -> mapItemService.updateMapItem(1L, 100L, request, principal(10L)))
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(e.getReason()).isEqualTo(ERROR_NEGATIVE_START_TIME);
+                });
+
+        verify(youtubeValidationService, never()).validateYoutubeUrl(any());
+        verify(persistenceService, never()).update(any(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
+    }
+
+    @Test
     void updateMapItem_startTimeGreaterThanOrEqualDuration_throwsBadRequest() {
         UpdateMapItemRequest request = new UpdateMapItemRequest(
                 1,

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapItemServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -36,6 +37,11 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MapItemServiceTest {
+
+    private static final String ERROR_INVALID_TIME_RANGE = "재생 구간은 시작 시간보다 종료 시간이 커야 합니다.";
+    private static final String ERROR_NEGATIVE_START_TIME = "재생 시작 시간은 0초 이상이어야 합니다.";
+    private static final String ERROR_START_TIME_EXCEEDS_DURATION = "재생 시작 시간은 YouTube 영상 길이보다 작아야 합니다.";
+    private static final String ERROR_END_TIME_EXCEEDS_DURATION = "재생 종료 시간은 YouTube 영상 길이를 초과할 수 없습니다.";
 
     @Mock
     private MapItemPersistenceService persistenceService;
@@ -71,8 +77,33 @@ class MapItemServiceTest {
         );
 
         assertThatThrownBy(() -> mapItemService.createMapItem(1L, request, principal(10L)))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("재생 구간은 시작 시간보다 종료 시간이 커야 합니다.");
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(e.getReason()).isEqualTo(ERROR_INVALID_TIME_RANGE);
+                });
+
+        verify(youtubeValidationService, never()).validateYoutubeUrl(any());
+        verify(persistenceService, never()).create(any(), any(), any(), any(), any(), any(), anyInt());
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
+    }
+
+    @Test
+    void createMapItem_negativeStartTime_skipsExternalCallsAndPersistence() {
+        CreateMapItemRequest request = new CreateMapItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=abcde123456",
+                -1,
+                30,
+                List.of("정답"),
+                "힌트",
+                15
+        );
+
+        assertThatThrownBy(() -> mapItemService.createMapItem(1L, request, principal(10L)))
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(e.getReason()).isEqualTo(ERROR_NEGATIVE_START_TIME);
+                });
 
         verify(youtubeValidationService, never()).validateYoutubeUrl(any());
         verify(persistenceService, never()).create(any(), any(), any(), any(), any(), any(), anyInt());
@@ -153,8 +184,10 @@ class MapItemServiceTest {
         when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
 
         assertThatThrownBy(() -> mapItemService.createMapItem(1L, request, principal(10L)))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("재생 시작 시간은 YouTube 영상 길이보다 작아야 합니다.");
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(e.getReason()).isEqualTo(ERROR_START_TIME_EXCEEDS_DURATION);
+                });
 
         verify(persistenceService, never()).create(any(), any(), any(), any(), any(), any(), anyInt());
         verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
@@ -176,8 +209,10 @@ class MapItemServiceTest {
         when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
 
         assertThatThrownBy(() -> mapItemService.createMapItem(1L, request, principal(10L)))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("재생 종료 시간은 YouTube 영상 길이를 초과할 수 없습니다.");
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(e.getReason()).isEqualTo(ERROR_END_TIME_EXCEEDS_DURATION);
+                });
 
         verify(persistenceService, never()).create(any(), any(), any(), any(), any(), any(), anyInt());
         verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
@@ -246,8 +281,10 @@ class MapItemServiceTest {
         when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
 
         assertThatThrownBy(() -> mapItemService.updateMapItem(1L, 100L, request, principal(10L)))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("재생 시작 시간은 YouTube 영상 길이보다 작아야 합니다.");
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(e.getReason()).isEqualTo(ERROR_START_TIME_EXCEEDS_DURATION);
+                });
 
         verify(persistenceService, never()).update(any(), any(), any(), any(), any(), any(), any(), anyInt());
         verify(mapCacheEvictor, never()).evictPublicMapCaches(any());
@@ -269,8 +306,10 @@ class MapItemServiceTest {
         when(youtubeValidationService.validateYoutubeUrl(request.youtubeUrl())).thenReturn(metadata);
 
         assertThatThrownBy(() -> mapItemService.updateMapItem(1L, 100L, request, principal(10L)))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("재생 종료 시간은 YouTube 영상 길이를 초과할 수 없습니다.");
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(e.getReason()).isEqualTo(ERROR_END_TIME_EXCEEDS_DURATION);
+                });
 
         verify(persistenceService, never()).update(any(), any(), any(), any(), any(), any(), any(), anyInt());
         verify(mapCacheEvictor, never()).evictPublicMapCaches(any());

--- a/src/test/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/youtube/service/YoutubeValidationServiceTest.java
@@ -148,7 +148,7 @@ class YoutubeValidationServiceTest {
 
     @Test
     void validateYoutubeUrl_successCacheHit_returnsCachedMetadata() {
-        YoutubeMetadata cached = new YoutubeMetadata(TEST_VIDEO_ID, "title", "artist", "thumb");
+        YoutubeMetadata cached = new YoutubeMetadata(TEST_VIDEO_ID, "title", "artist", "thumb", null);
         String serialized = jsonMapper.writeValueAsString(cached);
 
         when(valueOperations.get(RedisKeys.youtubeOembedSuccessKey(TEST_VIDEO_ID))).thenReturn(serialized);
@@ -157,6 +157,7 @@ class YoutubeValidationServiceTest {
 
         assertThat(result.videoId()).isEqualTo(TEST_VIDEO_ID);
         assertThat(result.title()).isEqualTo("title");
+        assertThat(result.durationSeconds()).isNull();
         verify(youtubeOEmbedClient, never()).fetchByVideoId(anyString());
     }
 
@@ -179,6 +180,7 @@ class YoutubeValidationServiceTest {
 
         assertThat(result.videoId()).isEqualTo(TEST_VIDEO_ID);
         assertThat(result.artist()).isEqualTo("new artist");
+        assertThat(result.durationSeconds()).isNull();
         verify(valueOperations).set(anyString(), anyString(), any());
     }
 


### PR DESCRIPTION
## 📣 Related Issue

- #176

## 📝 Summary

- YouTube metadata에 nullable `durationSeconds` 필드를 추가했습니다.
- 맵 문제 생성/수정 시 duration을 확보할 수 있는 경우 `startTime`, `endTime`이 영상 길이를 초과하지 않도록 검증했습니다.
- 현재 oEmbed 기반 검증에서는 영상 길이를 제공받을 수 없으므로 `durationSeconds == null`인 경우 기존처럼 기본 시간 범위 검증만 수행하도록 처리했습니다.
- 기존 `YoutubeMetadata` 4개 인자 생성자와의 호환성을 유지했습니다.
- 생성/수정 서비스 테스트에 duration 검증 케이스를 추가했습니다.

## 🙏PR point

- YouTube oEmbed는 영상 길이를 제공하지 않기 때문에 현재는 `durationSeconds`가 `null`로 유지됩니다.
- 따라서 현재 동작은 기존 URL 유효성 검증을 유지하면서, 향후 duration 확보 수단이 추가될 경우 동일한 검증 로직이 바로 강제 적용되도록 구조를 열어둔 형태입니다.
- `durationSeconds == null`인 경우에는 영상 길이 초과 검증을 생략합니다.

## 📬 Reference

- `YoutubeMetadata`
- `YoutubeValidationService`
- `MapItemService`
- `MapItemServiceTest`
- `YoutubeValidationServiceTest`