### PR TITLE
[Fix/#202] 빈 로비 reaper 후보 조회 누락 수정

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1176,6 +1176,14 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
   - 영구 퇴장 처리 후에는 기존 정답자 수로 라운드를 자동 종료하지 않습니다. 다만 누적된 스킵 투표나 재생 오류 보고가 변경된 참가자 수 기준에 도달하면 라운드를 스킵 종료할 수 있습니다.
   - 퇴장한 유저가 방장인 경우, 다음 순번 참여자에게 방장 권한이 위임됩니다. 로비 내 모든 사용자가 퇴장하여 남은 인원이 0명이 되면 로비는 즉시 폭파되며 인게임 세션 키도 즉시 삭제(deleteNow)됩니다.
 
+## 빈 로비 Reaper 정책
+
+- 정상 퇴장 경로의 로비 폭파는 `leave_lobby.lua`가 담당합니다. 마지막 참여자가 퇴장해 `participants`가 0명이 되면 로비 Hash, 참여자/순서/준비/강퇴 키와 공개/전체 인덱스를 원자적으로 삭제합니다.
+- `LobbyReaperScheduler`는 정상 DISCONNECT/leave 경로를 타지 못한 로비를 복구 정리하는 2차 안전망입니다. 삭제 판단은 `current_players` 캐시가 아니라 `lobby:{code}:participants`와 로비별 WebSocket 세션 키(`lobby:{code}:user_session:{userIdentifier}` 및 `ws:connection:{wsSessionId}`)를 기준으로 `reap_lobby.lua` 안에서 원자적으로 수행합니다.
+- 생성 직후 로비는 WebSocket 구독 전까지 참여자가 0명일 수 있으므로 `monomat.lobby.reaper.grace-ms` 기간 동안 `TOO_YOUNG`으로 보존합니다. grace 이후에도 참여자가 0명이거나 참여자 모두가 해당 로비에 대한 유효 WebSocket 세션을 갖지 않으면 `REAPED`로 폭파합니다.
+- reaper 후보 조회는 `lobby:all` Set을 `SSCAN`으로 점진 순회하며, 마지막 cursor를 `lobby:all:reaper:scan-cursor`에 저장해 다음 실행에서 이어서 검사합니다. Redis SCAN `COUNT`가 limit보다 많은 후보를 반환할 수 있으므로 초과 후보는 `lobby:all:reaper:scan-buffer`에 보관해 다음 실행에서 먼저 처리합니다.
+- reaper는 `lobby:all`에 등록된 로비만 후보로 볼 수 있습니다. `lobby:{code}` Hash는 존재하지만 `lobby:all`에서 누락된 로비는 전체 keyspace scan 없이는 발견할 수 없으므로, 운영 중 발견되면 별도 보정 작업으로 `lobby:all`을 복구하거나 follow-up cleanup을 추가해야 합니다.
+
 ## 게임 세션 Redis 키 정리 정책
 
 게임 세션 관련 Redis 키는 생성 시 **2시간(7200초) TTL**을 최종 안전망으로 가지며, 종료/폭파/롤백 시점에 명시적으로 정리한다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1182,6 +1182,7 @@ FE는 STOMP ERROR의 `message`를 파싱하지 않습니다.
 - `LobbyReaperScheduler`는 정상 DISCONNECT/leave 경로를 타지 못한 로비를 복구 정리하는 2차 안전망입니다. 삭제 판단은 `current_players` 캐시가 아니라 `lobby:{code}:participants`와 로비별 WebSocket 세션 키(`lobby:{code}:user_session:{userIdentifier}` 및 `ws:connection:{wsSessionId}`)를 기준으로 `reap_lobby.lua` 안에서 원자적으로 수행합니다.
 - 생성 직후 로비는 WebSocket 구독 전까지 참여자가 0명일 수 있으므로 `monomat.lobby.reaper.grace-ms` 기간 동안 `TOO_YOUNG`으로 보존합니다. grace 이후에도 참여자가 0명이거나 참여자 모두가 해당 로비에 대한 유효 WebSocket 세션을 갖지 않으면 `REAPED`로 폭파합니다.
 - reaper 후보 조회는 `lobby:all` Set을 `SSCAN`으로 점진 순회하며, 마지막 cursor를 `lobby:all:reaper:scan-cursor`에 저장해 다음 실행에서 이어서 검사합니다. Redis SCAN `COUNT`가 limit보다 많은 후보를 반환할 수 있으므로 초과 후보는 `lobby:all:reaper:scan-buffer`에 보관해 다음 실행에서 먼저 처리합니다.
+- 단일 로비 폭파는 `reap_lobby.lua` 안에서 원자적·멱등으로 수행되지만, `lobby:all` scan-cursor / scan-buffer 기반 후보 순회는 단일 scheduler 인스턴스 실행을 전제로 합니다. 멀티 인스턴스에서 전수 순회 보장이 필요하면 별도 Redis lock 또는 후보 조회 전용 Lua 원자화가 필요합니다.
 - reaper는 `lobby:all`에 등록된 로비만 후보로 볼 수 있습니다. `lobby:{code}` Hash는 존재하지만 `lobby:all`에서 누락된 로비는 전체 keyspace scan 없이는 발견할 수 없으므로, 운영 중 발견되면 별도 보정 작업으로 `lobby:all`을 복구하거나 follow-up cleanup을 추가해야 합니다.
 
 ## 게임 세션 Redis 키 정리 정책

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -200,8 +200,9 @@ public class LobbyLuaScriptExecutor {
      * ARGV[1] = lobbyCode
      * ARGV[2] = graceMillis (생성 직후 보호 기간)
      * ARGV[3] = lobbyUserSessionPrefix ("lobby:{code}:user_session:")
-     * ARGV[4] = wsConnectionPrefix ("ws:connection:")
-     * ARGV[5] = lobbyField (ws:connection Hash의 lobbyCode 필드명)
+     * ARGV[4] = lobbyUserSessionSeqPrefix ("lobby:{code}:user_session_seq:")
+     * ARGV[5] = wsConnectionPrefix ("ws:connection:")
+     * ARGV[6] = lobbyField (ws:connection Hash의 lobbyCode 필드명)
      *
      * @param code        대상 로비 코드
      * @param graceMillis 생성 직후 폭파를 보류할 grace 기간(ms)
@@ -227,6 +228,7 @@ public class LobbyLuaScriptExecutor {
                 code,
                 String.valueOf(graceMillis),
                 RedisKeys.lobbyUserSessionKeyPrefix(code),
+                RedisKeys.lobbyUserSessionSequenceKeyPrefix(code),
                 RedisKeys.wsConnectionKeyPrefix(),
                 WebSocketHeaders.SESSION_LOBBY_CODE
         );

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyLuaScriptExecutor.java
@@ -203,6 +203,8 @@ public class LobbyLuaScriptExecutor {
      * ARGV[4] = lobbyUserSessionSeqPrefix ("lobby:{code}:user_session_seq:")
      * ARGV[5] = wsConnectionPrefix ("ws:connection:")
      * ARGV[6] = lobbyField (ws:connection Hash의 lobbyCode 필드명)
+     * ARGV[7] = statusField (lobby Hash의 status 필드명)
+     * ARGV[8] = waitingStatus ("WAITING")
      *
      * @param code        대상 로비 코드
      * @param graceMillis 생성 직후 폭파를 보류할 grace 기간(ms)
@@ -230,7 +232,9 @@ public class LobbyLuaScriptExecutor {
                 RedisKeys.lobbyUserSessionKeyPrefix(code),
                 RedisKeys.lobbyUserSessionSequenceKeyPrefix(code),
                 RedisKeys.wsConnectionKeyPrefix(),
-                WebSocketHeaders.SESSION_LOBBY_CODE
+                WebSocketHeaders.SESSION_LOBBY_CODE,
+                RedisKeys.FIELD_STATUS,
+                LobbyStatus.WAITING.name()
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -417,6 +417,7 @@ public class LobbyRedisQueryRepository {
             });
         } catch (Exception e) {
             log.warn("빈 로비 reaper lobby:all SSCAN 후보 조회 실패", e);
+            resetReaperScanCursorAfterFailure();
         }
     }
 
@@ -497,6 +498,17 @@ public class LobbyRedisQueryRepository {
         );
     }
 
+    private void resetReaperScanCursorAfterFailure() {
+        try {
+            redisTemplate.opsForValue().set(
+                    RedisKeys.LOBBY_ALL_REAPER_SCAN_CURSOR,
+                    REDIS_SCAN_CURSOR_INITIAL
+            );
+        } catch (Exception resetException) {
+            log.warn("빈 로비 reaper lobby:all SSCAN cursor 리셋 실패", resetException);
+        }
+    }
+
     private void pushReaperScanBuffer(
             RedisConnection connection,
             String code
@@ -514,6 +526,12 @@ public class LobbyRedisQueryRepository {
     private String normalizeScanCursor(String cursor) {
         if (cursor == null || cursor.isBlank()) {
             return REDIS_SCAN_CURSOR_INITIAL;
+        }
+
+        for (int i = 0; i < cursor.length(); i++) {
+            if (!Character.isDigit(cursor.charAt(i))) {
+                return REDIS_SCAN_CURSOR_INITIAL;
+            }
         }
 
         return cursor;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepository.java
@@ -13,13 +13,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.data.redis.core.Cursor;
-import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.connection.ReturnType;
 
+import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +54,10 @@ public class LobbyRedisQueryRepository {
 
     private static final String ERROR_INVALID_LOBBY_DATA =
             "로비 정보가 유효하지 않습니다.";
+
+    private static final String REDIS_SCAN_CURSOR_INITIAL = "0";
+    private static final String LOBBY_ALL_SSCAN_SCRIPT =
+            "return redis.call('SSCAN', KEYS[1], ARGV[1], 'COUNT', ARGV[2])";
 
     private final StringRedisTemplate redisTemplate;
 
@@ -320,17 +327,24 @@ public class LobbyRedisQueryRepository {
     }
 
     /**
-     * 빈 로비 reaper용으로 lobby:all Set에서 임의의 로비 코드 후보를 조회한다.
+     * 빈 로비 reaper용으로 lobby:all Set을 cursor 기반으로 순회해 후보를 조회한다.
      *
      * [사용 목적]
      * reaper 스케줄러가 공개·비공개를 포함한 전체 로비를 제한된 개수만큼 검사하기 위해 사용한다.
      *
-     * [SRANDMEMBER(distinctRandomMembers) 사용 이유]
-     * SSCAN을 매 실행마다 cursor 0부터 새로 시작하면 항상 앞쪽 구간만 보게 되어
-     * 뒤쪽 stale 로비가 정리되지 않고 누적될 수 있다(cursor를 영속하지 않으면 재개 불가).
-     * reaper는 정렬이 불필요하고, 유령 로비는 폭파될 때까지 후보 풀에 남으므로
-     * 매 실행 임의 표본을 뽑으면 확률적으로 전체가 수렴 정리된다.
-     * 동일 API를 {@link #addPublicSetCleanupCandidates}에서도 사용한다.
+     * [SSCAN cursor 저장 이유]
+     * 랜덤 샘플링은 특정 stale 로비를 장기간 놓칠 수 있고, 매번 cursor 0부터 SSCAN을
+     * 시작하면 앞쪽 구간만 반복 검사할 수 있다. 따라서 마지막 cursor를 Redis에 저장해
+     * 다음 실행에서 이어서 순회한다.
+     *
+     * [batch limit 보존]
+     * Redis SCAN COUNT는 hint라서 limit보다 많은 member가 반환될 수 있다. 초과 후보는
+     * Redis buffer에 보관해 다음 호출에서 먼저 반환함으로써 scheduler batch size를 지킨다.
+     *
+     * [주의]
+     * 이 reaper는 lobby:all 인덱스에 들어 있는 code만 후보로 볼 수 있다. lobby:{code} Hash는
+     * 있지만 lobby:all에서 누락된 로비는 keyspace scan 없이는 발견할 수 없으므로, 운영상
+     * 발견되면 별도 보정 작업 또는 follow-up cleanup을 추가해야 한다.
      *
      * @param limit 조회할 최대 code 수
      * @return reaper 검사 후보 로비 코드 목록
@@ -340,23 +354,187 @@ public class LobbyRedisQueryRepository {
             return List.of();
         }
 
-        Set<String> codes = redisTemplate.opsForSet()
-                .distinctRandomMembers(RedisKeys.LOBBY_ALL, limit);
+        LinkedHashSet<String> candidates = new LinkedHashSet<>();
+        drainReaperScanBuffer(candidates, limit);
 
-        if (codes == null || codes.isEmpty()) {
-            return List.of();
+        if (candidates.size() >= limit) {
+            return new ArrayList<>(candidates);
         }
 
-        List<String> candidates = new ArrayList<>(codes.size());
+        scanAllLobbyCodesForReaping(candidates, limit);
 
-        for (String code : codes) {
-            if (code == null || code.isBlank()) {
-                continue;
+        return new ArrayList<>(candidates);
+    }
+
+    private void drainReaperScanBuffer(
+            Set<String> candidates,
+            int limit
+    ) {
+        while (candidates.size() < limit) {
+            String bufferedCode = redisTemplate.opsForList()
+                    .leftPop(RedisKeys.LOBBY_ALL_REAPER_SCAN_BUFFER);
+
+            if (bufferedCode == null) {
+                return;
             }
-            candidates.add(code);
+
+            addCleanupCandidate(candidates, bufferedCode, limit);
+        }
+    }
+
+    private void scanAllLobbyCodesForReaping(
+            Set<String> candidates,
+            int limit
+    ) {
+        try {
+            redisTemplate.execute((RedisCallback<Void>) connection -> {
+                String cursor = getStoredReaperScanCursor(connection);
+                int scanCount = 0;
+                int maxScanCount = Math.max(1, limit);
+
+                while (candidates.size() < limit && scanCount < maxScanCount) {
+                    int remainingLimit = limit - candidates.size();
+                    SScanResult scanResult = executeLobbyAllSScan(connection, cursor, remainingLimit);
+                    scanCount++;
+
+                    for (String code : scanResult.members()) {
+                        if (candidates.size() < limit) {
+                            addCleanupCandidate(candidates, code, limit);
+                        } else {
+                            pushReaperScanBuffer(connection, code);
+                        }
+                    }
+
+                    cursor = scanResult.nextCursor();
+                    storeReaperScanCursor(connection, cursor);
+
+                    if (REDIS_SCAN_CURSOR_INITIAL.equals(cursor)) {
+                        break;
+                    }
+                }
+
+                return null;
+            });
+        } catch (Exception e) {
+            log.warn("빈 로비 reaper lobby:all SSCAN 후보 조회 실패", e);
+        }
+    }
+
+    private SScanResult executeLobbyAllSScan(
+            RedisConnection connection,
+            String cursor,
+            int count
+    ) {
+        Object rawResult = connection.scriptingCommands().eval(
+                rawKey(LOBBY_ALL_SSCAN_SCRIPT),
+                ReturnType.MULTI,
+                1,
+                rawKey(RedisKeys.LOBBY_ALL),
+                rawKey(normalizeScanCursor(cursor)),
+                rawKey(String.valueOf(Math.max(1, count)))
+        );
+
+        return parseSScanResult(rawResult);
+    }
+
+    private SScanResult parseSScanResult(Object rawResult) {
+        List<?> result = toObjectList(rawResult);
+        if (result.size() < 2) {
+            return new SScanResult(REDIS_SCAN_CURSOR_INITIAL, List.of());
         }
 
-        return candidates;
+        String nextCursor = normalizeScanCursor(decodeRedisValue(result.get(0)));
+        List<String> members = new ArrayList<>();
+
+        for (Object rawMember : toObjectList(result.get(1))) {
+            String member = decodeRedisValue(rawMember);
+            if (member != null && !member.isBlank()) {
+                members.add(member);
+            }
+        }
+
+        return new SScanResult(nextCursor, members);
+    }
+
+    private List<?> toObjectList(Object value) {
+        if (value instanceof List<?> list) {
+            return list;
+        }
+
+        if (value instanceof Collection<?> collection) {
+            return new ArrayList<>(collection);
+        }
+
+        if (value != null && value.getClass().isArray()) {
+            int length = Array.getLength(value);
+            List<Object> result = new ArrayList<>(length);
+
+            for (int i = 0; i < length; i++) {
+                result.add(Array.get(value, i));
+            }
+
+            return result;
+        }
+
+        return List.of();
+    }
+
+    private String getStoredReaperScanCursor(RedisConnection connection) {
+        byte[] cursor = connection.stringCommands().get(
+                rawKey(RedisKeys.LOBBY_ALL_REAPER_SCAN_CURSOR)
+        );
+
+        return normalizeScanCursor(decodeRedisValue(cursor));
+    }
+
+    private void storeReaperScanCursor(
+            RedisConnection connection,
+            String cursor
+    ) {
+        connection.stringCommands().set(
+                rawKey(RedisKeys.LOBBY_ALL_REAPER_SCAN_CURSOR),
+                rawKey(normalizeScanCursor(cursor))
+        );
+    }
+
+    private void pushReaperScanBuffer(
+            RedisConnection connection,
+            String code
+    ) {
+        if (code == null || code.isBlank()) {
+            return;
+        }
+
+        connection.listCommands().rPush(
+                rawKey(RedisKeys.LOBBY_ALL_REAPER_SCAN_BUFFER),
+                rawKey(code)
+        );
+    }
+
+    private String normalizeScanCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return REDIS_SCAN_CURSOR_INITIAL;
+        }
+
+        return cursor;
+    }
+
+    private String decodeRedisValue(Object value) {
+        if (value instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        if (value == null) {
+            return null;
+        }
+
+        return String.valueOf(value);
+    }
+
+    private record SScanResult(
+            String nextCursor,
+            List<String> members
+    ) {
     }
 
     /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyReaperScheduler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyReaperScheduler.java
@@ -32,8 +32,10 @@ import java.util.List;
  * 이 스케줄러는 DISCONNECT 누락을 복구하는 2차 안전망이다.
  *
  * [단일 인스턴스 운영]
- * reap_lobby.lua가 원자적·멱등이므로 별도 분산 락 없이도 안전하다.
- * 다중 인스턴스 동시 실행 시에도 첫 폭파 이후는 STALE_INDEX로 수렴한다.
+ * 단일 로비 폭파는 reap_lobby.lua 안에서 원자적·멱등으로 수행된다. 다만 lobby:all
+ * scan-cursor / scan-buffer 기반 후보 순회는 단일 scheduler 인스턴스 실행을 전제로 한다.
+ * 멀티 인스턴스에서 전수 순회 보장이 필요하면 별도 Redis lock 또는 후보 조회 전용 Lua
+ * 원자화가 필요하다.
  */
 @Slf4j
 @Component

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -149,6 +149,24 @@ public final class RedisKeys {
     public static final String LOBBY_ALL = "lobby:all";
 
     /**
+     * 빈 로비 reaper가 lobby:all SSCAN 진행 위치를 저장하는 키.
+     *
+     * [사용 목적]
+     * 매 스케줄 실행마다 cursor 0부터 시작하면 특정 구간만 반복 검사할 수 있으므로,
+     * 마지막 SSCAN cursor를 저장해 다음 실행에서 이어서 순회한다.
+     */
+    public static final String LOBBY_ALL_REAPER_SCAN_CURSOR = "lobby:all:reaper:scan-cursor";
+
+    /**
+     * 빈 로비 reaper가 SSCAN batch limit을 초과해 받은 후보를 임시 보관하는 List 키.
+     *
+     * [필요 이유]
+     * Redis SCAN COUNT는 정확한 반환 개수가 아니라 hint이므로, 한 번에 limit보다 많은
+     * member가 반환될 수 있다. 초과 후보를 버리지 않고 다음 스케줄 실행에서 먼저 처리한다.
+     */
+    public static final String LOBBY_ALL_REAPER_SCAN_BUFFER = "lobby:all:reaper:scan-buffer";
+
+    /**
      * 공개 로비 최신순 정렬 인덱스 ZSET 키
      *
      * 저장 구조 :

--- a/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/constant/RedisKeys.java
@@ -754,6 +754,16 @@ public final class RedisKeys {
     }
 
     /**
+     * 로비 내 사용자별 현재 유효 WebSocket 세션 sequence 키의 prefix를 반환합니다.
+     *
+     * @param code 로비 초대 코드
+     * @return "lobby:{code}:user_session_seq:"
+     */
+    public static String lobbyUserSessionSequenceKeyPrefix(String code) {
+        return LOBBY_PREFIX + code + USER_SESSION_SEQUENCE_SUFFIX;
+    }
+
+    /**
      * 공개 맵 목록 캐시 버전 키를 반환합니다.
      *
      * @return "map:public:list:version"

--- a/src/main/resources/scripts/reap_lobby.lua
+++ b/src/main/resources/scripts/reap_lobby.lua
@@ -45,8 +45,9 @@ local publicMostAvailableIndexKey = KEYS[10]  -- lobby:public:most_available (ZS
 local lobbyCode = ARGV[1]                      -- 대상 로비 코드
 local graceMillis = tonumber(ARGV[2])          -- 생성 직후 보호 기간(ms)
 local lobbyUserSessionPrefix = ARGV[3]         -- 로비별 현재 세션 키 prefix ("lobby:{code}:user_session:")
-local wsConnectionPrefix = ARGV[4]             -- WebSocket 세션 매핑 Hash 키 prefix ("ws:connection:")
-local lobbyField = ARGV[5]                      -- ws:connection Hash의 lobbyCode 필드명
+local lobbyUserSessionSeqPrefix = ARGV[4]      -- 로비별 세션 sequence 키 prefix ("lobby:{code}:user_session_seq:")
+local wsConnectionPrefix = ARGV[5]             -- WebSocket 세션 매핑 Hash 키 prefix ("ws:connection:")
+local lobbyField = ARGV[6]                      -- ws:connection Hash의 lobbyCode 필드명
 
 local FIELD_CREATED_AT_EPOCH_MILLIS = 'created_at_epoch_millis'
 
@@ -110,6 +111,11 @@ end
 -- 4. 0명이거나 전원 오프라인이면 로비를 폭파한다.
 --    leave_lobby.lua의 DESTROYED 경로와 동일하게 모든 로비 키와 인덱스를 제거한다.
 redis.call('DEL', lobbyKey, participantsKey, orderKey, kickedKey, readyKey)
+
+for i = 1, #participants do
+    redis.call('DEL', lobbyUserSessionPrefix .. participants[i], lobbyUserSessionSeqPrefix .. participants[i])
+end
+
 removeAllIndexes()
 
 return "REAPED"

--- a/src/main/resources/scripts/reap_lobby.lua
+++ b/src/main/resources/scripts/reap_lobby.lua
@@ -48,6 +48,8 @@ local lobbyUserSessionPrefix = ARGV[3]         -- 로비별 현재 세션 키 pr
 local lobbyUserSessionSeqPrefix = ARGV[4]      -- 로비별 세션 sequence 키 prefix ("lobby:{code}:user_session_seq:")
 local wsConnectionPrefix = ARGV[5]             -- WebSocket 세션 매핑 Hash 키 prefix ("ws:connection:")
 local lobbyField = ARGV[6]                      -- ws:connection Hash의 lobbyCode 필드명
+local statusField = ARGV[7]                     -- 로비 Hash의 status 필드명
+local waitingStatus = ARGV[8]                   -- reaper 대상 로비 상태 ("WAITING")
 
 local FIELD_CREATED_AT_EPOCH_MILLIS = 'created_at_epoch_millis'
 
@@ -65,6 +67,11 @@ end
 if redis.call('EXISTS', lobbyKey) == 0 then
     removeAllIndexes()
     return "STALE_INDEX"
+end
+
+local currentStatus = redis.call('HGET', lobbyKey, statusField)
+if currentStatus ~= waitingStatus then
+    return "ALIVE"
 end
 
 -- 2. 생성 후 grace 기간이 지나지 않았으면 보존한다.

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyLeaveLifecycleRepositoryTest.java
@@ -153,6 +153,7 @@ class LobbyLeaveLifecycleRepositoryTest {
         assertThat(redisTemplate.hasKey(RedisKeys.lobbyKickedKey(LOBBY_CODE))).isFalse();
         assertThat(redisTemplate.hasKey(RedisKeys.lobbyReadyKey(LOBBY_CODE))).isFalse();
 
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_ALL, LOBBY_CODE)).isFalse();
         assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_PUBLIC, LOBBY_CODE)).isFalse();
         assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_LATEST, LOBBY_CODE)).isNull();
         assertThat(redisTemplate.opsForZSet().score(RedisKeys.LOBBY_PUBLIC_MOST_PLAYERS, LOBBY_CODE)).isNull();

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyReaperLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyReaperLifecycleRepositoryTest.java
@@ -1,6 +1,7 @@
 package io.github.ascrew.monomatbe.domain.lobby.repository;
 
 import io.github.ascrew.monomatbe.domain.lobby.ReapLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.global.constant.RedisKeys;
 import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
 import org.junit.jupiter.api.AfterEach;
@@ -169,6 +170,27 @@ class LobbyReaperLifecycleRepositoryTest {
         // then
         assertThat(result).isEqualTo(ReapLobbyResult.TOO_YOUNG);
         assertThat(redisTemplate.hasKey(RedisKeys.lobbyKey(LOBBY_CODE))).isTrue();
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_ALL, LOBBY_CODE)).isTrue();
+    }
+
+    @Test
+    @DisplayName("PLAYING 로비는 유효 세션이 없어도 reaper가 삭제하지 않는다")
+    void keepsPlayingLobbyWithoutValidSession() {
+        // given
+        givenLobby(LOBBY_CODE, HOST_ID, false, 4, agedCreatedAt(), HOST_ID, SECOND_USER_ID);
+        redisTemplate.opsForHash().put(
+                RedisKeys.lobbyKey(LOBBY_CODE),
+                RedisKeys.FIELD_STATUS,
+                LobbyStatus.PLAYING.name()
+        );
+
+        // when
+        ReapLobbyResult result = lobbyRepository.reapEmptyLobby(LOBBY_CODE, GRACE_MS);
+
+        // then
+        assertThat(result).isEqualTo(ReapLobbyResult.ALIVE);
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyKey(LOBBY_CODE))).isTrue();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyParticipantsKey(LOBBY_CODE))).isTrue();
         assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_ALL, LOBBY_CODE)).isTrue();
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyReaperLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyReaperLifecycleRepositoryTest.java
@@ -80,6 +80,10 @@ class LobbyReaperLifecycleRepositoryTest {
                 RedisKeys.FIELD_CURRENT_PLAYERS,
                 "0"
         );
+        redisTemplate.opsForValue().set(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, HOST_ID), WS_HOST);
+        redisTemplate.opsForValue().set(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, SECOND_USER_ID), WS_SECOND);
+        redisTemplate.opsForValue().set(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, HOST_ID), "1");
+        redisTemplate.opsForValue().set(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, SECOND_USER_ID), "2");
         addPublicIndexes(LOBBY_CODE, 2, 2);
 
         // when
@@ -101,6 +105,7 @@ class LobbyReaperLifecycleRepositoryTest {
 
         redisTemplate.opsForValue().set(RedisKeys.userStatusKey(SECOND_USER_ID), "ONLINE");
         redisTemplate.opsForValue().set(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, SECOND_USER_ID), WS_STALE);
+        redisTemplate.opsForValue().set(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, SECOND_USER_ID), "1");
         redisTemplate.opsForHash().put(
                 RedisKeys.wsConnectionKey(WS_STALE),
                 WebSocketHeaders.SESSION_LOBBY_CODE,
@@ -208,6 +213,10 @@ class LobbyReaperLifecycleRepositoryTest {
         assertThat(redisTemplate.hasKey(RedisKeys.lobbyOrderKey(LOBBY_CODE))).isFalse();
         assertThat(redisTemplate.hasKey(RedisKeys.lobbyKickedKey(LOBBY_CODE))).isFalse();
         assertThat(redisTemplate.hasKey(RedisKeys.lobbyReadyKey(LOBBY_CODE))).isFalse();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, HOST_ID))).isFalse();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyUserSessionKey(LOBBY_CODE, SECOND_USER_ID))).isFalse();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, HOST_ID))).isFalse();
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyUserSessionSequenceKey(LOBBY_CODE, SECOND_USER_ID))).isFalse();
 
         assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_ALL, LOBBY_CODE)).isFalse();
         assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_PUBLIC, LOBBY_CODE)).isFalse();
@@ -262,6 +271,8 @@ class LobbyReaperLifecycleRepositoryTest {
                 RedisKeys.lobbyReadyKey(lobbyCode),
                 RedisKeys.lobbyUserSessionKey(lobbyCode, HOST_ID),
                 RedisKeys.lobbyUserSessionKey(lobbyCode, SECOND_USER_ID),
+                RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, HOST_ID),
+                RedisKeys.lobbyUserSessionSequenceKey(lobbyCode, SECOND_USER_ID),
                 RedisKeys.userStatusKey(HOST_ID),
                 RedisKeys.userStatusKey(SECOND_USER_ID),
                 RedisKeys.wsConnectionKey(WS_HOST),

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyReaperLifecycleRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/LobbyReaperLifecycleRepositoryTest.java
@@ -75,6 +75,11 @@ class LobbyReaperLifecycleRepositoryTest {
     void reapsLobbyWhenNoValidSessionForThisLobby() {
         // given: 참여자는 있으나 로비별 세션 키가 없는(=유효 세션 없음) 10분 전 생성 로비
         givenLobby(LOBBY_CODE, HOST_ID, false, 4, agedCreatedAt(), HOST_ID, SECOND_USER_ID);
+        redisTemplate.opsForHash().put(
+                RedisKeys.lobbyKey(LOBBY_CODE),
+                RedisKeys.FIELD_CURRENT_PLAYERS,
+                "0"
+        );
         addPublicIndexes(LOBBY_CODE, 2, 2);
 
         // when
@@ -116,6 +121,27 @@ class LobbyReaperLifecycleRepositoryTest {
         // given: 참여자 2명 중 1명이 이 로비에 대한 유효 세션 보유
         givenLobby(LOBBY_CODE, HOST_ID, false, 4, agedCreatedAt(), HOST_ID, SECOND_USER_ID);
         markValidSessionForLobby(LOBBY_CODE, SECOND_USER_ID, WS_SECOND);
+
+        // when
+        ReapLobbyResult result = lobbyRepository.reapEmptyLobby(LOBBY_CODE, GRACE_MS);
+
+        // then
+        assertThat(result).isEqualTo(ReapLobbyResult.ALIVE);
+        assertThat(redisTemplate.hasKey(RedisKeys.lobbyKey(LOBBY_CODE))).isTrue();
+        assertThat(redisTemplate.opsForSet().isMember(RedisKeys.LOBBY_ALL, LOBBY_CODE)).isTrue();
+    }
+
+    @Test
+    @DisplayName("current_players가 0이어도 참여자에게 유효 세션이 있으면 삭제하지 않는다")
+    void keepsLobbyWhenCurrentPlayersCacheIsZeroButParticipantHasValidSession() {
+        // given: 표시/정렬용 current_players 캐시가 0으로 어긋났지만 실제 source of truth에는 유효 참여자가 있음
+        givenLobby(LOBBY_CODE, HOST_ID, false, 4, agedCreatedAt(), HOST_ID);
+        redisTemplate.opsForHash().put(
+                RedisKeys.lobbyKey(LOBBY_CODE),
+                RedisKeys.FIELD_CURRENT_PLAYERS,
+                "0"
+        );
+        markValidSessionForLobby(LOBBY_CODE, HOST_ID, WS_HOST);
 
         // when
         ReapLobbyResult result = lobbyRepository.reapEmptyLobby(LOBBY_CODE, GRACE_MS);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepositoryTest.java
@@ -173,6 +173,23 @@ class LobbyRedisQueryRepositoryTest {
         assertThat(actualCodes).containsAll(expectedCodes);
     }
 
+    @Test
+    @DisplayName("reaper 후보 조회는 저장된 cursor가 비정상 문자열이어도 0으로 보정해 실패하지 않는다")
+    void getAllLobbyCodesForReaping_recoversInvalidStoredCursor() {
+        // given
+        String lobbyCode = newLobbyCode();
+        redisTemplate.opsForSet().add(RedisKeys.LOBBY_ALL, lobbyCode);
+        redisTemplate.opsForValue().set(RedisKeys.LOBBY_ALL_REAPER_SCAN_CURSOR, "not-a-cursor");
+
+        // when
+        List<String> candidates = lobbyRedisQueryRepository.getAllLobbyCodesForReaping(10);
+
+        // then
+        assertThat(candidates).contains(lobbyCode);
+        assertThat(redisTemplate.opsForValue().get(RedisKeys.LOBBY_ALL_REAPER_SCAN_CURSOR))
+                .matches("\\d+");
+    }
+
     private String newLobbyCode() {
         String lobbyCode = "TEST_LOBBY_" + UUID.randomUUID();
         usedLobbyCodes.add(lobbyCode);

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepositoryTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/repository/redis/LobbyRedisQueryRepositoryTest.java
@@ -9,7 +9,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +34,13 @@ class LobbyRedisQueryRepositoryTest {
                     RedisKeys.lobbyParticipantsKey(lobbyCode),
                     RedisKeys.lobbyOrderKey(lobbyCode)
             ));
+            redisTemplate.opsForSet().remove(RedisKeys.LOBBY_ALL, lobbyCode);
         }
+
+        redisTemplate.delete(List.of(
+                RedisKeys.LOBBY_ALL_REAPER_SCAN_CURSOR,
+                RedisKeys.LOBBY_ALL_REAPER_SCAN_BUFFER
+        ));
 
         usedLobbyCodes.clear();
     }
@@ -138,6 +146,31 @@ class LobbyRedisQueryRepositoryTest {
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("reaper 후보 조회는 저장된 SSCAN cursor와 buffer를 사용해 lobby:all 전체를 점진 순회한다")
+    void getAllLobbyCodesForReaping_continuesScanWithStoredCursor() {
+        // given
+        Set<String> expectedCodes = new LinkedHashSet<>();
+        for (int i = 0; i < 30; i++) {
+            String lobbyCode = newLobbyCode();
+            expectedCodes.add(lobbyCode);
+            redisTemplate.opsForSet().add(RedisKeys.LOBBY_ALL, lobbyCode);
+        }
+
+        Set<String> actualCodes = new LinkedHashSet<>();
+
+        // when
+        for (int i = 0; i < 30 && !actualCodes.containsAll(expectedCodes); i++) {
+            List<String> candidates = lobbyRedisQueryRepository.getAllLobbyCodesForReaping(3);
+
+            assertThat(candidates).hasSizeLessThanOrEqualTo(3);
+            actualCodes.addAll(candidates);
+        }
+
+        // then
+        assertThat(actualCodes).containsAll(expectedCodes);
     }
 
     private String newLobbyCode() {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #202

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 빈 로비 reaper가 `lobby:all` 후보를 랜덤 샘플링하던 방식을 cursor 기반 순회 방식으로 변경했습니다.
- `lobby:all` 전체를 점진적으로 검사할 수 있도록 reaper scan cursor와 overflow buffer Redis key를 추가했습니다.
- reaper 후보 조회 중 batch limit을 초과한 로비 코드는 buffer에 보관해 다음 reaper 실행에서 먼저 처리되도록 했습니다.
- `current_players=0` 값만 신뢰하지 않고, 참가자 set과 WebSocket session key를 기준으로 빈 로비 여부를 판단하는 기존 정책을 유지했습니다.
- 마지막 유저 정상 퇴장 시 `lobby:all`에서도 로비 코드가 제거되는지 검증을 보강했습니다.
- stale participant, `current_players=0`, reaper 후보 순회 누락 케이스에 대한 회귀 테스트를 추가했습니다.
- `docs/ARCHITECTURE.md`에 빈 로비 reaper 정책과 Redis cursor/buffer key 동작을 문서화했습니다.

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 정상 퇴장으로 마지막 인원이 나가는 경우에는 기존 `leave_lobby.lua` 경로에서 즉시 로비가 폭파됩니다.
- 이번 수정은 비정상 이탈, stale session, `current_players=0` 등 reaper가 사후 정리해야 하는 로비가 `lobby:all` 후보 조회에서 장기간 누락될 수 있던 문제를 해결합니다.
- reaper는 여전히 `lobby:all`을 기준 인덱스로 사용하므로, `lobby:{code}`는 존재하지만 `lobby:all`에서 코드가 사라진 비정상 인덱스 손상 케이스는 별도 복구 작업 범위입니다.
- 직접 Spring Boot를 실행해 REST + WebSocket/SockJS + Redis 상태 기준으로 0명 로비, 정상 마지막 퇴장, WebSocket session key 유실, `current_players=0` stale 로비가 정상 삭제되는 것을 확인했습니다.
- 전체 `./gradlew test`는 Docker/Testcontainers 환경 미구성으로 실패했으며, 변경 범위의 targeted test는 통과했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->