### PR TITLE
[Fix/#195] prod 보안에서 /actuator/health 공개 허용

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/global/security/SecurityEndpoints.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/security/SecurityEndpoints.java
@@ -25,6 +25,9 @@ public final class SecurityEndpoints {
     // 토큰 재발급
     public static final String AUTH_REFRESH = "/api/auth/refresh";
 
+    // 헬스체크 (배포 워크플로/모니터링용. 그 외 actuator 경로는 비공개 유지)
+    public static final String ACTUATOR_HEALTH = "/actuator/health";
+
 
     // Swagger (dev 허용 / prod 차단)
 
@@ -42,7 +45,7 @@ public final class SecurityEndpoints {
      */
     public static String[] publicEndpoints() {
         return new String[] {
-                WS, AUTH_GUEST, AUTH_REGISTER, AUTH_LOGIN, AUTH_REFRESH
+                WS, AUTH_GUEST, AUTH_REGISTER, AUTH_LOGIN, AUTH_REFRESH, ACTUATOR_HEALTH
         };
     }
 


### PR DESCRIPTION
## 📣 Related Issue
- #195

## 📝 Summary
- prod 프로파일에서 `/actuator/health`가 인증에 막혀 **403**을 반환, 배포 워크플로의 헬스체크(`curl -f /actuator/health`)가 실패하는 문제를 수정합니다.
- `SecurityEndpoints.publicEndpoints()`에 `ACTUATOR_HEALTH("/actuator/health")`를 추가하여 dev/prod 공통으로 health만 인증 없이 허용합니다.

## 🙏PR point
- dev는 `.anyRequest().permitAll()`이라 통과되어 그동안 차이가 드러나지 않았고, prod 전환 후 첫 배포에서 발견됐습니다.
- **health 단일 경로만** 공개하며, 그 외 actuator 엔드포인트는 계속 비공개(prod 미노출) 유지합니다.
- 머지 후 develop → main 반영 시 배포 워크플로 헬스체크가 200(UP)으로 통과합니다.

## 📬 Reference
- `SecurityEndpoints`, `SecurityConfigProd` / `SecurityConfigDev`