### PR TITLE
[Fix/#203] 로비 명시적 퇴장 처리로 인원 수 실시간 반영

### DIFF
--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyEventController.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/controller/LobbyEventController.java
@@ -14,6 +14,7 @@ package io.github.ascrew.monomatbe.domain.lobby.controller;
 
 import io.github.ascrew.monomatbe.domain.lobby.dto.KickLobbyPlayerRequest;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyKickService;
+import io.github.ascrew.monomatbe.domain.lobby.service.LobbyLeaveService;
 import io.github.ascrew.monomatbe.domain.lobby.service.LobbyRealtimeNotifier;
 import io.github.ascrew.monomatbe.global.constant.WebSocketHeaders;
 import jakarta.validation.Valid;
@@ -34,6 +35,7 @@ public class LobbyEventController {
 
   private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
   private final LobbyKickService lobbyKickService;
+  private final LobbyLeaveService lobbyLeaveService;
 
   /**
    * 로비 생성 이벤트 수신
@@ -63,6 +65,31 @@ public class LobbyEventController {
   ) {
     String userIdentifier = extractUserIdentifier(accessor);
     lobbyRealtimeNotifier.notifyLobbyInfoRefresh(code, userIdentifier);
+  }
+
+  /**
+   * 로비 퇴장 이벤트 수신
+   *
+   * 클라이언트 송신 경로: /app/lobby/{code}/leave
+   *
+   * [동작]
+   * FE 퇴장 버튼 클릭 시 호출된다.
+   * 실제 퇴장 검증, leave_lobby.lua 실행, LEAVE 메시지/refresh 발행, 세션 키 정리는
+   * LobbyLeaveService가 담당한다.
+   *
+   * [설계 의도]
+   * 기존에는 퇴장 처리가 WebSocket DISCONNECT에만 의존하여,
+   * FE가 전역 STOMP 연결을 유지한 채 화면만 이동하면 인원 수가 즉시 갱신되지 않았다.
+   * 강퇴와 동일하게 명시적 퇴장 경로를 제공하여 실시간으로 반영되도록 한다.
+   */
+  @MessageMapping("/lobby/{code}/leave")
+  public void leaveLobby(
+          @DestinationVariable String code,
+          SimpMessageHeaderAccessor accessor
+  ) {
+    String userIdentifier = extractUserIdentifier(accessor);
+    String wsSessionId = accessor.getSessionId();
+    lobbyLeaveService.leaveByRequest(code, userIdentifier, wsSessionId);
   }
 
   /**

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyKickService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyKickService.java
@@ -175,6 +175,8 @@ public class LobbyKickService {
         }
 
         lobbyRealtimeNotifier.notifyLobbyInfoRefresh(lobbyCode);
+        // 목록 화면 구독자에게도 current_players 변동을 알린다. (#203)
+        lobbyRealtimeNotifier.notifyLobbyListRefresh();
 
         log.info(
                 "로비 유저 강퇴 완료 - lobbyCode: {}, targetUserIdentifier: {}, targetWsSessionId: {}",

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandler.java
@@ -17,13 +17,9 @@
  */
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
-import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
-import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -33,18 +29,15 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class LobbyLeaveEventHandler {
 
-    private final LobbyRepository lobbyRepository;
-    private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
-    private final ApplicationEventPublisher eventPublisher;
+    private final LobbyLeaveService lobbyLeaveService;
 
     /**
-     * 플레이어 퇴장 이벤트를 수신하여 퇴장 처리를 수행한다.
+     * 플레이어 퇴장 이벤트(WebSocket DISCONNECT)를 수신하여 퇴장 처리를 위임한다.
      *
-     * [처리 분기]
-     * - Destroyed : 마지막 유저 퇴장으로 로비 폭파 -> 전역 로비 목록 refresh
-     * - Delegated : 방장 퇴장으로 방장 위임 -> HOST_CHANGED 메시지 + 로비 내부 refresh
-     * - Left      : 일반 퇴장 -> 로비 내부 refresh
-     * - Error     : 처리 실패 -> 브로드캐스트 없이 로그만 기록
+     * [주의]
+     * DISCONNECT 경로의 LEAVE 시스템 메시지 발행과 세션 키 정리는
+     * WebSocketEventListener가 담당하므로, 여기서는 퇴장 상태 변경과
+     * 실시간 알림만 LobbyLeaveService.processLeave에 위임한다.
      */
     @EventListener
     public void handlePlayerLeave(PlayerLeaveEvent event) {
@@ -55,68 +48,6 @@ public class LobbyLeaveEventHandler {
             return;
         }
 
-        LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(code, userIdentifier);
-
-        switch (result) {
-            case LeaveLobbyResult.Destroyed destroyed -> {
-                log.info("[handlePlayerLeave] 로비 폭파 - 로비: {}", destroyed.lobbyCode());
-
-                /*
-                 * 게임 도중 전원 퇴장으로 로비가 폭파되면 게임 세션 Redis 키가 orphan으로 남는다.
-                 * 도메인 간 직접 결합을 피하기 위해 LobbyClosedEvent로 game 도메인에 정리를 위임한다.
-                 *
-                 * [순서·격리] 내부 정합성(세션 정리) 이벤트를 실시간 STOMP 브로드캐스트보다 먼저 발행하고,
-                 * 브로드캐스트는 try-catch로 격리한다. STOMP 전송 실패가 정리 이벤트 발행을 막아
-                 * Redis에 orphan 세션 키가 영구 잔존하는 것을 방지한다.
-                 */
-                eventPublisher.publishEvent(new LobbyClosedEvent(destroyed.lobbyCode()));
-
-                try {
-                    lobbyRealtimeNotifier.notifyLobbyListRefresh();
-                } catch (Exception e) {
-                    log.warn(
-                            "[handlePlayerLeave] 로비 폭파 목록 갱신 알림 실패 - 로비: {}",
-                            destroyed.lobbyCode(),
-                            e
-                    );
-                }
-            }
-
-            case LeaveLobbyResult.Delegated delegated -> {
-                log.info(
-                        "[handlePlayerLeave] 방장 위임 - 로비: {}, 새 방장: {}",
-                        delegated.lobbyCode(),
-                        delegated.newHostId()
-                );
-
-                boolean messagePublished = lobbyRealtimeNotifier.notifyHostChangedMessage(
-                        delegated.lobbyCode(),
-                        delegated.newHostId()
-                );
-
-                if (!messagePublished) {
-                    log.error(
-                            "[ALERT_REQUIRED] HOST_CHANGED 메시지 발행 실패 - code: {}, newHostId: {}",
-                            delegated.lobbyCode(),
-                            delegated.newHostId()
-                    );
-                }
-
-                lobbyRealtimeNotifier.notifyLobbyInfoRefresh(delegated.lobbyCode());
-            }
-
-            case LeaveLobbyResult.Left left -> {
-                log.info(
-                        "[handlePlayerLeave] 일반 퇴장 - 로비: {}, 식별자: {}",
-                        left.lobbyCode(),
-                        left.userId()
-                );
-                lobbyRealtimeNotifier.notifyLobbyInfoRefresh(left.lobbyCode());
-            }
-
-            case LeaveLobbyResult.Error error -> {
-                log.error("[handlePlayerLeave] 퇴장 처리 실패 - 사유: {}", error.reason());
-            }
-        }
+        lobbyLeaveService.processLeave(code, userIdentifier);
     }
 }

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveService.java
@@ -1,0 +1,185 @@
+/*
+ * 로비 퇴장 유스케이스 전용 서비스
+ *
+ * [책임]
+ * - leave_lobby.lua 실행 위임 및 결과 분기 처리
+ * - 퇴장 결과에 따른 실시간 알림 발행
+ * - 명시적 퇴장 요청 처리(LEAVE 시스템 메시지 발행 + ws:connection 키 정리)
+ *
+ * [설계 의도]
+ * 기존에는 퇴장 처리 로직이 WebSocket DISCONNECT 경로(LobbyLeaveEventHandler)에만 존재했다.
+ * 그 결과 FE 퇴장 버튼이 WebSocket 연결을 끊지 않으면 BE가 퇴장을 전혀 처리하지 못했다.
+ *
+ * 강퇴(LobbyKickService)와 동일하게, 퇴장도 명시적 유스케이스로 분리하여
+ * STOMP 퇴장 요청과 DISCONNECT 이벤트가 동일한 퇴장 처리 로직을 공유하도록 한다.
+ */
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LobbyLeaveService {
+
+    private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
+
+    private final LobbyRepository lobbyRepository;
+    private final LobbyRealtimeNotifier lobbyRealtimeNotifier;
+    private final ApplicationEventPublisher eventPublisher;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * leave_lobby.lua를 실행하고 결과에 따라 실시간 알림을 발행한다.
+     *
+     * [처리 분기]
+     * - Destroyed : 마지막 유저 퇴장으로 로비 폭파 -> LobbyClosedEvent + 전역 로비 목록 refresh
+     * - Delegated : 방장 퇴장으로 방장 위임 -> HOST_CHANGED 메시지 + 로비 내부 refresh
+     * - Left      : 일반 퇴장 -> 로비 내부 refresh
+     * - Error     : 처리 실패 -> 브로드캐스트 없이 로그만 기록
+     *
+     * [주의]
+     * 실제 participants/order/ready/세션 키 상태 변경은 Lua에서 원자적으로 처리한다.
+     * leave_lobby.lua는 이미 빠진 유저에 대해 멱등하므로 중복 호출되어도 안전하다.
+     *
+     * @return 퇴장 처리 결과(LEAVE 시스템 메시지 발행 여부 판단 등에 사용)
+     */
+    public LeaveLobbyResult processLeave(String code, String userIdentifier) {
+        LeaveLobbyResult result = lobbyRepository.executeLeaveLobbyProcess(code, userIdentifier);
+
+        switch (result) {
+            case LeaveLobbyResult.Destroyed destroyed -> {
+                log.info("[processLeave] 로비 폭파 - 로비: {}", destroyed.lobbyCode());
+
+                /*
+                 * 게임 도중 전원 퇴장으로 로비가 폭파되면 게임 세션 Redis 키가 orphan으로 남는다.
+                 * 도메인 간 직접 결합을 피하기 위해 LobbyClosedEvent로 game 도메인에 정리를 위임한다.
+                 *
+                 * [순서·격리] 내부 정합성(세션 정리) 이벤트를 실시간 STOMP 브로드캐스트보다 먼저 발행하고,
+                 * 브로드캐스트는 try-catch로 격리한다. STOMP 전송 실패가 정리 이벤트 발행을 막아
+                 * Redis에 orphan 세션 키가 영구 잔존하는 것을 방지한다.
+                 */
+                eventPublisher.publishEvent(new LobbyClosedEvent(destroyed.lobbyCode()));
+
+                try {
+                    lobbyRealtimeNotifier.notifyLobbyListRefresh();
+                } catch (Exception e) {
+                    log.warn(
+                            "[processLeave] 로비 폭파 목록 갱신 알림 실패 - 로비: {}",
+                            destroyed.lobbyCode(),
+                            e
+                    );
+                }
+            }
+
+            case LeaveLobbyResult.Delegated delegated -> {
+                log.info(
+                        "[processLeave] 방장 위임 - 로비: {}, 새 방장: {}",
+                        delegated.lobbyCode(),
+                        delegated.newHostId()
+                );
+
+                boolean messagePublished = lobbyRealtimeNotifier.notifyHostChangedMessage(
+                        delegated.lobbyCode(),
+                        delegated.newHostId()
+                );
+
+                if (!messagePublished) {
+                    log.error(
+                            "[ALERT_REQUIRED] HOST_CHANGED 메시지 발행 실패 - code: {}, newHostId: {}",
+                            delegated.lobbyCode(),
+                            delegated.newHostId()
+                    );
+                }
+
+                lobbyRealtimeNotifier.notifyLobbyInfoRefresh(delegated.lobbyCode());
+            }
+
+            case LeaveLobbyResult.Left left -> {
+                log.info(
+                        "[processLeave] 일반 퇴장 - 로비: {}, 식별자: {}",
+                        left.lobbyCode(),
+                        left.userId()
+                );
+                lobbyRealtimeNotifier.notifyLobbyInfoRefresh(left.lobbyCode());
+            }
+
+            case LeaveLobbyResult.Error error -> {
+                log.error("[processLeave] 퇴장 처리 실패 - 사유: {}", error.reason());
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * FE 퇴장 버튼 등 클라이언트의 명시적 퇴장 요청을 처리한다.
+     *
+     * [처리 흐름]
+     * 1. 로비 코드, 요청자 식별자 검증
+     * 2. processLeave로 Redis 상태 변경 및 실시간 알림 발행
+     * 3. 정상 퇴장(Left)/방장 위임(Delegated)인 경우 LEAVE 시스템 메시지 발행
+     * 4. 요청한 WebSocket 세션의 ws:connection 키 정리
+     *
+     * [ws:connection 키 정리 이유]
+     * 명시적 퇴장은 전역 STOMP 연결을 유지한 채 발생할 수 있다.
+     * ws:connection:{wsSessionId} 키를 미리 삭제하면 이후 실제 DISCONNECT 발생 시
+     * WebSocketEventListener.findLobbyCodeByWsSessionId가 null을 반환하여
+     * 이미 처리된 퇴장이 다시 처리(중복 브로드캐스트)되는 것을 방지한다.
+     */
+    public void leaveByRequest(String code, String userIdentifier, String wsSessionId) {
+        if (!StringUtils.hasText(code) || !LOBBY_CODE_PATTERN.matcher(code).matches()) {
+            log.warn("[leaveByRequest] 유효하지 않은 로비 코드 - code: {}", code);
+            return;
+        }
+
+        if (!StringUtils.hasText(userIdentifier)) {
+            log.warn("[leaveByRequest] 식별자 없는 퇴장 요청 무시 - 로비: {}", code);
+            return;
+        }
+
+        LeaveLobbyResult result = processLeave(code, userIdentifier);
+
+        if (result instanceof LeaveLobbyResult.Left
+                || result instanceof LeaveLobbyResult.Delegated) {
+            boolean leaveMessagePublished = lobbyRealtimeNotifier.notifyLeaveMessage(code, userIdentifier);
+
+            if (!leaveMessagePublished) {
+                log.error(
+                        "LEAVE 메시지 전송 실패 - Redis 퇴장 상태는 반영되었으나 클라이언트 알림이 누락될 수 있음. "
+                                + "lobbyCode: {}, userIdentifier: {}",
+                        code,
+                        userIdentifier
+                );
+            }
+        }
+
+        deleteWsConnection(wsSessionId);
+    }
+
+    /**
+     * 명시적 퇴장 요청을 보낸 WebSocket 세션의 ws:connection 키를 삭제한다.
+     */
+    private void deleteWsConnection(String wsSessionId) {
+        if (!StringUtils.hasText(wsSessionId)) {
+            return;
+        }
+
+        try {
+            stringRedisTemplate.delete(RedisKeys.wsConnectionKey(wsSessionId));
+        } catch (Exception e) {
+            log.warn("퇴장 요청 후 ws:connection 키 삭제 실패 - wsSessionId: {}", wsSessionId, e);
+        }
+    }
+}

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveService.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveService.java
@@ -104,6 +104,8 @@ public class LobbyLeaveService {
                 }
 
                 lobbyRealtimeNotifier.notifyLobbyInfoRefresh(delegated.lobbyCode());
+                // 목록 화면 구독자에게도 current_players 변동을 알린다. (#203)
+                lobbyRealtimeNotifier.notifyLobbyListRefresh();
             }
 
             case LeaveLobbyResult.Left left -> {
@@ -113,10 +115,17 @@ public class LobbyLeaveService {
                         left.userId()
                 );
                 lobbyRealtimeNotifier.notifyLobbyInfoRefresh(left.lobbyCode());
+                // 목록 화면 구독자에게도 current_players 변동을 알린다. (#203)
+                lobbyRealtimeNotifier.notifyLobbyListRefresh();
             }
 
             case LeaveLobbyResult.Error error -> {
-                log.error("[processLeave] 퇴장 처리 실패 - 사유: {}", error.reason());
+                log.error(
+                        "[processLeave] 퇴장 처리 실패 - 로비: {}, 식별자: {}, 사유: {}",
+                        code,
+                        userIdentifier,
+                        error.reason()
+                );
             }
         }
 
@@ -150,6 +159,20 @@ public class LobbyLeaveService {
         }
 
         LeaveLobbyResult result = processLeave(code, userIdentifier);
+
+        // 퇴장 처리가 실패(Error)하면 Redis 상태가 변경되지 않았을 수 있다.
+        // 이 경우 ws:connection 키를 삭제하면 이후 실제 DISCONNECT가 퇴장/키 정리를 재시도하지 못해
+        // 참가자/세션 키가 orphan으로 남는다. 따라서 LEAVE 메시지 발행과 ws:connection 정리를 모두 건너뛴다.
+        if (result instanceof LeaveLobbyResult.Error) {
+            log.warn(
+                    "[leaveByRequest] 퇴장 처리 실패로 ws:connection 정리 생략 - 이후 DISCONNECT 재시도에 위임. "
+                            + "로비: {}, 식별자: {}, wsSessionId: {}",
+                    code,
+                    userIdentifier,
+                    wsSessionId
+            );
+            return;
+        }
 
         if (result instanceof LeaveLobbyResult.Left
                 || result instanceof LeaveLobbyResult.Delegated) {

--- a/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyRealtimeNotifier.java
+++ b/src/main/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyRealtimeNotifier.java
@@ -46,6 +46,7 @@ public class LobbyRealtimeNotifier {
     private static final Pattern LOBBY_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,12}$");
 
     private static final String KICK_MESSAGE_FORMAT = "%s님이 강퇴되었습니다.";
+    private static final String LEAVE_MESSAGE_FORMAT = "%s님이 퇴장하셨습니다.";
     private static final String READY_CHANGED_MESSAGE_FORMAT = "%s님이 %s 상태로 변경했습니다.";
     private static final String HOST_CHANGED_MESSAGE_FORMAT = "%s님이 새로운 방장이 되었습니다.";
 
@@ -171,6 +172,29 @@ public class LobbyRealtimeNotifier {
                 targetUserIdentifier,
                 String.format(KICK_MESSAGE_FORMAT, targetUserIdentifier),
                 "KICK"
+        );
+    }
+
+    /**
+     * LEAVE 시스템 메시지를 로비 채팅 채널로 발행한다.
+     *
+     * [사용 시점]
+     * 클라이언트의 명시적 퇴장 요청으로 참여자가 로비를 나간 직후 호출한다.
+     *
+     * [주의]
+     * 퇴장 상태 변경은 leave_lobby.lua에서 이미 완료된 상태다.
+     * 메시지 발행 실패가 퇴장 자체를 롤백해서는 안 되므로 boolean 결과만 반환한다.
+     */
+    public boolean notifyLeaveMessage(
+            String lobbyCode,
+            String userIdentifier
+    ) {
+        return notifySystemChatMessage(
+                lobbyCode,
+                ChatMessageDto.MessageType.LEAVE,
+                userIdentifier,
+                String.format(LEAVE_MESSAGE_FORMAT, userIdentifier),
+                "LEAVE"
         );
     }
 

--- a/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/io/github/ascrew/monomatbe/global/websocket/WebSocketEventListener.java
@@ -300,6 +300,9 @@ public class WebSocketEventListener {
             eventPublisher.publishEvent(new PlayerInGameReconnectEvent(lobbyCode, userIdentifier));
             publishEnterMessage(lobbyCode, userIdentifier);
             notifyLobbyInfoRefresh(lobbyCode);
+            // 목록 화면 구독자에게도 current_players 변동을 알린다. (#203)
+            // ALREADY_JOINED/SESSION_REPLACED는 인원 미변동이므로 ENTERED에서만 발행한다.
+            notifyLobbyListRefresh();
             return;
         }
 
@@ -509,6 +512,18 @@ public class WebSocketEventListener {
         messagingTemplate.convertAndSend(
                 StompDestinations.subscribeLobbyRefresh(lobbyCode),
                 StompDestinations.MSG_REFRESH_LOBBY_INFO
+        );
+    }
+
+    /**
+     * 전역 로비 목록 새로고침 신호를 브로드캐스트한다.
+     *
+     * 입장으로 인원 수(current_players)가 변동되면 목록 화면 구독자도 재조회하도록 알린다. (#203)
+     */
+    private void notifyLobbyListRefresh() {
+        messagingTemplate.convertAndSend(
+                StompDestinations.SUBSCRIBE_LOBBY_LIST_REFRESH,
+                StompDestinations.MSG_REFRESH_LOBBY_LIST
         );
     }
 

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandlerTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveEventHandlerTest.java
@@ -1,153 +1,38 @@
 package io.github.ascrew.monomatbe.domain.lobby.service;
 
-import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
-import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
-import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
 import io.github.ascrew.monomatbe.global.websocket.event.PlayerLeaveEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.ApplicationEventPublisher;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class LobbyLeaveEventHandlerTest {
 
     private static final String LOBBY_CODE = "TEST94";
     private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
-    private static final String NEW_HOST_IDENTIFIER = "22222222-2222-2222-2222-222222222222";
 
-    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
-    private final LobbyRealtimeNotifier lobbyRealtimeNotifier = mock(LobbyRealtimeNotifier.class);
-    private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+    private final LobbyLeaveService lobbyLeaveService = mock(LobbyLeaveService.class);
 
-    private final LobbyLeaveEventHandler handler = new LobbyLeaveEventHandler(
-            lobbyRepository,
-            lobbyRealtimeNotifier,
-            eventPublisher
-    );
+    private final LobbyLeaveEventHandler handler = new LobbyLeaveEventHandler(lobbyLeaveService);
 
     @Test
-    @DisplayName("PlayerLeaveEvent 수신 시 로비 퇴장 처리를 실행한다")
-    void executeLeaveProcessWhenPlayerLeaveEventReceived() {
+    @DisplayName("PlayerLeaveEvent 수신 시 퇴장 처리를 LobbyLeaveService에 위임한다")
+    void delegatesToLobbyLeaveServiceWhenPlayerLeaveEventReceived() {
         // given
-        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
-                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
-
         PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
 
         // when
         handler.handlePlayerLeave(event);
 
         // then
-        verify(lobbyRepository).executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER);
+        verify(lobbyLeaveService).processLeave(LOBBY_CODE, USER_IDENTIFIER);
     }
 
     @Test
-    @DisplayName("일반 참가자 퇴장 결과이면 로비 내부 refresh를 발행한다")
-    void notifyLobbyInfoRefreshWhenParticipantLeft() {
-        // given
-        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
-                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
-
-        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
-
-        // when
-        handler.handlePlayerLeave(event);
-
-        // then
-        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
-    }
-
-    @Test
-    @DisplayName("방장 위임 결과이면 로비 내부 refresh를 발행한다")
-    void notifyLobbyInfoRefreshWhenHostDelegated() {
-        // given
-        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
-                .thenReturn(new LeaveLobbyResult.Delegated(LOBBY_CODE, NEW_HOST_IDENTIFIER));
-
-        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
-
-        // when
-        handler.handlePlayerLeave(event);
-
-        // then
-        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
-    }
-
-    @Test
-    @DisplayName("마지막 유저 퇴장으로 로비가 삭제되면 로비 목록 refresh를 발행한다")
-    void notifyLobbyListRefreshWhenLobbyDestroyed() {
-        // given
-        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
-                .thenReturn(new LeaveLobbyResult.Destroyed(LOBBY_CODE));
-
-        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
-
-        // when
-        handler.handlePlayerLeave(event);
-
-        // then
-        verify(lobbyRealtimeNotifier).notifyLobbyListRefresh();
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
-    }
-
-    @Test
-    @DisplayName("로비가 폭파되면 게임 세션 정리를 위한 LobbyClosedEvent를 발행한다")
-    void publishLobbyClosedEventWhenLobbyDestroyed() {
-        // given
-        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
-                .thenReturn(new LeaveLobbyResult.Destroyed(LOBBY_CODE));
-
-        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
-
-        // when
-        handler.handlePlayerLeave(event);
-
-        // then
-        verify(eventPublisher).publishEvent(new LobbyClosedEvent(LOBBY_CODE));
-    }
-
-    @Test
-    @DisplayName("로비가 폭파되지 않은 일반 퇴장에서는 LobbyClosedEvent를 발행하지 않는다")
-    void doesNotPublishLobbyClosedEventWhenNotDestroyed() {
-        // given
-        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
-                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
-
-        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
-
-        // when
-        handler.handlePlayerLeave(event);
-
-        // then
-        verify(eventPublisher, never()).publishEvent(new LobbyClosedEvent(LOBBY_CODE));
-    }
-
-    @Test
-    @DisplayName("퇴장 처리 실패 결과이면 refresh를 발행하지 않는다")
-    void doesNotNotifyWhenLeaveProcessFailed() {
-        // given
-        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
-                .thenReturn(new LeaveLobbyResult.Error("Redis Lua execution failed"));
-
-        PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, USER_IDENTIFIER);
-
-        // when
-        handler.handlePlayerLeave(event);
-
-        // then
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
-    }
-
-    @Test
-    @DisplayName("로비 코드가 없으면 퇴장 처리를 실행하지 않는다")
-    void doesNotExecuteLeaveProcessWhenLobbyCodeIsBlank() {
+    @DisplayName("로비 코드가 없으면 퇴장 처리를 위임하지 않는다")
+    void doesNotDelegateWhenLobbyCodeIsBlank() {
         // given
         PlayerLeaveEvent event = new PlayerLeaveEvent(" ", USER_IDENTIFIER);
 
@@ -155,13 +40,12 @@ class LobbyLeaveEventHandlerTest {
         handler.handlePlayerLeave(event);
 
         // then
-        verify(lobbyRepository, never()).executeLeaveLobbyProcess(" ", USER_IDENTIFIER);
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+        verify(lobbyLeaveService, never()).processLeave(" ", USER_IDENTIFIER);
     }
 
     @Test
-    @DisplayName("사용자 식별자가 없으면 퇴장 처리를 실행하지 않는다")
-    void doesNotExecuteLeaveProcessWhenUserIdentifierIsBlank() {
+    @DisplayName("사용자 식별자가 없으면 퇴장 처리를 위임하지 않는다")
+    void doesNotDelegateWhenUserIdentifierIsBlank() {
         // given
         PlayerLeaveEvent event = new PlayerLeaveEvent(LOBBY_CODE, " ");
 
@@ -169,7 +53,6 @@ class LobbyLeaveEventHandlerTest {
         handler.handlePlayerLeave(event);
 
         // then
-        verify(lobbyRepository, never()).executeLeaveLobbyProcess(LOBBY_CODE, " ");
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(lobbyLeaveService, never()).processLeave(LOBBY_CODE, " ");
     }
 }

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveServiceTest.java
@@ -1,0 +1,159 @@
+package io.github.ascrew.monomatbe.domain.lobby.service;
+
+import io.github.ascrew.monomatbe.domain.lobby.LeaveLobbyResult;
+import io.github.ascrew.monomatbe.domain.lobby.repository.LobbyRepository;
+import io.github.ascrew.monomatbe.global.constant.RedisKeys;
+import io.github.ascrew.monomatbe.global.event.LobbyClosedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LobbyLeaveServiceTest {
+
+    private static final String LOBBY_CODE = "TEST94";
+    private static final String USER_IDENTIFIER = "11111111-1111-1111-1111-111111111111";
+    private static final String NEW_HOST_IDENTIFIER = "22222222-2222-2222-2222-222222222222";
+    private static final String WS_SESSION_ID = "ws-session-1";
+
+    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
+    private final LobbyRealtimeNotifier lobbyRealtimeNotifier = mock(LobbyRealtimeNotifier.class);
+    private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+    private final StringRedisTemplate stringRedisTemplate = mock(StringRedisTemplate.class);
+
+    private final LobbyLeaveService service = new LobbyLeaveService(
+            lobbyRepository,
+            lobbyRealtimeNotifier,
+            eventPublisher,
+            stringRedisTemplate
+    );
+
+    // =========================================================
+    // processLeave 결과 분기
+    // =========================================================
+
+    @Test
+    @DisplayName("일반 참가자 퇴장 결과이면 로비 내부 refresh를 발행한다")
+    void notifyLobbyInfoRefreshWhenParticipantLeft() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
+
+        // when
+        service.processLeave(LOBBY_CODE, USER_IDENTIFIER);
+
+        // then
+        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+    }
+
+    @Test
+    @DisplayName("방장 위임 결과이면 HOST_CHANGED 메시지와 로비 내부 refresh를 발행한다")
+    void notifyHostChangedAndRefreshWhenHostDelegated() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Delegated(LOBBY_CODE, NEW_HOST_IDENTIFIER));
+
+        // when
+        service.processLeave(LOBBY_CODE, USER_IDENTIFIER);
+
+        // then
+        verify(lobbyRealtimeNotifier).notifyHostChangedMessage(LOBBY_CODE, NEW_HOST_IDENTIFIER);
+        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+    }
+
+    @Test
+    @DisplayName("마지막 유저 퇴장으로 로비가 삭제되면 로비 목록 refresh와 LobbyClosedEvent를 발행한다")
+    void notifyLobbyListRefreshAndPublishClosedEventWhenLobbyDestroyed() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Destroyed(LOBBY_CODE));
+
+        // when
+        service.processLeave(LOBBY_CODE, USER_IDENTIFIER);
+
+        // then
+        verify(lobbyRealtimeNotifier).notifyLobbyListRefresh();
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(eventPublisher).publishEvent(new LobbyClosedEvent(LOBBY_CODE));
+    }
+
+    @Test
+    @DisplayName("퇴장 처리 실패 결과이면 refresh를 발행하지 않는다")
+    void doesNotNotifyWhenLeaveProcessFailed() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Error("Redis Lua execution failed"));
+
+        // when
+        service.processLeave(LOBBY_CODE, USER_IDENTIFIER);
+
+        // then
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+        verify(lobbyRealtimeNotifier, never()).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(eventPublisher, never()).publishEvent(new LobbyClosedEvent(LOBBY_CODE));
+    }
+
+    // =========================================================
+    // leaveByRequest 명시적 퇴장
+    // =========================================================
+
+    @Test
+    @DisplayName("명시적 퇴장(Left)이면 LEAVE 메시지를 발행하고 ws:connection 키를 정리한다")
+    void publishLeaveMessageAndCleanupWsConnectionWhenLeft() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Left(LOBBY_CODE, USER_IDENTIFIER));
+
+        // when
+        service.leaveByRequest(LOBBY_CODE, USER_IDENTIFIER, WS_SESSION_ID);
+
+        // then
+        verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
+        verify(lobbyRealtimeNotifier).notifyLeaveMessage(LOBBY_CODE, USER_IDENTIFIER);
+        verify(stringRedisTemplate).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+    }
+
+    @Test
+    @DisplayName("명시적 퇴장으로 로비가 폭파되면 LEAVE 메시지는 발행하지 않고 ws:connection 키만 정리한다")
+    void doesNotPublishLeaveMessageWhenDestroyed() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Destroyed(LOBBY_CODE));
+
+        // when
+        service.leaveByRequest(LOBBY_CODE, USER_IDENTIFIER, WS_SESSION_ID);
+
+        // then
+        verify(lobbyRealtimeNotifier, never()).notifyLeaveMessage(LOBBY_CODE, USER_IDENTIFIER);
+        verify(stringRedisTemplate).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 로비 코드면 퇴장 처리를 실행하지 않는다")
+    void doesNotProcessWhenLobbyCodeIsInvalid() {
+        // when
+        service.leaveByRequest("bad-code!", USER_IDENTIFIER, WS_SESSION_ID);
+
+        // then
+        verify(lobbyRepository, never()).executeLeaveLobbyProcess("bad-code!", USER_IDENTIFIER);
+        verify(stringRedisTemplate, never()).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+    }
+
+    @Test
+    @DisplayName("식별자가 없으면 퇴장 처리를 실행하지 않는다")
+    void doesNotProcessWhenUserIdentifierIsBlank() {
+        // when
+        service.leaveByRequest(LOBBY_CODE, " ", WS_SESSION_ID);
+
+        // then
+        verify(lobbyRepository, never()).executeLeaveLobbyProcess(LOBBY_CODE, " ");
+        verify(stringRedisTemplate, never()).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+    }
+}

--- a/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveServiceTest.java
+++ b/src/test/java/io/github/ascrew/monomatbe/domain/lobby/service/LobbyLeaveServiceTest.java
@@ -49,11 +49,12 @@ class LobbyLeaveServiceTest {
 
         // then
         verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+        // 목록 화면 구독자에게도 인원 변동을 알린다. (#203)
+        verify(lobbyRealtimeNotifier).notifyLobbyListRefresh();
     }
 
     @Test
-    @DisplayName("방장 위임 결과이면 HOST_CHANGED 메시지와 로비 내부 refresh를 발행한다")
+    @DisplayName("방장 위임 결과이면 HOST_CHANGED 메시지와 로비 내부 refresh, 목록 refresh를 발행한다")
     void notifyHostChangedAndRefreshWhenHostDelegated() {
         // given
         when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
@@ -65,7 +66,8 @@ class LobbyLeaveServiceTest {
         // then
         verify(lobbyRealtimeNotifier).notifyHostChangedMessage(LOBBY_CODE, NEW_HOST_IDENTIFIER);
         verify(lobbyRealtimeNotifier).notifyLobbyInfoRefresh(LOBBY_CODE);
-        verify(lobbyRealtimeNotifier, never()).notifyLobbyListRefresh();
+        // 목록 화면 구독자에게도 인원 변동을 알린다. (#203)
+        verify(lobbyRealtimeNotifier).notifyLobbyListRefresh();
     }
 
     @Test
@@ -133,6 +135,22 @@ class LobbyLeaveServiceTest {
         // then
         verify(lobbyRealtimeNotifier, never()).notifyLeaveMessage(LOBBY_CODE, USER_IDENTIFIER);
         verify(stringRedisTemplate).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+    }
+
+    @Test
+    @DisplayName("퇴장 처리 실패(Error)이면 LEAVE 메시지/ws:connection 정리를 건너뛴다")
+    void doesNotPublishLeaveMessageNorCleanupWsConnectionWhenError() {
+        // given
+        when(lobbyRepository.executeLeaveLobbyProcess(LOBBY_CODE, USER_IDENTIFIER))
+                .thenReturn(new LeaveLobbyResult.Error("Redis Lua execution failed"));
+
+        // when
+        service.leaveByRequest(LOBBY_CODE, USER_IDENTIFIER, WS_SESSION_ID);
+
+        // then
+        // ws:connection 키를 유지해야 이후 실제 DISCONNECT가 퇴장/키 정리를 재시도할 수 있다.
+        verify(stringRedisTemplate, never()).delete(RedisKeys.wsConnectionKey(WS_SESSION_ID));
+        verify(lobbyRealtimeNotifier, never()).notifyLeaveMessage(LOBBY_CODE, USER_IDENTIFIER);
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue
- #203

## 📝 Summary
로비 대기실에서 퇴장 버튼을 눌러도 다른 사용자에게 인원 수가 즉시 갱신되지 않고,
누군가 새로고침을 해야 그제서야 인원이 빠지던 문제를 수정했습니다.

**원인**
- 백엔드에 명시적인 퇴장 처리 경로가 없어, 퇴장 처리가 WebSocket DISCONNECT 이벤트에만 의존했습니다.
- FE 퇴장 버튼이 전역 STOMP 연결을 유지한 채 화면만 이동하면 BE는 퇴장을 전혀 처리하지 못했고,
  사용자가 새로고침해 WS 연결이 끊겨야 비로소 DISCONNECT → 퇴장 처리 → 브로드캐스트가 발생했습니다.
- 강퇴(kick)는 명시적 STOMP 경로(`/app/lobby/{code}/kick`)가 있어 실시간 동작하던 것과 대조적입니다.

**해결**
- 강퇴와 동일하게 명시적 STOMP 퇴장 경로 `/app/lobby/{code}/leave`를 추가하여 실시간 반영되도록 했습니다.

**변경 사항**
- `LobbyLeaveService` 신규: 퇴장 처리/결과 분기 로직을 공용 서비스로 추출
  (DISCONNECT 경로와 명시적 퇴장 경로가 동일 로직 공유)
- `LobbyEventController`에 `@MessageMapping("/lobby/{code}/leave")` 추가
- 명시적 퇴장 시 LEAVE 시스템 메시지 발행 + `ws:connection` 키 정리로
  이후 실제 DISCONNECT의 이중 처리 방지
- `LobbyLeaveEventHandler`를 공용 서비스 위임 구조로 리팩터
- `LobbyRealtimeNotifier.notifyLeaveMessage` 추가

## 🙏 PR point
- ⚠️ **FE 연동 필요**: 퇴장 버튼 클릭 시 `/app/lobby/{code}/leave`를 송신해야 동작합니다.
  (`client.publish({ destination: '/app/lobby/{code}/leave' })`)
- 기존 STOMP destination 계약(`/topic/lobby/{code}/refresh`, `/topic/lobby/{code}/chat`)은 변경하지 않았습니다.
- `leave_lobby.lua`는 이미 빠진 유저에 대해 멱등(SREM no-op)하므로, 명시적 퇴장 후 실제 DISCONNECT가 와도
  안전하게 처리됩니다. 추가로 `ws:connection` 키를 선삭제하여 중복 브로드캐스트도 방지했습니다.
- 인게임(PLAYING) 상태 이탈은 별도 흐름(`PlayerInGameDisconnectEvent`)으로 처리되며 본 PR 범위 밖입니다.

## 📬 Reference
-