### PR TITLE
[Feat/#166] 인게임 스킵 투표 · 방장 강제 스킵 · 재생 불가 자동 스킵

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1060,6 +1060,31 @@ Content-Type: application/json
 
 ## 게임 및 인게임 (Game & In-Game)
 
+### 인게임 STOMP 송신/수신 계약
+
+#### 클라이언트 송신
+
+| 목적지 | Payload | 설명 |
+| --- | --- | --- |
+| `SEND /app/game/{code}/chat` | `{ "roundNo": 1, "content": "..." }` | 인게임 일반 채팅, 정답 제출, 스킵 명령(`/k`, `/p`)을 처리합니다. |
+| `SEND /app/game/{code}/ready-to-play` | `{ "roundNo": 1 }` | 라운드 비디오 로딩 완료를 서버에 알립니다. |
+| `SEND /app/game/{code}/playback-error` | `{ "roundNo": 1, "errorCode": "YOUTUBE_REGION_BLOCKED", "message": "..." }` | 클라이언트 재생 불가를 보고합니다. 과반수(`ceil(참가자수/2)`)가 보고하면 해당 라운드를 자동 스킵합니다. |
+
+#### 스킵 명령
+
+- `/k`: 현재 라운드 스킵 투표입니다. 정답자 포함 모든 현재 참가자가 1인 1표로 투표할 수 있으며, 중복 입력은 1표로 유지됩니다.
+- `/p`: 방장만 사용할 수 있는 강제 스킵입니다. 방장이 아닌 사용자의 `/p`는 명령으로 처리하지 않고 기존 채팅/정답 흐름에 따라 처리됩니다.
+- 명령은 메시지를 `trim()`한 결과가 정확히 `/k`, `/p`일 때만 인식합니다.
+- 모든 플레이어가 정답을 맞춰도 더 이상 자동으로 라운드가 종료되지 않습니다.
+
+#### 서버 브로드캐스트
+
+| 구독 경로 | 이벤트 타입 | 설명 |
+| --- | --- | --- |
+| `/topic/game/{code}/round` | `ROUND_SKIP_VOTE` | 스킵 투표 현황입니다. `roundNo`, `votes`, `requiredVotes`, `totalParticipants`를 포함합니다. |
+| `/topic/game/{code}/round` | `ROUND_SKIPPED` | 스킵 투표, 방장 강제 스킵, 재생 오류 과반으로 라운드 종료가 확정되었음을 알립니다. |
+| `/topic/game/{code}/round-end` | `ROUND_END` | 라운드 결과입니다. `endReason`은 `TIMEOUT`, `SKIP_VOTE`, `HOST_SKIP`, `PLAYBACK_ERROR` 중 하나입니다. |
+
 ### 현재 게임 및 라운드 상태 복구 조회
 
 ```http

--- a/docs/API.md
+++ b/docs/API.md
@@ -1068,12 +1068,12 @@ Content-Type: application/json
 | --- | --- | --- |
 | `SEND /app/game/{code}/chat` | `{ "roundNo": 1, "content": "..." }` | 인게임 일반 채팅, 정답 제출, 스킵 명령(`/k`, `/p`)을 처리합니다. |
 | `SEND /app/game/{code}/ready-to-play` | `{ "roundNo": 1 }` | 라운드 비디오 로딩 완료를 서버에 알립니다. |
-| `SEND /app/game/{code}/playback-error` | `{ "roundNo": 1, "errorCode": "YOUTUBE_REGION_BLOCKED", "message": "..." }` | 클라이언트 재생 불가를 보고합니다. 과반수(`ceil(참가자수/2)`)가 보고하면 해당 라운드를 자동 스킵합니다. |
+| `SEND /app/game/{code}/playback-error` | `{ "roundNo": 1, "errorCode": "150", "message": "..." }` | 클라이언트 재생 불가를 보고합니다. YouTube IFrame 오류 코드 `2`, `5`, `100`, `101`, `150`만 집계하며, 기준 도달 시 해당 라운드를 자동 스킵합니다. |
 
 #### 스킵 명령
 
 - `/k`: 현재 라운드 스킵 투표입니다. 정답자 포함 모든 현재 참가자가 1인 1표로 투표할 수 있으며, 중복 입력은 1표로 유지됩니다.
-- `/p`: 방장만 사용할 수 있는 강제 스킵입니다. 방장이 아닌 사용자의 `/p`는 명령으로 처리하지 않고 기존 채팅/정답 흐름에 따라 처리됩니다.
+- `/p`: 방장만 사용할 수 있는 강제 스킵입니다. 방장이 아닌 사용자의 `/p`도 명령으로 소비되지만 라운드 종료나 일반 채팅으로 이어지지 않습니다.
 - 명령은 메시지를 `trim()`한 결과가 정확히 `/k`, `/p`일 때만 인식합니다.
 - 모든 플레이어가 정답을 맞춰도 더 이상 자동으로 라운드가 종료되지 않습니다.
 
@@ -1082,8 +1082,10 @@ Content-Type: application/json
 | 구독 경로 | 이벤트 타입 | 설명 |
 | --- | --- | --- |
 | `/topic/game/{code}/round` | `ROUND_SKIP_VOTE` | 스킵 투표 현황입니다. `roundNo`, `votes`, `requiredVotes`, `totalParticipants`를 포함합니다. |
-| `/topic/game/{code}/round` | `ROUND_SKIPPED` | 스킵 투표, 방장 강제 스킵, 재생 오류 과반으로 라운드 종료가 확정되었음을 알립니다. |
+| `/topic/game/{code}/round` | `ROUND_SKIPPED` | 스킵 투표, 방장 강제 스킵, 재생 오류 기준으로 라운드 종료가 확정되었음을 알립니다. |
 | `/topic/game/{code}/round-end` | `ROUND_END` | 라운드 결과입니다. `endReason`은 `TIMEOUT`, `SKIP_VOTE`, `HOST_SKIP`, `PLAYBACK_ERROR` 중 하나입니다. |
+
+재생 오류 자동 스킵 기준은 참가자 1명 방에서는 1명, 2명 이상 방에서는 `max(2, ceil(참가자수/2))`입니다.
 
 ### 현재 게임 및 라운드 상태 복구 조회
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -570,7 +570,7 @@ KICK:
 ```
 
 - `/p`는 `lobby:{code}` hash의 `host_user_id`와 발신자가 일치할 때만 `endRound(HOST_SKIP)`으로 이어집니다.
-- `SEND /app/game/{code}/playback-error`는 `playback_errors` Set에 보고자를 적재하고, 기준 도달 시 `[MONITORING_REQUIRED]` 로그를 남긴 뒤 `endRound(PLAYBACK_ERROR)`를 호출합니다.
+- `SEND /app/game/{code}/playback-error`는 YouTube IFrame 오류 코드 `2`, `5`, `100`, `101`, `150`만 `playback_errors` Set에 적재하고, 기준 도달 시 `[MONITORING_REQUIRED]` 로그를 남긴 뒤 `endRound(PLAYBACK_ERROR)`를 호출합니다. 기준은 참가자 1명 방에서는 1명, 2명 이상 방에서는 `max(2, ceil(참가자수/2))`입니다.
 - 모든 종료 경로는 `GameRoundEndService.endRound()`의 `ended_lock`을 공유하므로 중복 종료 이벤트가 발생하지 않습니다.
 
 ---
@@ -1123,8 +1123,8 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 #### 2-1) 스킵 투표 및 재생 오류 Fail-over
 - `/k` 스킵 투표는 정답자 포함 모든 현재 참가자가 사용할 수 있고, Redis `skip_votes` Set으로 1인 1표 멱등 처리합니다.
 - 투표 수가 `ceil(참가자수/2)`에 도달하면 `GameRoundEndService.endRound(..., SKIP_VOTE)`를 호출합니다.
-- 방장의 `/p`는 즉시 `endRound(..., HOST_SKIP)`를 호출합니다. 비방장의 `/p`는 명령으로 처리하지 않습니다.
-- FE가 YouTube 지역 제한 등으로 재생 불가를 감지하면 `SEND /app/game/{code}/playback-error`로 보고합니다. 서버는 `playback_errors` Set에 보고자를 적재하고 기준 도달 시 `[MONITORING_REQUIRED]` 로그와 함께 `endRound(..., PLAYBACK_ERROR)`를 호출합니다.
+- 방장의 `/p`는 즉시 `endRound(..., HOST_SKIP)`를 호출합니다. 비방장의 `/p`는 명령으로 소비하되 라운드 종료나 일반 채팅으로 이어지지 않습니다.
+- FE가 YouTube 지역 제한 등으로 재생 불가를 감지하면 `SEND /app/game/{code}/playback-error`로 보고합니다. 서버는 YouTube IFrame 오류 코드 `2`, `5`, `100`, `101`, `150`만 `playback_errors` Set에 보고자를 적재하고, 참가자 1명 방에서는 1명, 2명 이상 방에서는 `max(2, ceil(참가자수/2))` 기준 도달 시 `[MONITORING_REQUIRED]` 로그와 함께 `endRound(..., PLAYBACK_ERROR)`를 호출합니다.
 - 스킵 투표 현황은 `/topic/game/{code}/round`의 `ROUND_SKIP_VOTE`로 브로드캐스트하고, 스킵 종료가 확정되면 같은 채널의 `ROUND_SKIPPED`와 `/topic/game/{code}/round-end`의 `ROUND_END`가 이어집니다.
 
 #### 3) 라운드 종료 결과 노출 및 랭킹 갱신 (핵심 계약)
@@ -1222,4 +1222,3 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 - 2시간 TTL 자동 만료에 의존 (별도 재처리 스케줄러를 두지 않음)
 
 성공 시 `metric:game:session:cleanup:success`를 증가시켜 정리 처리량을 관측한다.
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,13 +242,13 @@ LobbyRepositoryImpl
     └── Redis 저장에 필요한 mapId, mapTitle, mapCategory만 사용
 ```
 
-또한, 인게임 플레이 중에 이루어지는 채팅 및 정답 제출은 대기실/로비를 다루는 `chat` 도메인과의 순환 의존을 방지하기 위해 완전히 격리되어 있습니다. 인게임 채팅 엔드포인트 `/app/game/{code}/chat`은 `game` 도메인의 `GameEventController`가 수용하여 `GameAnswerService`로 직접 제어를 위임합니다.
+또한, 인게임 플레이 중에 이루어지는 채팅, 정답 제출, 스킵 명령, 재생 오류 보고는 대기실/로비를 다루는 `chat` 도메인과의 순환 의존을 방지하기 위해 완전히 격리되어 있습니다. 인게임 채팅 엔드포인트 `/app/game/{code}/chat`과 재생 오류 보고 엔드포인트 `/app/game/{code}/playback-error`는 `game` 도메인의 `GameEventController`가 수용합니다.
 
 ```text
 GameEventController (인게임 채팅 송신 수용)
      │
      ▼
-GameAnswerService (정답 여부 검증 및 라우팅)
+GameAnswerService / GameSkipVoteService (정답 여부 검증 및 스킵 라우팅)
      ├── (최초 정답자) -> Redis 정답자 Set 등록 및 SYSTEM 공지 발행 + 개별 성공 통지(/user/queue/game/answers)
      └── (오답 및 정답자 채팅) -> CHAT 타입 브로드캐스트 (스포일러 방지를 위해 정답 키워드 포함 시 *** 마스킹)
 ```
@@ -552,6 +552,26 @@ KICK:
       │ 2. 마스킹된 일반 채팅 수신 (CHAT 타입)        │
       │◄───────────────────────────────────────────────┤
 ```
+
+#### 3. 스킵 투표 및 재생 오류 Fail-over 흐름 (#166)
+라운드는 더 이상 모든 참가자가 정답을 맞췄다는 이유만으로 자동 종료되지 않습니다. 종료는 타임아웃, 스킵 투표 기준 도달, 방장 강제 스킵, 재생 오류 기준 도달 중 하나로만 발생합니다.
+
+```text
+클라이언트                                      서버
+      │                                         │
+      │ SEND /app/game/{code}/chat "/k"         │
+      ├────────────────────────────────────────►│ skip_votes SADD, 1인 1표
+      │                                         │ ceil(참가자수/2) 도달 여부 확인
+      │ [ROUND_SKIP_VOTE]                       │
+      │◄────────────────────────────────────────┤
+      │                                         │ 기준 도달 시 endRound(SKIP_VOTE)
+      │ [ROUND_SKIPPED] / [ROUND_END]           │
+      │◄────────────────────────────────────────┤
+```
+
+- `/p`는 `lobby:{code}` hash의 `host_user_id`와 발신자가 일치할 때만 `endRound(HOST_SKIP)`으로 이어집니다.
+- `SEND /app/game/{code}/playback-error`는 `playback_errors` Set에 보고자를 적재하고, 기준 도달 시 `[MONITORING_REQUIRED]` 로그를 남긴 뒤 `endRound(PLAYBACK_ERROR)`를 호출합니다.
+- 모든 종료 경로는 `GameRoundEndService.endRound()`의 `ended_lock`을 공유하므로 중복 종료 이벤트가 발생하지 않습니다.
 
 ---
 
@@ -1095,12 +1115,21 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
   - `CHAT`: 일반 사용자의 채팅 내용입니다. 본문 `content`가 `"***"`로 왔다면 이는 **정답을 맞춘 사용자가 정답 키워드를 누설하지 않도록 서버에서 마스킹한 스포일러 방지 본문**이므로, 그대로 화면에 출력합니다.
   - `SYSTEM`: 누군가 새로 정답을 맞췄을 때 브로드캐스트되는 공지입니다. (예: `"닉네임님이 정답을 맞췄습니다!"`)
 - **송신 규칙**: 사용자가 텍스트를 입력하고 전송할 때는 모두 `SEND /app/game/{code}/chat`으로 단일하게 송신합니다.
+- **스킵 명령**: 메시지를 `trim()`한 결과가 정확히 `/k`이면 스킵 투표, 정확히 `/p`이면 방장 강제 스킵 후보로 처리합니다. `/K`, `/ p`, `/p test` 등은 명령이 아닙니다.
 - **개별 결과 수신**: 자신이 제출한 채팅이 정답에 해당할 경우, 서버는 일반 채팅 브로드캐스트를 중단(Drop)하고, 해당 사용자에게 `/user/queue/game/answers` 채널로 개별 정답 성공 통지(`ROUND_CORRECT`)를 보냅니다.
   - 이 통지에는 오타 허용으로 정답 처리되었는지를 알 수 있는 `isFuzzy` 필드가 포함되어 있으므로, FE는 이를 활용하여 사용자에게 "오타 허용 정답!" 같은 전용 연출을 표시할 수 있습니다.
+  - 모든 참가자가 정답을 맞춰도 라운드는 자동 종료되지 않습니다.
+
+#### 2-1) 스킵 투표 및 재생 오류 Fail-over
+- `/k` 스킵 투표는 정답자 포함 모든 현재 참가자가 사용할 수 있고, Redis `skip_votes` Set으로 1인 1표 멱등 처리합니다.
+- 투표 수가 `ceil(참가자수/2)`에 도달하면 `GameRoundEndService.endRound(..., SKIP_VOTE)`를 호출합니다.
+- 방장의 `/p`는 즉시 `endRound(..., HOST_SKIP)`를 호출합니다. 비방장의 `/p`는 명령으로 처리하지 않습니다.
+- FE가 YouTube 지역 제한 등으로 재생 불가를 감지하면 `SEND /app/game/{code}/playback-error`로 보고합니다. 서버는 `playback_errors` Set에 보고자를 적재하고 기준 도달 시 `[MONITORING_REQUIRED]` 로그와 함께 `endRound(..., PLAYBACK_ERROR)`를 호출합니다.
+- 스킵 투표 현황은 `/topic/game/{code}/round`의 `ROUND_SKIP_VOTE`로 브로드캐스트하고, 스킵 종료가 확정되면 같은 채널의 `ROUND_SKIPPED`와 `/topic/game/{code}/round-end`의 `ROUND_END`가 이어집니다.
 
 #### 3) 라운드 종료 결과 노출 및 랭킹 갱신 (핵심 계약)
 - **라운드 종료 수신**: FE는 `/topic/game/{code}/round-end` 채널을 구독하여 라운드 종료 이벤트를 수신합니다.
-  - 이 이벤트는 각 라운드의 제한 시간이 종료되거나 모든 플레이어가 정답을 입력했을 때 서버에 의해 자동으로 트리거됩니다.
+  - 이 이벤트는 각 라운드의 제한 시간이 종료되거나 스킵 투표/방장 강제 스킵/재생 오류 기준 도달 시 서버에 의해 트리거됩니다.
 - **결과 노출 데이터**: 수신된 `RoundMetadataDto`에는 정답 곡 정보(`title`, `artist`, `answer`, `thumbnailUrl`)와 함께 플레이어들의 득점 및 실시간 순위 정보인 `rankings` 리스트가 포함되어 있습니다.
 - **랭킹 및 가점 연출**: `rankings` 리스트 내부의 각 객체는 `PlayerRankingDto` 타입으로, 플레이어의 현재 총점(`score`), 순위(`rank`), 그리고 해당 라운드에서 획득한 가점(`scoreAdded` - 1등 140점, 그 외 정답자 100점, 오답자 0점)을 가지고 있습니다. FE는 `scoreAdded`를 활용하여 "+140" 등 가점 애니메이션을 UI상에 연출하고 랭킹 리스트를 갱신합니다.
 - **자동 전환**: 라운드가 종료된 후 10초간 결과 화면을 노출한 뒤, 서버에 의해 자동으로 다음 라운드가 준비 상태(`ROUND_READY`)로 넘어가게 되므로 FE는 이에 맞춰 인게임 화면으로 복귀하여 비디오 재생 준비 신호를 다시 송신해야 합니다. 마지막 라운드인 경우에는 로비 및 게임 상태가 `FINISHED`로 변경되며 결과화면으로 자동 전환됩니다.
@@ -1144,7 +1173,7 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 - **유예 기간 초과(영구 퇴장) 정책**:
   - 5초 유예 기간 동안 복귀하지 못하면 영구 퇴장으로 판정되어 로비 참여자 목록(`participants`, `order`)에서 최종 제거되고, `{nickname}님이 퇴장하셨습니다.` (type: `LEAVE`) 메시지가 브로드캐스트됩니다.
   - 퇴장 유저의 획득 점수 및 순위 기록은 게임 결과 집계의 신뢰성을 위해 점수판(`game:session:{code}:players` 및 DB)에 그대로 유지됩니다.
-  - 영구 퇴장 처리와 동시에 남은 활성 참여자 중 모든 플레이어가 해당 라운드의 정답을 맞춘 상태가 되면, 라운드를 즉시 조기 종료합니다.
+  - 영구 퇴장 처리 후에는 기존 정답자 수로 라운드를 자동 종료하지 않습니다. 다만 누적된 스킵 투표나 재생 오류 보고가 변경된 참가자 수 기준에 도달하면 라운드를 스킵 종료할 수 있습니다.
   - 퇴장한 유저가 방장인 경우, 다음 순번 참여자에게 방장 권한이 위임됩니다. 로비 내 모든 사용자가 퇴장하여 남은 인원이 0명이 되면 로비는 즉시 폭파되며 인게임 세션 키도 즉시 삭제(deleteNow)됩니다.
 
 ## 게임 세션 Redis 키 정리 정책
@@ -1164,6 +1193,8 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 | `game:session:{code}:round:{n}:correct_players` | Set | 정답자 |
 | `game:session:{code}:round:{n}:correct_times` | Hash | 정답 제출 시각 |
 | `game:session:{code}:round:{n}:ended_lock` | String | 라운드 종료 중복 방지 락 |
+| `game:session:{code}:round:{n}:skip_votes` | Set | 라운드 스킵 투표자 |
+| `game:session:{code}:round:{n}:playback_errors` | Set | 라운드 재생 오류 보고자 |
 
 ### 생명주기와 정리 트리거
 
@@ -1178,7 +1209,7 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 
 ### 정리 메커니즘
 
-- `cleanup_game_session.lua` 단일 스크립트가 base 3종 + 라운드별 6종 키를 **원자적**으로 `DELETE` 또는 `EXPIRE`한다.
+- `cleanup_game_session.lua` 단일 스크립트가 base 3종 + 라운드별 9종 키를 **원자적**으로 `DELETE` 또는 `EXPIRE`한다.
 - 라운드 수는 `total_question_count` 해시 필드(없으면 `:rounds` LLEN)로 판별하고, 모든 하위 키 이름을 `sessionKey`로부터 **결정적으로 조립**한다. → 운영 비용·블로킹 위험이 있는 `SCAN`/`KEYS` 패턴 매칭을 사용하지 않는다.
 - **전제: 단일(standalone) Redis.** 라운드별 키는 KEYS로 선언하지 않고 직접 접근하므로, Redis Cluster 도입 시 `{code}` hash-tag 적용이 필요하다.
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
@@ -1,9 +1,11 @@
 package io.github.ascrew.monomatbe.domain.game.controller;
 
 import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
+import io.github.ascrew.monomatbe.domain.game.dto.PlaybackErrorReportDto;
 import io.github.ascrew.monomatbe.domain.game.dto.ReadyToPlayRequest;
 import io.github.ascrew.monomatbe.domain.game.service.GameAnswerService;
 import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
+import io.github.ascrew.monomatbe.domain.game.service.GameSkipVoteService;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class GameEventController {
 
     private final GameRoundStartService gameRoundStartService;
     private final GameAnswerService gameAnswerService;
+    private final GameSkipVoteService gameSkipVoteService;
 
     @MessageMapping("/game/{code}/ready-to-play")
     public void readyToPlay(
@@ -52,5 +55,24 @@ public class GameEventController {
         }
 
         gameAnswerService.processGameChat(code, principal.userIdentifier(), messageDto);
+    }
+
+    @MessageMapping("/game/{code}/playback-error")
+    public void handlePlaybackError(
+            @DestinationVariable("code") String code,
+            @Payload @Valid PlaybackErrorReportDto request,
+            CustomPrincipal principal) {
+
+        if (principal == null || principal.userIdentifier() == null) {
+            log.warn("GameEventController: 인증 정보 없음 - code: {}", code);
+            return;
+        }
+
+        if (request == null || request.roundNo() == null || request.roundNo() <= 0) {
+            log.warn("GameEventController: 잘못된 playback-error 요청 - code: {}, request: {}", code, request);
+            return;
+        }
+
+        gameSkipVoteService.reportPlaybackError(code, principal.userIdentifier(), request);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventController.java
@@ -6,14 +6,18 @@ import io.github.ascrew.monomatbe.domain.game.dto.ReadyToPlayRequest;
 import io.github.ascrew.monomatbe.domain.game.service.GameAnswerService;
 import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
 import io.github.ascrew.monomatbe.domain.game.service.GameSkipVoteService;
-import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
 
 @Slf4j
 @Controller
@@ -28,9 +32,10 @@ public class GameEventController {
     public void readyToPlay(
             @DestinationVariable("code") String code,
             @Payload ReadyToPlayRequest request,
-            CustomPrincipal principal) {
+            SimpMessageHeaderAccessor accessor) {
         
-        if (principal == null || principal.userIdentifier() == null) {
+        String userIdentifier = extractUserIdentifier(accessor);
+        if (!StringUtils.hasText(userIdentifier)) {
             log.warn("GameEventController: 인증 정보 없음 - code: {}", code);
             return;
         }
@@ -40,30 +45,32 @@ public class GameEventController {
             return;
         }
 
-        gameRoundStartService.processReadyToPlay(code, principal.userIdentifier(), request.roundNo());
+        gameRoundStartService.processReadyToPlay(code, userIdentifier, request.roundNo());
     }
 
     @MessageMapping("/game/{code}/chat")
     public void handleGameChat(
             @DestinationVariable("code") String code,
             @Payload @Valid GameChatMessageDto messageDto,
-            CustomPrincipal principal) {
+            SimpMessageHeaderAccessor accessor) {
 
-        if (principal == null || principal.userIdentifier() == null) {
+        String userIdentifier = extractUserIdentifier(accessor);
+        if (!StringUtils.hasText(userIdentifier)) {
             log.warn("GameEventController: 인증 정보 없음 - code: {}", code);
             return;
         }
 
-        gameAnswerService.processGameChat(code, principal.userIdentifier(), messageDto);
+        gameAnswerService.processGameChat(code, userIdentifier, messageDto);
     }
 
     @MessageMapping("/game/{code}/playback-error")
     public void handlePlaybackError(
             @DestinationVariable("code") String code,
             @Payload @Valid PlaybackErrorReportDto request,
-            CustomPrincipal principal) {
+            SimpMessageHeaderAccessor accessor) {
 
-        if (principal == null || principal.userIdentifier() == null) {
+        String userIdentifier = extractUserIdentifier(accessor);
+        if (!StringUtils.hasText(userIdentifier)) {
             log.warn("GameEventController: 인증 정보 없음 - code: {}", code);
             return;
         }
@@ -73,6 +80,24 @@ public class GameEventController {
             return;
         }
 
-        gameSkipVoteService.reportPlaybackError(code, principal.userIdentifier(), request);
+        gameSkipVoteService.reportPlaybackError(code, userIdentifier, request);
+    }
+
+    private String extractUserIdentifier(SimpMessageHeaderAccessor accessor) {
+        if (accessor == null) {
+            return null;
+        }
+
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            return null;
+        }
+
+        Object value = sessionAttributes.get(WebSocketHeaders.USER_IDENTIFIER);
+        if (value instanceof String userIdentifier && StringUtils.hasText(userIdentifier)) {
+            return userIdentifier;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/PlaybackErrorReportDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/PlaybackErrorReportDto.java
@@ -1,0 +1,19 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 클라이언트 재생 오류 보고 DTO.
+ */
+public record PlaybackErrorReportDto(
+        @NotNull(message = "라운드 번호는 필수입니다.")
+        Integer roundNo,
+
+        @Size(max = 100, message = "오류 코드는 최대 100자까지 전송 가능합니다.")
+        String errorCode,
+
+        @Size(max = 500, message = "오류 메시지는 최대 500자까지 전송 가능합니다.")
+        String message
+) {
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundEndReason.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundEndReason.java
@@ -1,0 +1,11 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+/**
+ * 라운드 종료 원인.
+ */
+public enum RoundEndReason {
+    TIMEOUT,
+    SKIP_VOTE,
+    HOST_SKIP,
+    PLAYBACK_ERROR
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundMetadataDto.java
@@ -16,11 +16,15 @@ public record RoundMetadataDto(
         String thumbnailUrl,
         List<PlayerRankingDto> rankings,
         int waitTimeSeconds,
-        boolean isLastRound
+        boolean isLastRound,
+        RoundEndReason endReason
 ) {
     public RoundMetadataDto {
         if (type == null || !GameEventTypes.ROUND_END.equals(type)) {
             type = GameEventTypes.ROUND_END;
+        }
+        if (endReason == null) {
+            endReason = RoundEndReason.TIMEOUT;
         }
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundSkipVoteDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundSkipVoteDto.java
@@ -1,0 +1,22 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import io.github.ascrew.monomatbe.global.constant.GameEventTypes;
+import lombok.Builder;
+
+/**
+ * 라운드 스킵 투표 현황 브로드캐스트 DTO.
+ */
+@Builder
+public record RoundSkipVoteDto(
+        String type,
+        int roundNo,
+        long votes,
+        long requiredVotes,
+        long totalParticipants
+) {
+    public RoundSkipVoteDto {
+        if (type == null || !GameEventTypes.ROUND_SKIP_VOTE.equals(type)) {
+            type = GameEventTypes.ROUND_SKIP_VOTE;
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundSkippedDto.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/dto/RoundSkippedDto.java
@@ -1,0 +1,20 @@
+package io.github.ascrew.monomatbe.domain.game.dto;
+
+import io.github.ascrew.monomatbe.global.constant.GameEventTypes;
+import lombok.Builder;
+
+/**
+ * 스킵 계열 경로로 라운드 종료 락을 획득했음을 알리는 DTO.
+ */
+@Builder
+public record RoundSkippedDto(
+        String type,
+        int roundNo,
+        RoundEndReason endReason
+) {
+    public RoundSkippedDto {
+        if (type == null || !GameEventTypes.ROUND_SKIPPED.equals(type)) {
+            type = GameEventTypes.ROUND_SKIPPED;
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -41,7 +41,7 @@ public class GameAnswerService {
     private final ChatSenderProfileResolver chatSenderProfileResolver;
     private final JsonMapper jsonMapper;
     private final RedisScript<String> submitGameAnswerScript;
-    private final GameRoundEndService gameRoundEndService;
+    private final GameSkipVoteService gameSkipVoteService;
 
     /**
      * 인게임 전용 채팅 인입 시 정답 여부를 판별하여 처리합니다.
@@ -92,6 +92,15 @@ public class GameAnswerService {
         if (messageDto.roundNo() != currentRoundNo) {
             log.warn("processGameChat: 라운드 번호 불일치 - code: {}, expected: {}, actual: {}", 
                      code, currentRoundNo, messageDto.roundNo());
+            return;
+        }
+
+        String trimmedContent = messageDto.content().trim();
+        if ("/k".equals(trimmedContent)) {
+            gameSkipVoteService.voteSkip(code, userIdentifier, currentRoundNo);
+            return;
+        }
+        if ("/p".equals(trimmedContent) && gameSkipVoteService.forceSkipByHost(code, userIdentifier, currentRoundNo)) {
             return;
         }
 
@@ -199,8 +208,6 @@ public class GameAnswerService {
                 // 정답 달성자 본인에게 개인 축하 응답 전송
                 sendDirectCorrectResponse(userIdentifier, currentRoundNo, isFuzzy);
 
-                // 모든 플레이어가 정답을 맞췄을 경우 라운드 즉시 조기 종료 트리거
-                checkAndTriggerEarlyRoundEnd(code, currentRoundNo, correctPlayersKey);
             } else if ("ALREADY_CORRECT".equals(result)) {
                 broadcastChatMessage(code, userIdentifier, messageDto.content());
             } else if ("TIMEOUT".equals(result) || "ROUND_NOT_STARTED".equals(result) || "ROUND_ALREADY_ENDED".equals(result)) {
@@ -275,18 +282,4 @@ public class GameAnswerService {
                 || messageDto.content().length() > 500;
     }
 
-    private void checkAndTriggerEarlyRoundEnd(String code, int roundNo, String correctPlayersKey) {
-        try {
-            String playersKey = RedisKeys.gameSessionPlayersKey(code);
-            Long totalPlayers = redisTemplate.opsForHash().size(playersKey);
-            Long correctPlayers = redisTemplate.opsForSet().size(correctPlayersKey);
-
-            if (totalPlayers != null && correctPlayers != null && correctPlayers >= totalPlayers && totalPlayers > 0) {
-                log.info("checkAndTriggerEarlyRoundEnd: 모든 플레이어가 정답을 맞췄습니다. 라운드를 즉시 조기 종료합니다. - code: {}, roundNo: {}", code, roundNo);
-                gameRoundEndService.endRound(code, roundNo);
-            }
-        } catch (Exception e) {
-            log.error("checkAndTriggerEarlyRoundEnd: 조기 종료 트리거 처리 중 오류 발생 - code: {}, roundNo: {}", code, roundNo, e);
-        }
-    }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameAnswerService.java
@@ -100,7 +100,11 @@ public class GameAnswerService {
             gameSkipVoteService.voteSkip(code, userIdentifier, currentRoundNo);
             return;
         }
-        if ("/p".equals(trimmedContent) && gameSkipVoteService.forceSkipByHost(code, userIdentifier, currentRoundNo)) {
+        if ("/p".equals(trimmedContent)) {
+            boolean handled = gameSkipVoteService.forceSkipByHost(code, userIdentifier, currentRoundNo);
+            if (!handled) {
+                log.info("비방장 강제 스킵 명령 무시 - code: {}, user: {}", code, userIdentifier);
+            }
             return;
         }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
@@ -21,6 +21,21 @@ public class GameLeaveEventHandler {
 
     @EventListener
     public void handlePlayerLeave(PlayerLeaveEvent event) {
+        try {
+            handlePlayerLeaveSafely(event);
+        } catch (RuntimeException e) {
+            log.warn("인게임 퇴장 후처리 실패 - code: {}, user: {}",
+                    event != null ? event.lobbyCode() : null,
+                    event != null ? event.userIdentifier() : null,
+                    e);
+        }
+    }
+
+    private void handlePlayerLeaveSafely(PlayerLeaveEvent event) {
+        if (event == null) {
+            return;
+        }
+
         String code = event.lobbyCode();
         String userIdentifier = event.userIdentifier();
 
@@ -30,7 +45,16 @@ public class GameLeaveEventHandler {
 
         // 1. 게임 세션 존재 여부 및 status/round_phase 검증
         String sessionKey = RedisKeys.gameSessionKey(code);
-        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of(RedisKeys.FIELD_STATUS, RedisKeys.FIELD_ROUND_PHASE, RedisKeys.FIELD_CURRENT_ROUND_NO));
+        List<Object> hashValues = redisTemplate.opsForHash().multiGet(sessionKey, List.of(
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE,
+                RedisKeys.FIELD_CURRENT_ROUND_NO
+        ));
+        if (hashValues == null || hashValues.size() < 3) {
+            log.warn("게임 세션 상태 조회 실패 - code: {}", code);
+            return;
+        }
+
         String status = (String) hashValues.get(0);
         String roundPhase = (String) hashValues.get(1);
         if (status == null || !"PLAYING".equals(status) || !"PLAYING".equals(roundPhase)) {
@@ -41,8 +65,16 @@ public class GameLeaveEventHandler {
         if (currentRoundNoStr == null) {
             return;
         }
-        int currentRoundNo = Integer.parseInt(currentRoundNoStr);
 
+        int currentRoundNo;
+        try {
+            currentRoundNo = Integer.parseInt(currentRoundNoStr);
+        } catch (NumberFormatException e) {
+            log.warn("현재 라운드 번호 파싱 실패 - code: {}, value: {}", code, currentRoundNoStr);
+            return;
+        }
+
+        gameSkipVoteService.removeParticipantRoundSignals(code, userIdentifier, currentRoundNo);
         gameSkipVoteService.reevaluateSkipThresholds(code, currentRoundNo);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandler.java
@@ -9,9 +9,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Component
@@ -19,7 +17,7 @@ import java.util.Set;
 public class GameLeaveEventHandler {
 
     private final StringRedisTemplate redisTemplate;
-    private final GameRoundEndService gameRoundEndService;
+    private final GameSkipVoteService gameSkipVoteService;
 
     @EventListener
     public void handlePlayerLeave(PlayerLeaveEvent event) {
@@ -45,34 +43,6 @@ public class GameLeaveEventHandler {
         }
         int currentRoundNo = Integer.parseInt(currentRoundNoStr);
 
-        // 2. 남은 참가자가 모두 정답을 맞췄는지 확인
-        String participantsKey = RedisKeys.lobbyParticipantsKey(code);
-        String correctPlayersKey = RedisKeys.gameSessionRoundCorrectPlayersKey(code, currentRoundNo);
-
-        Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
-        if (participants == null || participants.isEmpty()) {
-            return;
-        }
-
-        // 이미 나간 유저는 제외하고 체크해야 하므로, participants에서 현재 나간 userIdentifier는 제외
-        participants.remove(userIdentifier);
-
-        if (participants.isEmpty()) {
-            return;
-        }
-
-        Set<String> correctPlayers = redisTemplate.opsForSet().members(correctPlayersKey);
-        if (correctPlayers == null) {
-            correctPlayers = Collections.emptySet();
-        }
-
-        if (correctPlayers.containsAll(participants)) {
-            log.info("GameLeaveEventHandler: 이탈 발생 후 남은 모든 참가자가 정답을 맞췄습니다. 라운드를 즉시 조기 종료합니다. - code: {}, roundNo: {}", code, currentRoundNo);
-            try {
-                gameRoundEndService.endRound(code, currentRoundNo);
-            } catch (Exception e) {
-                log.error("GameLeaveEventHandler: 이탈 처리 중 라운드 조기 종료 실패 - code: {}, roundNo: {}", code, currentRoundNo, e);
-            }
-        }
+        gameSkipVoteService.reevaluateSkipThresholds(code, currentRoundNo);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRealtimeNotifier.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRealtimeNotifier.java
@@ -1,6 +1,8 @@
 package io.github.ascrew.monomatbe.domain.game.service;
 
 import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundSkipVoteDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundSkippedDto;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
 import io.github.ascrew.monomatbe.global.constant.StompDestinations;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,26 @@ public class GameRealtimeNotifier {
     public void notifyRoundEnd(String lobbyCode, RoundMetadataDto dto) {
         messagingTemplate.convertAndSend(
                 StompDestinations.subscribeGameRoundEnd(lobbyCode),
+                dto
+        );
+    }
+
+    /**
+     * 라운드 스킵 투표 현황을 브로드캐스트합니다.
+     */
+    public void notifyRoundSkipVote(String lobbyCode, RoundSkipVoteDto dto) {
+        messagingTemplate.convertAndSend(
+                StompDestinations.subscribeGameRound(lobbyCode),
+                dto
+        );
+    }
+
+    /**
+     * 스킵 계열 라운드 종료 확정 이벤트를 브로드캐스트합니다.
+     */
+    public void notifyRoundSkipped(String lobbyCode, RoundSkippedDto dto) {
+        messagingTemplate.convertAndSend(
+                StompDestinations.subscribeGameRound(lobbyCode),
                 dto
         );
     }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundEndService.java
@@ -3,7 +3,9 @@ package io.github.ascrew.monomatbe.domain.game.service;
 import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
 import io.github.ascrew.monomatbe.domain.game.dto.PlayerRankingDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundEndReason;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundSkippedDto;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSessionPlayer;
 import io.github.ascrew.monomatbe.domain.game.repository.GameSessionJpaRepository;
@@ -83,6 +85,15 @@ public class GameRoundEndService {
      */
     @Transactional
     public void endRound(String lobbyCode, int roundNo) {
+        endRound(lobbyCode, roundNo, RoundEndReason.TIMEOUT);
+    }
+
+    /**
+     * 특정 라운드를 종료하고 종료 사유를 결과 이벤트에 포함합니다.
+     */
+    @Transactional
+    public void endRound(String lobbyCode, int roundNo, RoundEndReason endReason) {
+        RoundEndReason resolvedEndReason = endReason != null ? endReason : RoundEndReason.TIMEOUT;
         String endedLockKey = RedisKeys.gameSessionRoundEndedLockKey(lobbyCode, roundNo);
         Boolean lockAcquired = redisTemplate.opsForValue().setIfAbsent(endedLockKey, "1", Duration.ofMinutes(5));
 
@@ -234,6 +245,7 @@ public class GameRoundEndService {
                     .rankings(rankings)
                     .waitTimeSeconds(10)
                     .isLastRound(isLastRound)
+                    .endReason(resolvedEndReason)
                     .build();
 
             // 8. 트랜잭션 성공 후 STOMP 브로드캐스트 및 스케줄링 등록
@@ -245,6 +257,7 @@ public class GameRoundEndService {
                     log.info("라운드 종료 트랜잭션 커밋 완료 - Redis 점수 반영 및 브로드캐스트 전송. code: {}, roundNo: {}, isLast: {}", lobbyCode, roundNo, isLastRound);
 
                     syncRedisScoresQuietly(lobbyCode, roundNo, playersKey, scoreAddedMap);
+                    notifyRoundSkippedQuietly(lobbyCode, roundNo, resolvedEndReason);
                     notifyRoundEndQuietly(lobbyCode, roundNo, metadataDto);
 
                     if (isLastRound) {
@@ -275,6 +288,29 @@ public class GameRoundEndService {
             }
             throw t;
         }
+    }
+
+    /** 스킵 계열 라운드 종료 확정 이벤트를 브로드캐스트한다. */
+    private void notifyRoundSkippedQuietly(String lobbyCode, int roundNo, RoundEndReason endReason) {
+        if (!isSkipReason(endReason)) {
+            return;
+        }
+        try {
+            RoundSkippedDto dto = RoundSkippedDto.builder()
+                    .roundNo(roundNo)
+                    .endReason(endReason)
+                    .build();
+            gameRealtimeNotifier.notifyRoundSkipped(lobbyCode, dto);
+        } catch (Exception e) {
+            log.error("ROUND_SKIPPED 브로드캐스트 실패 - code: {}, roundNo: {}, endReason: {}",
+                    lobbyCode, roundNo, endReason, e);
+        }
+    }
+
+    private boolean isSkipReason(RoundEndReason endReason) {
+        return endReason == RoundEndReason.SKIP_VOTE
+                || endReason == RoundEndReason.HOST_SKIP
+                || endReason == RoundEndReason.PLAYBACK_ERROR;
     }
 
     /** Redis 누적 점수(HINCRBY)를 반영한다. 실패해도 이후 후처리 단계 진행에 영향을 주지 않는다. */

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupService.java
@@ -16,7 +16,7 @@ import java.util.List;
  *
  * [책임]
  * cleanup_game_session.lua를 실행하여 하나의 로비 코드에 속한 모든 게임 세션 키를
- * 원자적으로 정리한다. (base 3종 + 라운드별 6종)
+ * 원자적으로 정리한다. (base 3종 + 라운드별 9종)
  *
  * [정리 시점]
  * - 게임 정상 종료      : expireWithGracePeriod() — 300초 짧은 TTL 전환

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCreateService.java
@@ -216,7 +216,7 @@ public class GameSessionCreateService {
                 if (status == STATUS_ROLLED_BACK) {
                     log.warn("DB 트랜잭션 롤백 감지 - Redis 세션 잔여 데이터 정리. code: {}", code);
                     /*
-                     * 통합 정리 스크립트로 base 3종 + 라운드별 6종 키를 원자적으로 삭제한다.
+                     * 통합 정리 스크립트로 base 3종 + 라운드별 9종 키를 원자적으로 삭제한다.
                      * (기존 개별 delete는 ready/playback_lock/correct_times/ended_lock 등을 누락할 수 있었다)
                      */
                     gameSessionCleanupService.deleteNow(code);

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteService.java
@@ -12,7 +12,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * 인게임 라운드 스킵 투표, 방장 강제 스킵, 재생 오류 fail-over를 처리하는 서비스.
@@ -23,6 +26,7 @@ import java.util.List;
 public class GameSkipVoteService {
 
     private static final Duration ROUND_SET_TTL = Duration.ofHours(2);
+    private static final Set<String> SUPPORTED_YOUTUBE_IFRAME_ERROR_CODES = Set.of("2", "5", "100", "101", "150");
 
     private final StringRedisTemplate redisTemplate;
     private final LobbyRepository lobbyRepository;
@@ -40,7 +44,8 @@ public class GameSkipVoteService {
         VoteState voteState = addVoteAndReadState(
                 RedisKeys.gameSessionRoundSkipVotesKey(code, roundNo),
                 userIdentifier,
-                code
+                code,
+                false
         );
         if (voteState.totalParticipants() <= 0) {
             log.warn("스킵 투표 처리 불가 - 참가자 수 없음. code: {}, roundNo: {}", code, roundNo);
@@ -68,7 +73,7 @@ public class GameSkipVoteService {
 
         Object hostUserId = redisTemplate.opsForHash().get(RedisKeys.lobbyKey(code), RedisKeys.FIELD_HOST_USER_ID);
         if (!userIdentifier.equals(hostUserId)) {
-            log.info("비방장 /p 입력 - 명령으로 처리하지 않음. code: {}, user: {}", code, userIdentifier);
+            log.info("비방장 /p 입력 - 라운드 종료 없이 무시. code: {}, user: {}", code, userIdentifier);
             return false;
         }
 
@@ -90,11 +95,17 @@ public class GameSkipVoteService {
         if (!isValidPlayingParticipant(code, userIdentifier, roundNo)) {
             return;
         }
+        if (!isSupportedPlaybackErrorCode(request.errorCode())) {
+            log.warn("재생 오류 보고 무시 - 지원하지 않는 errorCode. code: {}, user: {}, errorCode: {}",
+                    code, userIdentifier, request.errorCode());
+            return;
+        }
 
         VoteState voteState = addVoteAndReadState(
                 RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo),
                 userIdentifier,
-                code
+                code,
+                true
         );
         if (voteState.totalParticipants() <= 0) {
             log.warn("재생 오류 보고 처리 불가 - 참가자 수 없음. code: {}, roundNo: {}", code, roundNo);
@@ -122,7 +133,7 @@ public class GameSkipVoteService {
             return;
         }
 
-        VoteState skipState = readVoteState(RedisKeys.gameSessionRoundSkipVotesKey(code, roundNo), code);
+        VoteState skipState = readVoteState(RedisKeys.gameSessionRoundSkipVotesKey(code, roundNo), code, false);
         if (skipState.reachedThreshold()) {
             log.info("참가자 변경 후 스킵 투표 기준 도달 - code: {}, roundNo: {}, votes: {}, required: {}",
                     code, roundNo, skipState.votes(), skipState.requiredVotes());
@@ -130,7 +141,7 @@ public class GameSkipVoteService {
             return;
         }
 
-        VoteState playbackErrorState = readVoteState(RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo), code);
+        VoteState playbackErrorState = readVoteState(RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo), code, true);
         if (playbackErrorState.reachedThreshold()) {
             log.error("[MONITORING_REQUIRED] 참가자 변경 후 재생 오류 보고 기준 도달로 라운드 자동 스킵 - "
                             + "code: {}, roundNo: {}, reports: {}, required: {}",
@@ -139,18 +150,34 @@ public class GameSkipVoteService {
         }
     }
 
-    private VoteState addVoteAndReadState(String voteKey, String userIdentifier, String code) {
-        redisTemplate.opsForSet().add(voteKey, userIdentifier);
-        redisTemplate.expire(voteKey, ROUND_SET_TTL);
-        return readVoteState(voteKey, code);
+    /**
+     * 퇴장한 참가자의 라운드별 스킵/오류 신호를 제거한다.
+     */
+    public void removeParticipantRoundSignals(String code, String userIdentifier, int roundNo) {
+        if (!StringUtils.hasText(code) || !StringUtils.hasText(userIdentifier) || roundNo <= 0) {
+            return;
+        }
+
+        redisTemplate.opsForSet().remove(RedisKeys.gameSessionRoundSkipVotesKey(code, roundNo), userIdentifier);
+        redisTemplate.opsForSet().remove(RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo), userIdentifier);
     }
 
-    private VoteState readVoteState(String voteKey, String code) {
-        Long votes = redisTemplate.opsForSet().size(voteKey);
-        Long totalParticipants = redisTemplate.opsForSet().size(RedisKeys.lobbyParticipantsKey(code));
-        long total = totalParticipants != null ? totalParticipants : 0L;
-        long required = requiredVotes(total);
-        return new VoteState(votes != null ? votes : 0L, required, total);
+    private VoteState addVoteAndReadState(String voteKey, String userIdentifier, String code, boolean playbackError) {
+        redisTemplate.opsForSet().add(voteKey, userIdentifier);
+        redisTemplate.expire(voteKey, ROUND_SET_TTL);
+        return readVoteState(voteKey, code, playbackError);
+    }
+
+    private VoteState readVoteState(String voteKey, String code, boolean playbackError) {
+        Set<String> participants = redisTemplate.opsForSet().members(RedisKeys.lobbyParticipantsKey(code));
+        Set<String> voteMembers = redisTemplate.opsForSet().members(voteKey);
+        Set<String> activeParticipants = participants != null ? participants : Collections.emptySet();
+        Set<String> activeVotes = new HashSet<>(voteMembers != null ? voteMembers : Collections.emptySet());
+        activeVotes.retainAll(activeParticipants);
+
+        long total = activeParticipants.size();
+        long required = playbackError ? requiredPlaybackErrorReports(total) : requiredVotes(total);
+        return new VoteState(activeVotes.size(), required, total);
     }
 
     private void broadcastSkipVote(String code, int roundNo, VoteState voteState) {
@@ -185,7 +212,7 @@ public class GameSkipVoteService {
                 RedisKeys.FIELD_ROUND_PHASE,
                 RedisKeys.FIELD_CURRENT_ROUND_NO
         ));
-        if (values == null || values.get(0) == null) {
+        if (values == null || values.size() < 3 || values.get(0) == null) {
             log.warn("스킵 처리 무시 - 활성화된 게임 세션이 없음. code: {}", code);
             return false;
         }
@@ -199,7 +226,13 @@ public class GameSkipVoteService {
             return false;
         }
 
-        int currentRoundNo = Integer.parseInt(currentRoundNoStr);
+        int currentRoundNo;
+        try {
+            currentRoundNo = Integer.parseInt(currentRoundNoStr);
+        } catch (NumberFormatException e) {
+            log.warn("스킵 처리 무시 - 현재 라운드 번호 파싱 실패. code: {}, value: {}", code, currentRoundNoStr);
+            return false;
+        }
         if (roundNo != currentRoundNo) {
             log.warn("스킵 처리 무시 - 라운드 번호 불일치. code: {}, expected: {}, actual: {}",
                     code, currentRoundNo, roundNo);
@@ -208,11 +241,22 @@ public class GameSkipVoteService {
         return true;
     }
 
+    private boolean isSupportedPlaybackErrorCode(String errorCode) {
+        return StringUtils.hasText(errorCode) && SUPPORTED_YOUTUBE_IFRAME_ERROR_CODES.contains(errorCode.trim());
+    }
+
     private long requiredVotes(long totalParticipants) {
         if (totalParticipants <= 0) {
             return 0;
         }
         return (totalParticipants + 1) / 2;
+    }
+
+    private long requiredPlaybackErrorReports(long totalParticipants) {
+        if (totalParticipants <= 1) {
+            return totalParticipants;
+        }
+        return Math.max(2, (totalParticipants + 1) / 2);
     }
 
     private record VoteState(long votes, long requiredVotes, long totalParticipants) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteService.java
@@ -41,20 +41,23 @@ public class GameSkipVoteService {
             return;
         }
 
-        VoteState voteState = addVoteAndReadState(
+        VoteResult voteResult = addVoteAndReadState(
                 RedisKeys.gameSessionRoundSkipVotesKey(code, roundNo),
                 userIdentifier,
                 code,
                 false
         );
+        VoteState voteState = voteResult.voteState();
         if (voteState.totalParticipants() <= 0) {
             log.warn("스킵 투표 처리 불가 - 참가자 수 없음. code: {}, roundNo: {}", code, roundNo);
             return;
         }
 
-        broadcastSkipVote(code, roundNo, voteState);
+        if (voteResult.added()) {
+            broadcastSkipVote(code, roundNo, voteState);
+        }
 
-        if (voteState.reachedThreshold()) {
+        if (voteResult.added() && voteState.reachedThreshold()) {
             log.info("스킵 투표 기준 도달 - code: {}, roundNo: {}, votes: {}, required: {}",
                     code, roundNo, voteState.votes(), voteState.requiredVotes());
             gameRoundEndService.endRound(code, roundNo, RoundEndReason.SKIP_VOTE);
@@ -101,18 +104,19 @@ public class GameSkipVoteService {
             return;
         }
 
-        VoteState voteState = addVoteAndReadState(
+        VoteResult voteResult = addVoteAndReadState(
                 RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo),
                 userIdentifier,
                 code,
                 true
         );
+        VoteState voteState = voteResult.voteState();
         if (voteState.totalParticipants() <= 0) {
             log.warn("재생 오류 보고 처리 불가 - 참가자 수 없음. code: {}, roundNo: {}", code, roundNo);
             return;
         }
 
-        if (voteState.reachedThreshold()) {
+        if (voteResult.added() && voteState.reachedThreshold()) {
             log.error("[MONITORING_REQUIRED] 재생 오류 보고 기준 도달로 라운드 자동 스킵 - "
                             + "code: {}, roundNo: {}, reports: {}, required: {}, errorCode: {}, message: {}",
                     code,
@@ -162,10 +166,10 @@ public class GameSkipVoteService {
         redisTemplate.opsForSet().remove(RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo), userIdentifier);
     }
 
-    private VoteState addVoteAndReadState(String voteKey, String userIdentifier, String code, boolean playbackError) {
-        redisTemplate.opsForSet().add(voteKey, userIdentifier);
+    private VoteResult addVoteAndReadState(String voteKey, String userIdentifier, String code, boolean playbackError) {
+        Long added = redisTemplate.opsForSet().add(voteKey, userIdentifier);
         redisTemplate.expire(voteKey, ROUND_SET_TTL);
-        return readVoteState(voteKey, code, playbackError);
+        return new VoteResult(readVoteState(voteKey, code, playbackError), Long.valueOf(1L).equals(added));
     }
 
     private VoteState readVoteState(String voteKey, String code, boolean playbackError) {
@@ -263,5 +267,8 @@ public class GameSkipVoteService {
         boolean reachedThreshold() {
             return totalParticipants > 0 && votes >= requiredVotes;
         }
+    }
+
+    private record VoteResult(VoteState voteState, boolean added) {
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteService.java
@@ -1,0 +1,223 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.PlaybackErrorReportDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundEndReason;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundSkipVoteDto;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * 인게임 라운드 스킵 투표, 방장 강제 스킵, 재생 오류 fail-over를 처리하는 서비스.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameSkipVoteService {
+
+    private static final Duration ROUND_SET_TTL = Duration.ofHours(2);
+
+    private final StringRedisTemplate redisTemplate;
+    private final LobbyRepository lobbyRepository;
+    private final GameRoundEndService gameRoundEndService;
+    private final GameRealtimeNotifier gameRealtimeNotifier;
+
+    /**
+     * 사용자의 스킵 투표를 기록하고 기준 도달 시 라운드를 종료한다.
+     */
+    public void voteSkip(String code, String userIdentifier, int roundNo) {
+        if (!isValidPlayingParticipant(code, userIdentifier, roundNo)) {
+            return;
+        }
+
+        VoteState voteState = addVoteAndReadState(
+                RedisKeys.gameSessionRoundSkipVotesKey(code, roundNo),
+                userIdentifier,
+                code
+        );
+        if (voteState.totalParticipants() <= 0) {
+            log.warn("스킵 투표 처리 불가 - 참가자 수 없음. code: {}, roundNo: {}", code, roundNo);
+            return;
+        }
+
+        broadcastSkipVote(code, roundNo, voteState);
+
+        if (voteState.reachedThreshold()) {
+            log.info("스킵 투표 기준 도달 - code: {}, roundNo: {}, votes: {}, required: {}",
+                    code, roundNo, voteState.votes(), voteState.requiredVotes());
+            gameRoundEndService.endRound(code, roundNo, RoundEndReason.SKIP_VOTE);
+        }
+    }
+
+    /**
+     * 방장 명령이면 즉시 라운드를 종료한다.
+     *
+     * @return 방장 명령으로 처리했으면 true, 비방장이어서 명령으로 처리하지 않았으면 false
+     */
+    public boolean forceSkipByHost(String code, String userIdentifier, int roundNo) {
+        if (!isValidPlayingParticipant(code, userIdentifier, roundNo)) {
+            return true;
+        }
+
+        Object hostUserId = redisTemplate.opsForHash().get(RedisKeys.lobbyKey(code), RedisKeys.FIELD_HOST_USER_ID);
+        if (!userIdentifier.equals(hostUserId)) {
+            log.info("비방장 /p 입력 - 명령으로 처리하지 않음. code: {}, user: {}", code, userIdentifier);
+            return false;
+        }
+
+        log.info("방장 강제 스킵 처리 - code: {}, roundNo: {}, host: {}", code, roundNo, userIdentifier);
+        gameRoundEndService.endRound(code, roundNo, RoundEndReason.HOST_SKIP);
+        return true;
+    }
+
+    /**
+     * 클라이언트 재생 오류 보고를 기록하고 기준 도달 시 fail-over 스킵한다.
+     */
+    public void reportPlaybackError(String code, String userIdentifier, PlaybackErrorReportDto request) {
+        if (request == null || request.roundNo() == null) {
+            log.warn("재생 오류 보고 무시 - 잘못된 요청. code: {}, user: {}", code, userIdentifier);
+            return;
+        }
+
+        int roundNo = request.roundNo();
+        if (!isValidPlayingParticipant(code, userIdentifier, roundNo)) {
+            return;
+        }
+
+        VoteState voteState = addVoteAndReadState(
+                RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo),
+                userIdentifier,
+                code
+        );
+        if (voteState.totalParticipants() <= 0) {
+            log.warn("재생 오류 보고 처리 불가 - 참가자 수 없음. code: {}, roundNo: {}", code, roundNo);
+            return;
+        }
+
+        if (voteState.reachedThreshold()) {
+            log.error("[MONITORING_REQUIRED] 재생 오류 보고 기준 도달로 라운드 자동 스킵 - "
+                            + "code: {}, roundNo: {}, reports: {}, required: {}, errorCode: {}, message: {}",
+                    code,
+                    roundNo,
+                    voteState.votes(),
+                    voteState.requiredVotes(),
+                    request.errorCode(),
+                    request.message());
+            gameRoundEndService.endRound(code, roundNo, RoundEndReason.PLAYBACK_ERROR);
+        }
+    }
+
+    /**
+     * 참가자 퇴장 후 현재 누적된 스킵/오류 보고가 새 참가자 수 기준에 도달했는지 재평가한다.
+     */
+    public void reevaluateSkipThresholds(String code, int roundNo) {
+        if (!hasActivePlayingRound(code, roundNo)) {
+            return;
+        }
+
+        VoteState skipState = readVoteState(RedisKeys.gameSessionRoundSkipVotesKey(code, roundNo), code);
+        if (skipState.reachedThreshold()) {
+            log.info("참가자 변경 후 스킵 투표 기준 도달 - code: {}, roundNo: {}, votes: {}, required: {}",
+                    code, roundNo, skipState.votes(), skipState.requiredVotes());
+            gameRoundEndService.endRound(code, roundNo, RoundEndReason.SKIP_VOTE);
+            return;
+        }
+
+        VoteState playbackErrorState = readVoteState(RedisKeys.gameSessionRoundPlaybackErrorsKey(code, roundNo), code);
+        if (playbackErrorState.reachedThreshold()) {
+            log.error("[MONITORING_REQUIRED] 참가자 변경 후 재생 오류 보고 기준 도달로 라운드 자동 스킵 - "
+                            + "code: {}, roundNo: {}, reports: {}, required: {}",
+                    code, roundNo, playbackErrorState.votes(), playbackErrorState.requiredVotes());
+            gameRoundEndService.endRound(code, roundNo, RoundEndReason.PLAYBACK_ERROR);
+        }
+    }
+
+    private VoteState addVoteAndReadState(String voteKey, String userIdentifier, String code) {
+        redisTemplate.opsForSet().add(voteKey, userIdentifier);
+        redisTemplate.expire(voteKey, ROUND_SET_TTL);
+        return readVoteState(voteKey, code);
+    }
+
+    private VoteState readVoteState(String voteKey, String code) {
+        Long votes = redisTemplate.opsForSet().size(voteKey);
+        Long totalParticipants = redisTemplate.opsForSet().size(RedisKeys.lobbyParticipantsKey(code));
+        long total = totalParticipants != null ? totalParticipants : 0L;
+        long required = requiredVotes(total);
+        return new VoteState(votes != null ? votes : 0L, required, total);
+    }
+
+    private void broadcastSkipVote(String code, int roundNo, VoteState voteState) {
+        RoundSkipVoteDto dto = RoundSkipVoteDto.builder()
+                .roundNo(roundNo)
+                .votes(voteState.votes())
+                .requiredVotes(voteState.requiredVotes())
+                .totalParticipants(voteState.totalParticipants())
+                .build();
+        gameRealtimeNotifier.notifyRoundSkipVote(code, dto);
+    }
+
+    private boolean isValidPlayingParticipant(String code, String userIdentifier, int roundNo) {
+        if (!StringUtils.hasText(code) || !StringUtils.hasText(userIdentifier) || roundNo <= 0) {
+            return false;
+        }
+        if (!lobbyRepository.existsByCode(code)) {
+            log.warn("스킵 처리 무시 - 존재하지 않는 로비. code: {}", code);
+            return false;
+        }
+        if (!lobbyRepository.isParticipant(code, userIdentifier)) {
+            log.warn("스킵 처리 무시 - 로비 참여자가 아님. code: {}, user: {}", code, userIdentifier);
+            return false;
+        }
+        return hasActivePlayingRound(code, roundNo);
+    }
+
+    private boolean hasActivePlayingRound(String code, int roundNo) {
+        String sessionKey = RedisKeys.gameSessionKey(code);
+        List<Object> values = redisTemplate.opsForHash().multiGet(sessionKey, List.of(
+                RedisKeys.FIELD_STATUS,
+                RedisKeys.FIELD_ROUND_PHASE,
+                RedisKeys.FIELD_CURRENT_ROUND_NO
+        ));
+        if (values == null || values.get(0) == null) {
+            log.warn("스킵 처리 무시 - 활성화된 게임 세션이 없음. code: {}", code);
+            return false;
+        }
+
+        String status = (String) values.get(0);
+        String roundPhase = (String) values.get(1);
+        String currentRoundNoStr = (String) values.get(2);
+        if (!"PLAYING".equals(status) || !"PLAYING".equals(roundPhase) || currentRoundNoStr == null) {
+            log.warn("스킵 처리 무시 - 게임 진행 중이 아님. code: {}, status: {}, phase: {}",
+                    code, status, roundPhase);
+            return false;
+        }
+
+        int currentRoundNo = Integer.parseInt(currentRoundNoStr);
+        if (roundNo != currentRoundNo) {
+            log.warn("스킵 처리 무시 - 라운드 번호 불일치. code: {}, expected: {}, actual: {}",
+                    code, currentRoundNo, roundNo);
+            return false;
+        }
+        return true;
+    }
+
+    private long requiredVotes(long totalParticipants) {
+        if (totalParticipants <= 0) {
+            return 0;
+        }
+        return (totalParticipants + 1) / 2;
+    }
+
+    private record VoteState(long votes, long requiredVotes, long totalParticipants) {
+        boolean reachedThreshold() {
+            return totalParticipants > 0 && votes >= requiredVotes;
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/RedisScriptConfig.java
@@ -232,7 +232,7 @@ public class RedisScriptConfig {
      * 게임 세션 Redis 키 통합 정리 Lua 스크립트
      *
      * [처리 내용]
-     * - game:session:{code}* 의 base 3종 + 라운드별 6종 키를 원자적으로 정리
+     * - game:session:{code}* 의 base 3종 + 라운드별 9종 키를 원자적으로 정리
      * - DELETE 모드: 즉시 삭제 (로비 폭파 / 게임 시작 DB 롤백 보상)
      * - EXPIRE 모드: 존재하는 키만 짧은 TTL로 전환 (게임 정상 종료 후 grace period)
      */

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/GameEventTypes.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/GameEventTypes.java
@@ -6,6 +6,8 @@ public final class GameEventTypes {
     public static final String ROUND_PLAYBACK_STARTED = "ROUND_PLAYBACK_STARTED";
     public static final String ROUND_END = "ROUND_END";
     public static final String ROUND_CORRECT = "ROUND_CORRECT";
+    public static final String ROUND_SKIP_VOTE = "ROUND_SKIP_VOTE";
+    public static final String ROUND_SKIPPED = "ROUND_SKIPPED";
 
     private GameEventTypes() {}
 }

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -972,6 +972,28 @@ public final class RedisKeys {
     }
 
     /**
+     * 특정 라운드에서 스킵 투표를 한 유저 식별자 Set 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:skip_votes"
+     */
+    public static String gameSessionRoundSkipVotesKey(String lobbyCode, int roundNo) {
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":skip_votes";
+    }
+
+    /**
+     * 특정 라운드에서 재생 오류를 보고한 유저 식별자 Set 키를 반환합니다.
+     *
+     * @param lobbyCode 로비 초대 코드
+     * @param roundNo 라운드 번호
+     * @return "game:session:{lobbyCode}:round:{roundNo}:playback_errors"
+     */
+    public static String gameSessionRoundPlaybackErrorsKey(String lobbyCode, int roundNo) {
+        return gameSessionBase(lobbyCode) + ":round:" + roundNo + ":playback_errors";
+    }
+
+    /**
      * 특정 라운드의 재생 시작 시각 필드명을 반환합니다.
      *
      * @param roundNo 라운드 번호

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/StompDestinations.java
@@ -108,6 +108,11 @@ public final class StompDestinations {
         return PUBLISH_PREFIX + "/game/" + code + "/ready-to-play";
     }
 
+    /** @return "/app/game/{code}/playback-error" */
+    public static String publishGamePlaybackError(String code) {
+        return PUBLISH_PREFIX + "/game/" + code + "/playback-error";
+    }
+
     /** 인게임 정답 개별 통지 서버 전송용 User Queue 경로 (convertAndSendToUser 인자용) */
     public static final String SERVER_USER_GAME_ANSWERS = "/queue/game/answers";
 

--- a/src/main/resources/scripts/cleanup_game_session.lua
+++ b/src/main/resources/scripts/cleanup_game_session.lua
@@ -4,8 +4,9 @@
 -- [책임]
 -- 하나의 로비 코드에 속한 모든 game:session:{code}* 키를 원자적으로 정리한다.
 --   - base 키 3종      : game:session:{code}, :rounds, :players
---   - 라운드별 키 7종   : :round:{n}:ready, :playback_lock, :data,
---                        :correct_players, :correct_times, :ended_lock, :next_lock
+--   - 라운드별 키 9종   : :round:{n}:ready, :playback_lock, :data,
+--                        :correct_players, :correct_times, :ended_lock, :next_lock,
+--                        :skip_votes, :playback_errors
 --
 -- [정리 모드]
 --   - DELETE : 모든 키 즉시 삭제 (로비 폭파 / 게임 시작 DB 롤백 보상)
@@ -53,9 +54,9 @@ if totalRounds == nil then
     totalRounds = 0
 end
 
--- 정리 대상 키 수집 (base 3종 + 라운드별 7종)
+-- 정리 대상 키 수집 (base 3종 + 라운드별 9종)
 local keys = { sessionKey, roundsKey, playersKey }
-local roundSuffixes = { ':ready', ':playback_lock', ':data', ':correct_players', ':correct_times', ':ended_lock', ':next_lock' }
+local roundSuffixes = { ':ready', ':playback_lock', ':data', ':correct_players', ':correct_times', ':ended_lock', ':next_lock', ':skip_votes', ':playback_errors' }
 for n = 1, totalRounds do
     local roundBase = sessionKey .. ':round:' .. n
     for _, suffix in ipairs(roundSuffixes) do

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventControllerTest.java
@@ -1,17 +1,22 @@
 package io.github.ascrew.monomatbe.domain.game.controller;
 
-import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
 import io.github.ascrew.monomatbe.domain.game.dto.PlaybackErrorReportDto;
+import io.github.ascrew.monomatbe.domain.game.dto.ReadyToPlayRequest;
 import io.github.ascrew.monomatbe.domain.game.service.GameAnswerService;
 import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
 import io.github.ascrew.monomatbe.domain.game.service.GameSkipVoteService;
-import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -35,14 +40,39 @@ class GameEventControllerTest {
     private GameEventController gameEventController;
 
     @Test
+    @DisplayName("ready-to-play 요청은 STOMP 세션의 사용자 식별자와 함께 서비스로 위임한다")
+    void readyToPlayDelegatesToService() {
+        // given
+        ReadyToPlayRequest request = new ReadyToPlayRequest(1);
+
+        // when
+        gameEventController.readyToPlay(LOBBY_CODE, request, accessorWithUserIdentifier());
+
+        // then
+        verify(gameRoundStartService).processReadyToPlay(LOBBY_CODE, USER_IDENTIFIER, 1);
+    }
+
+    @Test
+    @DisplayName("게임 채팅 요청은 STOMP 세션의 사용자 식별자와 함께 서비스로 위임한다")
+    void gameChatDelegatesToService() {
+        // given
+        GameChatMessageDto request = new GameChatMessageDto(1, "/k");
+
+        // when
+        gameEventController.handleGameChat(LOBBY_CODE, request, accessorWithUserIdentifier());
+
+        // then
+        verify(gameAnswerService).processGameChat(LOBBY_CODE, USER_IDENTIFIER, request);
+    }
+
+    @Test
     @DisplayName("playback-error 요청은 인증 사용자의 식별자와 함께 서비스로 위임한다")
     void playbackErrorDelegatesToService() {
         // given
-        CustomPrincipal principal = new CustomPrincipal(1L, USER_IDENTIFIER, UserType.REGISTERED);
         PlaybackErrorReportDto request = new PlaybackErrorReportDto(1, "ERROR", "message");
 
         // when
-        gameEventController.handlePlaybackError(LOBBY_CODE, request, principal);
+        gameEventController.handlePlaybackError(LOBBY_CODE, request, accessorWithUserIdentifier());
 
         // then
         verify(gameSkipVoteService).reportPlaybackError(LOBBY_CODE, USER_IDENTIFIER, request);
@@ -65,13 +95,20 @@ class GameEventControllerTest {
     @DisplayName("playback-error 요청의 roundNo가 유효하지 않으면 서비스로 위임하지 않는다")
     void playbackErrorWithInvalidRoundNoIsIgnored() {
         // given
-        CustomPrincipal principal = new CustomPrincipal(1L, USER_IDENTIFIER, UserType.REGISTERED);
         PlaybackErrorReportDto request = new PlaybackErrorReportDto(0, "ERROR", "message");
 
         // when
-        gameEventController.handlePlaybackError(LOBBY_CODE, request, principal);
+        gameEventController.handlePlaybackError(LOBBY_CODE, request, accessorWithUserIdentifier());
 
         // then
         verify(gameSkipVoteService, never()).reportPlaybackError(LOBBY_CODE, USER_IDENTIFIER, request);
+    }
+
+    private SimpMessageHeaderAccessor accessorWithUserIdentifier() {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(WebSocketHeaders.USER_IDENTIFIER, USER_IDENTIFIER);
+        accessor.setSessionAttributes(attributes);
+        return accessor;
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventControllerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/controller/GameEventControllerTest.java
@@ -1,0 +1,77 @@
+package io.github.ascrew.monomatbe.domain.game.controller;
+
+import io.github.ascrew.monomatbe.domain.auth.entity.UserType;
+import io.github.ascrew.monomatbe.domain.game.dto.PlaybackErrorReportDto;
+import io.github.ascrew.monomatbe.domain.game.service.GameAnswerService;
+import io.github.ascrew.monomatbe.domain.game.service.GameRoundStartService;
+import io.github.ascrew.monomatbe.domain.game.service.GameSkipVoteService;
+import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GameEventControllerTest {
+
+    private static final String LOBBY_CODE = "ABC123";
+    private static final String USER_IDENTIFIER = "user-identifier";
+
+    @Mock
+    private GameRoundStartService gameRoundStartService;
+
+    @Mock
+    private GameAnswerService gameAnswerService;
+
+    @Mock
+    private GameSkipVoteService gameSkipVoteService;
+
+    @InjectMocks
+    private GameEventController gameEventController;
+
+    @Test
+    @DisplayName("playback-error 요청은 인증 사용자의 식별자와 함께 서비스로 위임한다")
+    void playbackErrorDelegatesToService() {
+        // given
+        CustomPrincipal principal = new CustomPrincipal(1L, USER_IDENTIFIER, UserType.REGISTERED);
+        PlaybackErrorReportDto request = new PlaybackErrorReportDto(1, "ERROR", "message");
+
+        // when
+        gameEventController.handlePlaybackError(LOBBY_CODE, request, principal);
+
+        // then
+        verify(gameSkipVoteService).reportPlaybackError(LOBBY_CODE, USER_IDENTIFIER, request);
+    }
+
+    @Test
+    @DisplayName("playback-error 요청에 인증 정보가 없으면 서비스로 위임하지 않는다")
+    void playbackErrorWithoutPrincipalIsIgnored() {
+        // given
+        PlaybackErrorReportDto request = new PlaybackErrorReportDto(1, "ERROR", "message");
+
+        // when
+        gameEventController.handlePlaybackError(LOBBY_CODE, request, null);
+
+        // then
+        verify(gameSkipVoteService, never()).reportPlaybackError(LOBBY_CODE, USER_IDENTIFIER, request);
+    }
+
+    @Test
+    @DisplayName("playback-error 요청의 roundNo가 유효하지 않으면 서비스로 위임하지 않는다")
+    void playbackErrorWithInvalidRoundNoIsIgnored() {
+        // given
+        CustomPrincipal principal = new CustomPrincipal(1L, USER_IDENTIFIER, UserType.REGISTERED);
+        PlaybackErrorReportDto request = new PlaybackErrorReportDto(0, "ERROR", "message");
+
+        // when
+        gameEventController.handlePlaybackError(LOBBY_CODE, request, principal);
+
+        // then
+        verify(gameSkipVoteService, never()).reportPlaybackError(LOBBY_CODE, USER_IDENTIFIER, request);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -58,6 +58,9 @@ class GameChatAnswerIntegrationTest {
     @MockitoBean
     private ChatSenderProfileResolver chatSenderProfileResolver;
 
+    @MockitoBean
+    private GameSkipVoteService gameSkipVoteService;
+
     @BeforeEach
     void setUp() {
         // Mock 기본 셋팅
@@ -84,6 +87,8 @@ class GameChatAnswerIntegrationTest {
         redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundCorrectTimesKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionPlayersKey(LOBBY_CODE));
     }
 
     private void givenGameSession(String status, int currentRoundNo, int timeLimit, Long playbackStartedAt) {
@@ -151,6 +156,88 @@ class GameChatAnswerIntegrationTest {
         // 3. Redis Set에 정답자로 등록 검증
         Boolean isCorrect = redisTemplate.opsForSet().isMember(RedisKeys.gameSessionRoundCorrectPlayersKey(LOBBY_CODE, 1), USER_ID);
         assertThat(isCorrect).isTrue();
+    }
+
+    @Test
+    @DisplayName("전원이 정답을 맞춰도 라운드 종료 락이 생성되지 않는다")
+    void allCorrectDoesNotTriggerEarlyRoundEnd() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        redisTemplate.opsForHash().put(RedisKeys.gameSessionPlayersKey(LOBBY_CODE), USER_ID, "0");
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "다이너마이트");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        assertThat(redisTemplate.hasKey(RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 1))).isFalse();
+    }
+
+    @Test
+    @DisplayName("/k는 스킵 투표로 위임되고 정답/일반 채팅으로 흐르지 않는다")
+    void skipVoteCommandDelegatesAndStopsChatFlow() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "/k");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        verify(gameSkipVoteService).voteSkip(LOBBY_CODE, USER_ID, 1);
+        verify(messagingTemplate, never()).convertAndSend(eq(StompDestinations.subscribeGameChat(LOBBY_CODE)), any(ChatMessageDto.class));
+        verify(messagingTemplate, never()).convertAndSendToUser(anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("방장 /p는 강제 스킵으로 처리되고 정답/일반 채팅으로 흐르지 않는다")
+    void hostForceSkipCommandDelegatesAndStopsChatFlow() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        when(gameSkipVoteService.forceSkipByHost(LOBBY_CODE, USER_ID, 1)).thenReturn(true);
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "/p");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        verify(gameSkipVoteService).forceSkipByHost(LOBBY_CODE, USER_ID, 1);
+        verify(messagingTemplate, never()).convertAndSend(eq(StompDestinations.subscribeGameChat(LOBBY_CODE)), any(ChatMessageDto.class));
+    }
+
+    @Test
+    @DisplayName("비방장 /p는 명령으로 처리하지 않고 기존 채팅 흐름에 태운다")
+    void nonHostForceSkipCommandFallsBackToChatFlow() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        when(gameSkipVoteService.forceSkipByHost(LOBBY_CODE, USER_ID, 1)).thenReturn(false);
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "/p");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        verify(gameSkipVoteService).forceSkipByHost(LOBBY_CODE, USER_ID, 1);
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq(StompDestinations.subscribeGameChat(LOBBY_CODE)), chatCaptor.capture());
+        assertThat(chatCaptor.getValue().getContent()).isEqualTo("/p");
+    }
+
+    @Test
+    @DisplayName("정확히 /k, /p가 아닌 입력은 명령으로 인식하지 않는다")
+    void similarCommandTextIsNotRecognizedAsCommand() {
+        // given
+        givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
+        GameChatMessageDto messageDto = new GameChatMessageDto(1, "/K");
+
+        // when
+        gameAnswerService.processGameChat(LOBBY_CODE, USER_ID, messageDto);
+
+        // then
+        verifyNoInteractions(gameSkipVoteService);
+        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+        verify(messagingTemplate).convertAndSend(eq(StompDestinations.subscribeGameChat(LOBBY_CODE)), chatCaptor.capture());
+        assertThat(chatCaptor.getValue().getContent()).isEqualTo("/K");
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameChatAnswerIntegrationTest.java
@@ -206,8 +206,8 @@ class GameChatAnswerIntegrationTest {
     }
 
     @Test
-    @DisplayName("비방장 /p는 명령으로 처리하지 않고 기존 채팅 흐름에 태운다")
-    void nonHostForceSkipCommandFallsBackToChatFlow() {
+    @DisplayName("비방장 /p는 명령으로 소비되고 일반 채팅으로 흐르지 않는다")
+    void nonHostForceSkipCommandIsConsumed() {
         // given
         givenGameSession("PLAYING", 1, 30, System.currentTimeMillis());
         when(gameSkipVoteService.forceSkipByHost(LOBBY_CODE, USER_ID, 1)).thenReturn(false);
@@ -218,9 +218,8 @@ class GameChatAnswerIntegrationTest {
 
         // then
         verify(gameSkipVoteService).forceSkipByHost(LOBBY_CODE, USER_ID, 1);
-        ArgumentCaptor<ChatMessageDto> chatCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
-        verify(messagingTemplate).convertAndSend(eq(StompDestinations.subscribeGameChat(LOBBY_CODE)), chatCaptor.capture());
-        assertThat(chatCaptor.getValue().getContent()).isEqualTo("/p");
+        verify(messagingTemplate, never()).convertAndSend(eq(StompDestinations.subscribeGameChat(LOBBY_CODE)), any(ChatMessageDto.class));
+        verify(messagingTemplate, never()).convertAndSendToUser(anyString(), anyString(), any());
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameLeaveEventHandlerTest.java
@@ -1,0 +1,93 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GameLeaveEventHandlerTest {
+
+    private static final String LOBBY_CODE = "LEAVE1";
+    private static final String USER_IDENTIFIER = "user-1";
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    @Mock
+    private GameSkipVoteService gameSkipVoteService;
+
+    private GameLeaveEventHandler gameLeaveEventHandler;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        gameLeaveEventHandler = new GameLeaveEventHandler(redisTemplate, gameSkipVoteService);
+    }
+
+    @Test
+    @DisplayName("퇴장 이벤트 처리 시 라운드 스킵 신호를 제거한 뒤 기준을 재평가한다")
+    void playerLeaveRemovesRoundSignalsBeforeReevaluation() {
+        // given
+        givenSessionValues(List.of("PLAYING", "PLAYING", "2"));
+
+        // when
+        gameLeaveEventHandler.handlePlayerLeave(new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER));
+
+        // then
+        verify(gameSkipVoteService).removeParticipantRoundSignals(LOBBY_CODE, USER_IDENTIFIER, 2);
+        verify(gameSkipVoteService).reevaluateSkipThresholds(LOBBY_CODE, 2);
+    }
+
+    @Test
+    @DisplayName("multiGet 결과가 부족하면 후처리를 건너뛴다")
+    void invalidHashValuesAreIgnored() {
+        // given
+        givenSessionValues(List.of("PLAYING"));
+
+        // when
+        gameLeaveEventHandler.handlePlayerLeave(new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER));
+
+        // then
+        verify(gameSkipVoteService, never()).removeParticipantRoundSignals(anyString(), anyString(), anyInt());
+        verify(gameSkipVoteService, never()).reevaluateSkipThresholds(anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("현재 라운드 번호 파싱 실패 시 후처리를 건너뛴다")
+    void invalidRoundNoIsIgnored() {
+        // given
+        givenSessionValues(List.of("PLAYING", "PLAYING", "not-number"));
+
+        // when
+        gameLeaveEventHandler.handlePlayerLeave(new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER));
+
+        // then
+        verify(gameSkipVoteService, never()).removeParticipantRoundSignals(anyString(), anyString(), anyInt());
+        verify(gameSkipVoteService, never()).reevaluateSkipThresholds(anyString(), anyInt());
+    }
+
+    private void givenSessionValues(List<Object> values) {
+        when(hashOperations.multiGet(
+                RedisKeys.gameSessionKey(LOBBY_CODE),
+                List.of(RedisKeys.FIELD_STATUS, RedisKeys.FIELD_ROUND_PHASE, RedisKeys.FIELD_CURRENT_ROUND_NO)
+        )).thenReturn(values);
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -351,6 +351,35 @@ class GameRoundProgressIntegrationTest {
     }
 
     @Test
+    @DisplayName("플레이어 이탈 시 현재 라운드의 스킵 투표와 재생 오류 보고에서 이탈자를 제거한다")
+    void playerLeaveRemovesRoundSkipSignals() {
+        // given
+        String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
+        redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, "round_phase", "PLAYING");
+        redisTemplate.opsForHash().put(sessionKey, "current_round_no", "1");
+
+        String participantsKey = RedisKeys.lobbyParticipantsKey(LOBBY_CODE);
+        redisTemplate.opsForSet().add(participantsKey, USER_ID_1, USER_ID_2, "remaining-player");
+
+        String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, 1);
+        String playbackErrorsKey = RedisKeys.gameSessionRoundPlaybackErrorsKey(LOBBY_CODE, 1);
+        redisTemplate.opsForSet().add(skipVotesKey, USER_ID_1, USER_ID_3);
+        redisTemplate.opsForSet().add(playbackErrorsKey, USER_ID_2, USER_ID_3);
+
+        PlayerLeaveEvent leaveEvent = new PlayerLeaveEvent(LOBBY_CODE, USER_ID_3);
+
+        // when
+        gameLeaveEventHandler.handlePlayerLeave(leaveEvent);
+
+        // then
+        assertThat(redisTemplate.opsForSet().isMember(skipVotesKey, USER_ID_3)).isFalse();
+        assertThat(redisTemplate.opsForSet().isMember(playbackErrorsKey, USER_ID_3)).isFalse();
+        assertThat(redisTemplate.opsForSet().isMember(skipVotesKey, USER_ID_1)).isTrue();
+        assertThat(redisTemplate.opsForSet().isMember(playbackErrorsKey, USER_ID_2)).isTrue();
+    }
+
+    @Test
     @DisplayName("라운드가 이미 종료되어 round_ended_at 필드가 존재하면 정답을 제출해도 ROUND_ALREADY_ENDED 처리되어 정답자로 등록되지 않고 마스킹 채팅으로 전파된다")
     void answerSubmissionBlockedIfRoundAlreadyEnded() {
         // given

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameRoundProgressIntegrationTest.java
@@ -5,7 +5,9 @@ import io.github.ascrew.monomatbe.domain.auth.entity.UserSession;
 import io.github.ascrew.monomatbe.domain.auth.entity.UserSessionStatus;
 import io.github.ascrew.monomatbe.domain.auth.repository.GuestSessionRepository;
 import io.github.ascrew.monomatbe.domain.auth.repository.UserSessionRepository;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundEndReason;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundMetadataDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundSkippedDto;
 import io.github.ascrew.monomatbe.domain.game.dto.RoundStartDto;
 import io.github.ascrew.monomatbe.domain.game.dto.GameChatMessageDto;
 import io.github.ascrew.monomatbe.domain.game.entity.GameSession;
@@ -203,6 +205,9 @@ class GameRoundProgressIntegrationTest {
         redisTemplate.delete(RedisKeys.gameSessionNextRoundLockKey(LOBBY_CODE, 2));
         redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionRoundDataKey(LOBBY_CODE, 3));
+        redisTemplate.delete(RedisKeys.lobbyParticipantsKey(LOBBY_CODE));
+        redisTemplate.delete(RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, 1));
+        redisTemplate.delete(RedisKeys.gameSessionRoundPlaybackErrorsKey(LOBBY_CODE, 1));
         redisTemplate.delete(RedisKeys.gameSessionKey(LOBBY_CODE));
     }
 
@@ -239,7 +244,24 @@ class GameRoundProgressIntegrationTest {
         assertThat(redisTemplate.opsForHash().get(playersKey, USER_ID_3)).isEqualTo("0");
 
         // Event publish check
-        verify(gameRealtimeNotifier, times(1)).notifyRoundEnd(eq(LOBBY_CODE), any(RoundMetadataDto.class));
+        ArgumentCaptor<RoundMetadataDto> metadataCaptor = ArgumentCaptor.forClass(RoundMetadataDto.class);
+        verify(gameRealtimeNotifier, times(1)).notifyRoundEnd(eq(LOBBY_CODE), metadataCaptor.capture());
+        assertThat(metadataCaptor.getValue().endReason()).isEqualTo(RoundEndReason.TIMEOUT);
+        verify(gameRealtimeNotifier, never()).notifyRoundSkipped(eq(LOBBY_CODE), any(RoundSkippedDto.class));
+    }
+
+    @Test
+    @DisplayName("스킵 사유로 라운드 종료 시 ROUND_SKIPPED와 종료 사유가 한 번만 브로드캐스트된다")
+    void skipReasonBroadcastsRoundSkippedOnce() {
+        // when
+        gameRoundEndService.endRound(LOBBY_CODE, 1, RoundEndReason.SKIP_VOTE);
+        gameRoundEndService.endRound(LOBBY_CODE, 1, RoundEndReason.SKIP_VOTE);
+
+        // then
+        ArgumentCaptor<RoundMetadataDto> metadataCaptor = ArgumentCaptor.forClass(RoundMetadataDto.class);
+        verify(gameRealtimeNotifier, times(1)).notifyRoundSkipped(eq(LOBBY_CODE), any(RoundSkippedDto.class));
+        verify(gameRealtimeNotifier, times(1)).notifyRoundEnd(eq(LOBBY_CODE), metadataCaptor.capture());
+        assertThat(metadataCaptor.getValue().endReason()).isEqualTo(RoundEndReason.SKIP_VOTE);
     }
 
     @Test
@@ -302,8 +324,8 @@ class GameRoundProgressIntegrationTest {
     }
 
     @Test
-    @DisplayName("플레이어 이탈 시 남은 플레이어들이 모두 정답 상태이면 라운드가 조기 종료된다")
-    void playerLeaveTriggersEarlyRoundEndIfAllRemainingCorrect() {
+    @DisplayName("플레이어 이탈 후 남은 플레이어들이 모두 정답 상태여도 라운드가 자동 종료되지 않는다")
+    void playerLeaveDoesNotTriggerEarlyRoundEndIfAllRemainingCorrect() {
         // given
         String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
         redisTemplate.opsForHash().put(sessionKey, "status", "PLAYING");
@@ -323,9 +345,9 @@ class GameRoundProgressIntegrationTest {
 
         // then
         String endedLockKey = RedisKeys.gameSessionRoundEndedLockKey(LOBBY_CODE, 1);
-        assertThat(redisTemplate.hasKey(endedLockKey)).isTrue();
-        
-        verify(gameRealtimeNotifier, times(1)).notifyRoundEnd(eq(LOBBY_CODE), any(RoundMetadataDto.class));
+        assertThat(redisTemplate.hasKey(endedLockKey)).isFalse();
+
+        verify(gameRealtimeNotifier, never()).notifyRoundEnd(eq(LOBBY_CODE), any(RoundMetadataDto.class));
     }
 
     @Test

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSessionCleanupIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * 게임 세션 Redis 키 정리(cleanup) 통합 테스트
  *
  * [검증 정책]
- * - deleteNow: base 3종 + 라운드별 7종 키를 모두 삭제한다. (로비 폭파 / 시작 롤백)
+ * - deleteNow: base 3종 + 라운드별 9종 키를 모두 삭제한다. (로비 폭파 / 시작 롤백)
  * - expireWithGracePeriod: 존재하는 모든 키를 0<ttl<=300 으로 전환한다. (정상 종료)
  * - 게임 세션이 없을 때 정리는 예외 없이 안전 no-op이다.
  * - 로비 폭파 이벤트(LobbyClosedEvent) 수신 시 게임 세션 키가 정리된다. (stale game session 방지)
@@ -73,7 +73,7 @@ class GameSessionCleanupIntegrationTest {
     }
 
     @Test
-    @DisplayName("deleteNow는 base 3종 + 라운드별 7종 게임 세션 키를 모두 삭제한다")
+    @DisplayName("deleteNow는 base 3종 + 라운드별 9종 게임 세션 키를 모두 삭제한다")
     void deleteNow_removesAllGameSessionKeys() {
         // given
         givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
@@ -94,7 +94,7 @@ class GameSessionCleanupIntegrationTest {
     @Test
     @DisplayName("cleanup Lua는 RedisKeys가 생성하는 모든 게임 세션 키를 빠짐없이 정리한다 (키 계약 고정)")
     void cleanupScript_deletesExactlyAllRedisKeysGameSessionKeys() {
-        // given - RedisKeys 팩토리로 만드는 base 3종 + 라운드별 7종을 모두 생성
+        // given - RedisKeys 팩토리로 만드는 base 3종 + 라운드별 9종을 모두 생성
         givenFullGameSession(LOBBY_CODE, TOTAL_ROUNDS);
         List<String> expectedKeys = allGameSessionKeys(LOBBY_CODE, TOTAL_ROUNDS);
         String sessionKey = RedisKeys.gameSessionKey(LOBBY_CODE);
@@ -198,7 +198,7 @@ class GameSessionCleanupIntegrationTest {
 
     /**
      * 실제 게임 진행 중 생성되는 모든 게임 세션 키를 채운다.
-     * base 3종(session/rounds/players) + 라운드별 7종을 모두 만든다.
+     * base 3종(session/rounds/players) + 라운드별 9종을 모두 만든다.
      */
     private void givenFullGameSession(String code, int totalRounds) {
         String sessionKey = RedisKeys.gameSessionKey(code);
@@ -218,6 +218,8 @@ class GameSessionCleanupIntegrationTest {
             redisTemplate.opsForValue().set(RedisKeys.gameSessionPlaybackLockKey(code, n), "1");
             redisTemplate.opsForHash().put(RedisKeys.gameSessionRoundDataKey(code, n), "title", "song-" + n);
             redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundCorrectPlayersKey(code, n), "player-1");
+            redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundSkipVotesKey(code, n), "player-1");
+            redisTemplate.opsForSet().add(RedisKeys.gameSessionRoundPlaybackErrorsKey(code, n), "player-1");
             redisTemplate.opsForHash().put(RedisKeys.gameSessionRoundCorrectTimesKey(code, n), "player-1", "1000");
             redisTemplate.opsForValue().set(RedisKeys.gameSessionRoundEndedLockKey(code, n), "1");
             redisTemplate.opsForValue().set(RedisKeys.gameSessionNextRoundLockKey(code, n), "1");
@@ -234,6 +236,8 @@ class GameSessionCleanupIntegrationTest {
             keys.add(RedisKeys.gameSessionPlaybackLockKey(code, n));
             keys.add(RedisKeys.gameSessionRoundDataKey(code, n));
             keys.add(RedisKeys.gameSessionRoundCorrectPlayersKey(code, n));
+            keys.add(RedisKeys.gameSessionRoundSkipVotesKey(code, n));
+            keys.add(RedisKeys.gameSessionRoundPlaybackErrorsKey(code, n));
             keys.add(RedisKeys.gameSessionRoundCorrectTimesKey(code, n));
             keys.add(RedisKeys.gameSessionRoundEndedLockKey(code, n));
             keys.add(RedisKeys.gameSessionNextRoundLockKey(code, n));

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteServiceTest.java
@@ -76,11 +76,13 @@ class GameSkipVoteServiceTest {
     }
 
     @Test
-    @DisplayName("중복 스킵 투표는 SADD 멱등 Set으로 기록되고 기준 미달이면 종료하지 않는다")
+    @DisplayName("중복 스킵 투표는 SADD 멱등 Set으로 기록되고 신규 투표일 때만 브로드캐스트한다")
     void duplicateSkipVoteCountsOnce() {
         // given
         String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
-        givenVoteState(skipVotesKey, Set.of(USER_1), Set.of(USER_1, USER_2, "user-3"));
+        when(setOperations.add(skipVotesKey, USER_1)).thenReturn(1L, 0L);
+        when(setOperations.members(skipVotesKey)).thenReturn(Set.of(USER_1));
+        when(setOperations.members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(Set.of(USER_1, USER_2, "user-3"));
 
         // when
         gameSkipVoteService.voteSkip(LOBBY_CODE, USER_1, ROUND_NO);
@@ -90,7 +92,7 @@ class GameSkipVoteServiceTest {
         verify(setOperations, times(2)).add(skipVotesKey, USER_1);
         verify(redisTemplate, times(2)).expire(skipVotesKey, Duration.ofHours(2));
         verify(gameRoundEndService, never()).endRound(anyString(), anyInt(), any(RoundEndReason.class));
-        verify(gameRealtimeNotifier, times(2)).notifyRoundSkipVote(eq(LOBBY_CODE), any(RoundSkipVoteDto.class));
+        verify(gameRealtimeNotifier, times(1)).notifyRoundSkipVote(eq(LOBBY_CODE), any(RoundSkipVoteDto.class));
     }
 
     @Test
@@ -98,6 +100,8 @@ class GameSkipVoteServiceTest {
     void skipVoteThresholdEndsRound() {
         // given
         String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
+        when(setOperations.add(skipVotesKey, USER_1)).thenReturn(1L);
+        when(setOperations.add(skipVotesKey, USER_2)).thenReturn(1L);
         when(setOperations.members(skipVotesKey)).thenReturn(Set.of(USER_1), Set.of(USER_1, USER_2));
         when(setOperations.members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(Set.of(USER_1, USER_2, "user-3"));
 
@@ -142,6 +146,8 @@ class GameSkipVoteServiceTest {
     void playbackErrorThresholdEndsRound(CapturedOutput output) {
         // given
         String playbackErrorsKey = RedisKeys.gameSessionRoundPlaybackErrorsKey(LOBBY_CODE, ROUND_NO);
+        when(setOperations.add(playbackErrorsKey, USER_1)).thenReturn(1L);
+        when(setOperations.add(playbackErrorsKey, USER_2)).thenReturn(1L);
         when(setOperations.members(playbackErrorsKey)).thenReturn(Set.of(USER_1), Set.of(USER_1, USER_2));
         when(setOperations.members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(Set.of(USER_1, USER_2, "user-3"));
 
@@ -182,6 +188,7 @@ class GameSkipVoteServiceTest {
     void staleVotesAreExcludedFromThreshold() {
         // given
         String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
+        when(setOperations.add(skipVotesKey, USER_1)).thenReturn(0L);
         givenVoteState(skipVotesKey, Set.of(USER_1, "left-user"), Set.of(USER_1, USER_2, "user-3"));
 
         // when

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -59,9 +60,9 @@ class GameSkipVoteServiceTest {
     void setUp() {
         lenient().when(redisTemplate.opsForSet()).thenReturn(setOperations);
         lenient().when(redisTemplate.opsForHash()).thenReturn(hashOperations);
-        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
-        when(lobbyRepository.isParticipant(eq(LOBBY_CODE), anyString())).thenReturn(true);
-        when(hashOperations.multiGet(
+        lenient().when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        lenient().when(lobbyRepository.isParticipant(eq(LOBBY_CODE), anyString())).thenReturn(true);
+        lenient().when(hashOperations.multiGet(
                 eq(RedisKeys.gameSessionKey(LOBBY_CODE)),
                 eq(List.of(RedisKeys.FIELD_STATUS, RedisKeys.FIELD_ROUND_PHASE, RedisKeys.FIELD_CURRENT_ROUND_NO))
         )).thenReturn(List.of("PLAYING", "PLAYING", "1"));
@@ -79,8 +80,7 @@ class GameSkipVoteServiceTest {
     void duplicateSkipVoteCountsOnce() {
         // given
         String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
-        when(setOperations.size(skipVotesKey)).thenReturn(1L);
-        when(setOperations.size(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(3L);
+        givenVoteState(skipVotesKey, Set.of(USER_1), Set.of(USER_1, USER_2, "user-3"));
 
         // when
         gameSkipVoteService.voteSkip(LOBBY_CODE, USER_1, ROUND_NO);
@@ -98,8 +98,8 @@ class GameSkipVoteServiceTest {
     void skipVoteThresholdEndsRound() {
         // given
         String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
-        when(setOperations.size(skipVotesKey)).thenReturn(1L, 2L);
-        when(setOperations.size(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(3L);
+        when(setOperations.members(skipVotesKey)).thenReturn(Set.of(USER_1), Set.of(USER_1, USER_2));
+        when(setOperations.members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(Set.of(USER_1, USER_2, "user-3"));
 
         // when
         gameSkipVoteService.voteSkip(LOBBY_CODE, USER_1, ROUND_NO);
@@ -142,23 +142,68 @@ class GameSkipVoteServiceTest {
     void playbackErrorThresholdEndsRound(CapturedOutput output) {
         // given
         String playbackErrorsKey = RedisKeys.gameSessionRoundPlaybackErrorsKey(LOBBY_CODE, ROUND_NO);
-        when(setOperations.size(playbackErrorsKey)).thenReturn(1L, 2L);
-        when(setOperations.size(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(3L);
+        when(setOperations.members(playbackErrorsKey)).thenReturn(Set.of(USER_1), Set.of(USER_1, USER_2));
+        when(setOperations.members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(Set.of(USER_1, USER_2, "user-3"));
 
+        // when
+        gameSkipVoteService.reportPlaybackError(
+                LOBBY_CODE,
+                USER_1,
+                new PlaybackErrorReportDto(ROUND_NO, "150", "region blocked")
+        );
+        gameSkipVoteService.reportPlaybackError(
+                LOBBY_CODE,
+                USER_2,
+                new PlaybackErrorReportDto(ROUND_NO, "150", "region blocked")
+        );
+
+        // then
+        verify(gameRoundEndService).endRound(LOBBY_CODE, ROUND_NO, RoundEndReason.PLAYBACK_ERROR);
+        assertThat(output).contains("[MONITORING_REQUIRED]");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 재생 오류 코드는 집계하지 않는다")
+    void unsupportedPlaybackErrorCodeIsIgnored() {
         // when
         gameSkipVoteService.reportPlaybackError(
                 LOBBY_CODE,
                 USER_1,
                 new PlaybackErrorReportDto(ROUND_NO, "YOUTUBE_REGION_BLOCKED", "region blocked")
         );
-        gameSkipVoteService.reportPlaybackError(
-                LOBBY_CODE,
-                USER_2,
-                new PlaybackErrorReportDto(ROUND_NO, "YOUTUBE_REGION_BLOCKED", "region blocked")
-        );
 
         // then
-        verify(gameRoundEndService).endRound(LOBBY_CODE, ROUND_NO, RoundEndReason.PLAYBACK_ERROR);
-        assertThat(output).contains("[MONITORING_REQUIRED]");
+        verify(setOperations, never()).add(RedisKeys.gameSessionRoundPlaybackErrorsKey(LOBBY_CODE, ROUND_NO), USER_1);
+        verify(gameRoundEndService, never()).endRound(anyString(), anyInt(), any(RoundEndReason.class));
+    }
+
+    @Test
+    @DisplayName("현재 참가자가 아닌 기존 표는 기준 계산에서 제외한다")
+    void staleVotesAreExcludedFromThreshold() {
+        // given
+        String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
+        givenVoteState(skipVotesKey, Set.of(USER_1, "left-user"), Set.of(USER_1, USER_2, "user-3"));
+
+        // when
+        gameSkipVoteService.voteSkip(LOBBY_CODE, USER_1, ROUND_NO);
+
+        // then
+        verify(gameRoundEndService, never()).endRound(anyString(), anyInt(), any(RoundEndReason.class));
+    }
+
+    @Test
+    @DisplayName("퇴장한 참가자의 스킵 투표와 재생 오류 보고를 라운드 Set에서 제거한다")
+    void removeParticipantRoundSignalsRemovesSkipAndPlaybackEntries() {
+        // when
+        gameSkipVoteService.removeParticipantRoundSignals(LOBBY_CODE, USER_1, ROUND_NO);
+
+        // then
+        verify(setOperations).remove(RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO), USER_1);
+        verify(setOperations).remove(RedisKeys.gameSessionRoundPlaybackErrorsKey(LOBBY_CODE, ROUND_NO), USER_1);
+    }
+
+    private void givenVoteState(String voteKey, Set<String> votes, Set<String> participants) {
+        when(setOperations.members(voteKey)).thenReturn(votes);
+        when(setOperations.members(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(participants);
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/game/service/GameSkipVoteServiceTest.java
@@ -1,0 +1,164 @@
+package io.github.ascrew.monomatbe.domain.game.service;
+
+import io.github.ascrew.monomatbe.domain.game.dto.PlaybackErrorReportDto;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundEndReason;
+import io.github.ascrew.monomatbe.domain.game.dto.RoundSkipVoteDto;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
+class GameSkipVoteServiceTest {
+
+    private static final String LOBBY_CODE = "SKIP12";
+    private static final String USER_1 = "user-1";
+    private static final String USER_2 = "user-2";
+    private static final int ROUND_NO = 1;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+
+    @Mock
+    private GameRoundEndService gameRoundEndService;
+
+    @Mock
+    private GameRealtimeNotifier gameRealtimeNotifier;
+
+    @Mock
+    private SetOperations<String, String> setOperations;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    private GameSkipVoteService gameSkipVoteService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        lenient().when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(lobbyRepository.existsByCode(LOBBY_CODE)).thenReturn(true);
+        when(lobbyRepository.isParticipant(eq(LOBBY_CODE), anyString())).thenReturn(true);
+        when(hashOperations.multiGet(
+                eq(RedisKeys.gameSessionKey(LOBBY_CODE)),
+                eq(List.of(RedisKeys.FIELD_STATUS, RedisKeys.FIELD_ROUND_PHASE, RedisKeys.FIELD_CURRENT_ROUND_NO))
+        )).thenReturn(List.of("PLAYING", "PLAYING", "1"));
+
+        gameSkipVoteService = new GameSkipVoteService(
+                redisTemplate,
+                lobbyRepository,
+                gameRoundEndService,
+                gameRealtimeNotifier
+        );
+    }
+
+    @Test
+    @DisplayName("중복 스킵 투표는 SADD 멱등 Set으로 기록되고 기준 미달이면 종료하지 않는다")
+    void duplicateSkipVoteCountsOnce() {
+        // given
+        String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
+        when(setOperations.size(skipVotesKey)).thenReturn(1L);
+        when(setOperations.size(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(3L);
+
+        // when
+        gameSkipVoteService.voteSkip(LOBBY_CODE, USER_1, ROUND_NO);
+        gameSkipVoteService.voteSkip(LOBBY_CODE, USER_1, ROUND_NO);
+
+        // then
+        verify(setOperations, times(2)).add(skipVotesKey, USER_1);
+        verify(redisTemplate, times(2)).expire(skipVotesKey, Duration.ofHours(2));
+        verify(gameRoundEndService, never()).endRound(anyString(), anyInt(), any(RoundEndReason.class));
+        verify(gameRealtimeNotifier, times(2)).notifyRoundSkipVote(eq(LOBBY_CODE), any(RoundSkipVoteDto.class));
+    }
+
+    @Test
+    @DisplayName("스킵 투표 기준 도달 시 SKIP_VOTE 사유로 라운드를 종료한다")
+    void skipVoteThresholdEndsRound() {
+        // given
+        String skipVotesKey = RedisKeys.gameSessionRoundSkipVotesKey(LOBBY_CODE, ROUND_NO);
+        when(setOperations.size(skipVotesKey)).thenReturn(1L, 2L);
+        when(setOperations.size(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(3L);
+
+        // when
+        gameSkipVoteService.voteSkip(LOBBY_CODE, USER_1, ROUND_NO);
+        gameSkipVoteService.voteSkip(LOBBY_CODE, USER_2, ROUND_NO);
+
+        // then
+        verify(gameRoundEndService).endRound(LOBBY_CODE, ROUND_NO, RoundEndReason.SKIP_VOTE);
+    }
+
+    @Test
+    @DisplayName("방장 /p는 HOST_SKIP 사유로 라운드를 종료한다")
+    void hostForceSkipEndsRound() {
+        // given
+        when(hashOperations.get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_HOST_USER_ID)).thenReturn(USER_1);
+
+        // when
+        boolean handled = gameSkipVoteService.forceSkipByHost(LOBBY_CODE, USER_1, ROUND_NO);
+
+        // then
+        assertThat(handled).isTrue();
+        verify(gameRoundEndService).endRound(LOBBY_CODE, ROUND_NO, RoundEndReason.HOST_SKIP);
+    }
+
+    @Test
+    @DisplayName("비방장 /p는 명령으로 처리하지 않는다")
+    void nonHostForceSkipIsNotHandled() {
+        // given
+        when(hashOperations.get(RedisKeys.lobbyKey(LOBBY_CODE), RedisKeys.FIELD_HOST_USER_ID)).thenReturn(USER_1);
+
+        // when
+        boolean handled = gameSkipVoteService.forceSkipByHost(LOBBY_CODE, USER_2, ROUND_NO);
+
+        // then
+        assertThat(handled).isFalse();
+        verify(gameRoundEndService, never()).endRound(anyString(), anyInt(), any(RoundEndReason.class));
+    }
+
+    @Test
+    @DisplayName("재생 오류 보고 기준 도달 시 모니터링 로그를 남기고 PLAYBACK_ERROR 사유로 종료한다")
+    void playbackErrorThresholdEndsRound(CapturedOutput output) {
+        // given
+        String playbackErrorsKey = RedisKeys.gameSessionRoundPlaybackErrorsKey(LOBBY_CODE, ROUND_NO);
+        when(setOperations.size(playbackErrorsKey)).thenReturn(1L, 2L);
+        when(setOperations.size(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).thenReturn(3L);
+
+        // when
+        gameSkipVoteService.reportPlaybackError(
+                LOBBY_CODE,
+                USER_1,
+                new PlaybackErrorReportDto(ROUND_NO, "YOUTUBE_REGION_BLOCKED", "region blocked")
+        );
+        gameSkipVoteService.reportPlaybackError(
+                LOBBY_CODE,
+                USER_2,
+                new PlaybackErrorReportDto(ROUND_NO, "YOUTUBE_REGION_BLOCKED", "region blocked")
+        );
+
+        // then
+        verify(gameRoundEndService).endRound(LOBBY_CODE, ROUND_NO, RoundEndReason.PLAYBACK_ERROR);
+        assertThat(output).contains("[MONITORING_REQUIRED]");
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/global/constant/RedisKeysTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/global/constant/RedisKeysTest.java
@@ -45,6 +45,8 @@ class RedisKeysTest {
         assertThat(RedisKeys.gameSessionPlaybackLockKey(CODE, 2)).contains(tag).endsWith(":round:2:playback_lock");
         assertThat(RedisKeys.gameSessionRoundDataKey(CODE, 2)).contains(tag).endsWith(":round:2:data");
         assertThat(RedisKeys.gameSessionRoundCorrectPlayersKey(CODE, 2)).contains(tag).endsWith(":round:2:correct_players");
+        assertThat(RedisKeys.gameSessionRoundSkipVotesKey(CODE, 2)).contains(tag).endsWith(":round:2:skip_votes");
+        assertThat(RedisKeys.gameSessionRoundPlaybackErrorsKey(CODE, 2)).contains(tag).endsWith(":round:2:playback_errors");
         assertThat(RedisKeys.gameSessionRoundCorrectTimesKey(CODE, 2)).contains(tag).endsWith(":round:2:correct_times");
         assertThat(RedisKeys.gameSessionRoundEndedLockKey(CODE, 2)).contains(tag).endsWith(":round:2:ended_lock");
         assertThat(RedisKeys.gameSessionRoundNextLockKey(CODE, 2)).contains(tag).endsWith(":round:2:next_round_lock");
@@ -57,6 +59,8 @@ class RedisKeysTest {
 
         assertThat(RedisKeys.gameSessionRoundsKey(CODE)).startsWith(base + ":");
         assertThat(RedisKeys.gameSessionRoundReadyKey(CODE, 1)).startsWith(base + ":round:1:");
+        assertThat(RedisKeys.gameSessionRoundSkipVotesKey(CODE, 1)).startsWith(base + ":round:1:");
+        assertThat(RedisKeys.gameSessionRoundPlaybackErrorsKey(CODE, 1)).startsWith(base + ":round:1:");
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

- #166

## 📝 Summary

- 라운드 종료 조건을 `TIMEOUT`, `SKIP_VOTE`, `HOST_SKIP`, `PLAYBACK_ERROR` 기반으로 확장했습니다.
- 기존 `GameRoundEndService.endRound()`를 종료 단일 진입점으로 유지하면서 종료 사유를 전달할 수 있도록 오버로드를 추가했습니다.
- 전원 정답 시 라운드가 자동 종료되던 흐름을 제거했습니다.
- 인게임 채팅에서 정확한 `/k`, `/p` 명령을 처리하도록 분기했습니다.
  - `/k`: 참가자 스킵 투표
  - `/p`: 방장 강제 스킵
  - `/ k`, `/K`, `/p test` 등은 명령으로 처리하지 않습니다.
- `GameSkipVoteService`를 추가해 스킵 투표, 방장 스킵, 재생 오류 fail-over를 처리하도록 분리했습니다.
- 라운드별 Redis Set 키를 추가했습니다.
  - `game:session:{code}:round:{n}:skip_votes`
  - `game:session:{code}:round:{n}:playback_errors`
- `ROUND_SKIP_VOTE`, `ROUND_SKIPPED` 이벤트를 추가하고, `ROUND_END`에 `endReason`을 포함했습니다.
- `SEND /app/game/{code}/playback-error` STOMP 엔드포인트를 추가했습니다.
- STOMP 인게임 컨트롤러가 `CustomPrincipal` 대신 WebSocket session attribute의 `userIdentifier`를 사용하도록 수정했습니다.
- 게임 세션 cleanup Lua에 신규 라운드별 키를 포함했습니다.
- `docs/API.md`, `docs/ARCHITECTURE.md`에 스킵/재생 오류 fail-over 계약을 반영했습니다.
- 관련 단위 테스트를 추가/갱신하고, 로컬 REST/STOMP E2E로 주요 종료 경로를 확인했습니다.
- 라운드 종료는 기존 `GameRoundEndService.endRound()` 경로를 재사용합니다.
- REST join 이후 실제 로비 참여 확정은 기존 구조와 동일하게 `SUBSCRIBE /topic/lobby/{code}` 시점에 처리됩니다.
- 로컬 E2E 확인 결과:
  - `/ready-to-play` 2명 전송 후 `ROUND_PLAYBACK_STARTED` 즉시 수신
  - 방장 `/p` → `ROUND_SKIPPED`, `ROUND_END.endReason = HOST_SKIP`
  - 게스트 `/k` → `ROUND_SKIP_VOTE`, `ROUND_SKIPPED`, `ROUND_END.endReason = SKIP_VOTE`
  - `playback-error` → `ROUND_SKIPPED`, `ROUND_END.endReason = PLAYBACK_ERROR`

## 🙏PR point

- 스킵 기준은 이슈 정의에 맞춰 `ceil(참가자 수 / 2)`로 구현했습니다.
  - 참가자 2명 기준 1표만으로 스킵 기준에 도달합니다.
- `/k`는 토글이 아닙니다. 라운드별 `skip_votes` Set에 `SADD`로 1인 1표만 기록합니다.
- `/p`는 방장만 명령으로 처리합니다. 비방장의 `/p`는 기존 채팅/정답 흐름으로 넘어갑니다.
- 스킵 계열 종료가 실제 `ended_lock`을 획득한 경우에만 `ROUND_SKIPPED`와 `ROUND_END`가 발행됩니다.
- `ROUND_END.endReason`은 아래 값 중 하나입니다.
  - `TIMEOUT`
  - `SKIP_VOTE`
  - `HOST_SKIP`
  - `PLAYBACK_ERROR`
- 재생 오류 보고는 `playback_errors` Set에 누적되며, 기준 도달 시 `[MONITORING_REQUIRED]` 로그를 남기고 `PLAYBACK_ERROR`로 라운드를 종료합니다.
- 인게임 STOMP 핸들러는 HTTP `@AuthenticationPrincipal`이 아니라 `StompChannelInterceptor`가 저장한 session attribute의 `userIdentifier`를 신뢰합니다.
- 로컬 검증 중 `mapId=2`는 `map.numOfSong` 메타데이터와 실제 활성 `map_item` 수가 불일치해 `/start`에서 409가 발생했습니다. 구현 검증은 새로 생성한 1곡짜리 테스트 맵으로 진행했습니다.

## 📬 Reference