### PR TITLE
[Feat/#186] 맵 생성 일괄 API 추가

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -615,6 +615,124 @@ HTTP/1.1 200 OK
 
 ---
 
+### 맵 생성 일괄 API
+
+맵 기본 정보와 문제 목록을 하나의 트랜잭션으로 생성합니다.  
+정식 회원만 사용할 수 있으며, 문제 중 하나라도 검증 또는 저장에 실패하면 맵 생성까지 전체 rollback됩니다.
+
+- Method: `POST`
+- URL: `/api/maps/with-items`
+- Auth: Required
+- Permission: `REGISTERED`
+
+#### Request Body
+
+```json
+{
+  "title": "J-POP 퀴즈",
+  "description": "J-POP 중심 퀴즈 맵",
+  "category": "J-POP",
+  "isPublic": false,
+  "items": [
+    {
+      "orderNum": 1,
+      "youtubeUrl": "https://www.youtube.com/watch?v=video1",
+      "startTime": 30,
+      "endTime": 60,
+      "answers": ["ditto"],
+      "hint": "ㄷㅌ",
+      "hintTime": 15
+    },
+    {
+      "orderNum": 2,
+      "youtubeUrl": "https://www.youtube.com/watch?v=video2",
+      "startTime": 0,
+      "endTime": 30,
+      "answers": ["omg"],
+      "hint": "ㅇㅇㅈ",
+      "hintTime": 15
+    }
+  ]
+}
+````
+
+#### Request Fields
+
+| 필드                   |       타입 | 필수 | 설명                             |
+| -------------------- | -------: | -: | ------------------------------ |
+| `title`              |   string |  O | 맵 제목                           |
+| `description`        |   string |  X | 맵 설명                           |
+| `category`           |   string |  O | 맵 카테고리                         |
+| `isPublic`           |  boolean |  O | 공개 요청 여부                       |
+| `items`              |    array |  O | 생성할 문제 목록                      |
+| `items[].orderNum`   |   number |  O | 문제 순서. 1부터 items 개수까지 중복 없이 지정 |
+| `items[].youtubeUrl` |   string |  O | YouTube URL                    |
+| `items[].startTime`  |   number |  O | 재생 시작 시간, 초 단위                 |
+| `items[].endTime`    |   number |  O | 재생 종료 시간, 초 단위                 |
+| `items[].answers`    | string[] |  O | 정답 목록                          |
+| `items[].hint`       |   string |  O | 힌트                             |
+| `items[].hintTime`   |   number |  X | 힌트 공개 시간. null이면 기본값 15초 적용    |
+
+#### Response 201 Created
+
+```json
+{
+  "map": {
+    "id": 1,
+    "ownerId": 10,
+    "ownerNickname": "owner",
+    "title": "J-POP 퀴즈",
+    "description": "J-POP 중심 퀴즈 맵",
+    "category": "J-POP",
+    "numOfSong": 2,
+    "totalPlayTime": 60,
+    "isPublic": false,
+    "pendingPublic": false,
+    "playCount": 0,
+    "createdAt": "2026-06-07T12:00:00",
+    "updatedAt": "2026-06-07T12:00:00"
+  },
+  "items": [
+    {
+      "id": 10,
+      "mapId": 1,
+      "orderNum": 1,
+      "youtubeUrl": "https://www.youtube.com/watch?v=video1",
+      "videoId": "video1",
+      "startTime": 30,
+      "endTime": 60,
+      "title": "YouTube title 1",
+      "artist": "YouTube author 1",
+      "thumbnailUrl": "https://thumbnail/1",
+      "answers": ["ditto"],
+      "hint": "ㄷㅌ",
+      "hintTime": 15,
+      "createdAt": "2026-06-07T12:00:00",
+      "updatedAt": "2026-06-07T12:00:00"
+    }
+  ]
+}
+```
+
+#### Error Responses
+
+|                       상태 코드 | 상황                                                 |
+| --------------------------: | -------------------------------------------------- |
+|           `400 Bad Request` | 요청 값 검증 실패, 중복 orderNum, orderNum 순서 불연속, 재생 구간 오류 |
+|          `401 Unauthorized` | 미인증                                                |
+|             `403 Forbidden` | 게스트 또는 정식 회원이 아닌 사용자                               |
+|              `409 Conflict` | 맵 최대 문제 수 초과, DB 저장 충돌                             |
+| `500 Internal Server Error` | 예상하지 못한 서버 오류                                      |
+
+#### Transaction Policy
+
+* 맵 기본 정보와 문제 목록은 하나의 트랜잭션으로 저장됩니다.
+* 아이템 중 하나라도 검증 또는 저장에 실패하면 `map`, `map_item` 모두 rollback됩니다.
+* YouTube URL/oEmbed 검증 정책은 기존 문제 생성 API와 동일합니다.
+* 생성 완료 후 `numOfSong`, `totalPlayTime`이 생성된 items 기준으로 반영됩니다.
+
+---
+
 ## 로비 (Lobby)
 
 ### 로비 생성

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/controller/MapController.java
@@ -1,6 +1,8 @@
 package io.github.ascrew.monomatbe.domain.map.controller;
 
 import io.github.ascrew.monomatbe.domain.map.dto.CreateMapRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
@@ -91,6 +93,20 @@ public class MapController {
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
         return ResponseEntity.status(HttpStatus.CREATED).body(mapService.createMap(request, principal));
+    }
+
+    @Operation(
+            summary = "맵 생성 일괄 API",
+            description = "맵 기본 정보와 문제 목록을 하나의 트랜잭션으로 생성합니다. 정식 회원(REGISTERED)만 생성 가능합니다."
+    )
+    @PostMapping("/with-items")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<CreateMapWithItemsResponse> createMapWithItems(
+            @Valid @RequestBody CreateMapWithItemsRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(mapManageService.createMapWithItems(request, principal));
     }
 
     @Operation(summary = "맵 수정", description = "맵 소유자만 수정 가능합니다.")

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapWithItemsItemRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapWithItemsItemRequest.java
@@ -1,0 +1,42 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateMapWithItemsItemRequest(
+        @NotNull(message = "문제 순서는 필수입니다.")
+        @Min(value = 1, message = "문제 순서는 1 이상이어야 합니다.")
+        Integer orderNum,
+
+        @NotBlank(message = "YouTube URL은 비어 있을 수 없습니다.")
+        @Size(max = 500, message = "YouTube URL은 500자를 초과할 수 없습니다.")
+        String youtubeUrl,
+
+        @NotNull(message = "시작 시간은 필수입니다.")
+        @Min(value = 0, message = "시작 시간은 0 이상이어야 합니다.")
+        Integer startTime,
+
+        @NotNull(message = "종료 시간은 필수입니다.")
+        @Min(value = 1, message = "종료 시간은 1 이상이어야 합니다.")
+        Integer endTime,
+
+        @NotNull(message = "정답 목록은 필수입니다.")
+        @Size(min = 1, max = 5, message = "정답은 1개 이상 5개 이하로 입력해야 합니다.")
+        List<@NotBlank(message = "정답 값은 비어 있을 수 없습니다.")
+        @Size(max = 255, message = "정답 값은 255자를 초과할 수 없습니다.")
+                String> answers,
+
+        @NotBlank(message = "힌트는 필수입니다.")
+        @Size(max = 50, message = "힌트는 50자를 초과할 수 없습니다.")
+        String hint,
+
+        @Min(value = 1, message = "힌트 공개 시간은 1초 이상이어야 합니다.")
+        @Max(value = 100, message = "힌트 공개 시간은 100초 이하여야 합니다.")
+        Integer hintTime
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapWithItemsRequest.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapWithItemsRequest.java
@@ -1,0 +1,33 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import io.github.ascrew.monomatbe.domain.map.MapItemPolicy;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateMapWithItemsRequest(
+        @NotBlank(message = "맵 제목은 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "맵 제목은 50자를 초과할 수 없습니다.")
+        String title,
+
+        @Size(max = 255, message = "맵 설명은 255자를 초과할 수 없습니다.")
+        String description,
+
+        @NotNull(message = "카테고리는 비어 있을 수 없습니다.")
+        MapCategory category,
+
+        boolean isPublic,
+
+        @NotNull(message = "문제 목록은 필수입니다.")
+        @Size(
+                min = 1,
+                max = MapItemPolicy.MAX_ITEMS_PER_MAP,
+                message = "문제는 1개 이상 등록할 수 있으며, 한 맵에 등록할 수 있는 문제 수를 초과할 수 없습니다."
+        )
+        List<@Valid CreateMapWithItemsItemRequest> items
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapWithItemsResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/dto/CreateMapWithItemsResponse.java
@@ -1,0 +1,12 @@
+package io.github.ascrew.monomatbe.domain.map.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CreateMapWithItemsResponse(
+        MapDetailResponse map,
+        List<MapItemResponse> items
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPrepareSource.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapItemPrepareSource.java
@@ -1,0 +1,15 @@
+package io.github.ascrew.monomatbe.domain.map.service;
+
+import java.util.List;
+
+record MapItemPrepareSource(
+        Long id,
+        Integer orderNum,
+        String youtubeUrl,
+        Integer startTime,
+        Integer endTime,
+        List<String> answers,
+        String hint,
+        Integer hintTime
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapManageService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapManageService.java
@@ -1,7 +1,12 @@
 package io.github.ascrew.monomatbe.domain.map.service;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.map.MapItemPolicy;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapResponse;
@@ -44,19 +49,23 @@ public class MapManageService {
     private static final String ERROR_NO_VALID_ANSWER = "정답은 최소 1개 이상이어야 합니다.";
     private static final String ERROR_MAP_ITEM_LIMIT_EXCEEDED =
             "한 맵에 등록할 수 있는 문제는 최대 " + MapItemPolicy.MAX_ITEMS_PER_MAP + "개입니다.";
+    private static final String ERROR_USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
 
     private final QuizMapJpaRepository quizMapJpaRepository;
     private final YoutubeValidationService youtubeValidationService;
     private final MapManageTransactionService mapManageTransactionService;
+    private final UserRepository userRepository;
     private final JsonMapper jsonMapper;
 
     public MapManageService(
             QuizMapJpaRepository quizMapJpaRepository,
+            UserRepository userRepository,
             YoutubeValidationService youtubeValidationService,
             MapManageTransactionService mapManageTransactionService,
             @Qualifier("pubSubJsonMapper") JsonMapper jsonMapper
     ) {
         this.quizMapJpaRepository = quizMapJpaRepository;
+        this.userRepository = userRepository;
         this.youtubeValidationService = youtubeValidationService;
         this.mapManageTransactionService = mapManageTransactionService;
         this.jsonMapper = jsonMapper;
@@ -83,6 +92,52 @@ public class MapManageService {
                 principal,
                 preparedItems
         );
+    }
+
+    public CreateMapWithItemsResponse createMapWithItems(
+            CreateMapWithItemsRequest request,
+            CustomPrincipal principal
+    ) {
+        validateRegisteredPrincipal(principal);
+        validateCreateRequest(request);
+
+        User owner = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, ERROR_USER_NOT_FOUND));
+
+        List<PreparedManageItem> preparedItems = prepareItemSources(request.items()
+                .stream()
+                .map(this::toPrepareSource)
+                .toList());
+
+        return mapManageTransactionService.createMapWithItemsInTransaction(
+                owner,
+                request,
+                preparedItems
+        );
+    }
+
+    private void validateCreateRequest(CreateMapWithItemsRequest request) {
+        if (request.items().size() > MapItemPolicy.MAX_ITEMS_PER_MAP) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_MAP_ITEM_LIMIT_EXCEEDED);
+        }
+
+        validateCreateOrderNumbers(request.items());
+    }
+
+    private void validateCreateOrderNumbers(List<CreateMapWithItemsItemRequest> items) {
+        Set<Integer> orderNumbers = new HashSet<>();
+
+        for (CreateMapWithItemsItemRequest item : items) {
+            if (!orderNumbers.add(item.orderNum())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_DUPLICATE_ORDER);
+            }
+        }
+
+        for (int orderNum = 1; orderNum <= items.size(); orderNum++) {
+            if (!orderNumbers.contains(orderNum)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_ORDER_SEQUENCE);
+            }
+        }
     }
 
     private void validateRegisteredPrincipal(CustomPrincipal principal) {
@@ -158,20 +213,52 @@ public class MapManageService {
     }
 
     private List<PreparedManageItem> prepareItems(List<ManageMapItemRequest> items) {
+        return prepareItemSources(items.stream()
+                .map(this::toPrepareSource)
+                .toList());
+    }
+
+    private MapItemPrepareSource toPrepareSource(ManageMapItemRequest item) {
+        return new MapItemPrepareSource(
+                item.id(),
+                item.orderNum(),
+                item.youtubeUrl(),
+                item.startTime(),
+                item.endTime(),
+                item.answers(),
+                item.hint(),
+                item.hintTime()
+        );
+    }
+
+    private MapItemPrepareSource toPrepareSource(CreateMapWithItemsItemRequest item) {
+        return new MapItemPrepareSource(
+                null,
+                item.orderNum(),
+                item.youtubeUrl(),
+                item.startTime(),
+                item.endTime(),
+                item.answers(),
+                item.hint(),
+                item.hintTime()
+        );
+    }
+
+    private List<PreparedManageItem> prepareItemSources(List<MapItemPrepareSource> sources) {
         List<PreparedManageItem> preparedItems = new ArrayList<>();
 
-        for (ManageMapItemRequest item : items) {
-            validateBasicTimeRange(item.startTime(), item.endTime());
+        for (MapItemPrepareSource source : sources) {
+            validateBasicTimeRange(source.startTime(), source.endTime());
 
-            YoutubeMetadata metadata = youtubeValidationService.validateYoutubeUrl(item.youtubeUrl());
-            validateTimeRangeWithinDuration(item.startTime(), item.endTime(), metadata.durationSeconds());
+            YoutubeMetadata metadata = youtubeValidationService.validateYoutubeUrl(source.youtubeUrl());
+            validateTimeRangeWithinDuration(source.startTime(), source.endTime(), metadata.durationSeconds());
 
             preparedItems.add(new PreparedManageItem(
-                    item,
+                    source,
                     metadata,
-                    serializeAnswers(item.answers()),
-                    item.hint().trim(),
-                    item.hintTime() == null ? DEFAULT_HINT_TIME : item.hintTime()
+                    serializeAnswers(source.answers()),
+                    source.hint().trim(),
+                    source.hintTime() == null ? DEFAULT_HINT_TIME : source.hintTime()
             ));
         }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapManageTransactionService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/MapManageTransactionService.java
@@ -1,8 +1,12 @@
 package io.github.ascrew.monomatbe.domain.map.service;
 
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapItemResponse;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
@@ -112,16 +116,16 @@ public class MapManageTransactionService {
             List<MapItem> latestItems = new ArrayList<>();
 
             for (PreparedManageItem preparedItem : preparedItems) {
-                ManageMapItemRequest itemRequest = preparedItem.request();
+                MapItemPrepareSource source = preparedItem.source();
 
-                if (itemRequest.id() == null) {
+                if (source.id() == null) {
                     MapItem saved = mapItemJpaRepository.save(MapItem.builder()
                             .map(quizMap)
-                            .orderNum(itemRequest.orderNum())
-                            .youtubeUrl(itemRequest.youtubeUrl().trim())
+                            .orderNum(source.orderNum())
+                            .youtubeUrl(source.youtubeUrl().trim())
                             .videoId(preparedItem.metadata().videoId())
-                            .startTime(itemRequest.startTime())
-                            .endTime(itemRequest.endTime())
+                            .startTime(source.startTime())
+                            .endTime(source.endTime())
                             .title(preparedItem.metadata().title())
                             .artist(preparedItem.metadata().artist())
                             .thumbnailUrl(preparedItem.metadata().thumbnailUrl())
@@ -134,17 +138,17 @@ public class MapManageTransactionService {
                     continue;
                 }
 
-                MapItem mapItem = activeItemById.get(itemRequest.id());
+                MapItem mapItem = activeItemById.get(source.id());
                 if (mapItem == null) {
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ERROR_INVALID_ITEM_ID);
                 }
 
                 mapItem.update(
-                        itemRequest.orderNum(),
-                        itemRequest.youtubeUrl().trim(),
+                        source.orderNum(),
+                        source.youtubeUrl().trim(),
                         preparedItem.metadata().videoId(),
-                        itemRequest.startTime(),
-                        itemRequest.endTime(),
+                        source.startTime(),
+                        source.endTime(),
                         preparedItem.metadata().title(),
                         preparedItem.metadata().artist(),
                         preparedItem.metadata().thumbnailUrl(),
@@ -174,6 +178,98 @@ public class MapManageTransactionService {
         }
     }
 
+    @Transactional
+    public CreateMapWithItemsResponse createMapWithItemsInTransaction(
+            User owner,
+            CreateMapWithItemsRequest request,
+            List<PreparedManageItem> preparedItems
+    ) {
+        validateCreatePreparedItems(request, preparedItems);
+
+        QuizMap quizMap = quizMapJpaRepository.save(QuizMap.builder()
+                .owner(owner)
+                .title(request.title())
+                .description(request.description())
+                .category(request.category())
+                .numOfSong(0)
+                .totalPlayTime(0)
+                .playCount(0L)
+                .isPublic(false)
+                .pendingPublic(false)
+                .isDeleted(false)
+                .build());
+
+        List<MapItem> savedItems = new ArrayList<>();
+
+        try {
+            for (PreparedManageItem preparedItem : preparedItems) {
+                MapItemPrepareSource source = preparedItem.source();
+
+                MapItem savedItem = mapItemJpaRepository.save(MapItem.builder()
+                        .map(quizMap)
+                        .orderNum(source.orderNum())
+                        .youtubeUrl(source.youtubeUrl().trim())
+                        .videoId(preparedItem.metadata().videoId())
+                        .startTime(source.startTime())
+                        .endTime(source.endTime())
+                        .title(preparedItem.metadata().title())
+                        .artist(preparedItem.metadata().artist())
+                        .thumbnailUrl(preparedItem.metadata().thumbnailUrl())
+                        .answers(preparedItem.answersJson())
+                        .hint(preparedItem.hint())
+                        .hintTime(preparedItem.hintTime())
+                        .isDeleted(false)
+                        .build());
+
+                savedItems.add(savedItem);
+            }
+
+            recalculateMapMetadata(quizMap, preparedItems);
+            applyPublicationChange(quizMap, request.isPublic());
+
+            mapItemJpaRepository.flush();
+
+            savedItems.sort(Comparator.comparing(MapItem::getOrderNum));
+
+            registerCacheEvictionAfterCommit(quizMap.getId());
+
+            return CreateMapWithItemsResponse.builder()
+                    .map(toMapDetailResponse(quizMap))
+                    .items(savedItems.stream().map(this::toMapItemResponse).toList())
+                    .build();
+        } catch (DataIntegrityViolationException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ERROR_DUPLICATE_ACTIVE_ORDER, e);
+        }
+    }
+
+    private void validateCreatePreparedItems(
+            CreateMapWithItemsRequest request,
+            List<PreparedManageItem> preparedItems
+    ) {
+        if (preparedItems == null || request.items().size() != preparedItems.size()) {
+            throw new IllegalStateException(ERROR_INVALID_PREPARED_ITEMS);
+        }
+
+        for (int i = 0; i < request.items().size(); i++) {
+            if (!toPrepareSource(request.items().get(i)).equals(preparedItems.get(i).source())) {
+                throw new IllegalStateException(ERROR_INVALID_PREPARED_ITEMS);
+            }
+        }
+    }
+
+    private MapItemPrepareSource toPrepareSource(CreateMapWithItemsItemRequest item) {
+        return new MapItemPrepareSource(
+                null,
+                item.orderNum(),
+                item.youtubeUrl(),
+                item.startTime(),
+                item.endTime(),
+                item.answers(),
+                item.hint(),
+                item.hintTime()
+        );
+    }
+
     private void validatePreparedItems(
             List<ManageMapItemRequest> requestItems,
             List<PreparedManageItem> preparedItems
@@ -183,10 +279,23 @@ public class MapManageTransactionService {
         }
 
         for (int i = 0; i < requestItems.size(); i++) {
-            if (!requestItems.get(i).equals(preparedItems.get(i).request())) {
+            if (!toPrepareSource(requestItems.get(i)).equals(preparedItems.get(i).source())) {
                 throw new IllegalStateException(ERROR_INVALID_PREPARED_ITEMS);
             }
         }
+    }
+
+    private MapItemPrepareSource toPrepareSource(ManageMapItemRequest item) {
+        return new MapItemPrepareSource(
+                item.id(),
+                item.orderNum(),
+                item.youtubeUrl(),
+                item.startTime(),
+                item.endTime(),
+                item.answers(),
+                item.hint(),
+                item.hintTime()
+        );
     }
 
     private QuizMap getOwnedMapForWriteOrThrow(Long mapId, Long ownerId) {
@@ -248,7 +357,7 @@ public class MapManageTransactionService {
     private void recalculateMapMetadata(QuizMap quizMap, List<PreparedManageItem> preparedItems) {
         int numOfSong = preparedItems.size();
         int totalPlayTime = preparedItems.stream()
-                .map(PreparedManageItem::request)
+                .map(PreparedManageItem::source)
                 .mapToInt(item -> item.endTime() - item.startTime())
                 .sum();
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/map/service/PreparedManageItem.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/map/service/PreparedManageItem.java
@@ -1,10 +1,9 @@
 package io.github.ascrew.monomatbe.domain.map.service;
 
-import io.github.ascrew.monomatbe.domain.map.dto.ManageMapItemRequest;
 import io.github.ascrew.monomatbe.domain.youtube.model.YoutubeMetadata;
 
 record PreparedManageItem(
-        ManageMapItemRequest request,
+        MapItemPrepareSource source,
         YoutubeMetadata metadata,
         String answersJson,
         String hint,

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/controller/MapControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/controller/MapControllerTest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.map.controller;
 
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapItemResponse;
@@ -22,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
@@ -123,6 +125,186 @@ class MapControllerTest {
 
         verify(mapService).getMyMap(100L, principal);
         verify(mapService, never()).getPublicMap(anyLong());
+    }
+
+    @Test
+    void createMapWithItems_withValidRequest_returns201() throws Exception {
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken(principal));
+
+        MapDetailResponse mapResponse = MapDetailResponse.builder()
+                .id(1L)
+                .ownerId(10L)
+                .ownerNickname("owner")
+                .title("J-POP 퀴즈")
+                .description("J-POP 중심 퀴즈 맵")
+                .category(MapCategory.JPOP)
+                .numOfSong(2)
+                .totalPlayTime(60)
+                .isPublic(false)
+                .pendingPublic(false)
+                .playCount(0L)
+                .createdAt(LocalDateTime.of(2026, 6, 7, 12, 0))
+                .updatedAt(LocalDateTime.of(2026, 6, 7, 12, 0))
+                .build();
+
+        MapItemResponse firstItemResponse = MapItemResponse.builder()
+                .id(10L)
+                .mapId(1L)
+                .orderNum(1)
+                .youtubeUrl("https://www.youtube.com/watch?v=video1")
+                .videoId("video1")
+                .startTime(30)
+                .endTime(60)
+                .title("YouTube title 1")
+                .artist("YouTube author 1")
+                .thumbnailUrl("https://thumbnail/1")
+                .answers(List.of("ditto"))
+                .hint("ㄷㅌ")
+                .hintTime(15)
+                .createdAt(LocalDateTime.of(2026, 6, 7, 12, 0))
+                .updatedAt(LocalDateTime.of(2026, 6, 7, 12, 0))
+                .build();
+
+        MapItemResponse secondItemResponse = MapItemResponse.builder()
+                .id(11L)
+                .mapId(1L)
+                .orderNum(2)
+                .youtubeUrl("https://www.youtube.com/watch?v=video2")
+                .videoId("video2")
+                .startTime(0)
+                .endTime(30)
+                .title("YouTube title 2")
+                .artist("YouTube author 2")
+                .thumbnailUrl("https://thumbnail/2")
+                .answers(List.of("omg"))
+                .hint("ㅇㅇㅈ")
+                .hintTime(15)
+                .createdAt(LocalDateTime.of(2026, 6, 7, 12, 0))
+                .updatedAt(LocalDateTime.of(2026, 6, 7, 12, 0))
+                .build();
+
+        CreateMapWithItemsResponse response = CreateMapWithItemsResponse.builder()
+                .map(mapResponse)
+                .items(List.of(firstItemResponse, secondItemResponse))
+                .build();
+
+        when(mapManageService.createMapWithItems(any(), eq(principal))).thenReturn(response);
+
+        mockMvc.perform(post("/api/maps/with-items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "title": "J-POP 퀴즈",
+                              "description": "J-POP 중심 퀴즈 맵",
+                              "category": "J-POP",
+                              "isPublic": false,
+                              "items": [
+                                {
+                                  "orderNum": 1,
+                                  "youtubeUrl": "https://www.youtube.com/watch?v=video1",
+                                  "startTime": 30,
+                                  "endTime": 60,
+                                  "answers": ["ditto"],
+                                  "hint": "ㄷㅌ",
+                                  "hintTime": 15
+                                },
+                                {
+                                  "orderNum": 2,
+                                  "youtubeUrl": "https://www.youtube.com/watch?v=video2",
+                                  "startTime": 0,
+                                  "endTime": 30,
+                                  "answers": ["omg"],
+                                  "hint": "ㅇㅇㅈ",
+                                  "hintTime": 15
+                                }
+                              ]
+                            }
+                            """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.map.id").value(1L))
+                .andExpect(jsonPath("$.map.ownerId").value(10L))
+                .andExpect(jsonPath("$.map.ownerNickname").value("owner"))
+                .andExpect(jsonPath("$.map.title").value("J-POP 퀴즈"))
+                .andExpect(jsonPath("$.map.description").value("J-POP 중심 퀴즈 맵"))
+                .andExpect(jsonPath("$.map.category").value("J-POP"))
+                .andExpect(jsonPath("$.map.numOfSong").value(2))
+                .andExpect(jsonPath("$.map.totalPlayTime").value(60))
+                .andExpect(jsonPath("$.map.isPublic").value(false))
+                .andExpect(jsonPath("$.map.pendingPublic").value(false))
+                .andExpect(jsonPath("$.map.playCount").value(0))
+                .andExpect(jsonPath("$.items[0].id").value(10L))
+                .andExpect(jsonPath("$.items[0].mapId").value(1L))
+                .andExpect(jsonPath("$.items[0].orderNum").value(1))
+                .andExpect(jsonPath("$.items[0].videoId").value("video1"))
+                .andExpect(jsonPath("$.items[0].answers[0]").value("ditto"))
+                .andExpect(jsonPath("$.items[0].hint").value("ㄷㅌ"))
+                .andExpect(jsonPath("$.items[1].id").value(11L))
+                .andExpect(jsonPath("$.items[1].mapId").value(1L))
+                .andExpect(jsonPath("$.items[1].orderNum").value(2))
+                .andExpect(jsonPath("$.items[1].videoId").value("video2"))
+                .andExpect(jsonPath("$.items[1].answers[0]").value("omg"))
+                .andExpect(jsonPath("$.items[1].hint").value("ㅇㅇㅈ"));
+
+        verify(mapManageService).createMapWithItems(any(), eq(principal));
+    }
+
+    @Test
+    void createMapWithItems_invalidRequest_returns400() throws Exception {
+        CustomPrincipal principal = new CustomPrincipal(10L, "u-10", UserType.REGISTERED);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken(principal));
+
+        mockMvc.perform(post("/api/maps/with-items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "title": "",
+                              "description": "J-POP 중심 퀴즈 맵",
+                              "category": "J-POP",
+                              "isPublic": false,
+                              "items": []
+                            }
+                            """))
+                .andExpect(status().isBadRequest());
+
+        verify(mapManageService, never()).createMapWithItems(any(), any());
+    }
+
+    @Test
+    void createMapWithItems_serviceForbidden_returns403() throws Exception {
+        CustomPrincipal principal = new CustomPrincipal(20L, "u-20", UserType.GUEST);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken(principal));
+
+        when(mapManageService.createMapWithItems(any(), eq(principal)))
+                .thenThrow(new ResponseStatusException(
+                        HttpStatus.FORBIDDEN,
+                        "정식 회원만 맵을 관리할 수 있습니다."
+                ));
+
+        mockMvc.perform(post("/api/maps/with-items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "title": "J-POP 퀴즈",
+                              "description": "J-POP 중심 퀴즈 맵",
+                              "category": "J-POP",
+                              "isPublic": false,
+                              "items": [
+                                {
+                                  "orderNum": 1,
+                                  "youtubeUrl": "https://www.youtube.com/watch?v=video1",
+                                  "startTime": 30,
+                                  "endTime": 60,
+                                  "answers": ["ditto"],
+                                  "hint": "ㄷㅌ",
+                                  "hintTime": 15
+                                }
+                              ]
+                            }
+                            """))
+                .andExpect(status().isForbidden());
+
+        verify(mapManageService).createMapWithItems(any(), eq(principal));
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapCreateWithItemsTransactionIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapCreateWithItemsTransactionIntegrationTest.java
@@ -1,0 +1,286 @@
+package io.github.ascrew.monomatbe.domain.map.service;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.User;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsItemRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsRequest;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.MapItemJpaRepository;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
+import io.github.ascrew.monomatbe.domain.youtube.model.YoutubeMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class MapCreateWithItemsTransactionIntegrationTest {
+
+    @Autowired
+    private MapManageTransactionService mapManageTransactionService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private QuizMapJpaRepository quizMapJpaRepository;
+
+    @Autowired
+    private MapItemJpaRepository mapItemJpaRepository;
+
+    private User owner;
+
+    @BeforeEach
+    void setUp() {
+        owner = userRepository.save(User.builder()
+                .username("bulk-owner-" + UUID.randomUUID())
+                .userType(UserType.REGISTERED)
+                .status(UserStatus.ACTIVE)
+                .build());
+    }
+
+    @Test
+    void createMapWithItemsInTransaction_success_persistsMapAndItems() {
+        CreateMapWithItemsItemRequest firstItemRequest = new CreateMapWithItemsItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=video1",
+                30,
+                60,
+                List.of("ditto"),
+                "ㄷㅌ",
+                15
+        );
+        CreateMapWithItemsItemRequest secondItemRequest = new CreateMapWithItemsItemRequest(
+                2,
+                "https://www.youtube.com/watch?v=video2",
+                0,
+                30,
+                List.of("omg"),
+                "ㅇㅇㅈ",
+                15
+        );
+
+        CreateMapWithItemsRequest request = new CreateMapWithItemsRequest(
+                "J-POP 퀴즈",
+                "J-POP 중심 퀴즈 맵",
+                MapCategory.JPOP,
+                false,
+                List.of(firstItemRequest, secondItemRequest)
+        );
+
+        List<PreparedManageItem> preparedItems = List.of(
+                preparedItem(
+                        firstItemRequest,
+                        new YoutubeMetadata(
+                                "video1",
+                                "YouTube title 1",
+                                "YouTube author 1",
+                                "https://thumbnail/1",
+                                null
+                        ),
+                        "[\"ditto\"]"
+                ),
+                preparedItem(
+                        secondItemRequest,
+                        new YoutubeMetadata(
+                                "video2",
+                                "YouTube title 2",
+                                "YouTube author 2",
+                                "https://thumbnail/2",
+                                null
+                        ),
+                        "[\"omg\"]"
+                )
+        );
+
+        var response = mapManageTransactionService.createMapWithItemsInTransaction(
+                owner,
+                request,
+                preparedItems
+        );
+
+        assertThat(response.map().id()).isNotNull();
+        assertThat(response.map().ownerId()).isEqualTo(owner.getId());
+        assertThat(response.map().ownerNickname()).isEqualTo(owner.getUsername());
+        assertThat(response.map().title()).isEqualTo("J-POP 퀴즈");
+        assertThat(response.map().description()).isEqualTo("J-POP 중심 퀴즈 맵");
+        assertThat(response.map().category()).isEqualTo(MapCategory.JPOP);
+        assertThat(response.map().numOfSong()).isEqualTo(2);
+        assertThat(response.map().totalPlayTime()).isEqualTo(60);
+        assertThat(response.map().isPublic()).isFalse();
+        assertThat(response.map().pendingPublic()).isFalse();
+        assertThat(response.map().playCount()).isZero();
+
+        assertThat(response.items()).hasSize(2);
+        assertThat(response.items())
+                .extracting(item -> item.orderNum())
+                .containsExactly(1, 2);
+
+        List<QuizMap> maps = findMapsOwnedBy(owner);
+        assertThat(maps).hasSize(1);
+
+        QuizMap savedMap = maps.get(0);
+        assertThat(savedMap.getOwner().getId()).isEqualTo(owner.getId());
+        assertThat(savedMap.getTitle()).isEqualTo("J-POP 퀴즈");
+        assertThat(savedMap.getDescription()).isEqualTo("J-POP 중심 퀴즈 맵");
+        assertThat(savedMap.getCategory()).isEqualTo(MapCategory.JPOP);
+        assertThat(savedMap.getNumOfSong()).isEqualTo(2);
+        assertThat(savedMap.getTotalPlayTime()).isEqualTo(60);
+        assertThat(savedMap.getIsPublic()).isFalse();
+        assertThat(savedMap.getPendingPublic()).isFalse();
+        assertThat(savedMap.getPlayCount()).isZero();
+
+        List<MapItem> items = findItemsByMaps(maps);
+        assertThat(items).hasSize(2);
+        assertThat(items)
+                .extracting(MapItem::getOrderNum)
+                .containsExactlyInAnyOrder(1, 2);
+        assertThat(items)
+                .extracting(MapItem::getVideoId)
+                .containsExactlyInAnyOrder("video1", "video2");
+    }
+
+    @Test
+    void createMapWithItemsInTransaction_whenItemFlushFails_rollsBackMapAndItems() {
+        CreateMapWithItemsItemRequest firstItemRequest = new CreateMapWithItemsItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=video1",
+                30,
+                60,
+                List.of("ditto"),
+                "ㄷㅌ",
+                15
+        );
+
+        /*
+         * Bean Validation은 Controller 계층에서 수행된다.
+         * 이 테스트는 TransactionService rollback 검증이 목적이므로
+         * 직접 DTO를 생성해 DB NOT NULL 제약 위반을 유도한다.
+         *
+         * orderNum = null
+         * → map_item.order_num NOT NULL 위반
+         * → flush/save 시 DataIntegrityViolationException
+         * → service에서 ResponseStatusException(409) 변환
+         * → @Transactional rollback
+         */
+        CreateMapWithItemsItemRequest invalidSecondItemRequest = new CreateMapWithItemsItemRequest(
+                null,
+                "https://www.youtube.com/watch?v=video2",
+                0,
+                30,
+                List.of("omg"),
+                "ㅇㅇㅈ",
+                15
+        );
+
+        CreateMapWithItemsRequest request = new CreateMapWithItemsRequest(
+                "Rollback 대상 맵",
+                "두 번째 아이템 저장 실패 시 map까지 rollback되어야 함",
+                MapCategory.JPOP,
+                false,
+                List.of(firstItemRequest, invalidSecondItemRequest)
+        );
+
+        List<PreparedManageItem> preparedItems = List.of(
+                preparedItem(
+                        firstItemRequest,
+                        new YoutubeMetadata(
+                                "video1",
+                                "YouTube title 1",
+                                "YouTube author 1",
+                                "https://thumbnail/1",
+                                null
+                        ),
+                        "[\"ditto\"]"
+                ),
+                preparedItem(
+                        invalidSecondItemRequest,
+                        new YoutubeMetadata(
+                                "video2",
+                                "YouTube title 2",
+                                "YouTube author 2",
+                                "https://thumbnail/2",
+                                null
+                        ),
+                        "[\"omg\"]"
+                )
+        );
+
+        assertThatThrownBy(() -> mapManageTransactionService.createMapWithItemsInTransaction(
+                owner,
+                request,
+                preparedItems
+        ))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT));
+
+        List<QuizMap> maps = findMapsOwnedBy(owner);
+        List<MapItem> items = findItemsByMaps(maps);
+
+        assertThat(maps).isEmpty();
+        assertThat(items).isEmpty();
+    }
+
+    private List<QuizMap> findMapsOwnedBy(User owner) {
+        return quizMapJpaRepository.findAll()
+                .stream()
+                .filter(map -> map.getOwner().getId().equals(owner.getId()))
+                .toList();
+    }
+
+    private List<MapItem> findItemsByMaps(List<QuizMap> maps) {
+        Set<Long> mapIds = maps.stream()
+                .map(QuizMap::getId)
+                .collect(Collectors.toSet());
+
+        if (mapIds.isEmpty()) {
+            return List.of();
+        }
+
+        return mapItemJpaRepository.findAll()
+                .stream()
+                .filter(item -> mapIds.contains(item.getMap().getId()))
+                .toList();
+    }
+
+    private PreparedManageItem preparedItem(
+            CreateMapWithItemsItemRequest item,
+            YoutubeMetadata metadata,
+            String answersJson
+    ) {
+        return new PreparedManageItem(
+                toPrepareSource(item),
+                metadata,
+                answersJson,
+                item.hint(),
+                item.hintTime()
+        );
+    }
+
+    private MapItemPrepareSource toPrepareSource(CreateMapWithItemsItemRequest item) {
+        return new MapItemPrepareSource(
+                null,
+                item.orderNum(),
+                item.youtubeUrl(),
+                item.startTime(),
+                item.endTime(),
+                item.answers(),
+                item.hint(),
+                item.hintTime()
+        );
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapManageServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapManageServiceTest.java
@@ -1,5 +1,6 @@
 package io.github.ascrew.monomatbe.domain.map.service;
 
+import io.github.ascrew.monomatbe.domain.auth.repository.UserRepository;
 import io.github.ascrew.monomatbe.domain.auth.entity.User;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
@@ -7,6 +8,8 @@ import io.github.ascrew.monomatbe.domain.map.dto.ManageMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapResponse;
 import io.github.ascrew.monomatbe.domain.map.dto.MapDetailResponse;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsItemRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsRequest;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
@@ -49,6 +52,9 @@ class MapManageServiceTest {
     private MapManageTransactionService mapManageTransactionService;
 
     @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private JsonMapper jsonMapper;
 
     private MapManageService mapManageService;
@@ -57,6 +63,7 @@ class MapManageServiceTest {
     void setUp() {
         mapManageService = new MapManageService(
                 quizMapJpaRepository,
+                userRepository,
                 youtubeValidationService,
                 mapManageTransactionService,
                 jsonMapper
@@ -269,6 +276,36 @@ class MapManageServiceTest {
         verify(mapManageTransactionService, never()).updateManagedMapInTransaction(anyLong(), any(), any(), any());
     }
 
+
+    @Test
+    void createMapWithItems_withoutPrincipal_returns401() {
+        CreateMapWithItemsRequest request = createMapWithItemsRequest();
+
+        assertThatThrownBy(() -> mapManageService.createMapWithItems(request, null))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED))
+                .hasMessageContaining("유효하지 않은 인증 정보입니다.");
+
+        verify(userRepository, never()).findById(anyLong());
+        verify(youtubeValidationService, never()).validateYoutubeUrl(any());
+        verify(mapManageTransactionService, never()).createMapWithItemsInTransaction(any(), any(), any());
+    }
+
+    @Test
+    void createMapWithItems_withGuestPrincipal_returns403() {
+        CreateMapWithItemsRequest request = createMapWithItemsRequest();
+        CustomPrincipal principal = new CustomPrincipal(10L, "guest-10", UserType.GUEST);
+
+        assertThatThrownBy(() -> mapManageService.createMapWithItems(request, principal))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN))
+                .hasMessageContaining("정식 회원만 맵을 관리할 수 있습니다.");
+
+        verify(userRepository, never()).findById(anyLong());
+        verify(youtubeValidationService, never()).validateYoutubeUrl(any());
+        verify(mapManageTransactionService, never()).createMapWithItemsInTransaction(any(), any(), any());
+    }
+
     private ManageMapRequest validEmptyRequest() {
         return new ManageMapRequest(
                 "title",
@@ -303,5 +340,23 @@ class MapManageServiceTest {
                 .pendingPublic(false)
                 .isDeleted(false)
                 .build();
+    }
+
+    private CreateMapWithItemsRequest createMapWithItemsRequest() {
+        return new CreateMapWithItemsRequest(
+                "J-POP 퀴즈",
+                "J-POP 중심 퀴즈 맵",
+                MapCategory.JPOP,
+                false,
+                List.of(new CreateMapWithItemsItemRequest(
+                        1,
+                        "https://www.youtube.com/watch?v=video1",
+                        30,
+                        60,
+                        List.of("ditto"),
+                        "ㄷㅌ",
+                        15
+                ))
+        );
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapManageTransactionServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/map/service/MapManageTransactionServiceTest.java
@@ -5,6 +5,9 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserStatus;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapItemRequest;
 import io.github.ascrew.monomatbe.domain.map.dto.ManageMapRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsItemRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsRequest;
+import io.github.ascrew.monomatbe.domain.map.dto.CreateMapWithItemsResponse;
 import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
 import io.github.ascrew.monomatbe.domain.map.entity.MapItem;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
@@ -16,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import static org.mockito.Mockito.times;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -125,19 +129,15 @@ class MapManageTransactionServiceTest {
         );
 
         List<PreparedManageItem> preparedItems = List.of(
-                new PreparedManageItem(
+                preparedItem(
                         updateItemRequest,
                         new YoutubeMetadata("new1", "YouTube title 1", "YouTube author 1", "https://thumbnail/1", null),
-                        "[\"ditto\"]",
-                        "ㄷㅌ",
-                        15
+                        "[\"ditto\"]"
                 ),
-                new PreparedManageItem(
+                preparedItem(
                         createItemRequest,
                         new YoutubeMetadata("new2", "YouTube title 2", "YouTube author 2", "https://thumbnail/2", null),
-                        "[\"omg\"]",
-                        "ㅇㅇㅈ",
-                        15
+                        "[\"omg\"]"
                 )
         );
 
@@ -223,12 +223,10 @@ class MapManageTransactionServiceTest {
                 1L,
                 request,
                 principal,
-                List.of(new PreparedManageItem(
+                List.of(preparedItem(
                         itemRequest,
                         new YoutubeMetadata("new", "title", "artist", "thumbnail", null),
-                        "[\"new\"]",
-                        "n",
-                        15
+                        "[\"new\"]"
                 ))
         ))
                 .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
@@ -264,12 +262,10 @@ class MapManageTransactionServiceTest {
                 List.of()
         );
 
-        List<PreparedManageItem> preparedItems = List.of(new PreparedManageItem(
+        List<PreparedManageItem> preparedItems = List.of(preparedItem(
                 itemRequest,
                 new YoutubeMetadata("new", "title", "artist", "thumbnail", null),
-                "[\"answer\"]",
-                "hint",
-                15
+                "[\"answer\"]"
         ));
 
         when(quizMapJpaRepository.findOwnedByIdAndIsDeletedFalseForUpdate(1L, 10L))
@@ -372,12 +368,10 @@ class MapManageTransactionServiceTest {
                 1L,
                 request,
                 principal,
-                List.of(new PreparedManageItem(
+                List.of(preparedItem(
                         preparedRequestItem,
                         new YoutubeMetadata("prepared", "title", "artist", "thumbnail", null),
-                        "[\"answer\"]",
-                        "hint",
-                        15
+                        "[\"answer\"]"
                 ))
         ))
                 .isInstanceOf(IllegalStateException.class)
@@ -385,6 +379,302 @@ class MapManageTransactionServiceTest {
 
         verify(quizMapJpaRepository, never()).findOwnedByIdAndIsDeletedFalseForUpdate(anyLong(), anyLong());
         verify(mapItemJpaRepository, never()).setTemporaryOrderNums(anyLong());
+    }
+
+    @Test
+    void createMapWithItemsInTransaction_success_createsMapAndItemsAtomically() {
+        User owner = registeredUser(10L, "owner");
+
+        CreateMapWithItemsItemRequest firstItemRequest = new CreateMapWithItemsItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=video1",
+                30,
+                60,
+                List.of("ditto"),
+                "ㄷㅌ",
+                15
+        );
+        CreateMapWithItemsItemRequest secondItemRequest = new CreateMapWithItemsItemRequest(
+                2,
+                "https://www.youtube.com/watch?v=video2",
+                0,
+                30,
+                List.of("omg"),
+                "ㅇㅇㅈ",
+                15
+        );
+
+        CreateMapWithItemsRequest request = new CreateMapWithItemsRequest(
+                "J-POP 퀴즈",
+                "J-POP 중심 퀴즈 맵",
+                MapCategory.JPOP,
+                false,
+                List.of(firstItemRequest, secondItemRequest)
+        );
+
+        QuizMap savedMap = QuizMap.builder()
+                .id(1L)
+                .owner(owner)
+                .title("J-POP 퀴즈")
+                .description("J-POP 중심 퀴즈 맵")
+                .category(MapCategory.JPOP)
+                .numOfSong(0)
+                .totalPlayTime(0)
+                .playCount(0L)
+                .isPublic(false)
+                .pendingPublic(false)
+                .isDeleted(false)
+                .build();
+
+        MapItem savedFirstItem = MapItem.builder()
+                .id(10L)
+                .map(savedMap)
+                .orderNum(1)
+                .youtubeUrl("https://www.youtube.com/watch?v=video1")
+                .videoId("video1")
+                .startTime(30)
+                .endTime(60)
+                .title("YouTube title 1")
+                .artist("YouTube author 1")
+                .thumbnailUrl("https://thumbnail/1")
+                .answers("[\"ditto\"]")
+                .hint("ㄷㅌ")
+                .hintTime(15)
+                .isDeleted(false)
+                .build();
+
+        MapItem savedSecondItem = MapItem.builder()
+                .id(11L)
+                .map(savedMap)
+                .orderNum(2)
+                .youtubeUrl("https://www.youtube.com/watch?v=video2")
+                .videoId("video2")
+                .startTime(0)
+                .endTime(30)
+                .title("YouTube title 2")
+                .artist("YouTube author 2")
+                .thumbnailUrl("https://thumbnail/2")
+                .answers("[\"omg\"]")
+                .hint("ㅇㅇㅈ")
+                .hintTime(15)
+                .isDeleted(false)
+                .build();
+
+        List<PreparedManageItem> preparedItems = List.of(
+                preparedItem(
+                        firstItemRequest,
+                        new YoutubeMetadata("video1", "YouTube title 1", "YouTube author 1", "https://thumbnail/1", null),
+                        "[\"ditto\"]"
+                ),
+                preparedItem(
+                        secondItemRequest,
+                        new YoutubeMetadata("video2", "YouTube title 2", "YouTube author 2", "https://thumbnail/2", null),
+                        "[\"omg\"]"
+                )
+        );
+
+        when(quizMapJpaRepository.save(any(QuizMap.class))).thenReturn(savedMap);
+        when(mapItemJpaRepository.save(any(MapItem.class)))
+                .thenReturn(savedFirstItem)
+                .thenReturn(savedSecondItem);
+        when(jsonMapper.readValue(eq("[\"ditto\"]"), any(TypeReference.class))).thenReturn(List.of("ditto"));
+        when(jsonMapper.readValue(eq("[\"omg\"]"), any(TypeReference.class))).thenReturn(List.of("omg"));
+
+        CreateMapWithItemsResponse response = mapManageTransactionService.createMapWithItemsInTransaction(
+                owner,
+                request,
+                preparedItems
+        );
+
+        assertThat(response.map().id()).isEqualTo(1L);
+        assertThat(response.map().ownerId()).isEqualTo(10L);
+        assertThat(response.map().ownerNickname()).isEqualTo("owner");
+        assertThat(response.map().title()).isEqualTo("J-POP 퀴즈");
+        assertThat(response.map().description()).isEqualTo("J-POP 중심 퀴즈 맵");
+        assertThat(response.map().category()).isEqualTo(MapCategory.JPOP);
+        assertThat(response.map().numOfSong()).isEqualTo(2);
+        assertThat(response.map().totalPlayTime()).isEqualTo(60);
+        assertThat(response.map().isPublic()).isFalse();
+        assertThat(response.map().pendingPublic()).isFalse();
+        assertThat(response.map().playCount()).isEqualTo(0L);
+
+        assertThat(response.items()).hasSize(2);
+        assertThat(response.items().get(0).id()).isEqualTo(10L);
+        assertThat(response.items().get(0).mapId()).isEqualTo(1L);
+        assertThat(response.items().get(0).orderNum()).isEqualTo(1);
+        assertThat(response.items().get(0).videoId()).isEqualTo("video1");
+        assertThat(response.items().get(0).answers()).containsExactly("ditto");
+
+        assertThat(response.items().get(1).id()).isEqualTo(11L);
+        assertThat(response.items().get(1).mapId()).isEqualTo(1L);
+        assertThat(response.items().get(1).orderNum()).isEqualTo(2);
+        assertThat(response.items().get(1).videoId()).isEqualTo("video2");
+        assertThat(response.items().get(1).answers()).containsExactly("omg");
+
+        assertThat(savedMap.getNumOfSong()).isEqualTo(2);
+        assertThat(savedMap.getTotalPlayTime()).isEqualTo(60);
+
+        verify(quizMapJpaRepository).save(any(QuizMap.class));
+        verify(mapItemJpaRepository, times(2)).save(any(MapItem.class));
+        verify(mapItemJpaRepository).flush();
+        verify(mapCacheEvictor).evictPublicMapCaches(1L);
+    }
+
+    @Test
+    void createMapWithItemsInTransaction_itemSaveFails_returns409AndDoesNotEvictCache() {
+        User owner = registeredUser(10L, "owner");
+
+        CreateMapWithItemsItemRequest firstItemRequest = new CreateMapWithItemsItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=video1",
+                30,
+                60,
+                List.of("ditto"),
+                "ㄷㅌ",
+                15
+        );
+        CreateMapWithItemsItemRequest secondItemRequest = new CreateMapWithItemsItemRequest(
+                2,
+                "https://www.youtube.com/watch?v=video2",
+                0,
+                30,
+                List.of("omg"),
+                "ㅇㅇㅈ",
+                15
+        );
+
+        CreateMapWithItemsRequest request = new CreateMapWithItemsRequest(
+                "J-POP 퀴즈",
+                "J-POP 중심 퀴즈 맵",
+                MapCategory.JPOP,
+                false,
+                List.of(firstItemRequest, secondItemRequest)
+        );
+
+        QuizMap savedMap = QuizMap.builder()
+                .id(1L)
+                .owner(owner)
+                .title("J-POP 퀴즈")
+                .description("J-POP 중심 퀴즈 맵")
+                .category(MapCategory.JPOP)
+                .numOfSong(0)
+                .totalPlayTime(0)
+                .playCount(0L)
+                .isPublic(false)
+                .pendingPublic(false)
+                .isDeleted(false)
+                .build();
+
+        MapItem savedFirstItem = MapItem.builder()
+                .id(10L)
+                .map(savedMap)
+                .orderNum(1)
+                .youtubeUrl("https://www.youtube.com/watch?v=video1")
+                .videoId("video1")
+                .startTime(30)
+                .endTime(60)
+                .title("YouTube title 1")
+                .artist("YouTube author 1")
+                .thumbnailUrl("https://thumbnail/1")
+                .answers("[\"ditto\"]")
+                .hint("ㄷㅌ")
+                .hintTime(15)
+                .isDeleted(false)
+                .build();
+
+        List<PreparedManageItem> preparedItems = List.of(
+                preparedItem(
+                        firstItemRequest,
+                        new YoutubeMetadata("video1", "YouTube title 1", "YouTube author 1", "https://thumbnail/1", null),
+                        "[\"ditto\"]"
+                ),
+                preparedItem(
+                        secondItemRequest,
+                        new YoutubeMetadata("video2", "YouTube title 2", "YouTube author 2", "https://thumbnail/2", null),
+                        "[\"omg\"]"
+                )
+        );
+
+        when(quizMapJpaRepository.save(any(QuizMap.class))).thenReturn(savedMap);
+        when(mapItemJpaRepository.save(any(MapItem.class)))
+                .thenReturn(savedFirstItem)
+                .thenThrow(new DataIntegrityViolationException("item save failed"));
+
+        assertThatThrownBy(() -> mapManageTransactionService.createMapWithItemsInTransaction(
+                owner,
+                request,
+                preparedItems
+        ))
+                .isInstanceOfSatisfying(ResponseStatusException.class, ex ->
+                        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT))
+                .hasMessageContaining("이미 사용 중인 문제 순서입니다.");
+
+        verify(quizMapJpaRepository).save(any(QuizMap.class));
+        verify(mapItemJpaRepository, times(2)).save(any(MapItem.class));
+        verify(mapItemJpaRepository, never()).flush();
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(anyLong());
+    }
+
+    @Test
+    void createMapWithItemsInTransaction_preparedItemsSizeMismatch_throwsIllegalStateException() {
+        CreateMapWithItemsItemRequest itemRequest = new CreateMapWithItemsItemRequest(
+                1,
+                "https://www.youtube.com/watch?v=video1",
+                30,
+                60,
+                List.of("ditto"),
+                "ㄷㅌ",
+                15
+        );
+
+        CreateMapWithItemsRequest request = new CreateMapWithItemsRequest(
+                "J-POP 퀴즈",
+                "J-POP 중심 퀴즈 맵",
+                MapCategory.JPOP,
+                false,
+                List.of(itemRequest)
+        );
+
+        User owner = registeredUser(10L, "owner");
+
+        assertThatThrownBy(() -> mapManageTransactionService.createMapWithItemsInTransaction(
+                owner,
+                request,
+                List.of()
+        ))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("맵 관리 일괄 저장 준비 데이터가 요청 데이터와 일치하지 않습니다.");
+
+        verify(quizMapJpaRepository, never()).save(any(QuizMap.class));
+        verify(mapItemJpaRepository, never()).save(any(MapItem.class));
+        verify(mapCacheEvictor, never()).evictPublicMapCaches(anyLong());
+    }
+
+    private PreparedManageItem preparedItem(
+            ManageMapItemRequest item,
+            YoutubeMetadata metadata,
+            String answersJson
+    ) {
+        return new PreparedManageItem(
+                toPrepareSource(item),
+                metadata,
+                answersJson,
+                item.hint(),
+                item.hintTime()
+        );
+    }
+
+    private MapItemPrepareSource toPrepareSource(ManageMapItemRequest item) {
+        return new MapItemPrepareSource(
+                item.id(),
+                item.orderNum(),
+                item.youtubeUrl(),
+                item.startTime(),
+                item.endTime(),
+                item.answers(),
+                item.hint(),
+                item.hintTime()
+        );
     }
 
     private User registeredUser(Long id, String username) {
@@ -457,5 +747,32 @@ class MapManageTransactionServiceTest {
                 .hintTime(15)
                 .isDeleted(false)
                 .build();
+    }
+
+    private PreparedManageItem preparedItem(
+            CreateMapWithItemsItemRequest item,
+            YoutubeMetadata metadata,
+            String answersJson
+    ) {
+        return new PreparedManageItem(
+                toPrepareSource(item),
+                metadata,
+                answersJson,
+                item.hint(),
+                item.hintTime()
+        );
+    }
+
+    private MapItemPrepareSource toPrepareSource(CreateMapWithItemsItemRequest item) {
+        return new MapItemPrepareSource(
+                null,
+                item.orderNum(),
+                item.youtubeUrl(),
+                item.startTime(),
+                item.endTime(),
+                item.answers(),
+                item.hint(),
+                item.hintTime()
+        );
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- #186

## 📝 Summary

- 맵 기본 정보와 맵 아이템 목록을 하나의 트랜잭션으로 생성하는 `POST /api/maps/with-items` API를 추가했습니다.
- 기존 맵 생성 후 아이템을 순차 생성하던 구조에서 발생할 수 있는 partial failure 상태를 방지하도록 변경했습니다.
- 생성/수정 일괄 저장에서 공통으로 사용할 수 있도록 아이템 준비 로직을 `MapItemPrepareSource`, `PreparedManageItem` 기반으로 정리했습니다.
- 생성 일괄 API에서도 기존 YouTube URL/oEmbed 검증, 재생 구간 검증, 정답 정규화 정책을 동일하게 재사용하도록 구성했습니다.
- 생성 완료 후 `numOfSong`, `totalPlayTime`이 생성된 아이템 기준으로 반영되도록 처리했습니다.
- 생성 성공 후 필요한 맵 캐시 무효화가 커밋 이후 수행되도록 기존 구조를 유지했습니다.
- `API.md`에 신규 생성 일괄 API 요청/응답/에러/트랜잭션 정책을 문서화했습니다.

## 🙏PR point

- 신규 API 경로는 `POST /api/maps/with-items`입니다.
- `PUT /api/maps/{mapId}/manage`는 기존 맵 수정/관리용으로 유지하고, 생성 일괄 API는 별도 DTO와 응답 DTO를 사용하도록 분리했습니다.
- 아이템 중 하나라도 저장에 실패하면 `map`, `map_item` 모두 rollback됩니다.
- 실제 DB rollback 여부는 `MapCreateWithItemsTransactionIntegrationTest`에서 검증했습니다.
- FE는 기존 `POST /api/maps` → `POST /api/maps/{mapId}/items` 반복 호출 대신, 신규 API 한 번으로 맵 생성 플로우를 대체할 수 있습니다.

## 📬 Reference

- 기존 맵 관리 일괄 저장 API: `PUT /api/maps/{mapId}/manage`
- 신규 맵 생성 일괄 API: `POST /api/maps/with-items`