### PR TITLE
[Feat/#208] 맵 곡 수 기반 로비 라운드 수 정책 적용

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -575,7 +575,7 @@ Content-Type: application/json
   "questionCount": 10,
   "timeLimitSeconds": 30
 }
-````
+```
 
 | 필드                 | 타입     | 필수 | 제한     | 설명           |
 | ------------------ | ------ | -- | ------ | ------------ |
@@ -830,7 +830,7 @@ HTTP/1.1 200 OK
 POST /api/lobbies
 Authorization: Bearer {accessToken}
 Content-Type: application/json
-````
+```
 
 로그인한 사용자가 게임 로비를 생성합니다. 게스트와 정식 회원 모두 로비를 생성할 수 있습니다.
 
@@ -928,7 +928,7 @@ HTTP/1.1 201 Created
 ```http
 GET /api/lobbies/{inviteCode}
 Authorization: Bearer {accessToken}
-````
+```
 
 로비 대기실 화면에 필요한 로비 기본 정보, 선택된 맵 정보, 선택된 맵의 등록 곡 수, 룰 정보, 참가자 목록, 시작 가능 여부를 조회합니다.
 
@@ -1037,115 +1037,7 @@ HTTP/1.1 200 OK
 |         403 | 로비 참여자가 아닌 사용자가 상세 조회를 시도함       |
 |         404 | 존재하지 않는 로비 초대 코드                 |
 
-### 로비 상세 조회
-
-```http
-GET /api/lobbies/{inviteCode}
-Authorization: Bearer {accessToken}
-```
-
-로비 대기실 화면에 필요한 로비 기본 정보, 선택된 맵 정보, 룰 정보, 참가자 목록, 시작 가능 여부를 조회합니다.
-
-참가자 목록은 Redis에 저장된 로비 참여자 상태를 기준으로 구성하며, 각 참가자의 `userIdentifier`에 대응하는 사용자 닉네임을 함께 반환합니다.
-
-#### WebSocket 연동 정책
-
-로비 참가, 퇴장, 준비 상태 변경 등으로 로비 상태가 변경되면 서버는 기존 WebSocket refresh 이벤트를 전송합니다.
-
-FE는 refresh 이벤트를 수신하면 이 API를 다시 호출하여 최신 로비 상세 정보를 동기화합니다.
-
-```text
-WebSocket refresh 이벤트 수신
-→ GET /api/lobbies/{inviteCode} 재조회
-→ 최신 players[].nickname / ready / host 상태 반영
-```
-
-#### Path Variables
-
-| 필드           | 타입     | 설명       |
-| ------------ | ------ | -------- |
-| `inviteCode` | string | 로비 초대 코드 |
-
-#### Success Response
-
-```http
-HTTP/1.1 200 OK
-```
-
-```json
-{
-  "inviteCode": "ABC123",
-  "title": "로비 제목",
-  "hostId": "host-user-identifier",
-  "hostNickname": "방장닉네임",
-  "maxPlayers": 4,
-  "currentPlayers": 2,
-  "status": "WAITING",
-  "mapId": 1,
-  "mapTitle": "K-POP 퀴즈",
-  "mapCategory": "K-POP",
-  "questionCount": 10,
-  "timeLimitSeconds": 30,
-  "players": [
-    {
-      "userIdentifier": "host-user-identifier",
-      "nickname": "방장닉네임",
-      "host": true,
-      "ready": false
-    },
-    {
-      "userIdentifier": "participant-user-identifier",
-      "nickname": "참가자닉네임",
-      "host": false,
-      "ready": true
-    }
-  ],
-  "canStart": false
-}
-```
-
-#### Response Fields
-
-| 필드                         | 타입            | 설명                                                |
-| -------------------------- | ------------- | ------------------------------------------------- |
-| `inviteCode`               | string        | 로비 초대 코드                                          |
-| `title`                    | string        | 로비 제목                                             |
-| `hostId`                   | string        | 방장 사용자 식별자. Redis/WebSocket 식별용 값                 |
-| `hostNickname`             | string        | 방장 표시 닉네임                                         |
-| `maxPlayers`               | number        | 최대 참여 인원                                          |
-| `currentPlayers`           | number        | 현재 참여 인원                                          |
-| `status`                   | string        | 로비 상태. `WAITING`, `PLAYING`, `FINISHED`           |
-| `mapId`                    | number \| null | 선택된 맵 ID. 맵 미선택 시 `null` |
-| `mapTitle`                 | string \| null | 선택된 맵 제목. 맵 미선택 시 `null` |
-| `mapCategory`              | string \| null | 선택된 맵 카테고리. 맵 미선택 시 `null` |
-| `questionCount`            | number \| null | 진행할 문제 수/라운드 수 |
-| `timeLimitSeconds`         | number \| null | 라운드당 제한 시간(초) |
-| `players`                  | array         | 로비 참가자 목록                                         |
-| `players[].userIdentifier` | string        | 참가자 식별자. Redis/WebSocket 식별용 값이며 화면 표시용으로 사용하지 않음 |
-| `players[].nickname`       | string        | 참가자 표시 닉네임                                        |
-| `players[].host`           | boolean       | 해당 참가자가 방장인지 여부                                   |
-| `players[].ready`          | boolean       | 해당 참가자의 준비 상태. 방장은 ready 대상이 아니므로 `false`일 수 있음   |
-| `canStart`                 | boolean       | 조회 시점 기준 게임 시작 버튼 활성화 가능 여부                       |
-
-#### 참가자 닉네임 정책
-
-| 항목          | 정책                                                         |
-| ----------- | ---------------------------------------------------------- |
-| 조회 기준       | `players[].userIdentifier` 기준으로 사용자 닉네임 조회                 |
-| 대상 사용자      | 게스트 사용자와 정식 회원 사용자 모두 지원                                   |
-| 조회 실패       | 로비 상세 조회 전체를 실패시키지 않고 fallback 닉네임 반환                      |
-| fallback 형식 | `Unknown-{hash}` 형식의 안전한 표시값                               |
-| 식별자 노출      | `userIdentifier` 원문 일부를 fallback 닉네임에 포함하지 않음              |
-| 순서          | 기존 Redis 참가자 목록 순서 유지                                      |
-| 방장 보정       | Redis participants Set에 방장이 누락된 경우 응답 목록 맨 앞에 방장을 보정할 수 있음 |
-
-#### Error Response
-
-| HTTP Status | 상황                               |
-| ----------: | -------------------------------- |
-|         401 | 인증 정보 없음 또는 유효하지 않은 Access Token |
-|         403 | 로비 참여자가 아닌 사용자가 상세 조회를 시도함       |
-|         404 | 존재하지 않는 로비 초대 코드                 |
+---
 
 ### 초대 코드 기반 로비 입장
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -830,11 +830,13 @@ HTTP/1.1 200 OK
 POST /api/lobbies
 Authorization: Bearer {accessToken}
 Content-Type: application/json
-```
+````
 
 로그인한 사용자가 게임 로비를 생성합니다. 게스트와 정식 회원 모두 로비를 생성할 수 있습니다.
 
 `maxPlayers`, `questionCount`, `timeLimitSeconds`는 생략할 수 있으며, 생략 시 서버 기본값이 적용됩니다.
+
+단, `mapId`가 있고 `questionCount`가 생략된 경우에는 고정 기본값이 아니라 선택된 맵의 등록 곡 수(`map.numOfSong`)를 기본 라운드 수로 사용합니다.
 
 #### Request Body
 
@@ -849,27 +851,32 @@ Content-Type: application/json
 }
 ```
 
-| 필드 | 타입 | 필수 | 기본값 | 제한 | 설명 |
-| --- | --- | ---: | ---: | --- | --- |
-| `title` | string | O | - | 최대 255자, blank 불가 | 로비 제목 |
-| `maxPlayers` | number | X | 4 | 2~8 | 최대 참여 인원 |
-| `isPrivate` | boolean | O | - | - | 비공개 로비 여부 |
-| `mapId` | number | X | null | 양수 | 연결할 맵 ID. 생략 시 맵 미선택 로비 생성 |
-| `questionCount` | number | X | 10 | 1~50 | 진행할 문제 수/라운드 수 |
-| `timeLimitSeconds` | number | X | 30 | 10~120 | 라운드당 제한 시간(초) |
+| 필드                 | 타입      | 필수 |                                기본값 | 제한                              | 설명                         |
+| ------------------ | ------- | -: | ---------------------------------: | ------------------------------- | -------------------------- |
+| `title`            | string  |  O |                                  - | 최대 255자, blank 불가               | 로비 제목                      |
+| `maxPlayers`       | number  |  X |                                  4 | 2~8                             | 최대 참여 인원                   |
+| `isPrivate`        | boolean |  O |                                  - | -                               | 비공개 로비 여부                  |
+| `mapId`            | number  |  X |                               null | 양수                              | 연결할 맵 ID. 생략 시 맵 미선택 로비 생성 |
+| `questionCount`    | number  |  X | 맵 선택 시 `map.numOfSong`, 맵 미선택 시 10 | 1~50, 맵 선택 시 `map.numOfSong` 이하 | 진행할 문제 수/라운드 수             |
+| `timeLimitSeconds` | number  |  X |                                 30 | 10~120                          | 라운드당 제한 시간(초)              |
 
 #### 로비 생성 기본값/제한 정책
 
-| 항목 | 최소값 | 기본값 | 최대값 |
-| --- | ---: | ---: | ---: |
-| 최대 인원 | 2명 | 4명 | 8명 |
-| 문제 수/라운드 수 | 1개 | 10개 | 50개 |
-| 라운드당 제한 시간 | 10초 | 30초 | 120초 |
+| 항목         | 최소값 |                                 기본값 |  최대값 |
+| ---------- | --: | ----------------------------------: | ---: |
+| 최대 인원      |  2명 |                                  4명 |   8명 |
+| 문제 수/라운드 수 |  1개 | 맵 선택 시 `map.numOfSong`, 맵 미선택 시 10개 |  50개 |
+| 라운드당 제한 시간 | 10초 |                                 30초 | 120초 |
 
 #### 맵 선택 시 문제 수 정책
 
-questionCount 생략 + mapId 있음 → min(10, map.numOfSong)
-questionCount 명시 + mapId 있음 + questionCount > map.numOfSong → 400
+| 조건                                                                 | 처리                                |
+| ------------------------------------------------------------------ | --------------------------------- |
+| `questionCount` 생략 + `mapId` 없음                                    | 기본값 10 사용                         |
+| `questionCount` 생략 + `mapId` 있음                                    | 선택된 맵의 등록 곡 수(`map.numOfSong`) 사용 |
+| `questionCount` 명시 + `mapId` 있음 + `questionCount <= map.numOfSong` | 요청한 `questionCount` 사용            |
+| `questionCount` 명시 + `mapId` 있음 + `questionCount > map.numOfSong`  | `400 Bad Request`                 |
+| `mapId` 있음 + 선택된 맵의 등록 곡 수가 1개 미만                                  | `409 Conflict`                    |
 
 #### Success Response
 
@@ -896,24 +903,139 @@ HTTP/1.1 201 Created
 맵 생성/수정 요청 및 로비 목록 `mapCategory` 필터에서 사용하는 카테고리 값은 아래 5종이다.
 
 | 응답/표시 값 | 허용 입력 값(대소문자·하이픈·언더스코어·공백 무시) |
-| --- | --- |
-| `K-POP` | `K-POP`, `KPOP`, `kpop` |
-| `J-POP` | `J-POP`, `JPOP`, `jpop` |
-| `POP` | `POP`, `pop` |
-| `OST` | `OST`, `ost` |
-| `애니` | `애니`, `ANIME`, `anime` |
+| ------- | ----------------------------- |
+| `K-POP` | `K-POP`, `KPOP`, `kpop`       |
+| `J-POP` | `J-POP`, `JPOP`, `jpop`       |
+| `POP`   | `POP`, `pop`                  |
+| `OST`   | `OST`, `ost`                  |
+| `애니`    | `애니`, `ANIME`, `anime`        |
 
 목록에 없는 값을 요청하면 400 Bad Request로 응답한다.
 
 #### Error Response
 
-| HTTP Status | 상황 |
-| ---: | --- |
-| 400 | 요청 본문 검증 실패 |
-| 400 | 선택한 맵의 등록 곡 수보다 `questionCount`가 큼 |
-| 401 | 인증 정보 없음 또는 유효하지 않은 Access Token |
-| 404 | 사용자 또는 선택한 맵을 찾을 수 없음 |
-| 500 | Redis 저장 후 DB 스냅샷 저장 실패 등 로비 생성 실패 |
+| HTTP Status | 상황                                  |
+| ----------: | ----------------------------------- |
+|         400 | 요청 본문 검증 실패                         |
+|         400 | 선택한 맵의 등록 곡 수보다 `questionCount`가 큼  |
+|         401 | 인증 정보 없음 또는 유효하지 않은 Access Token    |
+|         404 | 사용자 또는 선택한 맵을 찾을 수 없음               |
+|         409 | 삭제된 맵, 등록된 곡이 없는 맵 등 로비에 연결할 수 없는 맵 |
+|         500 | Redis 저장 후 DB 스냅샷 저장 실패 등 로비 생성 실패  |
+
+### 로비 상세 조회
+
+```http
+GET /api/lobbies/{inviteCode}
+Authorization: Bearer {accessToken}
+````
+
+로비 대기실 화면에 필요한 로비 기본 정보, 선택된 맵 정보, 선택된 맵의 등록 곡 수, 룰 정보, 참가자 목록, 시작 가능 여부를 조회합니다.
+
+참가자 목록은 Redis에 저장된 로비 참여자 상태를 기준으로 구성하며, 각 참가자의 `userIdentifier`에 대응하는 사용자 닉네임을 함께 반환합니다.
+
+`mapNumOfSong`은 FE에서 라운드 수 입력 범위를 `1 ~ mapNumOfSong`으로 제한하기 위한 값입니다. 맵이 선택되지 않은 로비에서는 `null`을 반환합니다.
+
+#### WebSocket 연동 정책
+
+로비 참가, 퇴장, 준비 상태 변경, 맵 변경, 로비 설정 변경 등으로 로비 상태가 변경되면 서버는 기존 WebSocket refresh 이벤트를 전송합니다.
+
+FE는 refresh 이벤트를 수신하면 이 API를 다시 호출하여 최신 로비 상세 정보를 동기화합니다.
+
+```text
+WebSocket refresh 이벤트 수신
+→ GET /api/lobbies/{inviteCode} 재조회
+→ 최신 mapNumOfSong / questionCount / players[].nickname / ready / host 상태 반영
+```
+
+#### Path Variables
+
+| 필드           | 타입     | 설명       |
+| ------------ | ------ | -------- |
+| `inviteCode` | string | 로비 초대 코드 |
+
+#### Success Response
+
+```http
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "inviteCode": "ABC123",
+  "title": "로비 제목",
+  "hostId": "host-user-identifier",
+  "hostNickname": "방장닉네임",
+  "maxPlayers": 4,
+  "currentPlayers": 2,
+  "status": "WAITING",
+  "mapId": 1,
+  "mapTitle": "K-POP 퀴즈",
+  "mapCategory": "K-POP",
+  "mapNumOfSong": 24,
+  "questionCount": 24,
+  "timeLimitSeconds": 30,
+  "players": [
+    {
+      "userIdentifier": "host-user-identifier",
+      "nickname": "방장닉네임",
+      "host": true,
+      "ready": false
+    },
+    {
+      "userIdentifier": "participant-user-identifier",
+      "nickname": "참가자닉네임",
+      "host": false,
+      "ready": true
+    }
+  ],
+  "canStart": false
+}
+```
+
+#### Response Fields
+
+| 필드                         | 타입            | 설명                                                |
+| -------------------------- | ------------- | ------------------------------------------------- |
+| `inviteCode`               | string        | 로비 초대 코드                                          |
+| `title`                    | string        | 로비 제목                                             |
+| `hostId`                   | string        | 방장 사용자 식별자. Redis/WebSocket 식별용 값                 |
+| `hostNickname`             | string        | 방장 표시 닉네임                                         |
+| `maxPlayers`               | number        | 최대 참여 인원                                          |
+| `currentPlayers`           | number        | 현재 참여 인원                                          |
+| `status`                   | string        | 로비 상태. `WAITING`, `PLAYING`, `FINISHED`           |
+| `mapId`                    | number | null | 선택된 맵 ID. 맵 미선택 시 `null`                          |
+| `mapTitle`                 | string | null | 선택된 맵 제목. 맵 미선택 시 `null`                          |
+| `mapCategory`              | string | null | 선택된 맵 카테고리. 맵 미선택 시 `null`                        |
+| `mapNumOfSong`             | number | null | 선택된 맵의 등록 곡/문제 수. 맵 미선택 시 `null`                  |
+| `questionCount`            | number | null | 진행할 문제 수/라운드 수                                    |
+| `timeLimitSeconds`         | number | null | 라운드당 제한 시간(초)                                     |
+| `players`                  | array         | 로비 참가자 목록                                         |
+| `players[].userIdentifier` | string        | 참가자 식별자. Redis/WebSocket 식별용 값이며 화면 표시용으로 사용하지 않음 |
+| `players[].nickname`       | string        | 참가자 표시 닉네임                                        |
+| `players[].host`           | boolean       | 해당 참가자가 방장인지 여부                                   |
+| `players[].ready`          | boolean       | 해당 참가자의 준비 상태. 방장은 ready 대상이 아니므로 `false`일 수 있음   |
+| `canStart`                 | boolean       | 조회 시점 기준 게임 시작 버튼 활성화 가능 여부                       |
+
+#### 참가자 닉네임 정책
+
+| 항목          | 정책                                                         |
+| ----------- | ---------------------------------------------------------- |
+| 조회 기준       | `players[].userIdentifier` 기준으로 사용자 닉네임 조회                 |
+| 대상 사용자      | 게스트 사용자와 정식 회원 사용자 모두 지원                                   |
+| 조회 실패       | 로비 상세 조회 전체를 실패시키지 않고 fallback 닉네임 반환                      |
+| fallback 형식 | `Unknown-{hash}` 형식의 안전한 표시값                               |
+| 식별자 노출      | `userIdentifier` 원문 일부를 fallback 닉네임에 포함하지 않음              |
+| 순서          | 기존 Redis 참가자 목록 순서 유지                                      |
+| 방장 보정       | Redis participants Set에 방장이 누락된 경우 응답 목록 맨 앞에 방장을 보정할 수 있음 |
+
+#### Error Response
+
+| HTTP Status | 상황                               |
+| ----------: | -------------------------------- |
+|         401 | 인증 정보 없음 또는 유효하지 않은 Access Token |
+|         403 | 로비 참여자가 아닌 사용자가 상세 조회를 시도함       |
+|         404 | 존재하지 않는 로비 초대 코드                 |
 
 ### 로비 상세 조회
 

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyDetailResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
  * - 로비 기본 정보
  * - 방장 식별자 및 표시 닉네임
  * - 선택된 맵 정보
+ * - 선택된 맵의 등록 곡 수
  * - 룰 정보 (questionCount, timeLimitSeconds)
  * - 참여자별 nickname / ready / host 상태
  * - 현재 게임 시작 버튼 활성화 가능 여부 (canStart)
@@ -29,6 +30,7 @@ public record LobbyDetailResponse(
         Long mapId,
         String mapTitle,
         String mapCategory,
+        Integer mapNumOfSong,
         Integer questionCount,
         Integer timeLimitSeconds,
         List<LobbyPlayerResponse> players,

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyMapMetadata.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/dto/LobbyMapMetadata.java
@@ -5,11 +5,12 @@ package io.github.ascrew.monomatbe.domain.lobby.dto;
  *
  * [설계 의도]
  * LobbyRepository는 Redis 저장 책임만 가지므로 QuizMap 엔티티에 직접 의존하지 않는다.
- * LobbyMapPolicy가 맵 접근 권한을 검증한 뒤, Redis Hash에 필요한 최소 정보만 이 DTO로 전달한다.
+ * LobbyMapPolicy가 맵 접근 권한을 검증한 뒤, Redis Hash와 서비스 로직에 필요한 최소 정보만 이 DTO로 전달한다.
  */
 public record LobbyMapMetadata(
         Long mapId,
         String mapTitle,
-        String mapCategory
+        String mapCategory,
+        Integer numOfSong
 ) {
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateService.java
@@ -5,13 +5,10 @@
  * - 인증 주체 검증
  * - 방장 User 조회
  * - 선택된 맵 접근 가능 여부 검증 위임
- * - questionCount 동적 검증 (선택 맵의 등록 곡 수 상한 검증)
+ * - questionCount 동적 검증
  * - Redis 로비 상태 생성
  * - DB GAME_LOBBY 스냅샷 저장
  * - DB 저장 실패 시 Redis 보상 삭제
- *
- * 로비 생성은 Redis 선저장 + DB 스냅샷 저장 + 보상 삭제라는 별도 트랜잭션 경계를 가지므로,
- * 독립 유스케이스 서비스로 분리한다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
@@ -24,8 +21,6 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
-import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,20 +34,12 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class LobbyCreateService {
 
-    // =========================================================
-    // 에러 메시지 상수
-    // =========================================================
-
     private static final String ERROR_INVALID_PRINCIPAL =
             "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
     private static final String ERROR_USER_NOT_FOUND =
             "사용자를 찾을 수 없습니다.";
     private static final String ERROR_CREATE_LOBBY_FAILED =
             "로비 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
-
-    // =========================================================
-    // 로그 메시지 상수
-    // =========================================================
 
     private static final String LOG_INVALID_PRINCIPAL =
             "로비 생성 요청 거부 - principal 또는 userId가 null. userIdentifier: {}";
@@ -68,26 +55,18 @@ public class LobbyCreateService {
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final UserRepository userRepository;
     private final LobbyMapPolicy lobbyMapPolicy;
-    private final QuizMapJpaRepository quizMapJpaRepository;
 
     /**
      * 로비를 생성한다.
      *
-     * [처리 순서]
-     * 1. principal null 및 userId null 검증
-     * 2. JWT에서 추출한 userId로 User 엔티티 조회
-     * 3. 선택된 mapId가 있으면 LobbyMapPolicy로 맵 존재/삭제/권한 검증
-     * 4. questionCount 결정:
-     *    - mapId 없음: request.questionCount가 null이면 DEFAULT_QUESTION_COUNT 적용
-     *    - mapId 있음 + questionCount 생략: min(DEFAULT_QUESTION_COUNT, numOfSong) 적용
-     *    - mapId 있음 + questionCount 명시: numOfSong 초과 시 400 BAD_REQUEST
-     * 5. Lua 스크립트로 초대 코드 선점 및 Redis 로비 데이터 원자 저장
-     * 6. DB에 GAME_LOBBY 스냅샷 저장
-     * 7. DB 저장 실패 시 Redis 보상 삭제
-     *
-     * [트랜잭션 경계]
-     * 로비 생성은 Redis와 DB를 함께 다룬다.
-     * DB 저장 실패 시 Redis 보상 삭제가 필요하므로 이 유스케이스 서비스에서 트랜잭션을 직접 관리한다.
+     * [questionCount 결정 규칙]
+     * - mapId 없음:
+     *   - request.questionCount == null → DEFAULT_QUESTION_COUNT
+     *   - request.questionCount != null → request.questionCount
+     * - mapId 있음:
+     *   - request.questionCount == null → 선택된 맵의 numOfSong
+     *   - request.questionCount > numOfSong → 400 BAD_REQUEST
+     *   - request.questionCount <= numOfSong → request.questionCount
      *
      * @param request   로비 생성 요청 DTO
      * @param principal JWT에서 추출한 인증 주체
@@ -110,12 +89,6 @@ public class LobbyCreateService {
                         ERROR_USER_NOT_FOUND
                 ));
 
-        /*
-         * 맵 연결 정책:
-         * - mapId가 없으면 맵 미선택 로비로 생성한다.
-         * - mapId가 있으면 LobbyMapPolicy에서 존재 여부, 삭제 여부, 접근 권한을 검증한다.
-         * - 검증된 최소 맵 정보만 Redis 저장 계층으로 전달한다.
-         */
         LobbyMapMetadata mapMetadata = lobbyMapPolicy.resolveLobbyMapMetadata(
                 request.mapId(),
                 principal.userId()
@@ -186,20 +159,6 @@ public class LobbyCreateService {
         }
     }
 
-    /**
-     * 유효한 questionCount를 결정한다.
-     *
-     * [결정 규칙]
-     * - mapId 없음:
-     *   - request.questionCount == null → DEFAULT_QUESTION_COUNT
-     *   - request.questionCount != null → request.questionCount
-     * - mapId 있음:
-     *   - request.questionCount == null → min(DEFAULT_QUESTION_COUNT, numOfSong)
-     *   - request.questionCount > numOfSong → 400 BAD_REQUEST
-     *   - request.questionCount <= numOfSong → request.questionCount
-     *
-     * LobbyMapPolicy가 이미 맵 존재·삭제·권한을 검증했으므로 findById는 항상 성공한다.
-     */
     private int resolveQuestionCount(CreateLobbyRequest request, LobbyMapMetadata mapMetadata) {
         Integer requestedQuestionCount = request.questionCount();
 
@@ -209,11 +168,10 @@ public class LobbyCreateService {
                     : requestedQuestionCount;
         }
 
-        QuizMap map = quizMapJpaRepository.findById(mapMetadata.mapId()).orElseThrow();
-        int numOfSong = map.getNumOfSong();
+        int numOfSong = mapMetadata.numOfSong();
 
         if (requestedQuestionCount == null) {
-            return Math.min(LobbyDefaults.DEFAULT_QUESTION_COUNT, numOfSong);
+            return numOfSong;
         }
 
         if (requestedQuestionCount > numOfSong) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapPolicy.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapPolicy.java
@@ -6,11 +6,12 @@
  * - 맵 존재 여부 검증
  * - 삭제된 맵 사용 차단
  * - 공개 맵 또는 본인 소유 비공개 맵만 사용 허용
- * - Redis 저장에 필요한 LobbyMapMetadata 생성
+ * - Redis 저장 및 라운드 수 계산에 필요한 LobbyMapMetadata 생성
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
 import io.github.ascrew.monomatbe.domain.lobby.dto.LobbyMapMetadata;
+import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
 import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,16 +23,14 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class LobbyMapPolicy {
 
-    // =========================================================
-    // 에러 메시지 상수
-    // =========================================================
-
     private static final String ERROR_MAP_NOT_FOUND =
             "존재하지 않는 맵입니다.";
     private static final String ERROR_MAP_DELETED =
             "삭제된 맵은 로비에 연결할 수 없습니다.";
     private static final String ERROR_PRIVATE_MAP_FORBIDDEN =
             "비공개 맵은 소유자만 로비에 연결할 수 있습니다.";
+    private static final String ERROR_MAP_HAS_NO_SONG =
+            "등록된 곡이 없는 맵은 로비에 연결할 수 없습니다.";
 
     private final QuizMapJpaRepository quizMapJpaRepository;
 
@@ -45,10 +44,7 @@ public class LobbyMapPolicy {
      * - 삭제된 맵은 409로 차단한다.
      * - 공개 맵은 누구나 사용할 수 있다.
      * - 비공개 맵은 소유자만 사용할 수 있다.
-     *
-     * [반환값]
-     * Redis 로비 Hash에 저장할 최소 메타데이터만 반환한다.
-     * 전체 QuizMap 엔티티를 외부로 노출하지 않아 로비 생성 서비스의 결합도를 낮춘다.
+     * - 등록 곡 수가 1개 미만인 맵은 로비에 연결할 수 없다.
      *
      * @param mapId           요청으로 전달된 맵 ID
      * @param requesterUserId 로비 생성 또는 설정 변경 요청자의 DB userId
@@ -66,25 +62,16 @@ public class LobbyMapPolicy {
                 ));
 
         validateUsableMap(quizMap, requesterUserId);
+        validateHasSong(quizMap);
 
         return new LobbyMapMetadata(
                 quizMap.getId(),
                 quizMap.getTitle(),
-                quizMap.getCategory().value()
+                quizMap.getCategory().value(),
+                quizMap.getNumOfSong()
         );
     }
 
-    /**
-     * 로비에서 사용할 수 있는 맵인지 검증한다.
-     *
-     * [검증]
-     * - 삭제된 맵인지 확인
-     * - 공개 맵인지 확인
-     * - 비공개 맵이면 요청자가 소유자인지 확인
-     *
-     * @param quizMap         검증 대상 맵
-     * @param requesterUserId 요청자 DB userId
-     */
     private void validateUsableMap(QuizMap quizMap, Long requesterUserId) {
         if (Boolean.TRUE.equals(quizMap.getIsDeleted())) {
             throw new ResponseStatusException(
@@ -101,17 +88,17 @@ public class LobbyMapPolicy {
         }
     }
 
-    /**
-     * 요청자가 해당 맵을 로비에 연결할 수 있는지 판단한다.
-     *
-     * [정책]
-     * - 공개 맵은 누구나 사용할 수 있다.
-     * - 비공개 맵은 맵 소유자만 사용할 수 있다.
-     *
-     * @param quizMap         검증 대상 맵
-     * @param requesterUserId 요청자 DB userId
-     * @return 사용할 수 있으면 true
-     */
+    private void validateHasSong(QuizMap quizMap) {
+        Integer numOfSong = quizMap.getNumOfSong();
+
+        if (numOfSong == null || numOfSong < LobbyDefaults.MIN_QUESTION_COUNT) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    ERROR_MAP_HAS_NO_SONG
+            );
+        }
+    }
+
     private boolean canUseMap(QuizMap quizMap, Long requesterUserId) {
         if (Boolean.TRUE.equals(quizMap.getIsPublic())) {
             return true;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateService.java
@@ -1,37 +1,5 @@
 /*
  * 로비 대기실 맵 변경 유스케이스를 담당하는 서비스.
- *
- * [책임]
- * - 인증 주체 검증 (userId / userIdentifier null 모두 차단)
- * - Redis 로비 1차 조회 (존재 여부 / WAITING 상태 / 방장 여부)
- * - 선택된 맵 접근 가능 여부 검증 위임 (LobbyMapPolicy 재사용)
- * - DB GAME_LOBBY 행에 대한 PESSIMISTIC_WRITE 락 획득 (게임 시작 경로와 직렬화)
- * - 락 획득 후 entity.status로 WAITING 재검증
- * - Redis 맵 메타데이터 갱신
- * - DB GAME_LOBBY.map_id 조건부 갱신
- * - 보상 복구를 status==WAITING 원자 조건으로 처리 (compensate_lobby_map.lua)
- * - DB row 누락 시 LobbyStartService와 동일한 reconciliation 패턴 적용
- * - 참여자 refresh 이벤트 발행 (트랜잭션 커밋 후)
- *
- * [정합성 정책]
- * Redis 1차 조회 → DB 행 락 → Redis 선갱신 → DB 조건부 갱신 순으로 진행한다.
- * DB 락이 게임 시작 경로(LobbyStartService.findByInviteCodeForUpdate)와 직렬화를 보장한다.
- * 보상 복구는 항상 Lua로 status==WAITING 원자 검증과 함께 수행되어
- * 이미 PLAYING으로 전환된 로비의 맵 메타데이터를 절대 건드리지 않는다.
- *
- * [Redis 선갱신 정책]
- * Redis가 로비 실시간 상태의 source of truth이므로 맵 변경도 Redis를 먼저 반영하여
- * 클라이언트 가시성(STOMP refresh로 즉시 노출)을 우선한다. DB는 영속/감사 스냅샷 역할이며,
- * DB 갱신 실패 시 compensate_lobby_map.lua가 status==WAITING 원자 검증 후 보상한다.
- * 자세한 정책은 docs/ARCHITECTURE.md "로비 맵 변경 Redis-DB 정합성" 섹션 참고.
- *
- * [보상 실패 시 운영 대응]
- * compensate Lua가 LOBBY_NOT_FOUND를 반환하거나 예외가 발생하면 [MONITORING_REQUIRED] 로그가
- * 남는다. 운영자는 해당 로그로 Redis/DB mapId 불일치를 수동 확인하고 정리한다.
- *
- * [Lock timeout 정책]
- * findByInviteCodeForUpdate에 jakarta.persistence.lock.timeout = 3000ms 힌트가 적용되어
- * 있다. 타임아웃 초과 시 PessimisticLockingFailureException을 잡아 409 CONFLICT로 변환한다.
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
@@ -43,8 +11,6 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
-import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,10 +29,6 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class LobbyMapUpdateService {
 
-    // =========================================================
-    // 에러 메시지 상수
-    // =========================================================
-
     private static final String ERROR_INVALID_PRINCIPAL =
             "유효하지 않은 인증 정보입니다. 다시 로그인해주세요.";
     private static final String ERROR_LOBBY_NOT_FOUND =
@@ -82,10 +44,6 @@ public class LobbyMapUpdateService {
     private static final String ERROR_LOBBY_LOCK_CONTENTION =
             "다른 로비 상태 변경이 진행 중입니다. 잠시 후 다시 시도해주세요.";
 
-    // =========================================================
-    // 로그 메시지 상수
-    // =========================================================
-
     private static final String LOG_ALERT_REQUIRED = "[ALERT_REQUIRED]";
     private static final String LOG_MONITORING_REQUIRED = "[MONITORING_REQUIRED]";
     private static final String LOG_DB_UPDATE_FAILED =
@@ -100,27 +58,11 @@ public class LobbyMapUpdateService {
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final LobbyMapPolicy lobbyMapPolicy;
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
-    private final QuizMapJpaRepository quizMapJpaRepository;
 
     /**
      * 로비 대기실에서 방장의 맵 변경 요청을 처리한다.
      *
-     * [처리 순서]
-     * 1. principal / userId / userIdentifier null 검증
-     * 2. Redis 1차 조회 (존재 / WAITING / 방장 검증)
-     * 3. LobbyMapPolicy로 맵 존재/삭제/권한 검증 (newMetadata 결정)
-     * 4. DB GAME_LOBBY 행 PESSIMISTIC_WRITE 락 획득
-     *    - row 없음 → handleMissingGameLobbySnapshot (409 SNAPSHOT_NOT_FOUND + reconciliation)
-     *    - status != WAITING → 409 NOT_WAITING (락 시점의 진실)
-     * 5. Redis 맵 메타데이터 선갱신
-     * 6. DB GAME_LOBBY.map_id 조건부 갱신 (방어용 - 락 보장으로 사실상 항상 1)
-     *    - 갱신 행 0 → 안전 보상 (compensateMapMetadataIfWaiting) 후 409
-     *    - DB 예외 → 안전 보상 후 500
-     * 7. 트랜잭션 커밋 후 참여자 refresh 이벤트 발행
-     *
-     * @param code      로비 초대 코드
-     * @param request   맵 변경 요청 DTO
-     * @param principal JWT에서 추출한 인증 주체
+     * 새 맵이 선택되면 questionCount는 새 맵의 numOfSong으로 재설정한다.
      */
     @Transactional
     public void updateMap(String code, UpdateLobbyMapRequest request, CustomPrincipal principal) {
@@ -156,7 +98,12 @@ public class LobbyMapUpdateService {
 
         LobbyMapMetadata oldMetadata = lobbyInfo.mapId() == null
                 ? null
-                : new LobbyMapMetadata(lobbyInfo.mapId(), lobbyInfo.mapTitle(), lobbyInfo.mapCategory());
+                : new LobbyMapMetadata(
+                lobbyInfo.mapId(),
+                lobbyInfo.mapTitle(),
+                lobbyInfo.mapCategory(),
+                null
+        );
 
         GameLobby gameLobby = acquireGameLobbyRowLock(code, principal.userIdentifier());
 
@@ -191,14 +138,6 @@ public class LobbyMapUpdateService {
         registerMapChangedEventAfterCommit(code);
     }
 
-    /**
-     * GAME_LOBBY 행에 대한 PESSIMISTIC_WRITE 락을 획득한다.
-     *
-     * [예외 처리]
-     * - row 부재 → handleMissingGameLobbySnapshot 분기 (409 SNAPSHOT_NOT_FOUND)
-     * - 락 획득 타임아웃(3초) → PessimisticLockingFailureException을 잡아 409 CONFLICT로 변환.
-     *   클라이언트가 "다른 상태 변경 진행 중" 의미를 명확히 받을 수 있게 한다.
-     */
     private GameLobby acquireGameLobbyRowLock(String code, String requesterIdentifier) {
         try {
             return gameLobbyJpaRepository.findByInviteCodeForUpdate(code)
@@ -214,12 +153,6 @@ public class LobbyMapUpdateService {
         }
     }
 
-    /**
-     * Redis 로비는 존재하지만 DB GAME_LOBBY 스냅샷이 없는 정합성 이상 상태를 처리한다.
-     *
-     * LobbyStartService.handleMissingGameLobbySnapshot과 동일한 패턴:
-     * Redis 잔존 로비 보상 삭제를 시도하고, 실패하면 reconciliation 큐에 적재한다.
-     */
     private GameLobby handleMissingGameLobbySnapshot(String code, String requesterIdentifier) {
         log.error(
                 "{} Redis 로비는 존재하지만 DB GAME_LOBBY 스냅샷이 없습니다. "
@@ -251,18 +184,6 @@ public class LobbyMapUpdateService {
         );
     }
 
-    /**
-     * Redis 맵 메타데이터와 문제 수를 status==WAITING 원자 조건으로 보상 복구한다.
-     *
-     * [안전 정책]
-     * 보상 시점에 다른 트랜잭션이 status를 PLAYING으로 바꿨다면 oldMetadata로 되돌리면 안 된다.
-     * Lua 내부에서 원자 검증하므로 SKIPPED_NOT_WAITING은 정상 경로로 간주하고 로그만 남긴다.
-     *
-     * [인프라 장애 분리]
-     * Lua 결과값(LOBBY_NOT_FOUND)은 로비 데이터가 Redis에 없는 정상 도메인 결과다.
-     * Redis 연결 단절·타임아웃·스크립트 로딩 실패 등 인프라 예외는 catch 블록에서 별도 처리하여
-     * 원인 분류와 운영 대응이 가능하도록 한다.
-     */
     private void compensateRedisMapMetadata(String code, LobbyMapMetadata oldMetadata, int oldQuestionCount) {
         try {
             LobbyMapCompensationResult result =
@@ -288,19 +209,11 @@ public class LobbyMapUpdateService {
         }
     }
 
-    /**
-     * 맵 변경 후 새 questionCount를 결정한다.
-     *
-     * 새 맵이 선택된 경우 해당 맵의 numOfSong으로 재설정한다.
-     * 맵이 해제된 경우(newMetadata == null) 기존 questionCount를 유지한다.
-     *
-     * LobbyMapPolicy가 이미 맵 존재·삭제·권한을 검증했으므로 findById는 항상 성공한다.
-     */
     private int resolveNewQuestionCount(GameLobby gameLobby, LobbyMapMetadata newMetadata) {
         if (newMetadata != null && newMetadata.mapId() != null) {
-            QuizMap newMap = quizMapJpaRepository.findById(newMetadata.mapId()).orElseThrow();
-            return newMap.getNumOfSong();
+            return newMetadata.numOfSong();
         }
+
         return gameLobby.getQuestionCount();
     }
 
@@ -313,6 +226,7 @@ public class LobbyMapUpdateService {
             );
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ERROR_UPDATE_MAP_FAILED);
         }
+
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -769,13 +769,15 @@ public class LobbyQueryService {
      * Redis 로비 Hash에는 맵 제목/카테고리/문제 수만 저장되어 있으므로,
      * FE가 라운드 수 범위를 안정적으로 계산할 수 있게 DB의 QuizMap 기준 numOfSong을 함께 내려준다.
      *
-     * DB GAME_LOBBY 스냅샷이 존재하면 해당 mapId를 우선 사용하고,
-     * 스냅샷이 없거나 mapId가 없으면 Redis 조회 결과의 mapId를 fallback으로 사용한다.
+     * 로비 상세 응답의 mapId/mapTitle/mapCategory는 Redis 조회 결과인 lobbyInfo를 기준으로 내려간다.
+     * 따라서 mapNumOfSong도 응답 내부 정합성을 위해 lobbyInfo.mapId()를 우선 기준으로 계산한다.
+     *
+     * DB GAME_LOBBY 스냅샷은 Redis mapId가 없는 과거/손상 데이터에 대한 fallback으로만 사용한다.
      */
     private Integer resolveMapNumOfSong(JoinLobbyResponse lobbyInfo, GameLobby gameLobby) {
-        Long mapId = gameLobby != null && gameLobby.getMapId() != null
-                ? gameLobby.getMapId()
-                : lobbyInfo.mapId();
+        Long mapId = lobbyInfo.mapId() != null
+                ? lobbyInfo.mapId()
+                : gameLobby != null ? gameLobby.getMapId() : null;
 
         if (mapId == null) {
             return null;

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryService.java
@@ -31,6 +31,7 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -73,6 +74,7 @@ public class LobbyQueryService {
     private final GameLobbyJpaRepository gameLobbyJpaRepository;
     private final LobbyCanStartPolicy lobbyCanStartPolicy;
     private final LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver;
+    private final QuizMapJpaRepository quizMapJpaRepository;
 
     /**
      * ZSET 기반 페이징 중 stale index를 감안해 추가 스캔할 배수.
@@ -753,11 +755,36 @@ public class LobbyQueryService {
                 .mapId(lobbyInfo.mapId())
                 .mapTitle(lobbyInfo.mapTitle())
                 .mapCategory(lobbyInfo.mapCategory())
+                .mapNumOfSong(resolveMapNumOfSong(lobbyInfo, gameLobby))
                 .questionCount(lobbyInfo.questionCount())
                 .timeLimitSeconds(lobbyInfo.timeLimitSeconds())
                 .players(players)
                 .canStart(canStart)
                 .build();
+    }
+
+    /**
+     * 로비 상세 응답에 사용할 현재 선택 맵의 등록 곡 수를 조회한다.
+     *
+     * Redis 로비 Hash에는 맵 제목/카테고리/문제 수만 저장되어 있으므로,
+     * FE가 라운드 수 범위를 안정적으로 계산할 수 있게 DB의 QuizMap 기준 numOfSong을 함께 내려준다.
+     *
+     * DB GAME_LOBBY 스냅샷이 존재하면 해당 mapId를 우선 사용하고,
+     * 스냅샷이 없거나 mapId가 없으면 Redis 조회 결과의 mapId를 fallback으로 사용한다.
+     */
+    private Integer resolveMapNumOfSong(JoinLobbyResponse lobbyInfo, GameLobby gameLobby) {
+        Long mapId = gameLobby != null && gameLobby.getMapId() != null
+                ? gameLobby.getMapId()
+                : lobbyInfo.mapId();
+
+        if (mapId == null) {
+            return null;
+        }
+
+        return quizMapJpaRepository.findById(mapId)
+                .filter(map -> !Boolean.TRUE.equals(map.getIsDeleted()))
+                .map(map -> map.getNumOfSong())
+                .orElse(null);
     }
 
     /**

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyCreateServiceTest.java
@@ -11,9 +11,6 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyDefaults;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
-import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
-import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,29 +52,26 @@ class LobbyCreateServiceTest {
     @Mock
     private LobbyMapPolicy lobbyMapPolicy;
 
-    @Mock
-    private QuizMapJpaRepository quizMapJpaRepository;
-
     @InjectMocks
     private LobbyCreateService lobbyCreateService;
 
     @Test
-    @DisplayName("맵 선택 상태에서 questionCount를 생략하고 맵 곡 수가 10개 이상이면 기본값 10개로 로비를 생성한다")
-    void createsLobbyWithDefaultQuestionCountWhenSelectedMapHasEnoughSongs() {
+    @DisplayName("맵 선택 상태에서 questionCount를 생략하면 맵 곡 수를 기본 문제 수로 사용한다")
+    void createsLobbyWithMapSongCountWhenQuestionCountIsNull() {
+        int mapSongCount = 15;
+
         CreateLobbyRequest request = createRequest(MAP_ID, null);
         CustomPrincipal principal = createPrincipal();
         User host = createHost();
-        LobbyMapMetadata mapMetadata = new LobbyMapMetadata(MAP_ID, "테스트 맵", "K-POP");
-        QuizMap map = createMap(LobbyDefaults.DEFAULT_QUESTION_COUNT);
+        LobbyMapMetadata mapMetadata = new LobbyMapMetadata(MAP_ID, "테스트 맵", "K-POP", mapSongCount);
 
         when(userRepository.findById(HOST_USER_ID)).thenReturn(Optional.of(host));
         when(lobbyMapPolicy.resolveLobbyMapMetadata(MAP_ID, HOST_USER_ID)).thenReturn(mapMetadata);
-        when(quizMapJpaRepository.findById(MAP_ID)).thenReturn(Optional.of(map));
         when(lobbyRepository.saveToRedis(
                 eq(request),
                 eq(HOST_IDENTIFIER),
                 eq(mapMetadata),
-                eq(LobbyDefaults.DEFAULT_QUESTION_COUNT),
+                eq(mapSongCount),
                 eq(LobbyDefaults.DEFAULT_TIME_LIMIT_SECONDS)
         )).thenReturn(INVITE_CODE);
         when(gameLobbyJpaRepository.save(any(GameLobby.class))).thenAnswer(invocation -> {
@@ -92,25 +86,23 @@ class LobbyCreateServiceTest {
         verify(gameLobbyJpaRepository).save(gameLobbyCaptor.capture());
 
         GameLobby savedLobby = gameLobbyCaptor.getValue();
-        assertThat(savedLobby.getQuestionCount()).isEqualTo(LobbyDefaults.DEFAULT_QUESTION_COUNT);
+        assertThat(savedLobby.getQuestionCount()).isEqualTo(mapSongCount);
         assertThat(savedLobby.getMaxPlayers()).isEqualTo(LobbyDefaults.DEFAULT_MAX_PLAYERS);
         assertThat(savedLobby.getTimeLimitSeconds()).isEqualTo(LobbyDefaults.DEFAULT_TIME_LIMIT_SECONDS);
     }
 
     @Test
-    @DisplayName("맵 선택 상태에서 questionCount를 생략하고 맵 곡 수가 10개보다 적으면 맵 곡 수로 보정해 생성한다")
-    void createsLobbyWithMapSongCountWhenDefaultQuestionCountExceedsSelectedMapSongCount() {
+    @DisplayName("맵 선택 상태에서 questionCount를 생략하고 맵 곡 수가 기본값보다 적어도 맵 곡 수를 그대로 사용한다")
+    void createsLobbyWithMapSongCountEvenWhenMapSongCountIsLessThanDefault() {
         int mapSongCount = LobbyDefaults.DEFAULT_QUESTION_COUNT - 1;
 
         CreateLobbyRequest request = createRequest(MAP_ID, null);
         CustomPrincipal principal = createPrincipal();
         User host = createHost();
-        LobbyMapMetadata mapMetadata = new LobbyMapMetadata(MAP_ID, "테스트 맵", "K-POP");
-        QuizMap map = createMap(mapSongCount);
+        LobbyMapMetadata mapMetadata = new LobbyMapMetadata(MAP_ID, "테스트 맵", "K-POP", mapSongCount);
 
         when(userRepository.findById(HOST_USER_ID)).thenReturn(Optional.of(host));
         when(lobbyMapPolicy.resolveLobbyMapMetadata(MAP_ID, HOST_USER_ID)).thenReturn(mapMetadata);
-        when(quizMapJpaRepository.findById(MAP_ID)).thenReturn(Optional.of(map));
         when(lobbyRepository.saveToRedis(
                 eq(request),
                 eq(HOST_IDENTIFIER),
@@ -144,12 +136,10 @@ class LobbyCreateServiceTest {
         CreateLobbyRequest request = createRequest(MAP_ID, requestedQuestionCount);
         CustomPrincipal principal = createPrincipal();
         User host = createHost();
-        LobbyMapMetadata mapMetadata = new LobbyMapMetadata(MAP_ID, "테스트 맵", "K-POP");
-        QuizMap map = createMap(mapSongCount);
+        LobbyMapMetadata mapMetadata = new LobbyMapMetadata(MAP_ID, "테스트 맵", "K-POP", mapSongCount);
 
         when(userRepository.findById(HOST_USER_ID)).thenReturn(Optional.of(host));
         when(lobbyMapPolicy.resolveLobbyMapMetadata(MAP_ID, HOST_USER_ID)).thenReturn(mapMetadata);
-        when(quizMapJpaRepository.findById(MAP_ID)).thenReturn(Optional.of(map));
 
         assertThatThrownBy(() -> lobbyCreateService.createLobby(request, principal))
                 .isInstanceOf(ResponseStatusException.class)
@@ -193,21 +183,6 @@ class LobbyCreateServiceTest {
                 .userType(UserType.REGISTERED)
                 .status(UserStatus.ACTIVE)
                 .role(UserRole.USER)
-                .build();
-    }
-
-    private static QuizMap createMap(int numOfSong) {
-        return QuizMap.builder()
-                .id(MAP_ID)
-                .owner(createHost())
-                .title("테스트 맵")
-                .description("테스트 맵 설명")
-                .category(MapCategory.KPOP)
-                .numOfSong(numOfSong)
-                .totalPlayTime(300)
-                .isPublic(true)
-                .pendingPublic(false)
-                .isDeleted(false)
                 .build();
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyMapUpdateServiceTest.java
@@ -10,8 +10,6 @@ import io.github.ascrew.monomatbe.domain.lobby.entity.GameLobby;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
-import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,21 +27,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * LobbyMapUpdateService의 맵 변경 정책을 검증한다.
- *
- * [테스트 범위]
- * - principal / userId / userIdentifier 검증
- * - 로비 미존재 처리
- * - WAITING 상태 제한 (Redis 1차 / DB 락 후 재검증)
- * - 방장 권한 제한
- * - 정상 변경 시 Redis/DB 갱신 및 realtime 이벤트 등록
- * - 맵 변경 시 questionCount가 새 맵의 numOfSong으로 재설정됨
- * - DB 갱신 실패 시 compensateMapMetadataIfWaiting 호출
- * - 기존 맵 미선택 로비에서 DB 실패 시 보상이 null oldMetadata로 호출됨
- * - DB GAME_LOBBY 스냅샷 누락 시 reconciliation 패턴 적용
  */
 class LobbyMapUpdateServiceTest {
 
@@ -51,14 +41,12 @@ class LobbyMapUpdateServiceTest {
     private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
     private final LobbyMapPolicy lobbyMapPolicy = mock(LobbyMapPolicy.class);
     private final LobbyRealtimeNotifier lobbyRealtimeNotifier = mock(LobbyRealtimeNotifier.class);
-    private final QuizMapJpaRepository quizMapJpaRepository = mock(QuizMapJpaRepository.class);
 
     private final LobbyMapUpdateService sut = new LobbyMapUpdateService(
             lobbyRepository,
             gameLobbyJpaRepository,
             lobbyMapPolicy,
-            lobbyRealtimeNotifier,
-            quizMapJpaRepository
+            lobbyRealtimeNotifier
     );
 
     private static final String CODE = "ABC123";
@@ -119,20 +107,13 @@ class LobbyMapUpdateServiceTest {
                 .build();
     }
 
-    /** 주어진 mapId의 맵 조회 시 numOfSong=NEW_MAP_NUM_OF_SONG(10)인 QuizMap을 반환하도록 설정 */
-    private void givenNewMapExists(Long mapId) {
-        QuizMap quizMap = QuizMap.builder()
-                .id(mapId)
-                .numOfSong(NEW_MAP_NUM_OF_SONG)
-                .build();
-        when(quizMapJpaRepository.findById(mapId)).thenReturn(Optional.of(quizMap));
+    private LobbyMapMetadata newMapMetadata(Long mapId, String title, String category) {
+        return new LobbyMapMetadata(mapId, title, category, NEW_MAP_NUM_OF_SONG);
     }
 
     private UpdateLobbyMapRequest request(long mapId) {
         return new UpdateLobbyMapRequest(mapId);
     }
-
-    // ─── principal 검증 ───────────────────────────────────
 
     @Test
     @DisplayName("principal이 null이면 401 Unauthorized를 던진다")
@@ -165,8 +146,6 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.UNAUTHORIZED));
     }
 
-    // ─── 로비 조회 검증 ──────────────────────────────────
-
     @Test
     @DisplayName("Redis에 로비가 없으면 404 Not Found를 던진다")
     void updateMap_throwsNotFound_whenLobbyNotFound() {
@@ -178,10 +157,8 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.NOT_FOUND));
     }
 
-    // ─── 상태 검증 ────────────────────────────────────────
-
     @Test
-    @DisplayName("Redis 상태가 PLAYING이면 409 Conflict를 던진다 (DB 락 획득 전 차단)")
+    @DisplayName("Redis 상태가 PLAYING이면 409 Conflict를 던진다")
     void updateMap_throwsConflict_whenLobbyNotWaiting() {
         JoinLobbyResponse playingLobby = JoinLobbyResponse.builder()
                 .inviteCode(CODE)
@@ -206,7 +183,8 @@ class LobbyMapUpdateServiceTest {
     @DisplayName("Redis는 WAITING이지만 DB 락 획득 후 status가 PLAYING이면 409를 던진다")
     void updateMap_throwsConflict_whenDbStatusIsPlayingAfterLockAcquired() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+
+        LobbyMapMetadata newMetadata = newMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.PLAYING, 10L)));
@@ -218,8 +196,6 @@ class LobbyMapUpdateServiceTest {
 
         verify(lobbyRepository, never()).updateMapMetadata(any(), any(), anyInt());
     }
-
-    // ─── 방장 검증 ────────────────────────────────────────
 
     @Test
     @DisplayName("방장이 아닌 사용자가 요청하면 403 Forbidden을 던진다")
@@ -234,13 +210,12 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.FORBIDDEN));
     }
 
-    // ─── 락 충돌 ─────────────────────────────────────────
-
     @Test
     @DisplayName("DB row lock 획득이 타임아웃되면 409 CONFLICT로 변환한다")
     void updateMap_throwsConflict_whenLockAcquisitionTimesOut() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+
+        LobbyMapMetadata newMetadata = newMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenThrow(new PessimisticLockingFailureException("lock wait timeout"));
@@ -257,13 +232,12 @@ class LobbyMapUpdateServiceTest {
         verify(lobbyRepository, never()).compensateMapMetadataIfWaiting(any(), any(), anyInt());
     }
 
-    // ─── DB 스냅샷 누락 ─────────────────────────────────
-
     @Test
     @DisplayName("DB GAME_LOBBY 스냅샷이 없으면 Redis 보상 삭제 후 409를 던진다")
     void updateMap_handlesMissingDbSnapshot_byDeletingRedisAndThrowingConflict() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+
+        LobbyMapMetadata newMetadata = newMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE)).thenReturn(Optional.empty());
         when(lobbyRepository.deleteFromRedis(CODE)).thenReturn(true);
@@ -282,7 +256,8 @@ class LobbyMapUpdateServiceTest {
     @DisplayName("DB 스냅샷 누락 + Redis 삭제 실패 시 reconciliation 큐에 적재한다")
     void updateMap_enqueuesReconciliation_whenSnapshotMissingAndRedisDeleteFails() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+
+        LobbyMapMetadata newMetadata = newMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE)).thenReturn(Optional.empty());
         when(lobbyRepository.deleteFromRedis(CODE)).thenReturn(false);
@@ -295,20 +270,20 @@ class LobbyMapUpdateServiceTest {
         verify(lobbyRepository).enqueueStartReconciliation(eq(CODE), eq("MAP_UPDATE_DB_SNAPSHOT_NOT_FOUND"));
     }
 
-    // ─── 정상 변경 ───────────────────────────────────────
-
     @Test
     @DisplayName("정상 요청 시 Redis/DB를 갱신하고 questionCount를 새 맵의 numOfSong으로 재설정한다")
     void updateMap_updatesRedisAndDb_andRegistersAfterCommitEvent() {
         TransactionSynchronizationManager.initSynchronization();
+
         try {
             when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-            LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+
+            LobbyMapMetadata newMetadata = newMapMetadata(2L, "POP 히트곡", "POP");
             when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
+
             GameLobby gameLobby = gameLobbyWith(LobbyStatus.WAITING, 10L);
             when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                     .thenReturn(Optional.of(gameLobby));
-            givenNewMapExists(2L);
             when(gameLobbyJpaRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
             sut.updateMap(CODE, request(2L), hostPrincipal());
@@ -325,17 +300,15 @@ class LobbyMapUpdateServiceTest {
         }
     }
 
-    // ─── DB 실패 시 보상 복구 ──────────────────────────────
-
     @Test
     @DisplayName("DB 갱신 실패 시 compensateMapMetadataIfWaiting으로 Redis 보상을 시도하고 500을 던진다")
     void updateMap_rollbacksRedis_whenDbSaveFails() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+
+        LobbyMapMetadata newMetadata = newMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        givenNewMapExists(2L);
         when(gameLobbyJpaRepository.saveAndFlush(any()))
                 .thenThrow(new RuntimeException("DB 장애"));
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any(), anyInt()))
@@ -346,7 +319,8 @@ class LobbyMapUpdateServiceTest {
                 .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
                         .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
-        LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP");
+        LobbyMapMetadata oldMetadata = new LobbyMapMetadata(10L, "K-POP 구곡", "K-POP", null);
+
         verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata), eq(NEW_MAP_NUM_OF_SONG));
         verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), eq(oldMetadata), eq(OLD_QUESTION_COUNT));
         verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(any());
@@ -356,11 +330,11 @@ class LobbyMapUpdateServiceTest {
     @DisplayName("기존 맵 미선택 로비에서 DB 실패 시 보상이 null oldMetadata로 호출된다")
     void updateMap_rollbacksRedisWithNull_whenNoMapLobbyAndDbFails() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobbyWithNoMap()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(1L, "K-POP 히트곡", "K-POP");
+
+        LobbyMapMetadata newMetadata = newMapMetadata(1L, "K-POP 히트곡", "K-POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(1L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, null)));
-        givenNewMapExists(1L);
         when(gameLobbyJpaRepository.saveAndFlush(any()))
                 .thenThrow(new RuntimeException("DB 장애"));
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any(), anyInt()))
@@ -372,18 +346,22 @@ class LobbyMapUpdateServiceTest {
                         .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
         verify(lobbyRepository).updateMapMetadata(eq(CODE), eq(newMetadata), eq(NEW_MAP_NUM_OF_SONG));
-        verify(lobbyRepository).compensateMapMetadataIfWaiting(eq(CODE), (LobbyMapMetadata) isNull(), eq(OLD_QUESTION_COUNT));
+        verify(lobbyRepository).compensateMapMetadataIfWaiting(
+                eq(CODE),
+                (LobbyMapMetadata) isNull(),
+                eq(OLD_QUESTION_COUNT)
+        );
     }
 
     @Test
     @DisplayName("보상 Lua가 SKIPPED_NOT_WAITING을 반환해도 호출자 예외 응답은 그대로 유지된다")
     void updateMap_handlesSkippedCompensation_whenStatusNoLongerWaiting() {
         when(lobbyRepository.findByInviteCode(CODE)).thenReturn(Optional.of(waitingLobby()));
-        LobbyMapMetadata newMetadata = new LobbyMapMetadata(2L, "POP 히트곡", "POP");
+
+        LobbyMapMetadata newMetadata = newMapMetadata(2L, "POP 히트곡", "POP");
         when(lobbyMapPolicy.resolveLobbyMapMetadata(2L, USER_ID)).thenReturn(newMetadata);
         when(gameLobbyJpaRepository.findByInviteCodeForUpdate(CODE))
                 .thenReturn(Optional.of(gameLobbyWith(LobbyStatus.WAITING, 10L)));
-        givenNewMapExists(2L);
         when(gameLobbyJpaRepository.saveAndFlush(any()))
                 .thenThrow(new RuntimeException("DB 장애"));
         when(lobbyRepository.compensateMapMetadataIfWaiting(eq(CODE), any(), anyInt()))

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceCanStartTest.java
@@ -24,14 +24,6 @@ import static org.mockito.Mockito.when;
 
 /**
  * LobbyQueryService의 로비 상세 조회 응답 중 canStart 계산을 검증한다.
- *
- * [변경 배경]
- * Issue #78에서 LobbyService facade를 제거하고,
- * 로비 상세 조회 책임을 LobbyQueryService로 분리했다.
- *
- * canStart 계산 자체는 LobbyCanStartPolicy가 담당하지만,
- * 이 테스트는 "로비 상세 조회 결과에 canStart가 올바르게 반영되는지"를 검증하므로
- * LobbyQueryService 기준으로 유지한다.
  */
 class LobbyQueryServiceCanStartTest {
 
@@ -56,7 +48,8 @@ class LobbyQueryServiceCanStartTest {
                 lobbyRepository,
                 gameLobbyJpaRepository,
                 lobbyCanStartPolicy,
-                lobbyPlayerNicknameResolver
+                lobbyPlayerNicknameResolver,
+                quizMapJpaRepository
         );
     }
 
@@ -83,6 +76,7 @@ class LobbyQueryServiceCanStartTest {
         );
 
         assertThat(response.canStart()).isTrue();
+        assertThat(response.mapNumOfSong()).isEqualTo(5);
     }
 
     @Test
@@ -108,6 +102,7 @@ class LobbyQueryServiceCanStartTest {
         );
 
         assertThat(response.canStart()).isFalse();
+        assertThat(response.mapNumOfSong()).isEqualTo(5);
     }
 
     @Test
@@ -133,6 +128,7 @@ class LobbyQueryServiceCanStartTest {
         );
 
         assertThat(response.canStart()).isFalse();
+        assertThat(response.mapNumOfSong()).isEqualTo(4);
     }
 
     private JoinLobbyResponse lobbyInfo(String code, String hostId) {

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyQueryServiceTest.java
@@ -10,6 +10,9 @@ import io.github.ascrew.monomatbe.domain.lobby.dto.LobbySearchCondition;
 import io.github.ascrew.monomatbe.domain.lobby.entity.LobbyStatus;
 import io.github.ascrew.monomatbe.domain.lobby.repository.GameLobbyJpaRepository;
 import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.domain.map.entity.MapCategory;
+import io.github.ascrew.monomatbe.domain.map.entity.QuizMap;
+import io.github.ascrew.monomatbe.domain.map.repository.QuizMapJpaRepository;
 import io.github.ascrew.monomatbe.global.security.jwt.CustomPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,12 +57,14 @@ class LobbyQueryServiceTest {
     private final GameLobbyJpaRepository gameLobbyJpaRepository = mock(GameLobbyJpaRepository.class);
     private final LobbyCanStartPolicy lobbyCanStartPolicy = mock(LobbyCanStartPolicy.class);
     private final LobbyPlayerNicknameResolver lobbyPlayerNicknameResolver = mock(LobbyPlayerNicknameResolver.class);
+    private final QuizMapJpaRepository quizMapJpaRepository = mock(QuizMapJpaRepository.class);
 
     private final LobbyQueryService lobbyQueryService = new LobbyQueryService(
             lobbyRepository,
             gameLobbyJpaRepository,
             lobbyCanStartPolicy,
-            lobbyPlayerNicknameResolver
+            lobbyPlayerNicknameResolver,
+            quizMapJpaRepository
     );
 
     @Test
@@ -986,6 +991,23 @@ class LobbyQueryServiceTest {
 
         when(lobbyCanStartPolicy.calculateCanStart(any(), any(), any()))
                 .thenReturn(false);
+
+        if (lobbyInfo.mapId() != null) {
+            when(quizMapJpaRepository.findById(lobbyInfo.mapId()))
+                    .thenReturn(Optional.of(quizMap(lobbyInfo.mapId(), 10)));
+        }
+    }
+
+    private QuizMap quizMap(Long mapId, int numOfSong) {
+        return QuizMap.builder()
+                .id(mapId)
+                .title("테스트 맵")
+                .category(MapCategory.KPOP)
+                .numOfSong(numOfSong)
+                .totalPlayTime(300)
+                .isPublic(true)
+                .isDeleted(false)
+                .build();
     }
 
     private CustomPrincipal registeredPrincipal(String userIdentifier) {


### PR DESCRIPTION
## 📣 Related Issue

- #208

## 📝 Summary

- 로비 상세 응답에 현재 선택된 맵의 곡 수를 나타내는 `mapNumOfSong` 필드를 추가했습니다.
- 로비 생성 시 맵이 선택되어 있고 `questionCount`가 생략된 경우, 기본 라운드 수를 선택된 맵의 곡 수로 설정하도록 변경했습니다.
- 로비 내 맵 변경 시 `questionCount`를 새로 선택한 맵의 곡 수로 재설정하도록 변경했습니다.
- `LobbyMapMetadata`에 `numOfSong`을 추가하여 맵 검증 이후 로비 생성/맵 변경 정책에서 동일한 맵 곡 수 정보를 사용할 수 있도록 수정했습니다.
- `questionCount`가 선택된 맵의 곡 수보다 큰 경우 예외를 발생시키는 검증 정책을 유지하고 관련 테스트를 보강했습니다.
- 변경된 생성자 및 DTO 계약에 맞춰 로비 생성/조회/맵 변경 서비스 테스트를 수정했습니다.
- API 문서에 `mapNumOfSong` 응답 필드와 맵 곡 수 기반 라운드 수 정책을 반영했습니다.

## 🙏PR point

- 기존에는 맵 선택 시 기본 라운드 수가 고정 기본값 또는 기존 설정값 중심으로 동작할 수 있었지만, 이제는 선택된 맵의 곡 수가 기본 라운드 수이자 최대 라운드 수의 기준이 됩니다.
- 로비 상세 응답의 `mapNumOfSong`은 FE에서 라운드 수 입력 범위를 `1 ~ mapNumOfSong`으로 제한하기 위한 필드입니다.
- 로비 맵 변경 시 기존 `questionCount`를 유지하지 않고 새 맵의 곡 수로 재설정합니다. 이 정책이 로비 설정 수정 UX와 잘 맞는지 확인 부탁드립니다.
- `mapNumOfSong`은 Redis에 별도 저장하지 않고, 로비 상세 조회 시 현재 선택된 맵 ID 기준으로 DB에서 조회하도록 구현했습니다.
- 로컬 테스트 중 기존 MySQL 스키마에 `map_item.end_time` 컬럼이 없어 Hibernate schema validation 오류가 발생했으나, 로컬 DB 컬럼 보정 후 `./gradlew test` 전체 통과 확인했습니다.

## 📬 Reference
