### PR TITLE
[Fix/#199] CORS allowCredentials 허용으로 SockJS 채팅 연결 실패 수정

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/global/config/CorsConfig.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/config/CorsConfig.java
@@ -30,7 +30,11 @@ public class CorsConfig {
         // JWT는 Authorization 헤더로 전달하고 쿠키를 사용하지 않으므로 필요한 헤더만 허용한다.
         // 추후 X-Request-Id 등 커스텀 헤더가 필요하면 명시적으로 추가한다.
         config.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
-        config.setAllowCredentials(false);
+        // SockJS(sockjs-client)는 /ws/info 등 모든 XHR 요청을 withCredentials=true(자격증명 모드)로 보낸다.
+        // 이때 브라우저는 응답에 Access-Control-Allow-Credentials: true 가 있어야만 응답을 허용하며,
+        // 이 값이 false면 응답이 200이어도 CORS로 차단되어 WebSocket 채팅 연결이 실패한다.
+        // 허용 출처는 정확한 Origin 목록(CorsProperties가 와일드카드/*를 기동 시 거부)이라 credentials=true 와 함께 써도 안전하다.
+        config.setAllowCredentials(true);
         config.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
## 📣 Related Issue
- #199

## 📝 Summary
- `sockjs-client`는 `/ws/info` 등 모든 XHR 요청을 `withCredentials=true`(자격증명 모드)로 보내는데, `CorsConfig`가 `setAllowCredentials(false)`라 응답에 `Access-Control-Allow-Credentials: true` 헤더가 없어 브라우저가 응답을 CORS로 차단, 운영 환경에서 WebSocket 채팅이 무한 "재연결 중" 상태에 머물던 문제를 수정합니다.
- `CorsConfig`의 `setAllowCredentials(false)` → `setAllowCredentials(true)`로 변경했습니다.

## 🙏PR point
- 허용 출처는 정확한 Origin 목록(`CorsProperties`가 와일드카드/`*`를 기동 시 거부)이라 `allowCredentials=true`와 함께 사용해도 스펙상 안전합니다.
- WebSocket 업그레이드(HTTP/1.1 `101`)·Caddy 라우팅·활성 프로파일(prod)·`CORS_ALLOWED_ORIGINS` 설정은 모두 정상이었고, 원인은 SockJS info 요청의 CORS 한 곳이었습니다.
- curl은 CORS를 강제하지 않아 동일 요청이 200으로 정상처럼 보입니다(원인 파악 시 참고).

## 📬 Reference
-