### PR TITLE
[Feat/#177] 내 맵 단건 조회 API 추가

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -226,7 +226,7 @@ FE는 `204 No Content` 수신 후 다음 처리를 수행해야 합니다.
 
 ## 맵 (Map)
 
-맵 API는 공개 맵 목록 조회, 내 맵 목록 조회, 공개 맵 상세 조회를 제공합니다.
+맵 API는 공개 맵 목록 조회, 내 맵 목록 조회, 내 맵 단건 조회, 공개 맵 상세 조회를 제공합니다.
 
 `playCount`는 해당 맵이 실제 게임 시작에 사용된 누적 횟수입니다.  
 로비 생성이나 맵 선택만으로는 증가하지 않으며, 선택된 맵으로 게임 세션 생성이 확정된 경우에만 증가합니다.
@@ -235,19 +235,19 @@ FE는 `204 No Content` 수신 후 다음 처리를 수행해야 합니다.
 
 ```http
 GET /api/maps?page=0&size=20&keyword=KPOP&category=KPOP&sort=NEWEST
-````
+```
 
 공개 상태인 맵 목록을 페이징하여 조회합니다.
 
 #### Query Parameters
 
-| 필드         | 타입     | 필수 |      기본값 | 설명             |
-| ---------- | ------ | -: | -------: | -------------- |
-| `page`     | number |  X |        0 | 0-based 페이지 번호 |
-| `size`     | number |  X |       20 | 페이지 크기. 최대 100 |
-| `keyword`  | string |  X |     null | 제목/설명 검색 키워드   |
-| `category` | string |  X |     null | 맵 카테고리         |
-| `sort`     | string |  X | `NEWEST` | 정렬 기준          |
+| 필드 | 타입 | 필수 | 기본값 | 설명 |
+| --- | --- | ---: | ---: | --- |
+| `page` | number | X | 0 | 0-based 페이지 번호 |
+| `size` | number | X | 20 | 페이지 크기. 최대 100 |
+| `keyword` | string | X | null | 제목/설명 검색 키워드 |
+| `category` | string | X | null | 맵 카테고리 |
+| `sort` | string | X | `NEWEST` | 정렬 기준 |
 
 #### Success Response
 
@@ -262,7 +262,7 @@ HTTP/1.1 200 OK
       "mapId": 1,
       "title": "K-POP 랜덤 퀴즈",
       "description": "인기 K-POP 문제 모음",
-      "category": "KPOP",
+      "category": "K-POP",
       "numOfSong": 10,
       "totalPlayTime": 300,
       "isPublic": true,
@@ -282,19 +282,19 @@ HTTP/1.1 200 OK
 
 #### Response Fields - Map Summary
 
-| 필드              | 타입            | 설명                        |
-| --------------- | ------------- | ------------------------- |
-| `mapId`         | number        | 맵 고유 ID                   |
-| `title`         | string        | 맵 제목                      |
-| `description`   | string | null | 맵 설명                      |
-| `category`      | string        | 맵 카테고리                    |
-| `numOfSong`     | number        | 맵에 등록된 곡/문제 수             |
-| `totalPlayTime` | number        | 맵 전체 재생 시간(초). 플레이 횟수가 아님 |
-| `isPublic`      | boolean       | 공개 여부                     |
-| `pendingPublic` | boolean       | 공개 의도 보존 여부               |
-| `ownerId`       | number        | 맵 소유자 ID                  |
-| `ownerNickname` | string        | 맵 소유자 닉네임                 |
-| `playCount`     | number        | 맵이 실제 게임 시작에 사용된 누적 횟수    |
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `mapId` | number | 맵 고유 ID |
+| `title` | string | 맵 제목 |
+| `description` | string \| null | 맵 설명 |
+| `category` | string | 맵 카테고리 |
+| `numOfSong` | number | 맵에 등록된 곡/문제 수 |
+| `totalPlayTime` | number | 맵 전체 재생 시간(초). 플레이 횟수가 아님 |
+| `isPublic` | boolean | 공개 여부 |
+| `pendingPublic` | boolean | 공개 의도 보존 여부 |
+| `ownerId` | number | 맵 소유자 ID |
+| `ownerNickname` | string | 맵 소유자 닉네임 |
+| `playCount` | number | 맵이 실제 게임 시작에 사용된 누적 횟수 |
 
 ---
 
@@ -388,8 +388,8 @@ Authorization: Bearer {accessToken}
 
 #### Path Variables
 
-| 필드      | 타입     | 설명         |
-| ------- | ------ | ---------- |
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
 | `mapId` | number | 조회할 내 맵 ID |
 
 #### Success Response
@@ -405,7 +405,7 @@ HTTP/1.1 200 OK
   "ownerNickname": "hyeon",
   "title": "J-POP 퀴즈 대결",
   "description": "J-POP 중심 퀴즈 맵",
-  "category": "JPOP",
+  "category": "J-POP",
   "numOfSong": 10,
   "totalPlayTime": 300,
   "isPublic": false,
@@ -418,31 +418,31 @@ HTTP/1.1 200 OK
 
 #### Response Fields
 
-| 필드              | 타입            | 설명                     |
-| --------------- | ------------- | ---------------------- |
-| `id`            | number        | 맵 고유 ID                |
-| `ownerId`       | number        | 맵 소유자 ID               |
-| `ownerNickname` | string        | 맵 소유자 닉네임              |
-| `title`         | string        | 맵 제목                   |
-| `description`   | string \| null | 맵 설명                   |
-| `category`      | string        | 맵 카테고리                 |
-| `numOfSong`     | number        | 맵에 등록된 곡/문제 수          |
-| `totalPlayTime` | number        | 맵 전체 재생 시간             |
-| `isPublic`      | boolean       | 공개 여부                  |
-| `pendingPublic` | boolean       | 공개 의도 보존 여부            |
-| `playCount`     | number        | 맵이 실제 게임 시작에 사용된 누적 횟수 |
-| `createdAt`     | string        | 맵 생성 시각                |
-| `updatedAt`     | string        | 맵 수정 시각                |
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `id` | number | 맵 고유 ID |
+| `ownerId` | number | 맵 소유자 ID |
+| `ownerNickname` | string | 맵 소유자 닉네임 |
+| `title` | string | 맵 제목 |
+| `description` | string \| null | 맵 설명 |
+| `category` | string | 맵 카테고리 |
+| `numOfSong` | number | 맵에 등록된 곡/문제 수 |
+| `totalPlayTime` | number | 맵 전체 재생 시간 |
+| `isPublic` | boolean | 공개 여부 |
+| `pendingPublic` | boolean | 공개 의도 보존 여부 |
+| `playCount` | number | 맵이 실제 게임 시작에 사용된 누적 횟수 |
+| `createdAt` | string | 맵 생성 시각 |
+| `updatedAt` | string | 맵 수정 시각 |
 
 #### Error Response
 
-| HTTP Status | 상황                               |
-| ----------: | -------------------------------- |
-|         401 | 인증 정보 없음 또는 유효하지 않은 Access Token |
-|         403 | 정식 회원이 아닌 사용자                    |
-|         403 | 본인 소유가 아닌 맵 조회                   |
-|         404 | 존재하지 않는 맵                        |
-|         404 | 삭제된 맵                            |
+| HTTP Status | 상황 |
+| ---: | --- |
+| 401 | 인증 정보 없음 또는 유효하지 않은 Access Token |
+| 403 | 정식 회원이 아닌 사용자 |
+| 403 | 본인 소유가 아닌 맵 조회 |
+| 404 | 존재하지 않는 맵 |
+| 404 | 삭제된 맵 |
 
 ---
 
@@ -456,8 +456,8 @@ GET /api/maps/{mapId}
 
 #### Path Variables
 
-| 필드      | 타입     | 설명       |
-| ------- | ------ | -------- |
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
 | `mapId` | number | 조회할 맵 ID |
 
 #### Success Response
@@ -473,7 +473,7 @@ HTTP/1.1 200 OK
   "ownerNickname": "owner",
   "title": "K-POP 랜덤 퀴즈",
   "description": "인기 K-POP 문제 모음",
-  "category": "KPOP",
+  "category": "K-POP",
   "numOfSong": 10,
   "totalPlayTime": 300,
   "isPublic": true,
@@ -486,27 +486,27 @@ HTTP/1.1 200 OK
 
 #### Response Fields
 
-| 필드              | 타입            | 설명                                 |
-| --------------- | ------------- | ---------------------------------- |
-| `id`            | number        | 맵 고유 ID                            |
-| `ownerId`       | number        | 맵 소유자 ID                           |
-| `ownerNickname` | string        | 맵 소유자 닉네임                          |
-| `title`         | string        | 맵 제목                               |
-| `description`   | string | null | 맵 설명                               |
-| `category`      | string        | 맵 카테고리                             |
-| `numOfSong`     | number        | 맵에 등록된 곡/문제 수                      |
-| `totalPlayTime` | number        | 맵 전체 재생 시간(초). 플레이 횟수가 아님          |
-| `isPublic`      | boolean       | 공개 여부                              |
-| `pendingPublic` | boolean       | 공개 의도 보존 여부                        |
-| `playCount`     | number        | 맵이 실제 게임 시작에 사용된 누적 횟수             |
-| `createdAt`     | string        | 맵 생성 시각. ISO-8601 LocalDateTime 형식 |
-| `updatedAt`     | string        | 맵 수정 시각. ISO-8601 LocalDateTime 형식 |
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `id` | number | 맵 고유 ID |
+| `ownerId` | number | 맵 소유자 ID |
+| `ownerNickname` | string | 맵 소유자 닉네임 |
+| `title` | string | 맵 제목 |
+| `description` | string \| null | 맵 설명 |
+| `category` | string | 맵 카테고리 |
+| `numOfSong` | number | 맵에 등록된 곡/문제 수 |
+| `totalPlayTime` | number | 맵 전체 재생 시간(초). 플레이 횟수가 아님 |
+| `isPublic` | boolean | 공개 여부 |
+| `pendingPublic` | boolean | 공개 의도 보존 여부 |
+| `playCount` | number | 맵이 실제 게임 시작에 사용된 누적 횟수 |
+| `createdAt` | string | 맵 생성 시각. ISO-8601 LocalDateTime 형식 |
+| `updatedAt` | string | 맵 수정 시각. ISO-8601 LocalDateTime 형식 |
 
 #### Error Response
 
-| HTTP Status | 상황            |
-| ----------: | ------------- |
-|         404 | 공개 맵을 찾을 수 없음 |
+| HTTP Status | 상황 |
+| ---: | --- |
+| 404 | 공개 맵을 찾을 수 없음 |
 
 ---
 
@@ -751,4 +751,3 @@ Content-Type: application/json
 | 403 | `강퇴된 로비의 게임 상태는 조회할 수 없습니다.` | 해당 로비에서 강퇴된 사용자가 조회를 시도함 |
 | 404 | `존재하지 않는 로비입니다.` | 존재하지 않는 로비 초대 코드 입력 |
 | 404 | `진행 중인 게임 세션이 없습니다.` | 해당 로비에 매핑된 활성화 상태의 게임 세션이 없음 |
-

--- a/docs/API.md
+++ b/docs/API.md
@@ -379,7 +379,7 @@ AND category 조건
 ```http
 GET /api/maps/me/{mapId}
 Authorization: Bearer {accessToken}
-````
+```
 
 로그인한 정식 회원이 본인 소유의 공개/비공개/공개 대기 맵을 단건 조회합니다.
 
@@ -424,7 +424,7 @@ HTTP/1.1 200 OK
 | `ownerId`       | number        | 맵 소유자 ID               |
 | `ownerNickname` | string        | 맵 소유자 닉네임              |
 | `title`         | string        | 맵 제목                   |
-| `description`   | string | null | 맵 설명                   |
+| `description`   | string \| null | 맵 설명                   |
 | `category`      | string        | 맵 카테고리                 |
 | `numOfSong`     | number        | 맵에 등록된 곡/문제 수          |
 | `totalPlayTime` | number        | 맵 전체 재생 시간             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -374,6 +374,78 @@ AND category 조건
 
 ---
 
+### 내 맵 단건 조회
+
+```http
+GET /api/maps/me/{mapId}
+Authorization: Bearer {accessToken}
+````
+
+로그인한 정식 회원이 본인 소유의 공개/비공개/공개 대기 맵을 단건 조회합니다.
+
+공개 맵 상세 조회 API(`GET /api/maps/{mapId}`)와 달리 공개 여부를 조회 조건으로 사용하지 않습니다.
+단, 삭제된 맵은 조회되지 않습니다.
+
+#### Path Variables
+
+| 필드      | 타입     | 설명         |
+| ------- | ------ | ---------- |
+| `mapId` | number | 조회할 내 맵 ID |
+
+#### Success Response
+
+```http
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "id": 1,
+  "ownerId": 10,
+  "ownerNickname": "hyeon",
+  "title": "J-POP 퀴즈 대결",
+  "description": "J-POP 중심 퀴즈 맵",
+  "category": "JPOP",
+  "numOfSong": 10,
+  "totalPlayTime": 300,
+  "isPublic": false,
+  "pendingPublic": false,
+  "playCount": 0,
+  "createdAt": "2026-06-05T18:00:00",
+  "updatedAt": "2026-06-05T18:30:00"
+}
+```
+
+#### Response Fields
+
+| 필드              | 타입            | 설명                     |
+| --------------- | ------------- | ---------------------- |
+| `id`            | number        | 맵 고유 ID                |
+| `ownerId`       | number        | 맵 소유자 ID               |
+| `ownerNickname` | string        | 맵 소유자 닉네임              |
+| `title`         | string        | 맵 제목                   |
+| `description`   | string | null | 맵 설명                   |
+| `category`      | string        | 맵 카테고리                 |
+| `numOfSong`     | number        | 맵에 등록된 곡/문제 수          |
+| `totalPlayTime` | number        | 맵 전체 재생 시간             |
+| `isPublic`      | boolean       | 공개 여부                  |
+| `pendingPublic` | boolean       | 공개 의도 보존 여부            |
+| `playCount`     | number        | 맵이 실제 게임 시작에 사용된 누적 횟수 |
+| `createdAt`     | string        | 맵 생성 시각                |
+| `updatedAt`     | string        | 맵 수정 시각                |
+
+#### Error Response
+
+| HTTP Status | 상황                               |
+| ----------: | -------------------------------- |
+|         401 | 인증 정보 없음 또는 유효하지 않은 Access Token |
+|         403 | 정식 회원이 아닌 사용자                    |
+|         403 | 본인 소유가 아닌 맵 조회                   |
+|         404 | 존재하지 않는 맵                        |
+|         404 | 삭제된 맵                            |
+
+---
+
 ### 공개 맵 상세 조회
 
 ```http

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
@@ -60,6 +60,19 @@ public class MapController {
         return ResponseEntity.ok(mapService.getMyMaps(page, size, keyword, category, sort, principal));
     }
 
+    @Operation(
+            summary = "내 맵 단건 조회",
+            description = "로그인한 정식 회원이 본인 소유의 공개/비공개/공개 대기 맵을 단건 조회합니다."
+    )
+    @GetMapping("/me/{mapId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MapDetailResponse> getMyMap(
+            @PathVariable Long mapId,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        return ResponseEntity.ok(mapService.getMyMap(mapId, principal));
+    }
+
     @Operation(summary = "공개 맵 단건 조회")
     @GetMapping("/{mapId}")
     public ResponseEntity<MapDetailResponse> getPublicMap(@PathVariable Long mapId) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapService.java
@@ -45,8 +45,10 @@ public class MapService {
 
     private static final String ERROR_INVALID_PRINCIPAL = "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
     private static final String ERROR_REGISTERED_ONLY = "정식 회원만 맵을 생성할 수 있습니다.";
+    private static final String ERROR_MY_MAP_REGISTERED_ONLY = "정식 회원만 본인 맵을 조회할 수 있습니다.";
     private static final String ERROR_MAP_NOT_FOUND = "맵을 찾을 수 없습니다.";
     private static final String ERROR_MAP_FORBIDDEN = "본인 소유의 맵만 수정/삭제할 수 있습니다.";
+    private static final String ERROR_MAP_READ_FORBIDDEN = "본인 소유의 맵만 조회할 수 있습니다.";
     private static final String ERROR_USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
 
     private final QuizMapJpaRepository quizMapJpaRepository;
@@ -70,6 +72,21 @@ public class MapService {
         this.mapCacheEvictor = mapCacheEvictor;
         this.redisTemplate = redisTemplate;
         this.jsonMapper = jsonMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public MapDetailResponse getMyMap(Long mapId, CustomPrincipal principal) {
+        validateMyMapReadablePrincipal(principal);
+
+        QuizMap quizMap = quizMapJpaRepository.findByIdAndIsDeletedFalse(mapId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        ERROR_MAP_NOT_FOUND
+                ));
+
+        validateReadOwnership(quizMap, principal);
+
+        return toDetailResponse(quizMap);
     }
 
     // 공개된 맵 목록을 검색 조건과 함께 페이징하여 조회합니다.
@@ -360,6 +377,26 @@ public class MapService {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "지원하지 않는 category입니다: " + rawCategory
+            );
+        }
+    }
+
+    private void validateMyMapReadablePrincipal(CustomPrincipal principal) {
+        validatePrincipal(principal);
+
+        if (principal.userType() != UserType.REGISTERED) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_MY_MAP_REGISTERED_ONLY
+            );
+        }
+    }
+
+    private void validateReadOwnership(QuizMap quizMap, CustomPrincipal principal) {
+        if (!quizMap.getOwner().getId().equals(principal.userId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    ERROR_MAP_READ_FORBIDDEN
             );
         }
     }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/controller/MapControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/controller/MapControllerTest.java
@@ -33,6 +33,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class MapControllerTest {
 
+    /*
+     * Security Filter Chain을 로딩하지 않는 standalone controller test
+     * 이 테스트는 신규 경로가 공개 맵 조회가 아니라 소유자 전용 조회 메서드로 매핑되는지,
+     * AuthenticationPrincipalArgumentResolver가 CustomPrincipal을 서비스로 전달하는지 검증한다.
+     *
+     * JWT 인증 실패(401)와 @PreAuthorize 동작은 Spring Security 통합 테스트에서 검증해야 한다.
+     */
+
     private MockMvc mockMvc;
 
     @Mock

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/controller/MapControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/controller/MapControllerTest.java
@@ -1,0 +1,119 @@
+package io.github.ascrew.monomatbe.domain.map.controller;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.service.MapService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class MapControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private MapService mapService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new MapController(mapService))
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getMyMap_withAuthenticatedOwner_returns200() throws Exception {
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken(principal));
+
+        MapDetailResponse response = MapDetailResponse.builder()
+                .id(100L)
+                .ownerId(10L)
+                .ownerNickname("owner")
+                .title("내 비공개 맵")
+                .description("관리 페이지에서 조회할 맵")
+                .category(MapCategory.JPOP)
+                .numOfSong(10)
+                .totalPlayTime(300)
+                .isPublic(false)
+                .pendingPublic(false)
+                .playCount(5L)
+                .createdAt(LocalDateTime.of(2026, 6, 5, 18, 0))
+                .updatedAt(LocalDateTime.of(2026, 6, 5, 18, 30))
+                .build();
+
+        when(mapService.getMyMap(100L, principal)).thenReturn(response);
+
+        mockMvc.perform(get("/api/maps/me/{mapId}", 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(100L))
+                .andExpect(jsonPath("$.ownerId").value(10L))
+                .andExpect(jsonPath("$.ownerNickname").value("owner"))
+                .andExpect(jsonPath("$.title").value("내 비공개 맵"))
+                .andExpect(jsonPath("$.description").value("관리 페이지에서 조회할 맵"))
+                .andExpect(jsonPath("$.category").value("J-POP"))
+                .andExpect(jsonPath("$.numOfSong").value(10))
+                .andExpect(jsonPath("$.totalPlayTime").value(300))
+                .andExpect(jsonPath("$.isPublic").value(false))
+                .andExpect(jsonPath("$.pendingPublic").value(false))
+                .andExpect(jsonPath("$.playCount").value(5));
+
+        verify(mapService).getMyMap(100L, principal);
+        verify(mapService, never()).getPublicMap(anyLong());
+    }
+
+    @Test
+    void getMyMap_notOwner_returns403() throws Exception {
+        CustomPrincipal principal = new CustomPrincipal(11L, "u-11", UserType.REGISTERED);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken(principal));
+
+        when(mapService.getMyMap(100L, principal))
+                .thenThrow(new ResponseStatusException(
+                        HttpStatus.FORBIDDEN,
+                        "본인 소유의 맵만 조회할 수 있습니다."
+                ));
+
+        mockMvc.perform(get("/api/maps/me/{mapId}", 100L))
+                .andExpect(status().isForbidden());
+
+        verify(mapService).getMyMap(100L, principal);
+        verify(mapService, never()).getPublicMap(anyLong());
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken(CustomPrincipal principal) {
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                AuthorityUtils.createAuthorityList("ROLE_USER")
+        );
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapServiceTest.java
@@ -660,4 +660,176 @@ class MapServiceTest {
 
         verify(quizMapJpaRepository, never()).findByIdAndIsDeletedFalseAndIsPublicTrue(any());
     }
+
+    @Test
+    void getMyMap_privateMapOwner_returnsMapDetail() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(100L)
+                .owner(owner)
+                .title("내 비공개 맵")
+                .description("관리 페이지에서 조회할 맵")
+                .category(MapCategory.JPOP)
+                .numOfSong(10)
+                .totalPlayTime(300)
+                .playCount(5L)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build();
+
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(100L))
+                .thenReturn(Optional.of(quizMap));
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        MapDetailResponse response = mapService.getMyMap(100L, principal);
+
+        assertThat(response.id()).isEqualTo(100L);
+        assertThat(response.ownerId()).isEqualTo(10L);
+        assertThat(response.ownerNickname()).isEqualTo("owner");
+        assertThat(response.title()).isEqualTo("내 비공개 맵");
+        assertThat(response.description()).isEqualTo("관리 페이지에서 조회할 맵");
+        assertThat(response.category()).isEqualTo(MapCategory.JPOP);
+        assertThat(response.numOfSong()).isEqualTo(10);
+        assertThat(response.totalPlayTime()).isEqualTo(300);
+        assertThat(response.playCount()).isEqualTo(5L);
+        assertThat(response.isPublic()).isFalse();
+        assertThat(response.pendingPublic()).isFalse();
+    }
+
+    @Test
+    void getMyMap_pendingPublicMapOwner_returnsMapDetail() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(101L)
+                .owner(owner)
+                .title("공개 대기 맵")
+                .description("아이템 추가 후 공개될 맵")
+                .category(MapCategory.KPOP)
+                .numOfSong(0)
+                .totalPlayTime(0)
+                .playCount(0L)
+                .isPublic(false)
+                .pendingPublic(true)
+                .build();
+
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(101L))
+                .thenReturn(Optional.of(quizMap));
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        MapDetailResponse response = mapService.getMyMap(101L, principal);
+
+        assertThat(response.id()).isEqualTo(101L);
+        assertThat(response.ownerId()).isEqualTo(10L);
+        assertThat(response.isPublic()).isFalse();
+        assertThat(response.pendingPublic()).isTrue();
+        assertThat(response.playCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void getMyMap_publicMapOwner_returnsMapDetail() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(102L)
+                .owner(owner)
+                .title("내 공개 맵")
+                .description("공개된 내 맵")
+                .category(MapCategory.POP)
+                .numOfSong(7)
+                .totalPlayTime(210)
+                .playCount(13L)
+                .isPublic(true)
+                .pendingPublic(false)
+                .build();
+
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(102L))
+                .thenReturn(Optional.of(quizMap));
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        MapDetailResponse response = mapService.getMyMap(102L, principal);
+
+        assertThat(response.id()).isEqualTo(102L);
+        assertThat(response.ownerId()).isEqualTo(10L);
+        assertThat(response.isPublic()).isTrue();
+        assertThat(response.pendingPublic()).isFalse();
+        assertThat(response.playCount()).isEqualTo(13L);
+    }
+
+    @Test
+    void getMyMap_guestUser_throws403AndDoesNotQueryRepository() {
+        CustomPrincipal guest = new CustomPrincipal(10L, "guest-10", UserType.GUEST);
+
+        assertThatThrownBy(() -> mapService.getMyMap(100L, guest))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN))
+                .hasMessageContaining("정식 회원만 본인 맵을 조회할 수 있습니다.");
+
+        verify(quizMapJpaRepository, never()).findByIdAndIsDeletedFalse(any());
+    }
+
+    @Test
+    void getMyMap_notFound_throws404() {
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(999L))
+                .thenReturn(Optional.empty());
+
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+
+        assertThatThrownBy(() -> mapService.getMyMap(999L, principal))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND))
+                .hasMessageContaining("맵을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void getMyMap_notOwner_throws403() {
+        User owner = User.builder()
+                .id(10L)
+                .username("owner")
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        QuizMap quizMap = QuizMap.builder()
+                .id(100L)
+                .owner(owner)
+                .title("타인 맵")
+                .description("타인 소유")
+                .category(MapCategory.OST)
+                .numOfSong(3)
+                .totalPlayTime(90)
+                .playCount(1L)
+                .isPublic(false)
+                .pendingPublic(false)
+                .build();
+
+        when(quizMapJpaRepository.findByIdAndIsDeletedFalse(100L))
+                .thenReturn(Optional.of(quizMap));
+
+        CustomPrincipal anotherUser = new CustomPrincipal(11L, "u-11", UserType.REGISTERED);
+
+        assertThatThrownBy(() -> mapService.getMyMap(100L, anotherUser))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN))
+                .hasMessageContaining("본인 소유의 맵만 조회할 수 있습니다.");
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #177

## 📝 Summary

- 로그인한 정식 회원이 본인 소유 맵을 단건 조회할 수 있는 `GET /api/maps/me/{mapId}` API를 추가했습니다.
- 기존 공개 맵 단건 조회 API(`GET /api/maps/{mapId}`)와 분리하여 공개/비공개/공개 대기 맵을 모두 조회할 수 있도록 했습니다.
- 삭제된 맵은 조회되지 않도록 `findByIdAndIsDeletedFalse` 조회 조건을 사용했습니다.
- 정식 회원 여부와 맵 소유권을 검증하여 게스트 사용자는 403, 타인 소유 맵 조회는 403을 반환하도록 처리했습니다.
- 기존 `MapDetailResponse`를 재사용해 FE 관리 페이지에서 동일한 상세 응답 구조를 사용할 수 있도록 했습니다.
- 서비스 테스트를 추가해 공개/비공개/공개 대기 맵 조회, 게스트 차단, 미존재 맵 404, 타인 소유 맵 403 케이스를 검증했습니다.
- API 문서에 내 맵 단건 조회 API 명세를 추가했습니다.

## 🙏PR point

- `GET /api/maps/{mapId}`는 기존처럼 공개 맵 단건 조회 전용으로 유지했습니다.
- `GET /api/maps/me/{mapId}`는 관리 페이지 전용 owner-only API입니다.
- 공개 여부(`isPublic`, `pendingPublic`)는 조회 조건이 아니라 응답 상태값으로만 사용됩니다.
- 타인 소유 맵은 존재 여부와 관계없이 권한 정책상 403으로 처리합니다.

## 📬 Reference

- 기존 공개 맵 단건 조회 API
- 기존 `MapDetailResponse`

