### PR TITLE
[Feat/#184] 프론트엔드 연동을 위한 REST CORS 설정 및 WebSocket 허용 출처 제한

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/global/config/CorsConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/CorsConfig.java
@@ -1,0 +1,41 @@
+package io.github.ascrew.monomatbe.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+/**
+ * REST API CORS 설정.
+ * 프론트엔드(메인 도메인)와 백엔드(api 서브도메인)가 서로 다른 출처이므로
+ * 허용 출처를 monomat.cors.allowed-origins(=${CORS_ALLOWED_ORIGINS})로 외부화한다.
+ * 빈 이름이 corsConfigurationSource이면 SecurityFilterChain의 http.cors()가 자동으로 사용한다.
+ */
+@Configuration
+public class CorsConfig {
+
+    private final List<String> allowedOrigins;
+
+    public CorsConfig(@Value("${monomat.cors.allowed-origins}") List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(allowedOrigins);
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        // JWT는 Authorization 헤더로 전달하며 쿠키를 사용하지 않으므로 credentials는 비활성화한다.
+        config.setAllowCredentials(false);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/CorsConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/CorsConfig.java
@@ -1,6 +1,5 @@
 package io.github.ascrew.monomatbe.global.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -11,26 +10,26 @@ import java.util.List;
 
 /**
  * REST API CORS 설정.
- * 프론트엔드(메인 도메인)와 백엔드(api 서브도메인)가 서로 다른 출처이므로
- * 허용 출처를 monomat.cors.allowed-origins(=${CORS_ALLOWED_ORIGINS})로 외부화한다.
+ * 허용 출처는 {@link CorsProperties}(monomat.cors.allowed-origins) 단일 소스를 참조한다.
  * 빈 이름이 corsConfigurationSource이면 SecurityFilterChain의 http.cors()가 자동으로 사용한다.
  */
 @Configuration
 public class CorsConfig {
 
-    private final List<String> allowedOrigins;
+    private final CorsProperties corsProperties;
 
-    public CorsConfig(@Value("${monomat.cors.allowed-origins}") List<String> allowedOrigins) {
-        this.allowedOrigins = allowedOrigins;
+    public CorsConfig(CorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
     }
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(allowedOrigins);
+        config.setAllowedOrigins(corsProperties.getAllowedOrigins());
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        config.setAllowedHeaders(List.of("*"));
-        // JWT는 Authorization 헤더로 전달하며 쿠키를 사용하지 않으므로 credentials는 비활성화한다.
+        // JWT는 Authorization 헤더로 전달하고 쿠키를 사용하지 않으므로 필요한 헤더만 허용한다.
+        // 추후 X-Request-Id 등 커스텀 헤더가 필요하면 명시적으로 추가한다.
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
         config.setAllowCredentials(false);
         config.setMaxAge(3600L);
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/CorsProperties.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/CorsProperties.java
@@ -1,0 +1,40 @@
+package io.github.ascrew.monomatbe.global.config;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CORS 허용 출처 설정 (단일 소스).
+ *
+ * 프론트엔드(메인 도메인)와 백엔드(api 서브도메인)가 서로 다른 출처이므로
+ * 허용 출처를 monomat.cors.allowed-origins(=${CORS_ALLOWED_ORIGINS})로 외부화한다.
+ * REST CORS({@code CorsConfig})와 WebSocket({@code WebSocketConfig})이 모두 이 객체 하나를 참조한다.
+ *
+ * prod 프로파일은 application-prod.properties에서 기본값 없이 ${CORS_ALLOWED_ORIGINS}를 주입하므로,
+ * 값이 비어 있으면 @NotEmpty 검증으로 기동 시점에 실패(fail-fast)한다.
+ */
+@Validated
+@Component
+@ConfigurationProperties(prefix = "monomat.cors")
+public class CorsProperties {
+
+    /**
+     * 허용할 프론트엔드 출처 목록. 콤마로 구분된 값이 바인딩된다.
+     * 예: https://monomat.games,https://www.monomat.games
+     */
+    @NotEmpty
+    private List<String> allowedOrigins = new ArrayList<>();
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/CorsProperties.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/CorsProperties.java
@@ -1,10 +1,12 @@
 package io.github.ascrew.monomatbe.global.config;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,6 +19,10 @@ import java.util.List;
  *
  * prod 프로파일은 application-prod.properties에서 기본값 없이 ${CORS_ALLOWED_ORIGINS}를 주입하므로,
  * 값이 비어 있으면 @NotEmpty 검증으로 기동 시점에 실패(fail-fast)한다.
+ *
+ * 추가로 기동 시점에 각 값을 정확한 Origin(scheme + host, path/와일드카드 없음)으로 강하게 검증한다.
+ * {@code *}나 {@code https://*.monomat.games} 같은 와일드카드는 거부하여 REST({@link CorsConfig},
+ * 정확 매칭)와 WebSocket({@link WebSocketConfig}, 패턴 매칭)의 동작 불일치를 막는다.
  */
 @Validated
 @Component
@@ -36,5 +42,56 @@ public class CorsProperties {
 
     public void setAllowedOrigins(List<String> allowedOrigins) {
         this.allowedOrigins = allowedOrigins;
+    }
+
+    /**
+     * 기동 시점에 허용 출처를 정규화하고 형식을 검증한다.
+     * 양끝 공백을 제거하고 빈 원소(후행 콤마 등)를 걸러낸 뒤, 각 값이 정확한 Origin인지 확인한다.
+     */
+    @PostConstruct
+    void validateAllowedOrigins() {
+        allowedOrigins = allowedOrigins.stream()
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toList();
+
+        if (allowedOrigins.isEmpty()) {
+            throw new IllegalStateException("monomat.cors.allowed-origins must not be empty");
+        }
+
+        allowedOrigins.forEach(CorsProperties::validateOrigin);
+    }
+
+    private static void validateOrigin(String origin) {
+        // *, https://*.monomat.games 등 모든 와일드카드를 거부한다.
+        // WebSocket의 setAllowedOriginPatterns가 패턴으로 해석해 의도보다 넓게 허용하는 것을 막는다.
+        if (origin.contains("*")) {
+            throw new IllegalStateException("Wildcard origin is not allowed: " + origin);
+        }
+
+        URI uri;
+        try {
+            uri = URI.create(origin);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid origin: " + origin, e);
+        }
+
+        if (uri.getScheme() == null || uri.getHost() == null) {
+            throw new IllegalStateException("Origin must include scheme and host: " + origin);
+        }
+
+        if (!"http".equals(uri.getScheme()) && !"https".equals(uri.getScheme())) {
+            throw new IllegalStateException("Origin scheme must be http or https: " + origin);
+        }
+
+        // 브라우저 Origin 헤더에는 path/query/fragment/userinfo가 없다.
+        // 후행 슬래시("/")까지 거부해 setAllowedOrigins에서 조용히 매칭되지 않는 오설정을 막는다.
+        if (uri.getRawPath() != null && !uri.getRawPath().isEmpty()) {
+            throw new IllegalStateException("Origin must not include path: " + origin);
+        }
+
+        if (uri.getRawQuery() != null || uri.getRawFragment() != null || uri.getRawUserInfo() != null) {
+            throw new IllegalStateException("Origin must not include query, fragment, or user info: " + origin);
+        }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigDev.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -26,6 +27,7 @@ public class SecurityConfigDev {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/SecurityConfig/SecurityConfigProd.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -26,6 +27,7 @@ public class SecurityConfigProd {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -17,6 +17,7 @@ package io.github.ascrew.monomatbe.global.config;
 import io.github.ascrew.monomatbe.global.websocket.CustomStompErrorHandler;
 import io.github.ascrew.monomatbe.global.websocket.StompChannelInterceptor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -34,11 +35,15 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final CustomStompErrorHandler customStompErrorHandler;
     private final StompChannelInterceptor stompChannelInterceptor;
 
+    // CORS와 동일한 출처 정책 사용 (monomat.cors.allowed-origins = ${CORS_ALLOWED_ORIGINS})
+    @Value("${monomat.cors.allowed-origins}")
+    private String[] allowedOrigins;
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
                 .addEndpoint("/ws") //최초로 웹소켓 연결을 하기위해 url /ws 지정
-                .setAllowedOriginPatterns("*") //모든 도메인에서 접속을 허용
+                .setAllowedOriginPatterns(allowedOrigins) //허용된 프론트엔드 출처에서만 접속 허용
                 .withSockJS(); //웹소켓 연결 실패시 일반 HTTP통신으로 연결
 
         registry.setErrorHandler(customStompErrorHandler);

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -17,7 +17,6 @@ package io.github.ascrew.monomatbe.global.config;
 import io.github.ascrew.monomatbe.global.websocket.CustomStompErrorHandler;
 import io.github.ascrew.monomatbe.global.websocket.StompChannelInterceptor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -35,15 +34,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final CustomStompErrorHandler customStompErrorHandler;
     private final StompChannelInterceptor stompChannelInterceptor;
 
-    // CORS와 동일한 출처 정책 사용 (monomat.cors.allowed-origins = ${CORS_ALLOWED_ORIGINS})
-    @Value("${monomat.cors.allowed-origins}")
-    private String[] allowedOrigins;
+    // REST CORS와 동일 프로퍼티(monomat.cors.allowed-origins)를 사용한다.
+    // 단 WebSocket은 패턴 기반(setAllowedOriginPatterns)이라 REST의 setAllowedOrigins와 달리
+    // https://*.monomat.games 같은 와일드카드 패턴 값도 그대로 패턴으로 해석된다.
+    private final CorsProperties corsProperties;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
                 .addEndpoint("/ws") //최초로 웹소켓 연결을 하기위해 url /ws 지정
-                .setAllowedOriginPatterns(allowedOrigins) //허용된 프론트엔드 출처에서만 접속 허용
+                .setAllowedOriginPatterns(corsProperties.getAllowedOrigins().toArray(new String[0])) //허용된 프론트엔드 출처에서만 접속 허용
                 .withSockJS(); //웹소켓 연결 실패시 일반 HTTP통신으로 연결
 
         registry.setErrorHandler(customStompErrorHandler);

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/WebSocketConfig.java
@@ -35,8 +35,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final StompChannelInterceptor stompChannelInterceptor;
 
     // REST CORS와 동일 프로퍼티(monomat.cors.allowed-origins)를 사용한다.
-    // 단 WebSocket은 패턴 기반(setAllowedOriginPatterns)이라 REST의 setAllowedOrigins와 달리
-    // https://*.monomat.games 같은 와일드카드 패턴 값도 그대로 패턴으로 해석된다.
+    // WebSocket은 setAllowedOriginPatterns(패턴 기반)를 쓰지만, CorsProperties가 기동 시점에
+    // 와일드카드(*, https://*.monomat.games 등)를 거부하고 정확한 Origin만 통과시키므로
+    // 여기에는 항상 정확한 Origin만 전달되며 REST(setAllowedOrigins, 정확 매칭)와 동작이 일치한다.
     private final CorsProperties corsProperties;
 
     @Override

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -24,6 +24,12 @@ spring.data.redis.host=${OCI_REDIS_HOST}
 spring.data.redis.port=${OCI_REDIS_PORT}
 
 
+# 4-1. CORS 허용 출처 (필수)
+# prod에서는 기본값을 두지 않는다. CORS_ALLOWED_ORIGINS 미설정 시 기동 실패(fail-fast)로
+# 배포 누락을 조기에 차단한다. (예: https://monomat.games,https://www.monomat.games)
+monomat.cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
+
+
 # 5. 로깅 설정
 # Spring Boot 4.x: SQL + 바인딩 파라미터 로그 prod에서는 로그 레벨 최소화
 logging.level.root=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,10 @@ auth.session.cleanup-fixed-delay-ms=${AUTH_SESSION_CLEANUP_FIXED_DELAY_MS:600000
 auth.session.inactive-retention-days=${AUTH_SESSION_INACTIVE_RETENTION_DAYS:7}
 auth.network.trust-forwarded-headers=${AUTH_NETWORK_TRUST_FORWARDED_HEADERS:false}
 
+# CORS 허용 출처 (프론트엔드 도메인). 콤마로 구분.
+# 기본값은 로컬 개발용. prod는 서버 .env의 CORS_ALLOWED_ORIGINS로 주입(예: https://monomat.games,https://www.monomat.games).
+monomat.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:3000}
+
 # YouTube oEmbed 호출 타임아웃 (Spring Boot Duration 형식: 2s, 500ms 등)
 youtube.oembed.connect-timeout=${YOUTUBE_OEMBED_CONNECT_TIMEOUT:2s}
 youtube.oembed.request-timeout=${YOUTUBE_OEMBED_REQUEST_TIMEOUT:5s}

--- a/src/test/java/io/github/ascrew/monomatbe/global/config/CorsPropertiesTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/config/CorsPropertiesTest.java
@@ -1,0 +1,68 @@
+package io.github.ascrew.monomatbe.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CorsPropertiesTest {
+
+    private CorsProperties withOrigins(String... origins) {
+        CorsProperties properties = new CorsProperties();
+        properties.setAllowedOrigins(List.of(origins));
+        return properties;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://monomat.games",
+            "https://www.monomat.games",
+            "http://localhost:5173",
+            "http://localhost:3000"
+    })
+    void validateAllowedOrigins_passesForExactOrigins(String origin) {
+        CorsProperties properties = withOrigins(origin);
+
+        assertThatCode(properties::validateAllowedOrigins).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateAllowedOrigins_normalizesWhitespaceAndBlankElements() {
+        CorsProperties properties = withOrigins("  https://monomat.games  ", "", "   ");
+
+        properties.validateAllowedOrigins();
+
+        assertThat(properties.getAllowedOrigins()).containsExactly("https://monomat.games");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "*",                          // 전체 허용
+            "https://*.monomat.games",    // 서브도메인 와일드카드
+            "monomat.games",              // scheme 없음
+            "https://monomat.games/",     // 후행 슬래시(path)
+            "https://monomat.games/app",  // path 포함
+            "ftp://monomat.games",        // 허용되지 않는 scheme
+            "https://user@monomat.games"  // userinfo 포함
+    })
+    void validateAllowedOrigins_throwsForInvalidOrigins(String origin) {
+        CorsProperties properties = withOrigins(origin);
+
+        assertThatThrownBy(properties::validateAllowedOrigins)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void validateAllowedOrigins_throwsWhenEmptyAfterNormalization() {
+        CorsProperties properties = withOrigins("", "   ");
+
+        assertThatThrownBy(properties::validateAllowedOrigins)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must not be empty");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
- #184

## 📝 Summary
- 프론트엔드(메인 도메인)와 백엔드(`api` 서브도메인) 출처 분리 배포에 대응하기 위해 REST API CORS 설정을 추가했습니다.
- 허용 출처를 `monomat.cors.allowed-origins`(=`${CORS_ALLOWED_ORIGINS}`) 프로퍼티로 외부화했습니다. (dev 기본값=로컬 포트, prod=서버 `.env` 주입)
- `CorsConfigurationSource` 빈(`CorsConfig`)을 추가하고 `SecurityConfigProd` / `SecurityConfigDev`에 `http.cors()`를 연결했습니다.
- WebSocket `allowedOriginPatterns`를 와일드카드(`*`)에서 동일 프로퍼티 기반으로 제한했습니다.

## 🙏PR point
- REST CORS와 WebSocket이 같은 출처 정책(`monomat.cors.allowed-origins`)을 공유하도록 통일했습니다.
- JWT를 Authorization 헤더로 전달하고 쿠키를 사용하지 않으므로 `allowCredentials=false`로 설정했습니다. (추후 쿠키 인증 도입 시 변경 필요)
- ⚠️ 배포 시 서버 `.env`에 `CORS_ALLOWED_ORIGINS=https://monomat.games,https://www.monomat.games` 추가가 필요합니다. (미설정 시 prod 기본값이 localhost로 떨어져 프론트엔드가 차단됩니다.)

## 📬 Reference
- 도메인 구성: 메인 도메인 → 프론트엔드, `api.monomat.games` → 백엔드 (Caddy HTTPS 리버스 프록시)
